### PR TITLE
fix: show exact words count on chapterButton

### DIFF
--- a/src/pages/Gallery/ChapterButton.tsx
+++ b/src/pages/Gallery/ChapterButton.tsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useEffect, useRef } from 'react'
 
-export const ChapterButton: React.FC<ChapterButtonProps> = ({ index, selected, onClick }) => {
+export const ChapterButton: React.FC<ChapterButtonProps> = ({ index, selected, wordCount, onClick }) => {
   const buttonRef = useRef<HTMLButtonElement>(null)
   useEffect(() => {
     if (selected && buttonRef.current !== null) {
@@ -11,16 +11,15 @@ export const ChapterButton: React.FC<ChapterButtonProps> = ({ index, selected, o
       container?.scrollTo({ top: Math.max(button.offsetTop - container.offsetTop - halfHeight, 0), behavior: 'smooth' })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [selected])
   return (
     <button
       ref={buttonRef}
       className="relative p-4 w-36 bg-gray-50 dark:bg-gray-700 dark:bg-opacity-10 border border-gray-300 dark:border-gray-500 shadow-lg rounded-md text-left overflow-hidden focus:outline-none"
       onClick={onClick}
     >
-      {/* TODO: 部分字典的最后一个章节并非20词  */}
       <p className="text-lg text-gray-800 dark:text-white dark:text-opacity-80 w-full">Chapter {index + 1}</p>
-      <p className="text-sm font-bold text-gray-600 dark:text-white dark:text-opacity-60">20 词</p>
+      <p className="text-sm font-bold text-gray-600 dark:text-white dark:text-opacity-60">{wordCount} 词</p>
       {selected ? (
         <FontAwesomeIcon
           className="absolute -right-4 -bottom-4 text-6xl text-green-500 dark:text-green-300 opacity-60"
@@ -37,5 +36,6 @@ export default ChapterButton
 export type ChapterButtonProps = {
   index: number
   selected: boolean
+  wordCount: number
   onClick: () => void
 }

--- a/src/pages/Gallery/ChapterGroup.tsx
+++ b/src/pages/Gallery/ChapterGroup.tsx
@@ -3,17 +3,36 @@ import { range } from 'lodash'
 import { useSelectedChapter } from 'store/AppState'
 import ChapterButton from './ChapterButton'
 
-const ChapterGroup: React.FC<ChapterGroupProps> = ({ count }) => {
+const ChapterGroup: React.FC<ChapterGroupProps> = ({ totalWords }) => {
   const [selectedChapter, setSelectedChapter] = useSelectedChapter()
+  const chapterCount = Math.ceil(totalWords / 20)
   return (
     <main className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 mr-4">
-      {range(count).map((index) => (
-        <ChapterButton key={index} selected={selectedChapter === index} index={index} onClick={() => setSelectedChapter(index)} />
-      ))}
+      {range(chapterCount).map((index) =>
+        index + 1 === chapterCount ? (
+          <ChapterButton
+            wordCount={totalWords % 20 || 20}
+            key={index}
+            selected={selectedChapter === index}
+            index={index}
+            onClick={() => setSelectedChapter(index)}
+          />
+        ) : (
+          <ChapterButton
+            wordCount={20}
+            key={index}
+            selected={selectedChapter === index}
+            index={index}
+            onClick={() => setSelectedChapter(index)}
+          />
+        ),
+      )}
     </main>
   )
 }
 
 export default ChapterGroup
 
-export type ChapterGroupProps = { count: number }
+export type ChapterGroupProps = {
+  totalWords: number
+}

--- a/src/pages/Gallery/index.tsx
+++ b/src/pages/Gallery/index.tsx
@@ -42,9 +42,8 @@ const GalleryPage: React.FC = () => {
           <h2 className="sticky top-0 mb-4 font-bold text-lg text-gray-700 dark:text-white dark:text-opacity-70 text-shadow z-10">
             章节选择
           </h2>
-          {/* TODO: remove magic number here. */}
           <div className="overflow-y-auto customized-scrollbar">
-            <ChapterGroup count={Math.ceil(selectedDictionary.length / 20)} />
+            <ChapterGroup totalWords={selectedDictionary.length} />
           </div>
         </div>
       </div>

--- a/src/store/AppState.tsx
+++ b/src/store/AppState.tsx
@@ -68,9 +68,7 @@ export function useSetDictionary(): (id: string) => void {
   return (id: string) => {
     const found = dictionaries.find((dict) => dict.id === id)
     if (found !== undefined) {
-      // TODO: remove magic number here.
-      const lastChapterNumber = Math.floor(found.length / 20)
-      dispatch({ ...state, selectedDictionary: found, selectedChapter: Math.min(state.selectedChapter, lastChapterNumber) })
+      dispatch({ ...state, selectedDictionary: found, selectedChapter: 0 })
     }
   }
 }


### PR DESCRIPTION
- 章节按钮显示单词数量
- 切换词典时，默认选择第一个章节
  - 章节部分的页面滚动到顶部