### PR TITLE
fix: InfoBox will no longer shake

### DIFF
--- a/src/components/Speed/InfoBox.tsx
+++ b/src/components/Speed/InfoBox.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const InfoBox: React.FC<InfoBoxProps> = ({ info, description }) => {
   return (
-    <div className="flex flex-grow flex-col items-center justify-center">
+    <div className="flex flex-1 flex-col items-center justify-center">
       <span className="font-bold w-4/5 text-center text-xl text-gray-600 dark:text-gray-400 transition-colors duration-300 pb-2 border-b">
         {info}
       </span>


### PR DESCRIPTION
`flex-grow` gives different width to these info boxes which will shake when the timer starts. Switch to `flex-1` will fix this issue.