### PR TITLE
增加一个用 Enter 键切换到下一个单词的功能

### DIFF
--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -34,18 +34,18 @@ const Modals: React.FC<ModalsProps> = ({
   thirdButtonHotkey = '',
 }) => {
   useHotkeys('enter', () => {
-    const e: MouseEvent = (null as unknown) as MouseEvent
-    firstButtonOnclick(e)
+    const button = document.getElementById('firstButton') as HTMLButtonElement
+    button.click()
   })
 
   useHotkeys('shift+enter', () => {
-    const e: MouseEvent = (null as unknown) as MouseEvent
-    secondButtonOnclick(e)
+    const button = document.getElementById('secondButton') as HTMLButtonElement
+    button.click()
   })
 
-  useHotkeys(thirdButtonHotkey, () => {
-    const e: MouseEvent = (null as unknown) as MouseEvent
-    if (thirdButtonOnclick) thirdButtonOnclick(e)
+  useHotkeys(thirdButtonHotkey, (event) => {
+    const button = document.getElementById('thirdButton') as HTMLButtonElement
+    button.click()
   })
 
   return (
@@ -107,6 +107,7 @@ const Modals: React.FC<ModalsProps> = ({
                 <Tooltip content="快捷键 Enter">
                   <button
                     type="button"
+                    id={'firstButton'}
                     className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white dark:text-opacity-80 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:w-auto sm:text-sm ${firstButtonClassName}`}
                     onClick={firstButtonOnclick}
                   >
@@ -117,6 +118,7 @@ const Modals: React.FC<ModalsProps> = ({
                 <Tooltip content="快捷键 Shift + Enter">
                   <button
                     type="button"
+                    id={'secondButton'}
                     className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm ${
                       secondButtonClassName ?? ''
                     }`}
@@ -130,6 +132,7 @@ const Modals: React.FC<ModalsProps> = ({
                   <Tooltip content={`快捷键 ${thirdButtonHotkey}`}>
                     <button
                       type="button"
+                      id={'thirdButton'}
                       className={`mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-white dark:text-opacity-60 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm ${
                         secondButtonClassName ?? ''
                       }`}

--- a/src/components/Modals/index.tsx
+++ b/src/components/Modals/index.tsx
@@ -44,6 +44,7 @@ const Modals: React.FC<ModalsProps> = ({
   })
 
   useHotkeys(thirdButtonHotkey, (event) => {
+    event.stopPropagation()
     const button = document.getElementById('thirdButton') as HTMLButtonElement
     button.click()
   })

--- a/src/components/Speed/index.tsx
+++ b/src/components/Speed/index.tsx
@@ -7,15 +7,15 @@ const Speed: React.FC<SpeedProps> = ({ correctCount, inputCount, isStart }) => {
   const correctRate = (correctCount / (inputCount === 0 ? 1 : inputCount)).toFixed(2)
   const time = seconds + minutes * 60 + hours * 60 * 60 + days * 12 * 60 * 60
   const speed = (correctCount / (time === 0 ? 1 : time)).toFixed(2)
-  const secondsStirng = seconds < 10 ? '0' + seconds : seconds + ''
-  const minutesStirng = minutes < 10 ? '0' + minutes : minutes + ''
+  const secondsString = seconds < 10 ? '0' + seconds : seconds + ''
+  const minutesString = minutes < 10 ? '0' + minutes : minutes + ''
   useEffect(() => {
     isStart ? start() : pause()
   }, [isStart, start, pause])
 
   return (
     <div className="w-3/5 flex bg-white dark:bg-gray-800 transition-colors duration-300 mt-auto rounded-large card p-4 py-10 opacity-45">
-      <InfoBox info={`${minutesStirng}:${secondsStirng}`} description="时间" />
+      <InfoBox info={`${minutesString}:${secondsString}`} description="时间" />
       <InfoBox info={inputCount + ''} description="输入数" />
       <InfoBox info={speed + ''} description="速度" />
       <InfoBox info={correctCount + ''} description="正确数" />

--- a/src/components/Speed/index.tsx
+++ b/src/components/Speed/index.tsx
@@ -11,7 +11,8 @@ const Speed: React.FC<SpeedProps> = ({ correctCount, inputCount, isStart }) => {
   const minutesString = minutes < 10 ? '0' + minutes : minutes + ''
   useEffect(() => {
     isStart ? start() : pause()
-  }, [isStart, start, pause])
+    // eslint-disable-next-line
+  }, [isStart])
 
   return (
     <div className="w-3/5 flex bg-white dark:bg-gray-800 transition-colors duration-300 mt-auto rounded-large card p-4 py-10 opacity-45">
@@ -29,5 +30,5 @@ export type SpeedProps = {
   inputCount: number
   isStart: boolean
 }
-
+Speed.displayName = 'Speed'
 export default React.memo(Speed)

--- a/src/components/Word/index.tsx
+++ b/src/components/Word/index.tsx
@@ -46,7 +46,7 @@ const Word: React.FC<WordProps> = ({ word = 'defaultWord', onFinish, addSpeedCor
 
   useEffect(() => {
     if (isStart && !isFinish) window.addEventListener('keydown', onKeydown)
-
+    if (!isStart || isFinish) window.removeEventListener('keydown', onKeydown)
     return () => {
       window.removeEventListener('keydown', onKeydown)
     }

--- a/src/components/Word/index.tsx
+++ b/src/components/Word/index.tsx
@@ -76,7 +76,8 @@ const Word: React.FC<WordProps> = ({ word = 'defaultWord', onFinish, addSpeedCor
         clearTimeout(timer)
       }
     }
-  }, [hasWrong, isFinish, playBeepSound, isAuto])
+    // eslint-disable-next-line
+  }, [hasWrong])
 
   useLayoutEffect(() => {
     let wordLength = word.length,
@@ -119,7 +120,8 @@ const Word: React.FC<WordProps> = ({ word = 'defaultWord', onFinish, addSpeedCor
         }
       }
     }
-  }, [inputWord.length, word.length, hasWrong, isAuto])
+    // eslint-disable-next-line
+  }, [inputWord])
 
   const playWordSound = pronunciation !== false
 

--- a/src/components/Word/index.tsx
+++ b/src/components/Word/index.tsx
@@ -80,6 +80,7 @@ const Word: React.FC<WordProps> = ({ word = 'defaultWord', onFinish, addSpeedCor
 
   useLayoutEffect(() => {
     let wordLength = word.length,
+      hasWrong = false,
       inputWordLength = inputWord.length
     const statesList: LetterState[] = []
 
@@ -87,12 +88,13 @@ const Word: React.FC<WordProps> = ({ word = 'defaultWord', onFinish, addSpeedCor
       if (word[i] === inputWord[i]) {
         statesList.push('correct')
       } else {
+        hasWrong = true
         statesList.push('wrong')
         setHasWrong(true)
         break
       }
     }
-    if (inputWordLength > oldInputLength) {
+    if (!hasWrong && inputWordLength > oldInputLength) {
       addSpeedCorrectCount(1)
       setOldInputLength(inputWordLength)
     }

--- a/src/pages/Typing/Switcher/index.tsx
+++ b/src/pages/Typing/Switcher/index.tsx
@@ -42,7 +42,14 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
     },
     [dispatch],
   )
-
+  useHotkeys(
+    'ctrl+x',
+    (e) => {
+      e.preventDefault()
+      dispatch('autoMode')
+    },
+    [dispatch],
+  )
   return (
     <div className="flex items-center justify-center space-x-3">
       <Tooltip content="开关键盘声音（Ctrl + M）">
@@ -87,6 +94,17 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
           }}
         >
           <FontAwesomeIcon icon={state.darkMode ? 'moon' : 'sun'} fixedWidth />
+        </button>
+      </Tooltip>
+      <Tooltip content="开关自动模式（Ctrl + X）">
+        <button
+          className={`text-indigo-400 text-lg focus:outline-none`}
+          onClick={(e) => {
+            dispatch('autoMode')
+            e.currentTarget.blur()
+          }}
+        >
+          {state.autoMode ? 'Auto' : 'Manual'}
         </button>
       </Tooltip>
     </div>

--- a/src/pages/Typing/Switcher/index.tsx
+++ b/src/pages/Typing/Switcher/index.tsx
@@ -96,7 +96,7 @@ const Switcher: React.FC<SwitcherPropsType> = ({ state, dispatch }) => {
           <FontAwesomeIcon icon={state.darkMode ? 'moon' : 'sun'} fixedWidth />
         </button>
       </Tooltip>
-      <Tooltip content="开关自动模式（Ctrl + X）">
+      <Tooltip content={`开关自动模式（Ctrl + X）${state.autoMode ? '' : 'Manual 模式用 Enter 切换单词'}`}>
         <button
           className={`text-indigo-400 text-lg focus:outline-none`}
           onClick={(e) => {

--- a/src/pages/Typing/hooks/useSwitcherState.ts
+++ b/src/pages/Typing/hooks/useSwitcherState.ts
@@ -1,11 +1,12 @@
 import { useState } from 'react'
-import { useSetSoundState, useDarkMode } from 'store/AppState'
+import { useSetSoundState, useDarkMode, useAutoMode } from 'store/AppState'
 
 export type SwitcherStateType = {
   phonetic: boolean
   wordVisible: boolean
   sound: boolean
   darkMode: boolean
+  autoMode: boolean
 }
 
 export type SwitcherDispatchType = (type: string, newStatus?: boolean) => void
@@ -19,7 +20,7 @@ const useSwitcherState = (initialState: {
   const [wordVisible, setWordVisible] = useState(initialState.wordVisible)
   const [sound, setSound] = useSetSoundState()
   const [darkMode, setDarkMode] = useDarkMode()
-
+  const [autoMode, setAutoMode] = useAutoMode()
   const dispatch: SwitcherDispatchType = (type, newStatus) => {
     switch (type) {
       case 'phonetic':
@@ -33,9 +34,12 @@ const useSwitcherState = (initialState: {
         break
       case 'darkMode':
         setDarkMode(newStatus ?? !darkMode)
+        break
+      case 'autoMode':
+        setAutoMode(newStatus ?? !autoMode)
     }
   }
-  return [{ phonetic, wordVisible, sound, darkMode }, dispatch]
+  return [{ phonetic, wordVisible, sound, darkMode, autoMode }, dispatch]
 }
 
 export default useSwitcherState

--- a/src/pages/Typing/index.tsx
+++ b/src/pages/Typing/index.tsx
@@ -76,7 +76,7 @@ const App: React.FC = () => {
           setInputCount((count) => count + 1)
         }
       }
-      setIsStart(true)
+      if (!modalState) setIsStart(true)
     }
     const onBlur = () => {
       if (isStart) {
@@ -96,7 +96,7 @@ const App: React.FC = () => {
       window.removeEventListener('blur', onBlur)
       document.getElementsByClassName('_hj_feedback_container')[0]?.removeEventListener('click', hjOnclick)
     }
-  }, [isStart])
+  }, [isStart, modalState])
 
   const modalHandlerGenerator = (chapter: number, order: number, modalState: boolean) => {
     return () => {

--- a/src/pages/Typing/index.tsx
+++ b/src/pages/Typing/index.tsx
@@ -18,16 +18,16 @@ import Layout from '../../components/Layout'
 import { NavLink } from 'react-router-dom'
 import usePronunciation from './hooks/usePronunciation'
 import Tooltip from 'components/Tooltip'
+import { useAutoMode } from '../../store/AppState'
 
 const App: React.FC = () => {
   const [order, setOrder] = useState<number>(0)
-
   const [inputCount, setInputCount] = useState<number>(0)
   const [correctCount, setCorrectCount] = useState<number>(0)
   const [isStart, setIsStart] = useState<boolean>(false)
-
   const [switcherState, switcherStateDispatch] = useSwitcherState({ wordVisible: true, phonetic: false })
   const wordList = useWordList()
+  const [isAuto] = useAutoMode()
   const [pronunciation, pronunciationDispatch] = usePronunciation()
 
   const {
@@ -60,12 +60,13 @@ const App: React.FC = () => {
 
   useHotkeys(
     'enter',
-    () => {
-      if (modalState === false) {
-        setIsStart((isStart) => !isStart)
+    (e) => {
+      e.preventDefault()
+      if (isStart && !isAuto && !modalState) {
+        onFinish()
       }
     },
-    [modalState],
+    [isStart, isAuto, modalState, order, wordList],
   )
 
   useEffect(() => {
@@ -105,7 +106,6 @@ const App: React.FC = () => {
       setIsStart(true)
     }
   }
-
   const onFinish = () => {
     if (wordList === undefined) {
       return
@@ -134,7 +134,6 @@ const App: React.FC = () => {
       }
     } else {
       setOrder((order) => order + 1)
-      setCorrectCount((count) => count + wordList.words[order].name.trim().length)
     }
   }
 
@@ -144,7 +143,9 @@ const App: React.FC = () => {
     },
     [pronunciationDispatch],
   )
-
+  const addCorrectCount = (number: number) => {
+    setCorrectCount((correctCount) => correctCount + number)
+  }
   return (
     <>
       {modalState && (
@@ -199,6 +200,7 @@ const App: React.FC = () => {
                     key={`word-${wordList.words[order].name}-${order}`}
                     word={wordList.words[order].name}
                     onFinish={onFinish}
+                    addSpeedCorrectCount={addCorrectCount}
                     isStart={isStart}
                     wordVisible={switcherState.wordVisible}
                   />

--- a/src/store/AppState.tsx
+++ b/src/store/AppState.tsx
@@ -32,6 +32,10 @@ export type AppState = {
    * Whether dark mode is enabled
    */
   darkMode: boolean
+  /**
+   * Whether auto mode is enabled
+   */
+  autoMode: boolean
 }
 
 export type AppStateData = {
@@ -113,6 +117,21 @@ export function useDarkMode(): [darkMode: boolean, setDarkMode: (state: boolean)
   return [state.darkMode, setDarkMode]
 }
 
+/**
+ * Auto Mode
+ */
+export function useAutoMode(): [autoMode: boolean, setAutoMode: (state: boolean) => void] {
+  const { state, dispatch } = useContext(AppStateContext)
+  const setAutoMode = useCallback(
+    (autoMode: boolean) => {
+      dispatch({ ...state, autoMode })
+    },
+    [state, dispatch],
+  )
+
+  return [state.autoMode, setAutoMode]
+}
+
 const defaultState: AppState = {
   sound: true,
   dictionaries,
@@ -120,6 +139,7 @@ const defaultState: AppState = {
   pronunciation: 'us',
   selectedChapter: 0,
   darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
+  autoMode: true,
 }
 
 export const AppStateProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {


### PR DESCRIPTION
手动模式的主要操作：
- 在手动模式下只能用 Enter 切换下一个单词。
- 一个单词可以输入多次，同时记录正确的次数，和错误的次数。
- 当然遇见简单的词，或不能输入的词也可以跳过。
- 可以用快捷键 Ctrl+X 进行 自动-手动模式切换

在完成手动切换单词功能的同时，发现了 bug 并修复了 #161 #149。
删除了几个不必要的 useEffect 依赖
功能截图

![manual mod feature](https://user-images.githubusercontent.com/16540656/148480829-b29fcdc2-3e55-4996-b5de-369217eedd79.png)