### PR TITLE
fix(pages/Gallery):修改滚动时标题和内容重叠的问题

### DIFF
--- a/src/pages/Gallery/ChapterGroup.tsx
+++ b/src/pages/Gallery/ChapterGroup.tsx
@@ -6,10 +6,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 const ChapterGroup: React.FC<ChapterGroupProps> = ({ count }) => {
   const [selectedChapter, setSelectedChapter] = useSelectedChapter()
   return (
-    <main className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+    <main className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 mr-4">
       {range(count).map((index) => (
         <button
-          className="relative p-4 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none"
+          className="relative p-4 w-36 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none"
           onClick={() => setSelectedChapter(index)}
           key={index}
         >

--- a/src/pages/Gallery/ChapterGroup.tsx
+++ b/src/pages/Gallery/ChapterGroup.tsx
@@ -9,7 +9,7 @@ const ChapterGroup: React.FC<ChapterGroupProps> = ({ count }) => {
     <main className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {range(count).map((index) => (
         <button
-          className="relative p-4 w-36 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none"
+          className="relative p-4 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none"
           onClick={() => setSelectedChapter(index)}
           key={index}
         >

--- a/src/pages/Gallery/DictionaryCard.tsx
+++ b/src/pages/Gallery/DictionaryCard.tsx
@@ -8,7 +8,7 @@ const DictionaryCard: React.FC<DictionaryCardProps> = ({ dictionary }) => {
   const setDictionary = useSetDictionary()
   return (
     <button
-      className="relative p-4 w-40 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none "
+      className="relative p-4 w-48 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none "
       onClick={setDictionary.bind(null, dictionary.id)}
     >
       <p className="mb-1 text-xl text-gray-800 dark:text-white dark:text-opacity-80">{dictionary.name}</p>

--- a/src/pages/Gallery/DictionaryCard.tsx
+++ b/src/pages/Gallery/DictionaryCard.tsx
@@ -8,7 +8,7 @@ const DictionaryCard: React.FC<DictionaryCardProps> = ({ dictionary }) => {
   const setDictionary = useSetDictionary()
   return (
     <button
-      className="relative p-4 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none "
+      className="relative p-4 w-40 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none "
       onClick={setDictionary.bind(null, dictionary.id)}
     >
       <p className="mb-1 text-xl text-gray-800 dark:text-white dark:text-opacity-80">{dictionary.name}</p>

--- a/src/pages/Gallery/DictionaryCard.tsx
+++ b/src/pages/Gallery/DictionaryCard.tsx
@@ -8,7 +8,7 @@ const DictionaryCard: React.FC<DictionaryCardProps> = ({ dictionary }) => {
   const setDictionary = useSetDictionary()
   return (
     <button
-      className="relative p-4 w-48 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none "
+      className="relative p-4 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none "
       onClick={setDictionary.bind(null, dictionary.id)}
     >
       <p className="mb-1 text-xl text-gray-800 dark:text-white dark:text-opacity-80">{dictionary.name}</p>

--- a/src/pages/Gallery/DictionaryGroup.tsx
+++ b/src/pages/Gallery/DictionaryGroup.tsx
@@ -4,7 +4,7 @@ import DictionaryCard from './DictionaryCard'
 
 const DictionaryGroup: React.FC<DictionaryGroupProps> = ({ title, dictionaries }) => {
   return (
-    <section>
+    <section className="mb-2 mr-4">
       <h3 className="mb-2 text-sm font-bold text-gray-600 dark:text-white dark:text-opacity-60">{title}</h3>
       <main className="grid gap-4 sm:grid-cols-1 md:grid-cols-2">
         {dictionaries.map((dict) => (

--- a/src/pages/Gallery/index.tsx
+++ b/src/pages/Gallery/index.tsx
@@ -25,20 +25,24 @@ const GalleryPage: React.FC = () => {
         </NavLink>
       </Header>
       <div className="mt-auto mb-auto flex w-auto space-x-4 overflow-y-auto">
-        <div className="bg-indigo-50 dark:bg-blue-gray-800 rounded-lg p-6 space-y-2 overflow-y-auto">
+        <div className="bg-indigo-50 dark:bg-blue-gray-800 rounded-lg p-6 space-y-2 overflow-y-auto flex flex-col">
           <h2 className="sticky top-0 mb-4 font-bold text-lg text-gray-700 dark:text-white dark:text-opacity-70 text-shadow z-10">
             词典选择
           </h2>
-          {groups.map(([name, items]) => (
-            <DictionaryGroup key={name} title={name} dictionaries={items} />
-          ))}
+          <div className="overflow-y-auto">
+            {groups.map(([name, items]) => (
+              <DictionaryGroup key={name} title={name} dictionaries={items} />
+            ))}
+          </div>
         </div>
-        <div className="p-6 overflow-y-auto bg-indigo-50 dark:bg-blue-gray-800 rounded-lg">
+        <div className="p-6 overflow-y-auto bg-indigo-50 dark:bg-blue-gray-800 rounded-lg flex flex-col">
           <h2 className="sticky top-0 mb-4 font-bold text-lg text-gray-700 dark:text-white dark:text-opacity-70 text-shadow z-10">
             章节选择
           </h2>
           {/* TODO: remove magic number here. */}
-          <ChapterGroup count={Math.ceil(selectedDictionary.length / 20)} />
+          <div className="overflow-y-auto">
+            <ChapterGroup count={Math.ceil(selectedDictionary.length / 20)} />
+          </div>
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
词典章节切换页面滚动的时候，词典选择和章节选择这两个标题会遮挡住后面的内容，不知道是刻意的还是没有注意到，我看着怪怪的，大致改了一下。