### PR TITLE
handle duplicated word

### DIFF
--- a/src/pages/Typing/index.tsx
+++ b/src/pages/Typing/index.tsx
@@ -183,7 +183,7 @@ const App: React.FC = () => {
               <div className="h-1/3"></div>
               <div>
                 <Word
-                  key={`word-${wordList.words[order].name}`}
+                  key={`word-${wordList.words[order].name}-${order}`}
                   word={wordList.words[order].name}
                   onFinish={onFinish}
                   isStart={isStart}


### PR DESCRIPTION
修复 dict 中重复（相邻）字段导致的卡死，比如 
```
$ head public/dicts/BEC_2_T.json 
[
  { "name": "pharmacy", "trans": ["药房；配药学，药剂学；制药业；一批备用药品"], "usphone": "'fɑrməsi", "ukphone": "'fɑːməsɪ" },
```

把 pharmacy 单词复制一遍，两个连续的相同单词会造成页面卡住。

改了 key 的逻辑，加上了 order 序。