### PR TITLE
Stop the timer when window defocuses (e.g. users turn to other apps or tabs)

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -97,6 +97,19 @@ const App: React.FC = () => {
     }
   }, [isStart])
 
+  // When users turn to other tabs or apps, we will stop the timer.
+  useEffect(() => {
+    const onBlur = () => {
+      if (isStart) {
+        setIsStart(false)
+      }
+    }
+    if (isStart) {
+      window.addEventListener('blur', onBlur)
+    }
+    return () => window.removeEventListener('blur', onBlur)
+  })
+
   useEffect(() => {
     setChapterListLength(Math.ceil(dict.length / chapterLength))
   }, [dict])


### PR DESCRIPTION
For example, press <kbd>⌘⇥</kbd> after you start, the timer should stop.

