### PR TITLE
封装 Tooltip 组件

### DIFF
--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -104,7 +104,7 @@ const Modals: React.FC<ModalsProps> = ({
               </div>
 
               <div className="bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                <Tooltip content="快捷键 Enter" placement="top">
+                <Tooltip content="快捷键 Enter">
                   <button
                     type="button"
                     className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white dark:text-opacity-80 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm ${firstButtonClassName}`}
@@ -114,7 +114,7 @@ const Modals: React.FC<ModalsProps> = ({
                   </button>
                 </Tooltip>
 
-                <Tooltip content="快捷键 Shift + Enter" placement="top">
+                <Tooltip content="快捷键 Shift + Enter">
                   <button
                     type="button"
                     className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm ${
@@ -127,7 +127,7 @@ const Modals: React.FC<ModalsProps> = ({
                 </Tooltip>
 
                 {thirdButton && thirdButtonOnclick && (
-                  <Tooltip content={`快捷键 ${thirdButtonHotkey}`} placement="top">
+                  <Tooltip content={`快捷键 ${thirdButtonHotkey}`}>
                     <button
                       type="button"
                       className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm ${

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -56,7 +56,7 @@ const Modals: React.FC<ModalsProps> = ({
           enter="ease-out duration-30"
           enterFrom="opacity-0 "
           enterTo="opacity-100 "
-          leave="esae-in duration-200"
+          leave="ease-in duration-200"
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
@@ -103,11 +103,11 @@ const Modals: React.FC<ModalsProps> = ({
                 </div>
               </div>
 
-              <div className="bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+              <div className="bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse sm:space-x-3 sm:space-x-reverse">
                 <Tooltip content="快捷键 Enter">
                   <button
                     type="button"
-                    className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white dark:text-opacity-80 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm ${firstButtonClassName}`}
+                    className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white dark:text-opacity-80 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:w-auto sm:text-sm ${firstButtonClassName}`}
                     onClick={firstButtonOnclick}
                   >
                     {firstButton}
@@ -117,7 +117,7 @@ const Modals: React.FC<ModalsProps> = ({
                 <Tooltip content="快捷键 Shift + Enter">
                   <button
                     type="button"
-                    className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm ${
+                    className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm ${
                       secondButtonClassName ?? ''
                     }`}
                     onClick={secondButtonOnclick}
@@ -130,7 +130,7 @@ const Modals: React.FC<ModalsProps> = ({
                   <Tooltip content={`快捷键 ${thirdButtonHotkey}`}>
                     <button
                       type="button"
-                      className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm ${
+                      className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm ${
                         secondButtonClassName ?? ''
                       }`}
                       onClick={thirdButtonOnclick}

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -2,6 +2,7 @@ import React, { MouseEvent } from 'react'
 import { Transition } from '@headlessui/react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import Tooltip from 'components/Tooltip'
 
 type ModalsProps = {
   state: boolean
@@ -103,7 +104,7 @@ const Modals: React.FC<ModalsProps> = ({
               </div>
 
               <div className="bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                <div className="group relative">
+                <Tooltip content="快捷键 Enter" placement="top">
                   <button
                     type="button"
                     className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white dark:text-opacity-80 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm ${firstButtonClassName}`}
@@ -111,12 +112,9 @@ const Modals: React.FC<ModalsProps> = ({
                   >
                     {firstButton}
                   </button>
-                  <div className="invisible group-hover:visible absolute bottom-full left-1/2 w-40 -ml-20 pl-2 flex items-center justify-center">
-                    <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">快捷键 Enter</span>
-                  </div>
-                </div>
+                </Tooltip>
 
-                <div className="group relative">
+                <Tooltip content="快捷键 Shift + Enter" placement="top">
                   <button
                     type="button"
                     className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm ${
@@ -126,13 +124,10 @@ const Modals: React.FC<ModalsProps> = ({
                   >
                     {secondButton}
                   </button>
-                  <div className="invisible group-hover:visible absolute bottom-full left-1/2 w-40 -ml-20 pl-3 flex items-center justify-center">
-                    <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">快捷键 Shift + Enter</span>
-                  </div>
-                </div>
+                </Tooltip>
 
                 {thirdButton && thirdButtonOnclick && (
-                  <div className="group relative">
+                  <Tooltip content={`快捷键 ${thirdButtonHotkey}`} placement="top">
                     <button
                       type="button"
                       className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm ${
@@ -142,10 +137,7 @@ const Modals: React.FC<ModalsProps> = ({
                     >
                       {thirdButton}
                     </button>
-                    <div className="invisible group-hover:visible absolute bottom-full left-1/2 w-40 -ml-20 pl-3 flex items-center justify-center">
-                      <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">快捷键 {thirdButtonHotkey}</span>
-                    </div>
-                  </div>
+                  </Tooltip>
                 )}
               </div>
             </div>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -7,12 +7,12 @@ const Tooltip: React.FC<
     /** 位置 */
     placement?: 'top' | 'bottom'
   }>
-> = ({ children, content, placement = 'bottom' }) => {
+> = ({ children, content, placement = 'top' }) => {
   const [visible, setVisible] = useState(false)
 
   const placementClasses = {
-    top: 'bottom-full pb-3',
-    bottom: 'top-full pt-3',
+    top: 'bottom-full pb-2',
+    bottom: 'top-full pt-2',
   }[placement]
 
   return (
@@ -22,10 +22,12 @@ const Tooltip: React.FC<
       </div>
       <div
         className={`${
-          visible ? 'visible' : 'invisible'
-        } ${placementClasses} absolute left-1/2 transform -translate-x-1/2 flex items-center justify-center`}
+          visible ? 'opacity-100' : 'opacity-0'
+        } ${placementClasses} absolute left-1/2 transform -translate-x-1/2 flex items-center justify-center pointer-events-none transition-opacity`}
       >
-        <span className="text-gray-500 dark:text-gray-400 text-xs whitespace-nowrap">{content}</span>
+        <span className="py-1 px-2 bg-white dark:bg-gray-700 rounded-lg shadow-md text-gray-500 dark:text-gray-300 text-xs whitespace-nowrap">
+          {content}
+        </span>
       </div>
     </div>
   )

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+
+const Tooltip: React.FC<
+  React.PropsWithChildren<{
+    /** 显示文本 */
+    content: string
+    /** 位置 */
+    placement?: 'top' | 'bottom'
+  }>
+> = ({ children, content, placement = 'bottom' }) => {
+  const [visible, setVisible] = useState(false)
+
+  const placementClasses = {
+    top: 'bottom-full pb-3',
+    bottom: 'top-full pt-3',
+  }[placement]
+
+  return (
+    <div className="group relative">
+      <div onMouseEnter={() => setVisible(true)} onMouseLeave={() => setVisible(false)}>
+        {children}
+      </div>
+      <div
+        className={`${
+          visible ? 'visible' : 'invisible'
+        } ${placementClasses} absolute left-1/2 transform -translate-x-1/2 flex items-center justify-center`}
+      >
+        <span className="text-gray-500 dark:text-gray-400 text-xs whitespace-nowrap">{content}</span>
+      </div>
+    </div>
+  )
+}
+
+export default Tooltip

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -16,7 +16,7 @@ const Tooltip: React.FC<
   }[placement]
 
   return (
-    <div className="group relative">
+    <div className="relative">
       <div onMouseEnter={() => setVisible(true)} onMouseLeave={() => setVisible(false)}>
         {children}
       </div>

--- a/src/pages/Typing/Switcher/index.tsx
+++ b/src/pages/Typing/Switcher/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { SwitcherStateType, SwitcherDispatchType } from '../hooks/useSwitcherState'
 import { useHotkeys } from 'react-hotkeys-hook'
+import Tooltip from 'components/Tooltip'
 
 export type SwitcherPropsType = {
   state: SwitcherStateType
@@ -44,7 +45,7 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
 
   return (
     <div className="flex items-center justify-center space-x-3">
-      <div className="group relative">
+      <Tooltip content="开关声音（Ctrl + M）">
         <button
           className={`${state.sound ? 'text-indigo-400' : 'text-gray-400'} text-lg focus:outline-none`}
           onClick={(e) => {
@@ -54,11 +55,8 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
         >
           <FontAwesomeIcon icon={state.sound ? 'volume-up' : 'volume-mute'} fixedWidth />
         </button>
-        <div className="invisible group-hover:visible absolute top-full left-1/2 w-40 -ml-20 pt-2 flex items-center justify-center">
-          <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">开关声音（Ctrl + M）</span>
-        </div>
-      </div>
-      <div className="group relative">
+      </Tooltip>
+      <Tooltip content="开关英语显示（Ctrl + V）">
         <button
           className={`${state.wordVisible ? 'text-indigo-400' : 'text-gray-400'} text-lg focus:outline-none`}
           onClick={(e) => {
@@ -68,11 +66,8 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
         >
           <FontAwesomeIcon icon={state.wordVisible ? 'eye' : 'eye-slash'} fixedWidth />
         </button>
-        <div className="invisible group-hover:visible absolute top-full left-1/2 w-44 -ml-20 pt-2 flex items-center justify-center">
-          <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">开关英语显示（Ctrl + V）</span>
-        </div>
-      </div>
-      <div className="group relative">
+      </Tooltip>
+      <Tooltip content="开关音标显示（Ctrl + P）">
         <button
           className={`${state.phonetic ? 'text-indigo-400' : 'text-gray-400'} text-lg focus:outline-none`}
           onClick={(e) => {
@@ -82,11 +77,8 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
         >
           <FontAwesomeIcon icon="assistive-listening-systems" fixedWidth />
         </button>
-        <div className="invisible group-hover:visible absolute top-full left-1/2 w-44 -ml-20 pt-2 flex items-center justify-center">
-          <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">开关音标显示（Ctrl + P）</span>
-        </div>
-      </div>
-      <div className="group relative">
+      </Tooltip>
+      <Tooltip content="开关深色模式（Ctrl + D）">
         <button
           className={`text-indigo-400 text-lg focus:outline-none`}
           onClick={(e) => {
@@ -96,10 +88,7 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
         >
           <FontAwesomeIcon icon={state.darkMode ? 'moon' : 'sun'} fixedWidth />
         </button>
-        <div className="invisible group-hover:visible absolute top-full left-1/2 w-44 -ml-20 pt-2 flex items-center justify-center">
-          <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">开关深色模式（Ctrl + D）</span>
-        </div>
-      </div>
+      </Tooltip>
     </div>
   )
 }

--- a/src/pages/Typing/index.tsx
+++ b/src/pages/Typing/index.tsx
@@ -156,7 +156,7 @@ const App: React.FC = () => {
               >
                 {wordList.dictName} 第 {wordList.chapter + 1} 章
               </NavLink>
-              <div className="invisible group-hover:visible absolute top-full left-1/2 w-40 -ml-20 pt-0 flex items-center justify-center">
+              <div className="invisible group-hover:visible absolute top-full left-1/2 w-40 -ml-20 pt-2 flex items-center justify-center">
                 <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">词典章节切换</span>
               </div>
             </div>

--- a/src/pages/Typing/index.tsx
+++ b/src/pages/Typing/index.tsx
@@ -17,6 +17,7 @@ import { useWordList } from './hooks/useWordList'
 import Layout from '../../components/Layout'
 import { NavLink } from 'react-router-dom'
 import usePronunciation from './hooks/usePronunciation'
+import Tooltip from 'components/Tooltip'
 
 const App: React.FC = () => {
   const [order, setOrder] = useState<number>(0)
@@ -149,20 +150,17 @@ const App: React.FC = () => {
       ) : (
         <Layout>
           <Header>
-            <div className="group relative">
+            <Tooltip content="词典章节切换">
               <NavLink
                 className="text-lg px-4 py-1 rounded-lg transition-colors duration-300 ease-in-out focus:outline-none dark:text-white dark:text-opacity-60 hover:bg-indigo-400 hover:text-opacity-100"
                 to="/gallery"
               >
                 {wordList.dictName} 第 {wordList.chapter + 1} 章
               </NavLink>
-              <div className="invisible group-hover:visible absolute top-full left-1/2 w-40 -ml-20 pt-2 flex items-center justify-center">
-                <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">词典章节切换</span>
-              </div>
-            </div>
+            </Tooltip>
             <PronunciationSwitcher state={pronunciation.toString()} changePronunciationState={changePronunciation} />
             <Switcher state={switcherState} dispatch={switcherStateDispatch} />
-            <div className="group relative">
+            <Tooltip content="快捷键 Enter">
               <button
                 className={`${
                   isStart ? 'bg-gray-300 dark:bg-gray-700' : 'bg-indigo-400'
@@ -173,10 +171,7 @@ const App: React.FC = () => {
               >
                 {isStart ? 'Pause' : 'Start'}
               </button>
-              <div className="invisible group-hover:visible absolute top-full left-1/2 w-40 -ml-20 pt-2 flex items-center justify-center">
-                <span className="py-1 px-3 text-gray-500 dark:text-gray-400 text-xs">快捷键 Enter</span>
-              </div>
-            </div>
+            </Tooltip>
           </Header>
           <Main>
             <div className="container h-full relative flex mx-auto flex-col items-center">

--- a/src/pages/Typing/index.tsx
+++ b/src/pages/Typing/index.tsx
@@ -152,7 +152,7 @@ const App: React.FC = () => {
           <Header>
             <Tooltip content="词典章节切换">
               <NavLink
-                className="text-lg px-4 py-1 rounded-lg transition-colors duration-300 ease-in-out focus:outline-none dark:text-white dark:text-opacity-60 hover:bg-indigo-400 hover:text-opacity-100"
+                className="text-lg px-4 py-1 rounded-lg transition-colors duration-300 ease-in-out focus:outline-none dark:text-white dark:text-opacity-60 hover:bg-indigo-400 hover:text-white dark:hover:text-opacity-100"
                 to="/gallery"
               >
                 {wordList.dictName} 第 {wordList.chapter + 1} 章


### PR DESCRIPTION
调整词典入口下方 hint 位置，与右边其他按钮的 hint 垂直位置对齐，以保证视觉效果一致性

调整前：

![image](https://user-images.githubusercontent.com/23160486/109606811-2607f800-7b62-11eb-9881-a4ecbcbc2b77.png)

调整后：

![image](https://user-images.githubusercontent.com/23160486/109606842-2f916000-7b62-11eb-866f-857f21207c62.png)

