### PR TITLE
解决GaoKao_3500词库的一些问题 #221

### DIFF
--- a/public/dicts/GaoKao_3500.json
+++ b/public/dicts/GaoKao_3500.json
@@ -1,1 +1,31010 @@
-[{"name": "a (an)", "usphone": "ə, eɪ(ən)", "ukphone": "", "trans": ["art. 一（个、件……）"]}, {"name": "abandon", "usphone": "əˈbændən", "ukphone": "", "trans": ["v.抛弃，舍弃，放弃"]}, {"name": "ability", "usphone": "əˈbɪlɪtɪ", "ukphone": "", "trans": ["n. 能力；才能"]}, {"name": "able", "usphone": "ˈeɪb(ə)l", "ukphone": "", "trans": ["a. 能够；有能力的"]}, {"name": "abnormal", "usphone": "æbˈnɔːm(ə)l", "ukphone": "", "trans": ["a. 反常的，变态的"]}, {"name": "aboard", "usphone": "əˈbɔːd", "ukphone": "", "trans": ["prep. 上（船，飞机，火车，汽车等）"]}, {"name": "abolish", "usphone": "əˈbɔlɪʃ", "ukphone": "", "trans": ["v. 废除，废止"]}, {"name": "abortion", "usphone": "əˈbɔːʃ(ə)n", "ukphone": "", "trans": ["v. 人工流产，堕胎"]}, {"name": "about", "usphone": "əˈbaʊt", "ukphone": "", "trans": ["ad. 大约；到处；四处 prep. 关于；在各处；四处"]}, {"name": "above", "usphone": "əˈbʌv", "ukphone": "", "trans": ["prep. 在……上面 a. 上面的 ad. 在……之上"]}, {"name": "abroad", "usphone": "əˈbrɔːd", "ukphone": "", "trans": ["ad. 到（在）国外"]}, {"name": "abrupt", "usphone": "əˈbrʌpt", "ukphone": "", "trans": ["a. 突然的，意外的，粗鲁"]}, {"name": "absence", "usphone": "ˈæbsəns", "ukphone": "", "trans": ["n. 不在，缺席"]}, {"name": "absent", "usphone": "ˈæbsənt", "ukphone": "", "trans": ["a. 缺席， 不在"]}, {"name": "absolute", "usphone": "ˈæbsəluːt", "ukphone": "", "trans": ["a. 完全，全部，绝对的"]}, {"name": "absorb", "usphone": "əbˈsɔːb", "ukphone": "", "trans": ["v. 吸收，使全神贯注"]}, {"name": "abstract", "usphone": "ˈæbstrækt", "ukphone": "", "trans": ["a./ n. 抽象的（作品）"]}, {"name": "absurd", "usphone": "əbˈsɜːd", "ukphone": "", "trans": ["a.荒谬的，怪诞不经的"]}, {"name": "abundant", "usphone": "əˈbʌndənt", "ukphone": "", "trans": ["a.大量,丰盛的,充裕的"]}, {"name": "abuse", "usphone": "əˈbjuːz", "ukphone": "", "trans": ["v.（酗酒）滥用,虐待,恶语"]}, {"name": "academic", "usphone": "ækəˈdemɪk", "ukphone": "", "trans": ["a. / n. 学术的，教学的"]}, {"name": "academy", "usphone": "əˈkædəmɪ", "ukphone": "", "trans": ["n.专科学院,（美）私立学校"]}, {"name": "accelerate", "usphone": "əkˈseləreɪt", "ukphone": "", "trans": ["v.（使）加速，加快"]}, {"name": "accent", "usphone": "ˈæksənt", "ukphone": "", "trans": ["n. 口音，音调"]}, {"name": "accept", "usphone": "əkˈsept", "ukphone": "", "trans": ["vt. 接受"]}, {"name": "access", "usphone": "ˈækses", "ukphone": "", "trans": ["n. / v. 通道，入径，存取（计算机文件）"]}, {"name": "accessible", "usphone": "əkˈsesɪb(ə)l", "ukphone": "", "trans": ["a. 可到达的，可接受的，易相处的）"]}, {"name": "accident", "usphone": "ˈæksɪdənt", "ukphone": "", "trans": ["n. 事故，意外的事"]}, {"name": "accommodation", "usphone": "əkɔməˈdeɪʃ(ə)n", "ukphone": "", "trans": ["n.住宿，膳宿"]}, {"name": "accompany", "usphone": "əˈkʌmpənɪ", "ukphone": "", "trans": ["v. 陪同，陪伴，与…同时发生"]}, {"name": "accomplish", "usphone": "əˈkʌmplɪʃ", "ukphone": "", "trans": ["v. 完成"]}, {"name": "according to", "usphone": "əˈkɔːdɪŋ tʊ", "ukphone": "", "trans": ["ad. 按照，根据"]}, {"name": "account", "usphone": "əˈkaʊnt", "ukphone": "", "trans": ["n. 账目;描述"]}, {"name": "accountant", "usphone": "əˈkaʊnt(ə)nt", "ukphone": "", "trans": ["n. 会计，会计师"]}, {"name": "accumulate", "usphone": "əˈkjuːmjʊleɪt", "ukphone": "", "trans": ["v. 积累，积聚"]}, {"name": "accuracy", "usphone": "ˈækjʊrəsɪ", "ukphone": "", "trans": ["n. 准确，精确"]}, {"name": "accuse", "usphone": "əˈkjuːz", "ukphone": "", "trans": ["v. 正确无误的,精确的"]}, {"name": "accustomed", "usphone": "əˈkʌstəmd", "ukphone": "", "trans": ["a. 习惯于,惯常的"]}, {"name": "ache", "usphone": "eɪk", "ukphone": "", "trans": ["vi.& n. 痛，疼痛"]}, {"name": "achieve", "usphone": "əˈtʃiːv", "ukphone": "", "trans": ["vt. 达到，取得"]}, {"name": "achievement", "usphone": "əˈtʃiːvmənt", "ukphone": "", "trans": ["n. 成就,成绩,功绩"]}, {"name": "acid", "usphone": "ˈæsɪd", "ukphone": "", "trans": ["a. 酸的"]}, {"name": "acknowledge", "usphone": "əkˈnɔlɪdʒ", "ukphone": "", "trans": ["v. 承认"]}, {"name": "acquaintance", "usphone": "əˈkweɪntəns", "ukphone": "", "trans": ["n. 熟人，（与某人）认识"]}, {"name": "acquire", "usphone": "əˈkwaɪə(r)", "ukphone": "", "trans": ["v. 获得，得到"]}, {"name": "acquisition", "usphone": "ækwɪˈzɪʃ(ə)n", "ukphone": "", "trans": ["n. 获得，得到"]}, {"name": "acre", "usphone": "ˈeɪkə(r)", "ukphone": "", "trans": ["n. 英亩"]}, {"name": "across", "usphone": "əˈkrɔs", "ukphone": "", "trans": ["prep. 横过，穿过"]}, {"name": "act", "usphone": "ækt", "ukphone": "", "trans": ["n. 法令，条例 v. （戏）表演，扮演（角色），演出（戏）；行动，做事"]}, {"name": "action", "usphone": "ˈækʃ(ə)n", "ukphone": "", "trans": ["n. 行动"]}, {"name": "active", "usphone": "ˈæktɪv", "ukphone": "", "trans": ["a. 积极的，主动的"]}, {"name": "activity", "usphone": "ækˈtɪvɪtɪ", "ukphone": "", "trans": ["n. 活动"]}, {"name": "actor", "usphone": "ˈæktə(r)", "ukphone": "", "trans": ["n. 男演员"]}, {"name": "actress", "usphone": "ˈæktrɪs", "ukphone": "", "trans": ["n. 女演员"]}, {"name": "actual", "usphone": "ˈæktʃʊəl", "ukphone": "", "trans": ["a. 实际的； 现实的"]}, {"name": "acut", "usphone": "", "ukphone": "", "trans": ["a.十分严重的,（病）急性的"]}, {"name": "AD", "usphone": "", "ukphone": "", "trans": ["n. 公元"]}, {"name": "ad", "usphone": "æd", "ukphone": "", "trans": ["(缩) =advertisement n.广告"]}, {"name": "adapt", "usphone": "əˈdæpt", "ukphone": "", "trans": ["v. 使适应，适合，改编"]}, {"name": "adaptation", "usphone": "ədæpˈteɪʃ(ə)n", "ukphone": "", "trans": ["n. 适应，改编本"]}, {"name": "add", "usphone": "æd", "ukphone": "", "trans": ["vt.添加，增加"]}, {"name": "addicted", "usphone": "əˈdɪktɪd", "ukphone": "", "trans": ["a. 上瘾，成瘾，入迷"]}, {"name": "addition", "usphone": "əˈdɪʃ(ə)n", "ukphone": "", "trans": ["n.增加;（算数用语）加"]}, {"name": "address", "usphone": "əˈdres", "ukphone": "", "trans": ["n. 地址"]}, {"name": "adequate", "usphone": "ˈædɪkwət", "ukphone": "", "trans": ["a. 合适的，合乎需要的"]}, {"name": "adjust", "usphone": "əˈdʒʌst", "ukphone": "", "trans": ["v.调整,调节,适应,习惯"]}, {"name": "adjustment", "usphone": "əˈdʒʌstmənt", "ukphone": "", "trans": ["n. 调整，适应"]}, {"name": "administration", "usphone": "ədmɪnɪˈstreɪʃ(ə)n", "ukphone": "", "trans": ["n.管理,行政部门"]}, {"name": "admirable", "usphone": "ˈædmərəb(ə)l", "ukphone": "", "trans": ["a.值得赞赏的,可钦佩的"]}, {"name": "admire", "usphone": "ədˈmaɪə(r)", "ukphone": "", "trans": ["v. 钦佩；羡慕"]}, {"name": "admission", "usphone": "ədˈmɪʃ(ə)n", "ukphone": "", "trans": ["n. 准入, 接纳"]}, {"name": "admit", "usphone": "ədˈmɪt", "ukphone": "", "trans": ["vt. 承认，准许（入场，入学，入会）"]}, {"name": "adolescence", "usphone": "ædəʊˈlesns", "ukphone": "", "trans": ["n. 青春，青春期"]}, {"name": "adolescent", "usphone": "ædəˈlesənt", "ukphone": "", "trans": ["n. 青少年"]}, {"name": "adopt", "usphone": "əˈdɔpt", "ukphone": "", "trans": ["v. 收养，领养"]}, {"name": "adore", "usphone": "əˈdɔː(r)", "ukphone": "", "trans": ["v. （不用于进行时）热爱，爱慕某人"]}, {"name": "adult", "usphone": "ˈædʌlt", "ukphone": "", "trans": ["n. 成年人"]}, {"name": "advance", "usphone": "ədˈvɑːns; (US) ədˈvæns", "ukphone": "", "trans": ["v. 推进，促进；前进"]}, {"name": "advantage", "usphone": "ədˈvɑːntɪdʒ", "ukphone": "", "trans": ["n. 优点； 好处"]}, {"name": "adventure", "usphone": "ədˈventʃə(r)", "ukphone": "", "trans": ["n. 冒险； 奇遇"]}, {"name": "advertise", "usphone": "ˈædvətaɪz", "ukphone": "", "trans": ["vt. 为……做广告"]}, {"name": "advertisement", "usphone": "ədˈvɜːtɪsmənt", "ukphone": "", "trans": ["n. 广告"]}, {"name": "advice", "usphone": "ədˈvaɪs", "ukphone": "", "trans": ["n. 忠告，劝告，建议"]}, {"name": "advise", "usphone": "ədˈvaɪz", "ukphone": "", "trans": ["vt. 忠告，劝告，建议"]}, {"name": "advocate", "usphone": "ˈædvəkət", "ukphone": "", "trans": ["v. 拥护，支持，提倡"]}, {"name": "aeroplane", "usphone": "`erə,pleɪn", "ukphone": "", "trans": ["n. (英)飞机"]}, {"name": "affair", "usphone": "əˈfeə(r)", "ukphone": "", "trans": ["n. 事，事情"]}, {"name": "affect", "usphone": "əˈfekt", "ukphone": "", "trans": ["vt. 影响"]}, {"name": "affection", "usphone": "əˈfekʃ(ə)n", "ukphone": "", "trans": ["n. 喜爱，钟爱"]}, {"name": "afford", "usphone": "əˈfɔːd", "ukphone": "", "trans": ["vt. 负担得起（……的费用）；抽得出（时间）；提供"]}, {"name": "afraid", "usphone": "əˈfreɪd", "ukphone": "", "trans": ["a. 害怕的；担心"]}, {"name": "Africa", "usphone": "ˈæfrɪkə", "ukphone": "", "trans": ["* n. 非洲"]}, {"name": "African", "usphone": "ˈæfrɪkən", "ukphone": "", "trans": ["a. 非洲的，非洲人的 n. 非洲人"]}, {"name": "afte", "usphone": "ˈɑːftə(r)", "ukphone": "", "trans": ["r ad. 在后；后来prep. 在…之后；在 后面 conj. 在…以后"]}, {"name": "afternoon", "usphone": "ɑːftəˈnuːn", "ukphone": "", "trans": ["n. 下午，午后"]}, {"name": "afterward(s)", "usphone": "ˈɑːftəwəd(z)", "ukphone": "", "trans": ["ad. 后来"]}, {"name": "again", "usphone": "əˈɡeɪn", "ukphone": "", "trans": ["ad. 再一次；再，又"]}, {"name": "against", "usphone": "əˈɡeɪnst", "ukphone": "", "trans": ["prep. 对着，反对"]}, {"name": "age", "usphone": "eɪdʒ", "ukphone": "", "trans": ["n. 年龄；时代"]}, {"name": "agency", "usphone": "ˈeɪdʒənsɪ", "ukphone": "", "trans": ["n. 代理机构"]}, {"name": "agenda", "usphone": "əˈdʒendə", "ukphone": "", "trans": ["n. （会议）议程表，议事日程"]}, {"name": "agent", "usphone": "ˈeɪdʒənt", "ukphone": "", "trans": ["n. 代理人，经济人"]}, {"name": "aggression", "usphone": "ˈəɡreʃ(ə)n", "ukphone": "", "trans": ["n. 侵略"]}, {"name": "aggressive", "usphone": "ˈəɡresɪv", "ukphone": "", "trans": ["a. 侵略的；咄咄逼人"]}, {"name": "ago", "usphone": "əˈɡəʊ", "ukphone": "", "trans": ["ad. 以前"]}, {"name": "agree", "usphone": "əˈɡriː", "ukphone": "", "trans": ["v. 同意；应允"]}, {"name": "agreement", "usphone": "əˈɡriːmənt", "ukphone": "", "trans": ["n. 同意，一致；协定，协议"]}, {"name": "agricultural", "usphone": "æɡrɪˈkʌltʃər(ə)l", "ukphone": "", "trans": ["a. 农业的"]}, {"name": "agriculture", "usphone": "ˈæɡrɪkʌltʃə(r)", "ukphone": "", "trans": ["n. 农业，农学"]}, {"name": "ahead", "usphone": "əˈhed", "ukphone": "", "trans": ["ad. 在前，向前"]}, {"name": "aid", "usphone": "eɪd", "ukphone": "", "trans": ["n. 援助；救护；辅助器具"]}, {"name": "AIDS", "usphone": "eɪdz", "ukphone": "", "trans": ["n. 艾滋病"]}, {"name": "aim", "usphone": "eɪm", "ukphone": "", "trans": ["n.目的；目标 v. 计划，打算；瞄准；针对"]}, {"name": "air", "usphone": "eə(r)", "ukphone": "", "trans": ["n. 空气；大气"]}, {"name": "aircraft", "usphone": "ˈeəkrɑːft", "ukphone": "", "trans": ["n. 飞机 (单复数同)"]}, {"name": "airline", "usphone": "", "ukphone": "", "trans": ["n. 航空公司；航空系统"]}, {"name": "airmail", "usphone": "ˈeəmeɪl", "ukphone": "", "trans": ["n. 航空邮件"]}, {"name": "airplane", "usphone": "ˈeəpleɪn", "ukphone": "", "trans": ["n. （美）飞机"]}, {"name": "airport", "usphone": "ˈeəpɔːt", "ukphone": "", "trans": ["n. 航空站，飞机场"]}, {"name": "airspace", "usphone": "ˈeəspeɪs", "ukphone": "", "trans": ["n.领空,（某国的）空域"]}, {"name": "alarm", "usphone": "əˈlɑːm", "ukphone": "", "trans": ["n. 警报"]}, {"name": "album", "usphone": "ˈælbəm", "ukphone": "", "trans": ["n. 相册，影集，集邮簿"]}, {"name": "alcohol", "usphone": "ˈælkəhɔl", "ukphone": "", "trans": ["n. 含酒精饮料，酒"]}, {"name": "alcoholic", "usphone": "ælkəˈhɔlɪk", "ukphone": "", "trans": ["a. / n. 含酒精的，酒鬼"]}, {"name": "algebra", "usphone": "ˈældʒɪbrə", "ukphone": "", "trans": ["n. 代数"]}, {"name": "alike", "usphone": "əˈlaɪk", "ukphone": "", "trans": ["ad. 很相似地，同样地"]}, {"name": "alive", "usphone": "əˈlaɪv", "ukphone": "", "trans": ["a. 活着的，存在的"]}, {"name": "all", "usphone": "ɔːl", "ukphone": "", "trans": ["ad. 全部地 a. 全（部）;所有的;总;整 pron.全部;全体人员"]}, {"name": "allergic", "usphone": "əˈlɜːdʒɪk", "ukphone": "", "trans": ["a. 过敏的，厌恶"]}, {"name": "alley", "usphone": "ˈælɪ", "ukphone": "", "trans": ["n. 小巷，胡同"]}, {"name": "allocate", "usphone": "ˈæləkeɪt", "ukphone": "", "trans": ["v. 拨给,划归,分配…给"]}, {"name": "allow", "usphone": "əˈlaʊ", "ukphone": "", "trans": ["vt. 允许，准许"]}, {"name": "allowance", "usphone": "əˈlaʊəns", "ukphone": "", "trans": ["n. 津贴，补助"]}, {"name": "almost", "usphone": "ˈɔːlməʊst", "ukphone": "", "trans": ["ad. 几乎，差不多"]}, {"name": "alone", "usphone": "əˈləʊn", "ukphone": "", "trans": ["a. 单独的，孤独的"]}, {"name": "along", "usphone": "əˈlɔŋ; (US) əˈlɔŋ", "ukphone": "", "trans": ["ad. 向前；和…一起；一同 prep. 沿着；顺着"]}, {"name": "alongside", "usphone": "əlɔŋˈsaɪd; (US) əlɔːŋˈsaɪd", "ukphone": "", "trans": ["ad.在…旁边,与…同时"]}, {"name": "aloud", "usphone": "əˈlaʊd", "ukphone": "", "trans": ["ad. 大声地"]}, {"name": "alphabet", "usphone": "ˈælfəbet", "ukphone": "", "trans": ["n. 字母表，字母"]}, {"name": "already", "usphone": "ɔːlˈredɪ", "ukphone": "", "trans": ["ad. 已经"]}, {"name": "also", "usphone": "ˈɔːlsəʊ", "ukphone": "", "trans": ["ad. 也"]}, {"name": "alternative", "usphone": "ɔːlˈtɜːnətɪv", "ukphone": "", "trans": ["a.可供替代,非传统的"]}, {"name": "although", "usphone": "ɔːlˈðəʊ", "ukphone": "", "trans": ["conj. 虽然，尽管"]}, {"name": "altitude", "usphone": "ˈæltɪtjuːd; (US) ælˈtɪtuːd", "ukphone": "", "trans": ["n. 海拔高度"]}, {"name": "altogether", "usphone": "ɔːltəˈɡeðə(r)", "ukphone": "", "trans": ["ad. 总共"]}, {"name": "aluminium", "usphone": "æljʊˈmɪnɪəm", "ukphone": "", "trans": ["n. （化）铝"]}, {"name": "always", "usphone": "ˈɔːlweɪz", "ukphone": "", "trans": ["ad. 总是；一直；永远"]}, {"name": "am", "usphone": "æm", "ukphone": "", "trans": ["v. be的人称形式之一 "]}, {"name": "ａ.m./A.M.", "usphone": "", "ukphone": "", "trans": ["n. 午前，上午"]}, {"name": "amateur", "usphone": "ˈæmətə(r)", "ukphone": "", "trans": ["a. 业余爱好的"]}, {"name": "amaze", "usphone": "əˈmeɪz", "ukphone": "", "trans": ["v. 惊奇，惊叹；震惊"]}, {"name": "amazing", "usphone": "əˈmeɪzɪŋ", "ukphone": "", "trans": ["a.惊奇,惊叹的;震惊的"]}, {"name": "ambassador (ambassadress)", "usphone": "æmˈbæsədə(r)", "ukphone": "", "trans": ["n.大使"]}, {"name": "ambiguous", "usphone": "æmˈbɪɡjʊəs", "ukphone": "", "trans": ["a. 模棱两可的"]}, {"name": "ambition", "usphone": "æmˈbɪʃ(ə)n", "ukphone": "", "trans": ["n.目标,野心,雄心,抱负"]}, {"name": "ambulance", "usphone": "ˈæmbjʊləns", "ukphone": "", "trans": ["n. 救护车"]}, {"name": "America", "usphone": "əˈmerɪkə", "ukphone": "", "trans": ["* n. 美国；美洲"]}, {"name": "American", "usphone": "əˈmerɪkən", "ukphone": "", "trans": ["a. 美国的；美国人的n. 美国人"]}, {"name": "among", "usphone": "əˈmʌŋ", "ukphone": "", "trans": ["prep. 在…中间；在（三个以上）之间"]}, {"name": "amount", "usphone": "əˈmaʊnt", "ukphone": "", "trans": ["n. / v. 金额，数量，总计"]}, {"name": "ample", "usphone": "ˈæmp(ə)l", "ukphone": "", "trans": ["a. 足够的，丰裕的"]}, {"name": "amuse", "usphone": "əˈmjuːz", "ukphone": "", "trans": ["vt. （使人）快乐，逗乐"]}, {"name": "amusement", "usphone": "əˈmjuːzmənt", "ukphone": "", "trans": ["n. 娱乐"]}, {"name": "analyze", "usphone": "`ænl,aɪz", "ukphone": "", "trans": ["v. 分析"]}, {"name": "analysis", "usphone": "əˈnæləsɪs", "ukphone": "", "trans": ["n. 分析，分析结果"]}, {"name": "ancestor", "usphone": "ˈænsəstə(r)", "ukphone": "", "trans": ["n. 祖宗； 祖先"]}, {"name": "anchor", "usphone": "", "ukphone": "", "trans": ["v. / n. 锚，抛锚"]}, {"name": "ancient", "usphone": "ˈeɪnʃənt", "ukphone": "", "trans": ["a. 古代的，古老的"]}, {"name": "and", "usphone": "ənd, ænd", "ukphone": "", "trans": ["conj. 和；又；而"]}, {"name": "anecdote", "usphone": "ˈænɪkdəʊt", "ukphone": "", "trans": ["n. 逸事，趣闻"]}, {"name": "anger", "usphone": "ˈæŋɡə(r)", "ukphone": "", "trans": ["n. 怒，愤怒"]}, {"name": "angle", "usphone": "ˈæŋɡ(ə)l", "ukphone": "", "trans": ["n. 角度"]}, {"name": "angry", "usphone": "ˈænɡrɪ", "ukphone": "", "trans": ["a. 生气的，愤怒的"]}, {"name": "animal", "usphone": "ˈænɪm(ə)l", "ukphone": "", "trans": ["n. 动物"]}, {"name": "ankle", "usphone": "ˈæŋk(ə)l", "ukphone": "", "trans": ["n. 踝，踝关节"]}, {"name": "anniversary", "usphone": "ænɪˈvɜːsərɪ", "ukphone": "", "trans": ["n. 周年纪念日"]}, {"name": "announce", "usphone": "əˈnaʊns", "ukphone": "", "trans": ["vt. 宣布，宣告"]}, {"name": "announcement", "usphone": "əˈnaʊnsmənt", "ukphone": "", "trans": ["n. 通告，通知"]}, {"name": "annoy", "usphone": "əˈnɔɪ", "ukphone": "", "trans": ["vt. （使）烦恼"]}, {"name": "annual", "usphone": "ˈænjʊəl", "ukphone": "", "trans": ["a. 每年的，年度的，一年一次的"]}, {"name": "another", "usphone": "əˈnʌðə(r)", "ukphone": "", "trans": ["a. 再一；另一；别的；不同的 pron. 另一个"]}, {"name": "answer", "usphone": "ˈɑːnsə(r); (US) ˈænsər", "ukphone": "", "trans": ["n.回答,答复;回信;答案 v.回答,答复;回信;（作出）答案"]}, {"name": "ant", "usphone": "ænt", "ukphone": "", "trans": ["n. 蚂蚁"]}, {"name": "Antarctic", "usphone": "ænˈtɑːktɪk", "ukphone": "", "trans": ["a. 南极的"]}, {"name": "the Antarctic", "usphone": "ænˈtɑːktɪk", "ukphone": "", "trans": ["南极"]}, {"name": "Antarctica", "usphone": "ænˈtɑ:ktikə", "ukphone": "", "trans": ["* n. 南极洲"]}, {"name": "antique", "usphone": "ænˈtiːk", "ukphone": "", "trans": ["n. 古董"]}, {"name": "anxiety", "usphone": "æŋˈzaɪətɪ", "ukphone": "", "trans": ["n. 担忧，焦虑"]}, {"name": "anxious", "usphone": "ˈæŋkʃəs", "ukphone": "", "trans": ["a. 忧虑的，焦急的"]}, {"name": "any", "usphone": "ˈenɪ", "ukphone": "", "trans": ["pron. （无论）哪一个；哪些 任何的；（用于疑问句、否定句）一些；什么"]}, {"name": "anybody", "usphone": "ˈenɪbɔdɪ", "ukphone": "", "trans": ["pron. 任何人，无论谁"]}, {"name": "anyhow", "usphone": "ˈenɪhaʊ", "ukphone": "", "trans": ["ad. 不管怎样"]}, {"name": "anyone", "usphone": "ˈenɪwʌn", "ukphone": "", "trans": ["pron. 任何人，无论谁"]}, {"name": "anything", "usphone": "ˈenɪθɪŋ", "ukphone": "", "trans": ["pron. 什么事（物）；任何事（物）"]}, {"name": "anyway", "usphone": "ˈenɪweɪ", "ukphone": "", "trans": ["y ad. 不管怎样"]}, {"name": "anywhere", "usphone": "ˈenɪweə(r)", "ukphone": "", "trans": ["ad. 任何地方"]}, {"name": "apart", "usphone": "əˈpɑːt", "ukphone": "", "trans": ["ad, / a. 相隔，相距，除外"]}, {"name": "apartment", "usphone": "əˈpɑːtmənt", "ukphone": "", "trans": ["n. （美）楼中单元房，一套房间；房间"]}, {"name": "apologize", "usphone": "əˈpɔlədʒaɪz", "ukphone": "", "trans": ["vi. 道歉，谢罪"]}, {"name": "apology", "usphone": "əˈpɔlədʒɪ", "ukphone": "", "trans": ["n. 道歉；歉意"]}, {"name": "apparent", "usphone": "əˈpærənt", "ukphone": "", "trans": ["a. 显而易见"]}, {"name": "appeal", "usphone": "əˈpiːl", "ukphone": "", "trans": ["v. 上诉，申诉，吸引力"]}, {"name": "appear", "usphone": "əˈpɪə(r)", "ukphone": "", "trans": ["vi. 出现"]}, {"name": "appearance", "usphone": "əˈpɪərəns", "ukphone": "", "trans": ["n. 出现，露面；容貌"]}, {"name": "appendix", "usphone": "əˈpendɪks", "ukphone": "", "trans": ["n. 附录，阑尾"]}, {"name": "appetite", "usphone": "ˈæpɪtaɪt", "ukphone": "", "trans": ["n. 食欲，胃口"]}, {"name": "applaud", "usphone": "əˈplɔːd", "ukphone": "", "trans": ["v. / n. 鼓掌,赞许,赞赏"]}, {"name": "apple", "usphone": "ˈæp(ə)l", "ukphone": "", "trans": ["n. 苹果"]}, {"name": "applicant", "usphone": "ˈæplɪkənt", "ukphone": "", "trans": ["n. 申请人"]}, {"name": "application", "usphone": "æplɪˈkeɪʃ(ə)n", "ukphone": "", "trans": ["n. 申请"]}, {"name": "apply", "usphone": "əˈplaɪ", "ukphone": "", "trans": ["v. 申请"]}, {"name": "appoint", "usphone": "əˈpɔɪnt", "ukphone": "", "trans": ["v. 任命，委任，安排，确定（时间，地点）"]}, {"name": "appointment", "usphone": "əˈpɔɪntmənt", "ukphone": "", "trans": ["n. 约会"]}, {"name": "appreciate", "usphone": "əˈpriːʃɪeɪt", "ukphone": "", "trans": ["v. 欣赏； 感激"]}, {"name": "appreciation", "usphone": "əpriːʃɪˈeɪʃ(ə)n", "ukphone": "", "trans": ["n. 欣赏,鉴定,评估"]}, {"name": "approach", "usphone": "əˈprəʊtʃ", "ukphone": "", "trans": ["n. / v. 靠近，接近，建议，要求"]}, {"name": "appropriate", "usphone": "əˈprəʊprɪət", "ukphone": "", "trans": ["a. 合适的，恰当的"]}, {"name": "approve", "usphone": "əˈpruːv", "ukphone": "", "trans": ["v.赞成,同意,批准,通过"]}, {"name": "approximately", "usphone": "əprɔksɪˈmətlɪ", "ukphone": "", "trans": ["ad.近似，大约"]}, {"name": "apron", "usphone": "ˈeɪprən", "ukphone": "", "trans": ["n. （机场的）停机坪"]}, {"name": "arbitrary", "usphone": "ˈɑːbɪtrərɪ; (US) ˈɑːrbɪtrerɪ", "ukphone": "", "trans": ["a. 随心所欲的，独裁的，专断的"]}, {"name": "arch", "usphone": "ɑːtʃ", "ukphone": "", "trans": ["n. 拱，拱门"]}, {"name": "architect", "usphone": "ˈɑːkɪtekt", "ukphone": "", "trans": ["n. 建筑师，设计师"]}, {"name": "architecture", "usphone": "ˈɑːkɪtektʃə(r)", "ukphone": "", "trans": ["n.建筑学，建筑设计，风格"]}, {"name": "April", "usphone": "ˈeɪpr(ə)l", "ukphone": "", "trans": ["n. 4月"]}, {"name": "Arab", "usphone": "ˈærəb", "ukphone": "", "trans": ["* a. 阿拉伯的 n. 阿拉伯人"]}, {"name": "Arabic", "usphone": "ˈærəbɪk", "ukphone": "", "trans": ["a. 阿拉伯语的 n. 阿拉伯语"]}, {"name": "Arctic", "usphone": "ˈɑːktɪk", "ukphone": "", "trans": ["a. 北极的"]}, {"name": "the Arctic", "usphone": "ˈɑːktɪk", "ukphone": "", "trans": ["北极"]}, {"name": "the Arctic Ocean", "usphone": "ˈɑːktɪk ˈəʊʃ(ə)n", "ukphone": "", "trans": ["北冰洋"]}, {"name": "are", "usphone": "ɑː(r)", "ukphone": "", "trans": ["v.(be) 是"]}, {"name": "area", "usphone": "ˈeərɪə", "ukphone": "", "trans": ["n. 面积；地域，地方，区域；范围，领域"]}, {"name": "argue", "usphone": "ˈɑːɡjuː", "ukphone": "", "trans": ["vi. 争辩， 争论"]}, {"name": "argument", "usphone": "ˈɑːɡjʊmənt", "ukphone": "", "trans": ["n. 争论，辩论"]}, {"name": "arise (arose, arisen)", "usphone": "əˈraɪz", "ukphone": "", "trans": ["vi. 起来，升起；出现"]}, {"name": "arithmetic", "usphone": "əˈrɪθmətɪk", "ukphone": "", "trans": ["n. 算术"]}, {"name": "arm", "usphone": "ɑːm", "ukphone": "", "trans": ["n. 臂,支架 v. 以…装备,武装起来n. （美）武器,武力"]}, {"name": "armchair", "usphone": "ɑːmˈtʃeə(r)", "ukphone": "", "trans": ["n. 扶手椅"]}, {"name": "army", "usphone": "ˈɑːmɪ", "ukphone": "", "trans": ["n. 军队"]}, {"name": "around", "usphone": "əˈraʊnd", "ukphone": "", "trans": ["ad. 在周围；在附近prep. 在……周围；大约"]}, {"name": "arrange", "usphone": "əˈreɪndʒ", "ukphone": "", "trans": ["v. 安排，布置"]}, {"name": "arrangement", "usphone": "əˈreɪndʒmənt", "ukphone": "", "trans": ["n. 安排，布置"]}, {"name": "arrest", "usphone": "əˈrest", "ukphone": "", "trans": ["v. 逮捕，拘留"]}, {"name": "arrival", "usphone": "əˈraɪv(ə)l", "ukphone": "", "trans": ["n. 到来，到达"]}, {"name": "arrive", "usphone": "əˈraɪv", "ukphone": "", "trans": ["vi. 到达；达到"]}, {"name": "arrow", "usphone": "ˈærəʊ", "ukphone": "", "trans": ["n. 箭；箭头"]}, {"name": "art", "usphone": "ɑːt", "ukphone": "", "trans": ["n. 艺术，美术；技艺"]}, {"name": "article", "usphone": "ˈɑːtɪk(ə)l", "ukphone": "", "trans": ["n.文章;东西,物品;冠词"]}, {"name": "artificial", "usphone": "ɑːtɪˈfɪʃ(ə)l", "ukphone": "", "trans": ["a. 人工的，人造的"]}, {"name": "artist", "usphone": "ˈɑːtɪst", "ukphone": "", "trans": ["n.艺术家"]}, {"name": "as", "usphone": "əz, æz", "ukphone": "", "trans": ["ad.& conj.像……一样；如同；因为 prep. 作为，当做"]}, {"name": "ash", "usphone": "æʃ", "ukphone": "", "trans": ["n. 灰； 灰末"]}, {"name": "ashamed", "usphone": "əˈʃeɪmd", "ukphone": "", "trans": ["a. 惭愧； 害臊"]}, {"name": "Asia", "usphone": "ˈeɪʃə", "ukphone": "", "trans": ["* n. 亚洲"]}, {"name": "Asian", "usphone": "ˈeɪʃ(ə)n, ˈeɪʒ(ə)n", "ukphone": "", "trans": ["a. 亚洲（人）的n. 亚洲人"]}, {"name": "aside", "usphone": "əˈsaɪd", "ukphone": "", "trans": ["ad. 在旁边"]}, {"name": "ask", "usphone": "ɑːsk", "ukphone": "", "trans": ["v. 问；请求，要求；邀请"]}, {"name": "asleep", "usphone": "əˈsliːp", "ukphone": "", "trans": ["a. 睡着的，熟睡"]}, {"name": "aspect", "usphone": "ˈæspekt", "ukphone": "", "trans": ["n. 方面，外观，外表"]}, {"name": "assess", "usphone": "əˈses", "ukphone": "", "trans": ["v.评价,评定（性质,质量）"]}, {"name": "assessment", "usphone": "əˈsesmənt", "ukphone": "", "trans": ["n. 看法，评价"]}, {"name": "assist", "usphone": "əˈsɪst", "ukphone": "", "trans": ["v. 帮助，协助"]}, {"name": "assistance", "usphone": "əˈsɪst(ə)ns", "ukphone": "", "trans": ["n. 帮助，援助，支持"]}, {"name": "assistant", "usphone": "əˈsɪst(ə)nt", "ukphone": "", "trans": ["n. 助手，助理"]}, {"name": "associate", "usphone": "əˈsəʊʃɪeɪt", "ukphone": "", "trans": ["v. 联想，联系"]}, {"name": "association", "usphone": "əsəʊsɪˈeɪʃ(ə)n", "ukphone": "", "trans": ["n. 协会，社团，联系"]}, {"name": "assume", "usphone": "əˈsjuːm; (US) əˈsuːm", "ukphone": "", "trans": ["v. 假定，假设"]}, {"name": "assumption", "usphone": "əˈsʌmpʃ(ə)n", "ukphone": "", "trans": ["n. 假定，假设"]}, {"name": "astonish", "usphone": "əˈstɔnɪʃ", "ukphone": "", "trans": ["vt. 使惊讶"]}, {"name": "astronaut", "usphone": "ˈæstrənɔːt", "ukphone": "", "trans": ["n. 宇航员"]}, {"name": "astronomer", "usphone": "əˈstrɔnəmə(r)", "ukphone": "", "trans": ["n. 天文学家"]}, {"name": "astronomy", "usphone": "əˈstrɔnəmɪ", "ukphone": "", "trans": ["n. 天文学"]}, {"name": "at", "usphone": "æt", "ukphone": "", "trans": ["prep.在（几点钟）;在（某处）"]}, {"name": "athlete", "usphone": "ˈæθliːt", "ukphone": "", "trans": ["n. 运动员"]}, {"name": "athletic", "usphone": "æθˈletɪk", "ukphone": "", "trans": ["a. 健壮的,体育运动的"]}, {"name": "athletics", "usphone": "æθˈletɪks", "ukphone": "", "trans": ["n. 田径"]}, {"name": "Atlantic", "usphone": "ətˈlæntɪk", "ukphone": "", "trans": ["a. 大西洋的"]}, {"name": "the Atlantic Ocean", "usphone": "ətˈlæntɪk ˈəʊʃ(ə)n", "ukphone": "", "trans": ["大西洋"]}, {"name": "atmosphere", "usphone": "ˈætməsfɪə(r)", "ukphone": "", "trans": ["n. 大气；气氛"]}, {"name": "atom", "usphone": "ˈætəm", "ukphone": "", "trans": ["n. 原子，微粒"]}, {"name": "attach", "usphone": "əˈtætʃ", "ukphone": "", "trans": ["v. 把…固定，重视"]}, {"name": "attack", "usphone": "əˈtæk", "ukphone": "", "trans": ["vt. / n. 攻击，袭击"]}, {"name": "attain", "usphone": "əˈteɪn", "ukphone": "", "trans": ["v.（经过努力）获得,得到"]}, {"name": "attempt", "usphone": "əˈtempt", "ukphone": "", "trans": ["vt. 试图，尝试"]}, {"name": "attend", "usphone": "əˈtend", "ukphone": "", "trans": ["v. 看护，照料，服侍；出席，参加"]}, {"name": "attention", "usphone": "əˈtenʃ(ə)n", "ukphone": "", "trans": ["n. 注意，关心"]}, {"name": "attentively", "usphone": "əˈtentivli", "ukphone": "", "trans": ["ad. 注意地"]}, {"name": "attitude", "usphone": "ˈætɪtjuːd; (US) ˈætɪtud", "ukphone": "", "trans": ["n. 态度，看法"]}, {"name": "attract", "usphone": "əˈtrækt", "ukphone": "", "trans": ["v. 吸引，引起"]}, {"name": "attraction", "usphone": "əˈtrækʃ(ə)n", "ukphone": "", "trans": ["n. 吸引，爱慕"]}, {"name": "attractive", "usphone": "əˈtræktɪv", "ukphone": "", "trans": ["a. 迷人的，有吸引力的"]}, {"name": "audience", "usphone": "ˈɔːdɪəns", "ukphone": "", "trans": ["n. 观众，听众"]}, {"name": "authentic", "usphone": "ɜːˈθentɪk", "ukphone": "", "trans": ["a. 真正的，真品的"]}, {"name": "author", "usphone": "ˈɔːθə(r)", "ukphone": "", "trans": ["n. 作者，作家"]}, {"name": "authority", "usphone": "ɔːˈθɔrɪtɪ", "ukphone": "", "trans": ["n.权力,权威,威信,官方"]}, {"name": "automatic", "usphone": "ɔːtəˈmætɪk", "ukphone": "", "trans": ["a. 自动的，机械的"]}, {"name": "autonomous", "usphone": "ɔːˈtɔnəməs", "ukphone": "", "trans": ["a. 自治的，自主的"]}, {"name": "August", "usphone": "ˈɔːɡəst", "ukphone": "", "trans": ["n. 8月"]}, {"name": "aunt", "usphone": "ɑːnt; (US) ænt", "ukphone": "", "trans": ["n. 伯母；舅母；婶；姑；姨"]}, {"name": "Australia", "usphone": "ɔˈstreɪljə", "ukphone": "", "trans": ["* n. 澳洲；澳大利亚"]}, {"name": "Australian", "usphone": "ɔˈstreɪlɪən", "ukphone": "", "trans": ["a. 澳洲的，澳大利亚人的 n. 澳大利亚人"]}, {"name": "autumn", "usphone": "ˈɔːtəm", "ukphone": "", "trans": ["n. 秋天，秋季"]}, {"name": "available", "usphone": "ˈɔːtəm", "ukphone": "", "trans": ["a. 可获得的，有空的"]}, {"name": "avenue", "usphone": "ˈævənjuːˈævənuː", "ukphone": "", "trans": ["n. 大道"]}, {"name": "average", "usphone": "ˈævərɪdʒ", "ukphone": "", "trans": ["a.平均；普通的 n.平均数"]}, {"name": "avoid", "usphone": "əˈvɔɪd", "ukphone": "", "trans": ["v. 避免，躲开，逃避"]}, {"name": "awake (awoke, awoken)", "usphone": "əˈweɪk", "ukphone": "", "trans": ["v. 唤醒 a. 醒着的"]}, {"name": "award", "usphone": "wɔːd", "ukphone": "", "trans": ["n. 奖品，奖励"]}, {"name": "aware", "usphone": "əˈweə(r)", "ukphone": "", "trans": ["a. 知道，意识到，发觉"]}, {"name": "away", "usphone": "əˈweɪ", "ukphone": "", "trans": ["ad. 离开；远离"]}, {"name": "awesome", "usphone": "ˈɔːsəm", "ukphone": "", "trans": ["a.令人惊叹,很困难的"]}, {"name": "awful", "usphone": "ˈɔːfʊl", "ukphone": "", "trans": ["a. 很坏的，极讨厌的"]}, {"name": "awkward", "usphone": "ˈɔːkwəd", "ukphone": "", "trans": ["a.令人尴尬,使人难堪的"]}, {"name": "Baby", "usphone": "ˈbeɪbɪ", "ukphone": "", "trans": ["n. 婴儿"]}, {"name": "bachelor", "usphone": "ˈbætʃələ(r)", "ukphone": "", "trans": ["n. 未婚男子，单身汉"]}, {"name": "back", "usphone": "bæk", "ukphone": "", "trans": ["ad. 回（原处）；向后 a. 后面的 n. 背后，后部；背"]}, {"name": "backache", "usphone": "ˈbækeɪk", "ukphone": "", "trans": ["n. 背痛"]}, {"name": "background", "usphone": "ˈbækɡraʊnd", "ukphone": "", "trans": ["n. 背景"]}, {"name": "backward(s)", "usphone": "ˈbækwəd", "ukphone": "", "trans": ["ad. 向后"]}, {"name": "bacon", "usphone": "ˈbeɪkən", "ukphone": "", "trans": ["n. 咸猪肉；熏猪肉 "]}, {"name": "bacterium", "usphone": "bækˈtɪərɪəm", "ukphone": "", "trans": ["(复bacteria) n. 细菌"]}, {"name": "bad (worse, worst)", "usphone": "bæd", "ukphone": "", "trans": ["a. 坏的；有害的，不利的；严重的"]}, {"name": "badly", "usphone": "ˈbædlɪ", "ukphone": "", "trans": ["ad. 坏，恶劣地"]}, {"name": "badminton", "usphone": "ˈbædmɪntən", "ukphone": "", "trans": ["n. 羽毛球"]}, {"name": "bag", "usphone": "bæɡ", "ukphone": "", "trans": ["n. 书包；提包；袋子"]}, {"name": "baggage", "usphone": "ˈbæɡɪdʒ", "ukphone": "", "trans": ["n. 行李"]}, {"name": "bake", "usphone": "beɪk", "ukphone": "", "trans": ["v. 烤； 烘（面包）"]}, {"name": "bakery", "usphone": "ˈbeɪkərɪ", "ukphone": "", "trans": ["n. 面包店"]}, {"name": "balance", "usphone": "ˈbæləns", "ukphone": "", "trans": ["n. 平衡"]}, {"name": "balcony", "usphone": "ˈbælkənɪ", "ukphone": "", "trans": ["n. 阳台；楼座"]}, {"name": "ball", "usphone": "bɔːl", "ukphone": "", "trans": ["n. 球 n. 舞会"]}, {"name": "ballet", "usphone": "ˈbæleɪ", "ukphone": "", "trans": ["n. 芭蕾舞"]}, {"name": "balloon", "usphone": "bəˈluːn", "ukphone": "", "trans": ["n. 气球"]}, {"name": "ballpoint = ballpoint pen", "usphone": "`bɔl,pɔɪnt", "ukphone": "", "trans": ["圆珠笔"]}, {"name": "bamboo", "usphone": "bæmˈbuː", "ukphone": "", "trans": ["n. 竹"]}, {"name": "ban", "usphone": "bæn", "ukphone": "", "trans": ["n. 禁令 v. 禁止；取缔"]}, {"name": "banana", "usphone": "bəˈnɑːnə; (US) bəˈnænə", "ukphone": "", "trans": ["n. 香蕉"]}, {"name": "band", "usphone": "bænd", "ukphone": "", "trans": ["n. 乐队"]}, {"name": "bandage", "usphone": "ˈbændɪdʒ", "ukphone": "", "trans": ["n. 绷带"]}, {"name": "bang", "usphone": "bæŋ", "ukphone": "", "trans": ["int. 砰"]}, {"name": "bank", "usphone": "bæŋk", "ukphone": "", "trans": ["n. （河海湖的）岸，堤 n. 银行"]}, {"name": "bank account", "usphone": "bæŋk əˈkaʊnt", "ukphone": "", "trans": ["n. 银行账户"]}, {"name": "bar", "usphone": "bɑː(r)", "ukphone": "", "trans": ["n. 条（长方）块，棒，横木 n.（酒店的）买酒柜台；酒吧；（卖东西的）柜台"]}, {"name": "barbecue", "usphone": "ˈbɑːbɪkjuː", "ukphone": "", "trans": ["n. 烤肉野餐"]}, {"name": "barber", "usphone": "ˈbɑːbə(r)", "ukphone": "", "trans": ["n. （为男人理发）理发师"]}, {"name": "barbershop", "usphone": "`bɑrbər,ʃɑp", "ukphone": "", "trans": ["n. 理发店"]}, {"name": "bare", "usphone": "beə(r)", "ukphone": "", "trans": ["a. 裸露的，光秃秃的"]}, {"name": "bargain", "usphone": "ˈbɑːɡɪn", "ukphone": "", "trans": ["n. （经讨价还价后）成交的商品；廉价货 v. 讨价还价"]}, {"name": "bark", "usphone": "bɑːk", "ukphone": "", "trans": ["v. 狗叫 n. 狗叫声"]}, {"name": "barrier", "usphone": "ˈbærɪə", "ukphone": "", "trans": ["n. 屏障，障碍，关卡"]}, {"name": "base", "usphone": "beɪs", "ukphone": "", "trans": ["n. 根据地，基地（棒球）垒"]}, {"name": "baseball", "usphone": "ˈbeɪsbɔːl", "ukphone": "", "trans": ["n. 棒球"]}, {"name": "basement", "usphone": "ˈbeɪsmənt", "ukphone": "", "trans": ["n. 地下室"]}, {"name": "basic", "usphone": "ˈbeɪsɪk", "ukphone": "", "trans": ["a. 基本的"]}, {"name": "basin", "usphone": "ˈbeɪs(ə)n", "ukphone": "", "trans": ["n. 水盆，脸盆"]}, {"name": "basis", "usphone": "ˈbeɪsɪs", "ukphone": "", "trans": ["n. 原因，缘由，要素"]}, {"name": "basket", "usphone": "ˈbɑːskɪt; (US) ˈbæskɪt", "ukphone": "", "trans": ["n. 篮子"]}, {"name": "basketball", "usphone": "ˈbɑːskɪtbɔːl", "ukphone": "", "trans": ["n. 篮球"]}, {"name": "bat", "usphone": "bæt", "ukphone": "", "trans": ["n. （棒球、板球的）球棒 n. 蝙蝠"]}, {"name": "bath", "usphone": "bɑːθ; (US) bæθ", "ukphone": "", "trans": ["n. 洗澡；浴室；澡盆"]}, {"name": "bathe", "usphone": "beɪð", "ukphone": "", "trans": ["vi. 洗澡；游泳"]}, {"name": "bathrobe", "usphone": "ˈbɑːθrəʊb", "ukphone": "", "trans": ["n. 浴衣"]}, {"name": "bathroom", "usphone": "ˈbɑːθruːm", "ukphone": "", "trans": ["n. 浴室，盥洗室"]}, {"name": "bathtub", "usphone": "ˈbɑ:θtʌb", "ukphone": "", "trans": ["n. 澡盆"]}, {"name": "battery", "usphone": "ˈbætərɪ", "ukphone": "", "trans": ["n. 电池"]}, {"name": "battle", "usphone": "ˈbæt(ə)l", "ukphone": "", "trans": ["n. 战斗；战役"]}, {"name": "battleground", "usphone": "ˈbæt(ə)lɡraʊnd", "ukphone": "", "trans": ["n. 战场"]}, {"name": "bay", "usphone": "beɪ", "ukphone": "", "trans": ["n. 湾； 海湾"]}, {"name": "BC", "usphone": "ˌbiːˈsiː", "ukphone": "", "trans": ["n. 公元前"]}, {"name": "be", "usphone": "biː", "ukphone": "", "trans": ["v. 是（原形）,其人称和时态形式有(am, is, are, was, were, being, been)；成为"]}, {"name": "beach", "usphone": "biːtʃ", "ukphone": "", "trans": ["n. 海滨，海滩"]}, {"name": "beam", "usphone": "biːm", "ukphone": "", "trans": ["n. 平衡木"]}, {"name": "bean", "usphone": "biːn", "ukphone": "", "trans": ["n. 豆，豆科植物"]}, {"name": "beancurd", "usphone": "ˈbi:nkə:d", "ukphone": "", "trans": ["n. 豆腐"]}, {"name": "bear", "usphone": "beə(r)", "ukphone": "", "trans": ["v. 承受，负担，承担；忍受；容忍 n. 熊"]}, {"name": "beard", "usphone": "bɪəd", "ukphone": "", "trans": ["n. （下巴上的）胡须"]}, {"name": "beast", "usphone": "biːst", "ukphone": "", "trans": ["n. 野兽；牲畜"]}, {"name": "beat (beat, beaten)", "usphone": "biːt", "ukphone": "", "trans": ["v. 敲打；跳动；打赢 n. （音乐）节拍"]}, {"name": "beautiful", "usphone": "ˈbjuːtɪf(ə)l", "ukphone": "", "trans": ["a. 美，美丽，美观的"]}, {"name": "beauty", "usphone": "ˈbjuːtɪ", "ukphone": "", "trans": ["n. 美丽，美人"]}, {"name": "because", "usphone": "bɪˈkɔz; (US) bɪˈkɔːz", "ukphone": "", "trans": ["conj. 因为"]}, {"name": "become (became, be come)", "usphone": "bɪˈkʌm", "ukphone": "", "trans": ["v. 变得；成为"]}, {"name": "bed", "usphone": "bed", "ukphone": "", "trans": ["n. 床"]}, {"name": "bedclothes", "usphone": "ˈbedkləʊðz", "ukphone": "", "trans": ["n. 铺盖（被褥等）"]}, {"name": "beddings", "usphone": "ˈbedɪŋ", "ukphone": "", "trans": ["n. 卧具，铺盖"]}, {"name": "bedroom", "usphone": "ˈbedruːm", "ukphone": "", "trans": ["n. 寝室，卧室"]}, {"name": "bee", "usphone": "biː", "ukphone": "", "trans": ["n.. 蜜蜂"]}, {"name": "beef", "usphone": "biːf", "ukphone": "", "trans": ["n. 牛肉"]}, {"name": "beehive", "usphone": "ˈbiːhaɪv", "ukphone": "", "trans": ["n. 蜂箱"]}, {"name": "beer", "usphone": "bɪə(r)", "ukphone": "", "trans": ["n. 啤酒"]}, {"name": "before", "usphone": "bɪˈfɔː(r)", "ukphone": "", "trans": ["prep. 在…以前；在…前面 ad. 以前 conj. 在…之前"]}, {"name": "beg", "usphone": "beɡ", "ukphone": "", "trans": ["v. 请求，乞求，乞讨 "]}, {"name": "begin(began,begun)", "usphone": "bɪˈɡɪn", "ukphone": "", "trans": [" v.开始,着手"]}, {"name": "beginning", "usphone": "bɪˈɡɪnɪŋ", "ukphone": "", "trans": ["n. 开始，开端"]}, {"name": "behalf", "usphone": "bɪˈhɑːf", "ukphone": "", "trans": ["n. 代表某人，为了某人"]}, {"name": "behave", "usphone": "bɪˈheɪv", "ukphone": "", "trans": ["v. 守规矩，行为"]}, {"name": "behaviour", "usphone": "bɪ`heɪvjər", "ukphone": "", "trans": ["n. 行为，举止"]}, {"name": "behind", "usphone": "bɪˈhaɪnd", "ukphone": "", "trans": ["prep. (表示位置)在…后面 ad. 在后面；向后"]}, {"name": "being", "usphone": "ˈbiːɪŋ", "ukphone": "", "trans": ["n. 物；生物；人"]}, {"name": "Belgium", "usphone": "ˈbeldʒəm", "ukphone": "", "trans": ["* n. 比利时"]}, {"name": "belief", "usphone": "bɪˈliːf", "ukphone": "", "trans": ["n. 信条，信念"]}, {"name": "believe", "usphone": "bɪˈliːv", "ukphone": "", "trans": ["v. 相信，认为"]}, {"name": "bell", "usphone": "bel", "ukphone": "", "trans": ["n. 钟,铃;钟(铃)声;钟形物"]}, {"name": "belly", "usphone": "ˈbelɪ", "ukphone": "", "trans": ["n. 肚子"]}, {"name": "belong", "usphone": "bɪˈlɔŋ", "ukphone": "", "trans": ["vi. 属，附属"]}, {"name": "below", "usphone": "bɪˈləʊ", "ukphone": "", "trans": ["prep. 在……下面"]}, {"name": "belt", "usphone": "belt", "ukphone": "", "trans": ["n. （皮）带"]}, {"name": "bench", "usphone": "bentʃ", "ukphone": "", "trans": ["n. 长凳；工作台"]}, {"name": "bend (bent, bent)", "usphone": "bend", "ukphone": "", "trans": ["vt. 使弯曲"]}, {"name": "beneath", "usphone": "bɪˈniːθ", "ukphone": "", "trans": ["prep. 在…下方（面）"]}, {"name": "beneficial", "usphone": "benɪˈfɪʃ(ə)l", "ukphone": "", "trans": ["a. 有利的，有帮助的，有用的"]}, {"name": "benefit", "usphone": "ˈbenɪfɪt", "ukphone": "", "trans": ["n. / v.优势,益处,使…受益"]}, {"name": "bent", "usphone": "bent", "ukphone": "", "trans": ["a. 弯的"]}, {"name": "beside", "usphone": "bɪˈsaɪd", "ukphone": "", "trans": ["prep. 在…旁边；靠近"]}, {"name": "besides", "usphone": "bɪˈsaɪdz", "ukphone": "", "trans": ["prep. 除…以外（还有） ad. 还有，此外"]}, {"name": "best（good, well 的最 高级）", "usphone": "best", "ukphone": "", "trans": ["a. & ad.最好的；最好地，最 n. 最好的（人或物）"]}, {"name": "best--seller", "usphone": "best- ˈselə(r)", "ukphone": "", "trans": ["n. 畅销书"]}, {"name": "better (good, well 的 比较级)", "usphone": "ˈbetə(r)", "ukphone": "", "trans": ["a.& ad. 较好的，更好的；好些； 更好地；更，更多n. 较好的事物；较优者 v. 改善；胜过"]}, {"name": "betray", "usphone": "bɪˈtreɪ", "ukphone": "", "trans": ["v.出卖,泄露（机密）,辜负"]}, {"name": "between", "usphone": "bɪˈtwiːn", "ukphone": "", "trans": ["prep. 在（两者）之间；在…中间"]}, {"name": "beyond", "usphone": "bɪˈjɔnd", "ukphone": "", "trans": ["prep. (表示位置) 在…的那边"]}, {"name": "bicycle", "usphone": "ˈbaɪsɪk(ə)l", "ukphone": "", "trans": ["n. 自行车"]}, {"name": "bid", "usphone": "bɪd", "ukphone": "", "trans": ["v./ n. 出价，投标，向（某人）道别"]}, {"name": "big", "usphone": "bɪɡ", "ukphone": "", "trans": ["a. 大的"]}, {"name": "bike = bicycle", "usphone": "baɪk", "ukphone": "", "trans": ["n. 自行车"]}, {"name": "bill", "usphone": "bɪl", "ukphone": "", "trans": ["n.账单；法案，议案； （美）钞票，纸币"]}, {"name": "billion", "usphone": "ˈbɪlɪən", "ukphone": "", "trans": ["num. 十亿，百亿"]}, {"name": "bingo", "usphone": "ˈbɪŋɡəʊ", "ukphone": "", "trans": ["n. 宾戈游戏"]}, {"name": "biochemistry", "usphone": "", "ukphone": "", "trans": ["n. 生物化学"]}, {"name": "biography", "usphone": "baɪˈɔɡrəfɪ", "ukphone": "", "trans": ["n. 传记"]}, {"name": "biology", "usphone": "baɪˈɔlədʒɪ", "ukphone": "", "trans": ["n. 生物（学）"]}, {"name": "bird", "usphone": "bɜːd", "ukphone": "", "trans": ["n. 鸟"]}, {"name": "birdcage", "usphone": "ˈbɜːdkeɪdʒ", "ukphone": "", "trans": ["n. 鸟笼"]}, {"name": "birth", "usphone": "bɜːθ", "ukphone": "", "trans": ["n. 出生； 诞生"]}, {"name": "birthday", "usphone": "ˈbɜːθdeɪ", "ukphone": "", "trans": ["n. 生日"]}, {"name": "birthplace", "usphone": "ˈbɜːθpleɪs", "ukphone": "", "trans": ["n. 出生地；故乡"]}, {"name": "biscuit", "usphone": "ˈbɪskɪt", "ukphone": "", "trans": ["n. 饼干"]}, {"name": "bishop", "usphone": "ˈbɪʃəp", "ukphone": "", "trans": ["n. 主教"]}, {"name": "bit", "usphone": "bɪt", "ukphone": "", "trans": ["n. 一点，一些，少量的"]}, {"name": "bite (bit, bitten)", "usphone": "baɪt", "ukphone": "", "trans": ["v. 咬；叮"]}, {"name": "bitter", "usphone": "ˈbɪtə(r)", "ukphone": "", "trans": ["a. 有苦味的；痛苦的，难过的；严酷的"]}, {"name": "black", "usphone": "blæk", "ukphone": "", "trans": ["n. 黑色 a. 黑色的"]}, {"name": "blackboard", "usphone": "ˈblækbɔːd", "ukphone": "", "trans": ["n. 黑板"]}, {"name": "blame", "usphone": "bleɪm", "ukphone": "", "trans": ["n.& v. 责备；责怪"]}, {"name": "blank", "usphone": "blæŋk", "ukphone": "", "trans": ["n.& a. 空格，空白（处）；空的；茫然无表情的"]}, {"name": "blanket", "usphone": "ˈblæŋkɪt", "ukphone": "", "trans": ["n. 毛毯，毯子"]}, {"name": "bleed", "usphone": "bliːd", "ukphone": "", "trans": ["vi. 出血，流血"]}, {"name": "bless", "usphone": "bles", "ukphone": "", "trans": ["vt. 保佑，降福"]}, {"name": "blind", "usphone": "blaɪnd", "ukphone": "", "trans": ["a. 瞎的"]}, {"name": "block", "usphone": "blɔk", "ukphone": "", "trans": ["n. 大块；（木、石等）块；街区；路障 vt. 阻塞；阻挡"]}, {"name": "blood", "usphone": "blʌd", "ukphone": "", "trans": ["n. 血，血液"]}, {"name": "blouse", "usphone": "blaʊz; u.S. blaʊs", "ukphone": "", "trans": ["n. 宽罩衫；（妇女、儿童穿的）短上衣"]}, {"name": "blow", "usphone": "bləʊ", "ukphone": "", "trans": ["n. 击；打击"]}, {"name": "blow (blew, blown)", "usphone": "bləʊ", "ukphone": "", "trans": ["v. 吹；刮风；吹气"]}, {"name": "blue", "usphone": "bluː", "ukphone": "", "trans": ["n. 蓝色 a.蓝色的 a. 悲伤的；沮丧的"]}, {"name": "board", "usphone": "bɔːd", "ukphone": "", "trans": ["n. 木板；布告牌；委员会；（政府的）部 v. 上（船、火车、飞机）"]}, {"name": "boat", "usphone": "bəʊt", "ukphone": "", "trans": ["n. 小船，小舟"]}, {"name": "boat--race", "usphone": "bəʊt-reɪs", "ukphone": "", "trans": ["n. 划船比赛"]}, {"name": "boating", "usphone": "ˈbəʊtɪŋ", "ukphone": "", "trans": ["n. 划船（游玩），泛舟 body n. 身体"]}, {"name": "body--building", "usphone": "ˈbɔdɪ-ˈbɪldɪŋ", "ukphone": "", "trans": ["n. 健美"]}, {"name": "boil", "usphone": "bɔɪl", "ukphone": "", "trans": ["v. 沸腾；烧开；煮……"]}, {"name": "bomb", "usphone": "bɔm", "ukphone": "", "trans": ["n. 炸弹 v. 轰炸"]}, {"name": "bond", "usphone": "bɔnd", "ukphone": "", "trans": ["n. /v. 纽带，联系，使牢固"]}, {"name": "bone", "usphone": "bəʊn", "ukphone": "", "trans": ["n. 骨头，骨质（复数bones骨骼；骨骸）"]}, {"name": "bonus", "usphone": "ˈbəʊnəs", "ukphone": "", "trans": ["n. 津贴，奖金，红利"]}, {"name": "book", "usphone": "bʊk", "ukphone": "", "trans": ["n. 书；本子 v. 预定，定（房间、车票等）"]}, {"name": "bookcase", "usphone": "ˈbʊkkeɪs", "ukphone": "", "trans": ["n. 书橱"]}, {"name": "bookmark", "usphone": "ˈbʊkmɑːk", "ukphone": "", "trans": ["n. 书签"]}, {"name": "bookshelf", "usphone": "`bʊk,ʃelf", "ukphone": "", "trans": ["n. 书架"]}, {"name": "bookshop", "usphone": "ˈbʊkʃɔp", "ukphone": "", "trans": ["n. 书店"]}, {"name": "bookstore", "usphone": "ˈbʊkstɔː(r)", "ukphone": "", "trans": ["n. 书店"]}, {"name": "boom", "usphone": "buːm", "ukphone": "", "trans": ["n. / v. 繁荣，轰鸣，激增"]}, {"name": "boot", "usphone": "buːt", "ukphone": "", "trans": ["n. 长统靴；靴"]}, {"name": "booth", "usphone": "buːð", "ukphone": "", "trans": ["n.岗；（为某种用途而设的）亭或小隔间"]}, {"name": "telephone booth", "usphone": "ˈtelɪfəʊn- buːð", "ukphone": "", "trans": ["电话亭"]}, {"name": "border", "usphone": "ˈbɔːdə(r)", "ukphone": "", "trans": ["n. 边缘；边境，国界"]}, {"name": "bored", "usphone": "bɔrd", "ukphone": "", "trans": ["a.（对人，事）厌倦的，烦闷的"]}, {"name": "boring", "usphone": "`bɔrɪŋ", "ukphone": "", "trans": ["a. 乏味的，无聊的"]}, {"name": "born", "usphone": "bɔːn", "ukphone": "", "trans": ["a. 出生"]}, {"name": "borrow", "usphone": "ˈbɔrəʊ", "ukphone": "", "trans": ["v. （向别人）借用；借"]}, {"name": "boss", "usphone": "bɔs", "ukphone": "", "trans": ["n. 领班；老板"]}, {"name": "botanical", "usphone": "bəˈtænɪk(ə)l", "ukphone": "", "trans": ["a. 植物学的"]}, {"name": "botany", "usphone": "ˈbɔtənɪ", "ukphone": "", "trans": ["n. 植物； 植物学"]}, {"name": "both", "usphone": "bəʊθ", "ukphone": "", "trans": ["a. 两；双 pron. 两者；双方"]}, {"name": "bottle", "usphone": "ˈbɔt(ə)l", "ukphone": "", "trans": ["n. 瓶子"]}, {"name": "bottom", "usphone": "ˈbɔtəm", "ukphone": "", "trans": ["n. 底部；底"]}, {"name": "bounce", "usphone": "baʊns", "ukphone": "", "trans": ["v. 弹起，蹦，上下晃动"]}, {"name": "bound", "usphone": "baʊnd", "ukphone": "", "trans": ["a. 被束缚的；被绑的；有义务的  v.& n. 跳跃"]}, {"name": "boundary", "usphone": "ˈbaʊndərɪ", "ukphone": "", "trans": ["n. 边界，界限"]}, {"name": "bow", "usphone": "bəʊ", "ukphone": "", "trans": ["v.& n. 鞠躬，弯腰行礼"]}, {"name": "bowl", "usphone": "bəʊl", "ukphone": "", "trans": ["n. 碗"]}, {"name": "bowling", "usphone": "ˈbəʊlɪŋ", "ukphone": "", "trans": ["n. 保龄球"]}, {"name": "box", "usphone": "bɔks", "ukphone": "", "trans": ["n. 盒子，箱子"]}, {"name": "boxing", "usphone": "ˈbɔksɪŋ", "ukphone": "", "trans": ["n. 拳击（运动）"]}, {"name": "boy", "usphone": "bɔɪ", "ukphone": "", "trans": ["n. 男孩"]}, {"name": "boycott", "usphone": "ˈbɔɪkɔt", "ukphone": "", "trans": ["v. 拒绝购买，抵制"]}, {"name": "brain", "usphone": "breɪn", "ukphone": "", "trans": ["n. 脑（子）"]}, {"name": "brake", "usphone": "breɪk", "ukphone": "", "trans": ["n. 闸 vi. 刹车"]}, {"name": "branch", "usphone": "brɑːntʃ", "ukphone": "", "trans": ["n. 树枝；分枝；分公司，分店；支部"]}, {"name": "brand", "usphone": "brænd", "ukphone": "", "trans": ["n. 品牌"]}, {"name": "brave", "usphone": "breɪv", "ukphone": "", "trans": ["a. 勇敢的"]}, {"name": "bravery", "usphone": "ˈbreɪvərɪ", "ukphone": "", "trans": ["n. 勇气"]}, {"name": "bread", "usphone": "bred", "ukphone": "", "trans": ["n. 面包"]}, {"name": "break", "usphone": "breɪk", "ukphone": "", "trans": ["n. 间隙"]}, {"name": "break (broke, bro ken)", "usphone": "breɪk", "ukphone": "", "trans": ["v. 打破（断，碎）；损坏，撕开"]}, {"name": "breakfast", "usphone": "ˈbrekfəst", "ukphone": "", "trans": ["n. 早餐"]}, {"name": "breakthrough", "usphone": "ˈbreɪkθruː", "ukphone": "", "trans": ["n. 重大进展，突破"]}, {"name": "breast", "usphone": "brest", "ukphone": "", "trans": ["n. 乳房，胸脯"]}, {"name": "breath", "usphone": "breθ", "ukphone": "", "trans": ["n. 气息；呼吸"]}, {"name": "breathe", "usphone": "briːð", "ukphone": "", "trans": ["vi. 呼吸"]}, {"name": "breathless", "usphone": "ˈbreθlɪs", "ukphone": "", "trans": ["a. 气喘吁吁的，上气不接下气的"]}, {"name": "brewery", "usphone": "ˈbruːərɪ", "ukphone": "", "trans": ["n. 啤酒厂（公司）"]}, {"name": "brick", "usphone": "brɪk", "ukphone": "", "trans": ["n. 砖；砖块"]}, {"name": "bride", "usphone": "braɪd", "ukphone": "", "trans": ["n. 新娘"]}, {"name": "bridegroom", "usphone": "ˈbraɪdɡruːm", "ukphone": "", "trans": ["n. 新郎"]}, {"name": "bridge", "usphone": "brɪdʒ", "ukphone": "", "trans": ["n. 桥"]}, {"name": "brief", "usphone": "briːf", "ukphone": "", "trans": ["a. 简洁的"]}, {"name": "bright", "usphone": "braɪt", "ukphone": "", "trans": ["a. 明亮的；聪明的"]}, {"name": "brilliant", "usphone": "ˈbrɪlɪənt", "ukphone": "", "trans": ["a. 巧妙的，使人印象深刻的，技艺高的"]}, {"name": "bring (brought, brought)", "usphone": "brɪŋ", "ukphone": "", "trans": ["vt. 拿来，带来，取来"]}, {"name": "Britain", "usphone": "ˈbrɪtən", "ukphone": "", "trans": ["* n. 英国；不列颠"]}, {"name": "British", "usphone": "ˈbrɪtɪʃ", "ukphone": "", "trans": ["a. 英国的；大不列颠的；英国人的"]}, {"name": "the British", "usphone": "ˈbrɪtɪʃ", "ukphone": "", "trans": ["n. 英国国民；大不列颠人"]}, {"name": "broad", "usphone": "brɔːd", "ukphone": "", "trans": ["a. 宽的，宽大的"]}, {"name": "broadcast", "usphone": "ˈbrɔːdkɑːst", "ukphone": "", "trans": ["n. 广播节目"]}, {"name": "broadcast（broadcast, broadcast或--ed,--ed）", "usphone": "ˈbrɔːdkɑːst", "ukphone": "", "trans": ["vt. 广播"]}, {"name": "brochure", "usphone": "brəʊˈʃə(r); (US) brəʊˈʃʊər", "ukphone": "", "trans": ["n. 资料（或广告）手册"]}, {"name": "broken", "usphone": "ˈbrəʊkən", "ukphone": "", "trans": ["a. 弄坏了的"]}, {"name": "broom", "usphone": "bruːm", "ukphone": "", "trans": ["n. 扫帚"]}, {"name": "brother", "usphone": "ˈbrʌðə(r)", "ukphone": "", "trans": ["n. 兄；弟"]}, {"name": "brotherhood", "usphone": "ˈbrʌðəhʊd", "ukphone": "", "trans": ["n. 兄弟般的关系"]}, {"name": "brown", "usphone": "braʊn", "ukphone": "", "trans": ["n. 褐色，棕色 a. 褐色的，棕色的"]}, {"name": "brunch", "usphone": "ˈbrʌntʃ", "ukphone": "", "trans": ["n. 早午饭（晚早饭）"]}, {"name": "brush", "usphone": "brʌʃ", "ukphone": "", "trans": ["v. 刷；擦 n. 刷子"]}, {"name": "bucket", "usphone": "ˈbʌkɪt", "ukphone": "", "trans": ["n. 铲斗；桶"]}, {"name": "Buddhism", "usphone": "ˈbʊdɪz(ə)m", "ukphone": "", "trans": ["n. 佛教"]}, {"name": "Buddhist", "usphone": "ˈbudist", "ukphone": "", "trans": ["n. 佛教徒"]}, {"name": "budget", "usphone": "ˈbʌdʒɪt", "ukphone": "", "trans": ["n. 预算"]}, {"name": "buffet", "usphone": "ˈbʊfeɪ; (US) bəˈfeɪ", "ukphone": "", "trans": ["n. 自助餐"]}, {"name": "build (built, built)", "usphone": "bɪld", "ukphone": "", "trans": ["v. 建筑；造"]}, {"name": "building", "usphone": "ˈbɪldɪŋ", "ukphone": "", "trans": ["n. 建筑物；房屋；大楼"]}, {"name": "bun", "usphone": "bʌn", "ukphone": "", "trans": ["n. 馒头；小甜面包"]}, {"name": "bunch", "usphone": "bʌntʃ", "ukphone": "", "trans": ["n. 串,束,扎,大量,大批"]}, {"name": "bungalow", "usphone": "ˈbʌŋɡələʊ", "ukphone": "", "trans": ["n. 平房"]}, {"name": "burden", "usphone": "ˈbɜːd(ə)n", "ukphone": "", "trans": ["n. （义务，责任的）重担，负担"]}, {"name": "bureaucratic", "usphone": "bjuəˌrəuˈkrætik", "ukphone": "", "trans": ["a. 官僚的"]}, {"name": "burglar", "usphone": "ˈbɜːɡlə(r)", "ukphone": "", "trans": ["n. 入室窃贼"]}, {"name": "burial", "usphone": "ˈberɪəl", "ukphone": "", "trans": ["n. 埋葬"]}, {"name": "burn (--ed, --ed 或 burnt, burnt)", "usphone": "bɜːn", "ukphone": "", "trans": ["v. 燃，烧，着火；使烧焦；使晒黑 n. 烧伤；晒伤"]}, {"name": "burst", "usphone": "ˈbɜːst", "ukphone": "", "trans": ["v. 突然发生； 突然发作"]}, {"name": "bury", "usphone": "ˈberɪ", "ukphone": "", "trans": ["vt. 埋；葬"]}, {"name": "bus", "usphone": "bʌs", "ukphone": "", "trans": ["n. 公共汽车"]}, {"name": "bus stop", "usphone": "bʌs stɔp", "ukphone": "", "trans": ["n。公共汽车站"]}, {"name": "bush", "usphone": "bʊʃ", "ukphone": "", "trans": ["n. 灌木丛，矮树丛"]}, {"name": "business", "usphone": "ˈbɪznɪs", "ukphone": "", "trans": ["n. （本分）工作，职业；职责；生意，交易；事业"]}, {"name": "businessman (pl. businessmen)", "usphone": "ˈbɪznɪsmæn", "ukphone": "", "trans": ["n. 商人（男）；男企业家"]}, {"name": "businesswoman (businesswomen)", "usphone": "ˈbɪznɪswʊmæn", "ukphone": "", "trans": ["n. 商人（女）；女企业家"]}, {"name": "busy", "usphone": "ˈbɪzɪ", "ukphone": "", "trans": ["a. 忙（碌）的"]}, {"name": "but", "usphone": "bət, bʌt", "ukphone": "", "trans": ["conj. 但是，可是 prep. 除了, 除……外"]}, {"name": "butcher", "usphone": "ˈbʊtʃə", "ukphone": "", "trans": ["n. vt. 肉店；屠夫 屠宰（动物）；残杀（人）"]}, {"name": "butter", "usphone": "ˈbʌtə(r)", "ukphone": "", "trans": ["n. 黄油，奶油"]}, {"name": "butterfly", "usphone": "ˈbʌtəflaɪ", "ukphone": "", "trans": ["n. 蝴蝶"]}, {"name": "the butterfly", "usphone": "", "ukphone": "", "trans": ["蝶泳"]}, {"name": "button", "usphone": "ˈbʌt(ə)n", "ukphone": "", "trans": ["n. 纽扣；（电铃等的）按钮 v. 扣（纽扣） "]}, {"name": "buy (bought,bought)", "usphone": "baɪ", "ukphone": "", "trans": ["vt. 买"]}, {"name": "by", "usphone": "baɪ", "ukphone": "", "trans": ["prep. 靠近，在…旁；在…时间；不迟于；被；用；由；乘（车）"]}, {"name": "bye", "usphone": "baɪ", "ukphone": "", "trans": ["int. 再见"]}, {"name": "cab", "usphone": "kæb", "ukphone": "", "trans": ["n. （美）出租车"]}, {"name": "cabbage", "usphone": "ˈkæbɪdʒ", "ukphone": "", "trans": ["n. 卷心菜，洋白菜"]}, {"name": "café", "usphone": "ˈkæfeɪ; (US) kæˈfeɪ", "ukphone": "", "trans": ["n. 咖啡馆； 餐馆"]}, {"name": "cafeteria", "usphone": "kæfɪˈtɪərɪə", "ukphone": "", "trans": ["n. 自助餐厅"]}, {"name": "cage", "usphone": "keɪdʒ", "ukphone": "", "trans": ["n 笼；鸟笼"]}, {"name": "calculate", "usphone": "ˈkælkjʊleɪt", "ukphone": "", "trans": ["v. 计算，核算，推测"]}, {"name": "cake", "usphone": "keɪk", "ukphone": "", "trans": ["n. 蛋糕，糕点；饼"]}, {"name": "call", "usphone": "kɔːl", "ukphone": "", "trans": ["n. 喊，叫；电话，通话 v. 称呼；呼唤；喊，叫"]}, {"name": "calm", "usphone": "kɑːm; (US) kɑːlm", "ukphone": "", "trans": ["a. 镇静,沉着的 v.镇静沉着"]}, {"name": "camel", "usphone": "ˈkæm(ə)l", "ukphone": "", "trans": ["n. 骆驼"]}, {"name": "camera", "usphone": "ˈkæmərə", "ukphone": "", "trans": ["n. 照相机；摄像机"]}, {"name": "camp", "usphone": "kæmp", "ukphone": "", "trans": ["n.（夏令）营 vi.野营,宿营"]}, {"name": "campaign", "usphone": "kæmˈpeɪn", "ukphone": "", "trans": ["n. 运动，战役"]}, {"name": "can (could) canˈt = can not modal", "usphone": "ken, kæn", "ukphone": "", "trans": ["v. 可能；能够；可以 不能 n.（美）罐头；罐子"]}, {"name": "a garbage can", "usphone": "ˈɡɑːbɪdʒ", "ukphone": "", "trans": ["（美）垃圾桶"]}, {"name": "a can opener", "usphone": "ˈəʊpənə(r)", "ukphone": "", "trans": ["开罐器"]}, {"name": "Canada", "usphone": "ˈkænədə", "ukphone": "", "trans": ["* n. 加拿大"]}, {"name": "Canadian", "usphone": "kəˈneɪdɪən", "ukphone": "", "trans": ["a. 加拿大的；加拿大人的 n. 加拿大人"]}, {"name": "canal", "usphone": "kəˈnæl", "ukphone": "", "trans": ["n. 运河；水道"]}, {"name": "cancel", "usphone": "ˈkæns(ə)l", "ukphone": "", "trans": ["vt. 取消"]}, {"name": "cance", "usphone": "ˈkænsə(r)", "ukphone": "", "trans": ["r n. 癌"]}, {"name": "candidate", "usphone": "ˈkændɪdət; (US) ˈkændɪdeɪt", "ukphone": "", "trans": ["n. 候选人，申请人"]}, {"name": "candle", "usphone": "ˈkænd(ə)l", "ukphone": "", "trans": ["n. 蜡烛"]}, {"name": "candy", "usphone": "ˈkændɪ", "ukphone": "", "trans": ["n. 糖果"]}, {"name": "canteen", "usphone": "kænˈtiːn", "ukphone": "", "trans": ["n. 餐厅；食堂"]}, {"name": "cap", "usphone": "kæp", "ukphone": "", "trans": ["n. （无檐的或仅在前面有檐的）帽子；（瓶子的）盖；（钢笔等的）笔套"]}, {"name": "capital", "usphone": "ˈkæpɪt(ə)l", "ukphone": "", "trans": ["n.首都.省会.大写；资本"]}, {"name": "capsule", "usphone": "ˈkæpsjuːl; (US) ˈkæpsl", "ukphone": "", "trans": ["n. （药）胶囊"]}, {"name": "captain", "usphone": "ˈkæptɪn", "ukphone": "", "trans": ["n. （海军）上校；船长，舰长；队长"]}, {"name": "caption", "usphone": "ˈkæpʃ(ə)n", "ukphone": "", "trans": ["n. （图片，漫画等的）说明文字"]}, {"name": "car", "usphone": "kɑː(r)", "ukphone": "", "trans": ["n. 汽车，小卧车"]}, {"name": "carbon", "usphone": "ˈkɑːbən", "ukphone": "", "trans": ["n. 碳"]}, {"name": "card", "usphone": "kɑːd", "ukphone": "", "trans": ["n.卡片；名片；纸牌"]}, {"name": "card games", "usphone": "kɑːd ɡeɪm", "ukphone": "", "trans": ["纸牌游戏"]}, {"name": "care", "usphone": "keə(r)", "ukphone": "", "trans": ["n. 照料，保护；小心v. 介意……，在乎；关心"]}, {"name": "careful", "usphone": "ˈkeəfʊl", "ukphone": "", "trans": ["a. 小心，仔细，谨慎的"]}, {"name": "careless", "usphone": "ˈkeəlɪs", "ukphone": "", "trans": ["a. 粗心的，漫不经心的"]}, {"name": "carpenter", "usphone": "ˈkɑːpɪntə(r)", "ukphone": "", "trans": ["n. 木工，木匠"]}, {"name": "carpet", "usphone": "ˈkɑːpɪt", "ukphone": "", "trans": ["n. 地毯"]}, {"name": "carriage", "usphone": "ˈkærɪdʒ", "ukphone": "", "trans": ["n. 四轮马车;（火车）客车厢"]}, {"name": "carrier", "usphone": "ˈkærɪə(r)", "ukphone": "", "trans": ["n. 搬运者；媒介;（自行车等的）置物架；（车的）货架"]}, {"name": "carrot", "usphone": "ˈkærət", "ukphone": "", "trans": ["n.胡萝卜"]}, {"name": "carry", "usphone": "ˈkærɪ", "ukphone": "", "trans": ["vt. 拿，搬，带，提，抬，背，抱，运等"]}, {"name": "cartoon", "usphone": "kɑːˈtuːn", "ukphone": "", "trans": ["n. 动画片，卡通；漫画"]}, {"name": "carve", "usphone": "kɑːv", "ukphone": "", "trans": ["vt.刻；雕刻"]}, {"name": "case", "usphone": "keɪs", "ukphone": "", "trans": ["n. 情况；病例；案件；真相  n. 箱；盒；容器"]}, {"name": "cash", "usphone": "kæʃ", "ukphone": "", "trans": ["n. 现金，现钞 v. 兑现"]}, {"name": "cassettle", "usphone": "kæˈset", "ukphone": "", "trans": ["n. 磁带"]}, {"name": "cast (cast, cast)", "usphone": "kɑːst; (US) kæst", "ukphone": "", "trans": ["v. 扔，抛，撒"]}, {"name": "castle", "usphone": "ˈkɑːs(ə)l; (US) ˈkæsl", "ukphone": "", "trans": ["n. 城堡"]}, {"name": "casual", "usphone": "ˈkæʒʊəl", "ukphone": "", "trans": ["a. 漫不经心的，不经意的，非正式的"]}, {"name": "cat", "usphone": "kæt", "ukphone": "", "trans": ["n. 猫 "]}, {"name": "catalogue", "usphone": "ˈkætəlɔg", "ukphone": "", "trans": ["n. 目录"]}, {"name": "catastrophe", "usphone": "kəˈtæstrəfɪ", "ukphone": "", "trans": ["n. 灾难，灾祸，不幸事件"]}, {"name": "catch(caught,caught)", "usphone": "kætʃ", "ukphone": "", "trans": ["v. 接住；捉住；赶上；染上（疾病）"]}, {"name": "category", "usphone": "ˈkætɪɡərɪ", "ukphone": "", "trans": ["n. 类别，种类"]}, {"name": "cater", "usphone": "ˈkeɪtə(r)", "ukphone": "", "trans": ["v. 提供饮食，承办酒席"]}, {"name": "catholic", "usphone": "ˈkæθəlɪk", "ukphone": "", "trans": ["a. 天主教的"]}, {"name": "cathedral", "usphone": "kəˈθiːdr(ə)l", "ukphone": "", "trans": ["n. 大教堂（天主教）"]}, {"name": "cattle", "usphone": "ˈkæt(ə)l", "ukphone": "", "trans": ["n. 牛（总称），家畜"]}, {"name": "cause", "usphone": "kɔːz", "ukphone": "", "trans": ["n. 原因，起因 vt. 促使，引起，使发生"]}, {"name": "caution", "usphone": "ˈkɔːʃ(ə)n", "ukphone": "", "trans": ["n. 谨慎，小心，警告"]}, {"name": "cautious", "usphone": "ˈkɔːʃəs", "ukphone": "", "trans": ["a. 小心的，谨慎的"]}, {"name": "cave", "usphone": "keɪv", "ukphone": "", "trans": ["n. 洞，穴；地窖"]}, {"name": "CD", "usphone": "ˌsi:ˈdi:", "ukphone": "", "trans": ["光盘 (compact disk的缩写)"]}, {"name": "CDROM", "usphone": "ˌsi:ˈdi: -rɔm,rəʊm", "ukphone": "", "trans": ["信息储存光盘(compact disk readonly memory的缩写)"]}, {"name": "ceiling", "usphone": "ˈsiːlɪŋ", "ukphone": "", "trans": ["n. 天花板，顶棚"]}, {"name": "celebrate", "usphone": "ˈselɪbreɪt", "ukphone": "", "trans": ["v. 庆祝"]}, {"name": "celebration", "usphone": "selɪˈbreɪʃ(ə)n", "ukphone": "", "trans": ["n. 庆祝；庆祝会"]}, {"name": "cell", "usphone": "sel", "ukphone": "", "trans": ["n.（监狱的）单人牢房；（修道院等的）单人小室；（蜂巢的）小蜂窝，蜂房；［生物］ 细胞"]}, {"name": "cellar", "usphone": "ˈselə(r)", "ukphone": "", "trans": ["n. 地窖；地下储藏室"]}, {"name": "cent", "usphone": "sent", "ukphone": "", "trans": ["n. 美分（100 cents = 1 dollar）"]}, {"name": "centigrade", "usphone": "ˈsentɪɡreɪd", "ukphone": "", "trans": ["a. 摄氏的"]}, {"name": "centimetre", "usphone": "ˈsentiˌmi:tə(r)", "ukphone": "", "trans": ["(美 centimeter) n. 公分，厘米"]}, {"name": "central", "usphone": "ˈsentr(ə)l", "ukphone": "", "trans": ["a. 中心，中央；主要的"]}, {"name": "centre (美 center )", "usphone": "", "ukphone": "", "trans": ["n. 中心，中央"]}, {"name": "century", "usphone": "ˈsentʃərɪ", "ukphone": "", "trans": ["n. 世纪，百年"]}, {"name": "ceremony", "usphone": "ˈserɪmənɪ", "ukphone": "", "trans": ["n. 典礼，仪式，礼节"]}, {"name": "certain", "usphone": "ˈsɜːt(ə)n", "ukphone": "", "trans": ["a. （未指明真实名称的）某…；确定的，无疑的；一定会…"]}, {"name": "certainly", "usphone": "ˈsɜːtənlɪ", "ukphone": "", "trans": ["ad. 当然；一定，无疑"]}, {"name": "certificate", "usphone": "səˈtɪfɪkət", "ukphone": "", "trans": ["n. 证明，证明书"]}, {"name": "chain", "usphone": "tʃeɪn", "ukphone": "", "trans": ["n. 链； 链条"]}, {"name": "chain store(s)", "usphone": "tʃeɪn stɔː(r)", "ukphone": "", "trans": ["连锁店"]}, {"name": "chair", "usphone": "tʃeə(r)", "ukphone": "", "trans": ["n. 椅子"]}, {"name": "chairman", "usphone": "ˈtʃeəmən", "ukphone": "", "trans": ["(pl. chairmen) n. 主席，会长；议长"]}, {"name": "chairwoman (pl. chairwomen)", "usphone": "ˈtʃɛəˌwumən", "ukphone": "", "trans": ["n. 女主席, 女会长；女议长"]}, {"name": "chalk", "usphone": "tʃɔːk", "ukphone": "", "trans": ["n. 粉笔"]}, {"name": "challenge", "usphone": "ˈtʃælɪndʒ", "ukphone": "", "trans": ["n.挑战(性)"]}, {"name": "challenging", "usphone": "ˈtʃælɪndʒɪŋ", "ukphone": "", "trans": ["a.具有挑战性的"]}, {"name": "champion", "usphone": "ˈtʃæmpɪən", "ukphone": "", "trans": ["n. 冠军，优胜者"]}, {"name": "chance", "usphone": "tʃɑːns; (US) tʃæns", "ukphone": "", "trans": ["n. 机会，可能性"]}, {"name": "changeable", "usphone": "ˈtʃeɪndʒəb(ə)l", "ukphone": "", "trans": ["a.易变的，变化无常的"]}, {"name": "change", "usphone": "tʃeɪndʒ", "ukphone": "", "trans": ["n. 零钱；找头v. 改变，变化；更换；兑换"]}, {"name": "channel", "usphone": "ˈtʃæn(ə)l", "ukphone": "", "trans": ["n.频道；通道；水渠"]}, {"name": "chant", "usphone": "tʃɑːnt", "ukphone": "", "trans": ["v./ n.反复呼喊"]}, {"name": "chaos", "usphone": "ˈkeɪɔs", "ukphone": "", "trans": ["n. 混乱，杂乱，紊乱"]}, {"name": "character", "usphone": "ˈkærɪktə(r)", "ukphone": "", "trans": ["n.（汉）字.字体；品格"]}, {"name": "characteristic", "usphone": "kærɪktəˈrɪstɪk", "ukphone": "", "trans": ["a. 典型的，独特的"]}, {"name": "charge", "usphone": "tʃɑːdʒ", "ukphone": "", "trans": ["v. 要求收费；索价；将(电池)充电 n. 费用；价钱"]}, {"name": "chapter", "usphone": "ˈtʃæptə(r)", "ukphone": "", "trans": ["n. 章"]}, {"name": "chart", "usphone": "tʃɑːt", "ukphone": "", "trans": ["n. 图表；航海图"]}, {"name": "chat", "usphone": "tʃæt", "ukphone": "", "trans": ["n. & vi. 聊天，闲谈"]}, {"name": "cheap", "usphone": "tʃiːp", "ukphone": "", "trans": ["a. 便宜的，贱"]}, {"name": "cheat", "usphone": "tʃiːt", "ukphone": "", "trans": ["n. & v. 骗取，哄骗；作弊"]}, {"name": "check", "usphone": "tʃek", "ukphone": "", "trans": ["n. 检查；批改 vt. 校对，核对； 检查；批改"]}, {"name": "cheek", "usphone": "tʃiːk", "ukphone": "", "trans": ["n. 面颊，脸蛋"]}, {"name": "cheer", "usphone": "tʃɪə(r)", "ukphone": "", "trans": ["n. & vi.欢呼； 喝彩"]}, {"name": "Cheer up", "usphone": "tʃɪə(r)-ʌp", "ukphone": "", "trans": ["振作起来！提起精神！"]}, {"name": "cheerful", "usphone": "ˈtʃɪəfʊl", "ukphone": "", "trans": ["a.兴高采烈的，快活的"]}, {"name": "cheers", "usphone": "tʃɪə(r)", "ukphone": "", "trans": ["int. 干杯，(口)谢谢，再见"]}, {"name": "cheese", "usphone": "tʃiːz", "ukphone": "", "trans": ["n. 奶酪"]}, {"name": "chef", "usphone": "ʃef", "ukphone": "", "trans": ["n. 厨师长，主厨"]}, {"name": "chemical", "usphone": "ˈkemɪk(ə)l", "ukphone": "", "trans": ["a. 化学的 n. 化学品"]}, {"name": "chemist", "usphone": "ˈkemɪst", "ukphone": "", "trans": ["n. 药剂师；化学家"]}, {"name": "chemistry", "usphone": "ˈkemɪstrɪ", "ukphone": "", "trans": ["n. 化学"]}, {"name": "cheque", "usphone": "tʃek", "ukphone": "", "trans": ["(美check) n. 支票"]}, {"name": "chess", "usphone": "tʃes", "ukphone": "", "trans": ["n. 棋"]}, {"name": "chest", "usphone": "tʃest", "ukphone": "", "trans": ["n. 箱子；盒子；胸部"]}, {"name": "chew", "usphone": "tʃuː", "ukphone": "", "trans": ["vt. 咀嚼"]}, {"name": "chick", "usphone": "tʃɪk", "ukphone": "", "trans": ["n. 小鸡"]}, {"name": "chicken", "usphone": "ˈtʃɪkən", "ukphone": "", "trans": ["n. 鸡；鸡肉"]}, {"name": "chief", "usphone": "tʃiːf", "ukphone": "", "trans": ["a. 主要,首要的 n.领导，头"]}, {"name": "child (复children)", "usphone": "tʃaɪld", "ukphone": "", "trans": ["n. 孩子，儿童"]}, {"name": "childhood", "usphone": "ˈtʃaɪldhʊd", "ukphone": "", "trans": ["n. 幼年时代，童年"]}, {"name": "chimney", "usphone": "ˈtʃɪmnɪ", "ukphone": "", "trans": ["n. 烟囱，烟筒"]}, {"name": "China", "usphone": "ˈtʃaɪnə", "ukphone": "", "trans": ["* n. 中国"]}, {"name": "Chinese", "usphone": "tʃaɪˈniːz", "ukphone": "", "trans": ["a.中国的；中国人的；中国话的，汉语的 n.中国人；中国话，汉语，中文"]}, {"name": "chips", "usphone": "tʃɪp", "ukphone": "", "trans": ["n. (pl.)炸土豆条（片）"]}, {"name": "chocolate", "usphone": "ˈtʃɔklət", "ukphone": "", "trans": ["n. 巧克力"]}, {"name": "choice", "usphone": "tʃɔɪs", "ukphone": "", "trans": ["n. 选择；抉择"]}, {"name": "choir", "usphone": "ˈkwaɪə(r)", "ukphone": "", "trans": ["n. 合唱团，教堂的唱诗班"]}, {"name": "choke", "usphone": "tʃəʊk", "ukphone": "", "trans": ["n. & v. 窒息"]}, {"name": "choose (chose, chosen)", "usphone": "tʃuːz", "ukphone": "", "trans": ["vt. 选择"]}, {"name": "chopsticks", "usphone": "ˈtʃɔpstɪks", "ukphone": "", "trans": ["n. 筷子"]}, {"name": "chorus", "usphone": "ˈkɔːrəs", "ukphone": "", "trans": ["n. 合唱曲，歌咏队"]}, {"name": "Christian", "usphone": "ˈkrɪstɪən", "ukphone": "", "trans": ["n. 基督教徒和天主教徒的总称"]}, {"name": "Christmas", "usphone": "ˈkrɪsməs", "ukphone": "", "trans": ["n. 圣诞节（12月25日）"]}, {"name": "Christmas card", "usphone": "ˈkrɪsməs kɑːd", "ukphone": "", "trans": ["圣诞卡"]}, {"name": "Christmas tree", "usphone": "ˈkrɪsməs triː", "ukphone": "", "trans": ["圣诞树"]}, {"name": "Christmas Eve", "usphone": "ˈkrɪsməs iːv ", "ukphone": "", "trans": ["圣诞（前）夜"]}, {"name": "church", "usphone": "tʃɜːtʃ", "ukphone": "", "trans": ["n. 教堂；教会"]}, {"name": "cigar", "usphone": "sɪˈɡɑː(r)", "ukphone": "", "trans": ["n. 雪茄烟"]}, {"name": "cigarette", "usphone": "sɪɡəˈret", "ukphone": "", "trans": ["n. 纸烟，香烟"]}, {"name": "cinema", "usphone": "ˈsɪnəmə", "ukphone": "", "trans": ["n. 电影院；电影"]}, {"name": "circle", "usphone": "ˈsɜːk(ə)l", "ukphone": "", "trans": ["n. /vt. 圆圈 将…圈起来"]}, {"name": "circuit", "usphone": "ˈsɜːkɪt", "ukphone": "", "trans": ["n. 环形路线，巡回赛"]}, {"name": "circulate", "usphone": "ˈsɜːkjʊleɪt", "ukphone": "", "trans": ["v. （液体或气体）环流，循环"]}, {"name": "circumstance", "usphone": "ˈsɜːkəmstəns", "ukphone": "", "trans": ["n.条件,环境,状况"]}, {"name": "circus", "usphone": "ˈsɜːkəs", "ukphone": "", "trans": ["n. 马戏团"]}, {"name": "citizen", "usphone": "ˈsɪtɪz(ə)n", "ukphone": "", "trans": ["n. 公民；居民"]}, {"name": "city", "usphone": "ˈsɪtɪ", "ukphone": "", "trans": ["n. 市，城市，都市"]}, {"name": "civil", "usphone": "ˈsɪv(ə)l", "ukphone": "", "trans": ["a. 国内的；平民（非军人）的；民用的"]}, {"name": "civilian", "usphone": "sɪˈvɪlɪən", "ukphone": "", "trans": ["n. 平民，老百姓"]}, {"name": "civilization", "usphone": "sɪvɪlaɪˈzeɪʃ(ə)n; (US) sɪvəlɪˈzeɪʃən", "ukphone": "", "trans": ["n. 文明"]}, {"name": "clap", "usphone": "klæp", "ukphone": "", "trans": ["vi. 拍手；鼓掌"]}, {"name": "clarify", "usphone": "ˈklærɪfaɪ", "ukphone": "", "trans": ["v. 澄清，阐明"]}, {"name": "class", "usphone": "klɑːs; (US) klæs", "ukphone": "", "trans": ["n. （学校的）班；年级；课"]}, {"name": "classic", "usphone": "ˈklæsɪk", "ukphone": "", "trans": ["a. 一流的，典型的，有代表性的"]}, {"name": "classical", "usphone": "ˈklæsɪk(ə)l", "ukphone": "", "trans": ["a. 传统的；古典的"]}, {"name": "classify", "usphone": "ˈklæsɪfaɪ", "ukphone": "", "trans": ["v. 分类，归类"]}, {"name": "classmate", "usphone": "ˈklɑːsmeɪt", "ukphone": "", "trans": ["n. 同班同学"]}, {"name": "classroom", "usphone": "ˈklɑːsruːm", "ukphone": "", "trans": ["n. 教室"]}, {"name": "claw", "usphone": "klɔː", "ukphone": "", "trans": ["n. 爪"]}, {"name": "clay", "usphone": "kleɪ", "ukphone": "", "trans": ["n. 黏土，陶土"]}, {"name": "clean", "usphone": "kliːn", "ukphone": "", "trans": ["vt. 弄干净，擦干净 a. 清洁的，干净的"]}, {"name": "cleaner", "usphone": "kliːnə(r)", "ukphone": "", "trans": ["n.清洁工.,清洁器.,清洁剂"]}, {"name": "clear", "usphone": "klɪə(r)", "ukphone": "", "trans": ["a. 清晰；明亮的；清楚的"]}, {"name": "clearly", "usphone": "ˈklɪəlɪ", "ukphone": "", "trans": ["ad. 清楚地，无疑地"]}, {"name": "clerk", "usphone": "klɑːk; (US) klərk", "ukphone": "", "trans": ["n. 书记员；办事员；职员"]}, {"name": "clever", "usphone": "ˈklevə(r)", "ukphone": "", "trans": ["a. 聪明的，伶俐的"]}, {"name": "click", "usphone": "klɪk", "ukphone": "", "trans": ["v. 点击（计算机用语）"]}, {"name": "climate", "usphone": "ˈklaɪmɪt", "ukphone": "", "trans": ["n. 气候"]}, {"name": "climb", "usphone": "klaɪm", "ukphone": "", "trans": ["v. 爬，攀登"]}, {"name": "clinic", "usphone": "ˈklɪnɪk", "ukphone": "", "trans": ["n. 诊所"]}, {"name": "clock", "usphone": "klɔk", "ukphone": "", "trans": ["n. 钟"]}, {"name": "clone", "usphone": "kləʊn", "ukphone": "", "trans": ["n.克隆（无性繁殖出来的有机体群）"]}, {"name": "close", "usphone": "kləʊz", "ukphone": "", "trans": ["a. 亲密的；近，靠近 ad. 近，靠近 vt. 关，关闭"]}, {"name": "cloth", "usphone": "klɔθ; (US) klɔθ", "ukphone": "", "trans": ["n. 布"]}, {"name": "clothes", "usphone": "klɔðz; (US) kləʊz", "ukphone": "", "trans": ["n. 衣服；各种衣物"]}, {"name": "clothing", "usphone": "ˈkləʊðɪŋ", "ukphone": "", "trans": ["n. (总称) 衣服"]}, {"name": "cloud", "usphone": "ˈkləʊðɪŋ", "ukphone": "", "trans": ["n. 云；云状物；阴影"]}, {"name": "cloudy", "usphone": "ˈklaʊdɪ", "ukphone": "", "trans": ["a. 多云的，阴天的"]}, {"name": "club", "usphone": "klʌb", "ukphone": "", "trans": ["n. 俱乐部；纸牌中的梅花"]}, {"name": "clumsy", "usphone": "ˈklʌmzɪ", "ukphone": "", "trans": ["a. 笨拙的，不灵巧的"]}, {"name": "coach", "usphone": "kəʊtʃ", "ukphone": "", "trans": ["n. 教练；马车；长途车"]}, {"name": "coal", "usphone": "kəʊl", "ukphone": "", "trans": ["n. 煤；煤块"]}, {"name": "coast", "usphone": "kəʊst", "ukphone": "", "trans": ["n. 海岸；海滨"]}, {"name": "coat", "usphone": "kəʊt", "ukphone": "", "trans": ["n. 外套；涂层；表皮；皮毛 vt. 给……穿外套；涂上"]}, {"name": "cock", "usphone": "kɔk", "ukphone": "", "trans": ["n. 公鸡"]}, {"name": "cocoa", "usphone": "ˈkəʊkəʊ", "ukphone": "", "trans": ["n. 可可粉"]}, {"name": "coffee", "usphone": "ˈkɔfɪ; (US) ˈkɔːfɪ", "ukphone": "", "trans": ["n. 咖啡"]}, {"name": "coin", "usphone": "kɔɪn", "ukphone": "", "trans": ["n. 硬币"]}, {"name": "coincidence", "usphone": "kəʊɪnˈsɪdəns", "ukphone": "", "trans": ["n. 巧合，巧事"]}, {"name": "coke", "usphone": "kəʊk", "ukphone": "", "trans": ["n. 可口可乐"]}, {"name": "cold", "usphone": "kəʊld", "ukphone": "", "trans": ["a. 冷的，寒的 n. 寒冷；感冒，伤风"]}, {"name": "cold--blooded", "usphone": "kəʊld blʌdɪd", "ukphone": "", "trans": ["a. (动物) 冷血的"]}, {"name": "collar", "usphone": "ˈkɔlə(r)", "ukphone": "", "trans": ["n. 衣领； 硬领"]}, {"name": "colleague", "usphone": "ˈkɔliːɡ", "ukphone": "", "trans": ["n. 同事"]}, {"name": "collect", "usphone": "kəˈlekt", "ukphone": "", "trans": ["vt. 收集，搜集"]}, {"name": "collection", "usphone": "kəˈlekʃ(ə)n", "ukphone": "", "trans": ["n. 收藏品，收集物"]}, {"name": "college", "usphone": "ˈkɔlɪdʒ", "ukphone": "", "trans": ["n. 学院；专科学校"]}, {"name": "collision", "usphone": "kəˈlɪʒ(ə)n", "ukphone": "", "trans": ["n. 碰撞事故"]}, {"name": "colour (美color)", "usphone": "ˈkʌlə", "ukphone": "", "trans": ["n. 颜色 vt.给…着色，涂色"]}, {"name": "comb", "usphone": "kəʊm", "ukphone": "", "trans": ["n. 梳子 v. 梳"]}, {"name": "combine", "usphone": "kəmˈbaɪn", "ukphone": "", "trans": ["vt. 使联合；使结合"]}, {"name": "come (came, come)", "usphone": "kʌm", "ukphone": "", "trans": ["vi. 来，来到"]}, {"name": "comedy", "usphone": "ˈkɔmədɪ", "ukphone": "", "trans": ["n. 喜剧"]}, {"name": "comfort", "usphone": "ˈkʌmfət", "ukphone": "", "trans": ["n. 安慰； 慰问"]}, {"name": "comfortable", "usphone": "ˈkʌmfətəb(ə)l; (US) ˈkʌmfərtəbl", "ukphone": "", "trans": ["a. 舒服的；安逸的；舒服自在的"]}, {"name": "comma", "usphone": "ˈkɔmə", "ukphone": "", "trans": ["n. 逗号"]}, {"name": "command", "usphone": "kəˈmɑːnd; (US) kəˈmænd", "ukphone": "", "trans": ["n. & v. 命令"]}, {"name": "comment", "usphone": "ˈkɔment", "ukphone": "", "trans": ["n. 评论"]}, {"name": "commericia", "usphone": "", "ukphone": "", "trans": ["a.贸易的，商业的"]}, {"name": "commit", "usphone": "kəˈmɪt", "ukphone": "", "trans": ["v.犯（罪，错），自杀"]}, {"name": "commitment", "usphone": "kəˈmɪtmənt", "ukphone": "", "trans": ["n. 承诺,允诺,承担"]}, {"name": "committee", "usphone": "kəˈmɪtɪ", "ukphone": "", "trans": ["n. 委员会"]}, {"name": "common", "usphone": "ˈkɔmən", "ukphone": "", "trans": ["a. 普通，一般；共有的"]}, {"name": "communicate", "usphone": "kəˈmjuːnɪkeɪt", "ukphone": "", "trans": ["v. 交际；传达（感情，信息等）"]}, {"name": "communication", "usphone": "kəmjuːnɪˈkeɪʃ(ə)n", "ukphone": "", "trans": ["n.交际,交往;通讯"]}, {"name": "communism", "usphone": "ˈkɔmjʊnɪz(ə)m", "ukphone": "", "trans": ["n. 共产主义"]}, {"name": "communist", "usphone": "ˈkɔmjuːnɪst", "ukphone": "", "trans": ["n. 共产主义者 a. 共产党的；共产主义的"]}, {"name": "companion", "usphone": "kəmˈpænɪən", "ukphone": "", "trans": ["n. 同伴；同事"]}, {"name": "company", "usphone": "ˈkʌmpənɪ", "ukphone": "", "trans": ["n. 公司"]}, {"name": "compare", "usphone": "kəmˈpeə(r)", "ukphone": "", "trans": ["vt. 比较，对照"]}, {"name": "compass", "usphone": "ˈkʌmpəs", "ukphone": "", "trans": ["n. 罗盘，指南针"]}, {"name": "compensate", "usphone": "ˈkɔmpenseɪt", "ukphone": "", "trans": ["v. 补偿，弥补"]}, {"name": "compete", "usphone": "kəmˈpiːt", "ukphone": "", "trans": ["vi. 比赛，竞赛"]}, {"name": "competence", "usphone": "ˈkɔmpətəns", "ukphone": "", "trans": ["n.能力,胜任,管辖权"]}, {"name": "competition", "usphone": "kɔmpəˈtɪʃ(ə)n", "ukphone": "", "trans": ["n. 比赛，竞赛"]}, {"name": "competitor", "usphone": "kəmˈpetɪtə(r)", "ukphone": "", "trans": ["n. 竞赛者，比赛者"]}, {"name": "complete", "usphone": "kəmˈpliːt", "ukphone": "", "trans": ["a. 完成vt. 完成，结束"]}, {"name": "complex", "usphone": "ˈkɔmpleks", "ukphone": "", "trans": ["a. / n. 复杂的，建筑群"]}, {"name": "component", "usphone": "kəmˈpəʊnənt", "ukphone": "", "trans": ["n. 组成部分，部件"]}, {"name": "composition", "usphone": "kɔmpəˈzɪʃ(ə)n", "ukphone": "", "trans": ["n. 作文；作曲"]}, {"name": "comprehension", "usphone": "kɔmprɪˈhenʃ(ə)n", "ukphone": "", "trans": ["n. 理解"]}, {"name": "compromise", "usphone": "ˈkɔmprəmaɪz", "ukphone": "", "trans": ["v. 妥协,折中,让步"]}, {"name": "compulsory", "usphone": "kəmˈpʌlsərɪ", "ukphone": "", "trans": ["a. 强制的,必须做的"]}, {"name": "computer", "usphone": "kəmˈpjuːtə(r)", "ukphone": "", "trans": ["n. 电子计算机"]}, {"name": "computer game", "usphone": "kəmˈpjuːtə(r) ɡeɪm", "ukphone": "", "trans": ["电子游戏"]}, {"name": "comrade", "usphone": "ˈkɔmrɪd; (US) ˈkɑmræd", "ukphone": "", "trans": ["n. 同志"]}, {"name": "concentrate", "usphone": "ˈkɔnsəntreɪt", "ukphone": "", "trans": ["v. 聚精会神"]}, {"name": "concept", "usphone": "ˈkɔnsept", "ukphone": "", "trans": ["n. 概念"]}, {"name": "concern", "usphone": "kənˈsɜːn", "ukphone": "", "trans": ["v. / n. 涉及，关心"]}, {"name": "concert", "usphone": "ˈkɔnsət", "ukphone": "", "trans": ["n. 音乐会；演奏会"]}, {"name": "conclude", "usphone": "kənˈkluːd", "ukphone": "", "trans": ["v. 完成，结束"]}, {"name": "conclusion", "usphone": "kənˈkluːʒ(ə)n", "ukphone": "", "trans": ["n. 结论；结束"]}, {"name": "concrete", "usphone": "ˈkɔŋkriːt", "ukphone": "", "trans": ["a. 混凝土制的"]}, {"name": "condition", "usphone": "kənˈdɪʃ(ə)n", "ukphone": "", "trans": ["n. 条件，状况"]}, {"name": "condemn", "usphone": "kənˈdem", "ukphone": "", "trans": ["v. 谴责，指责，宣判"]}, {"name": "conduct", "usphone": "ˈkɔndʌkt", "ukphone": "", "trans": ["vt. 引导，带领"]}, {"name": "conductor", "usphone": "kənˈdʌktə(r)", "ukphone": "", "trans": ["n. 管理人；指导者；（车上的）售票员，列车员；乐队指挥"]}, {"name": "confident", "usphone": "ˈkɔnfɪdənt", "ukphone": "", "trans": ["a. 自信的"]}, {"name": "confidential", "usphone": "kɔnfɪˈdenʃ(ə)l", "ukphone": "", "trans": ["a. 机密的，保密的"]}, {"name": "conference", "usphone": "ˈkɔnfərəns", "ukphone": "", "trans": ["n. (正式的)会议；讨论"]}, {"name": "confirm", "usphone": "kənˈfɜːm", "ukphone": "", "trans": ["v. 证实，证明，确认"]}, {"name": "conflict", "usphone": "ˈkɔnflɪkt", "ukphone": "", "trans": ["n. 冲突，争执，争论"]}, {"name": "confuse", "usphone": "kənˈfjuːz", "ukphone": "", "trans": ["v. 使迷惑，混淆"]}, {"name": "congratulate", "usphone": "kənˈɡrætjʊleɪt", "ukphone": "", "trans": ["vt. 祝贺"]}, {"name": "congratulation", "usphone": "kənɡrætjʊˈleɪʃ(ə)n", "ukphone": "", "trans": ["n. 祝贺，庆贺"]}, {"name": "connect", "usphone": "kəˈnekt", "ukphone": "", "trans": ["v. 连接，把…联系起来"]}, {"name": "connection", "usphone": "kəˈnekʃ(ə)n", "ukphone": "", "trans": ["n.连接物;接触,联系"]}, {"name": "conscience", "usphone": "ˈkɔnʃəns", "ukphone": "", "trans": ["n. 良心，良知，内疚"]}, {"name": "consensus", "usphone": "kənˈsensəs", "ukphone": "", "trans": ["n. 一致的意见，共识"]}, {"name": "consequence", "usphone": "ˈkɔnsɪkwəns; (US) ˈkɔnsɪkwens", "ukphone": "", "trans": ["n. 结果，后果"]}, {"name": "conservation", "usphone": "kɔnsəˈveɪʃ(ə)n", "ukphone": "", "trans": ["n 保存；（自然资源的）保护，管理"]}, {"name": "conservative", "usphone": "kənˈsɜːvətɪv", "ukphone": "", "trans": ["a. 保守的，守旧的；保守主义的；谨慎的 n.保守的人，保守主义"]}, {"name": "consider", "usphone": "kənˈsɪdə(r)", "ukphone": "", "trans": ["vt. 考虑"]}, {"name": "considerate", "usphone": "kənˈsɪdərət", "ukphone": "", "trans": ["a. 体贴的"]}, {"name": "consideration", "usphone": "kənsɪdəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n. 考虑；关心"]}, {"name": "consist", "usphone": "kənˈsɪst", "ukphone": "", "trans": ["v. 包含，组成，构成"]}, {"name": "consistent", "usphone": "kənˈsɪst(ə)nt", "ukphone": "", "trans": ["a. 一致的，始终如一的，连续的"]}, {"name": "constant", "usphone": "ˈkɔnstənt", "ukphone": "", "trans": ["a. 经常的，不断的"]}, {"name": "constitution", "usphone": "kɔnstɪˈtjuːʃ(ə)n; (US) kɔnstəˈtuːʃən", "ukphone": "", "trans": ["n. 宪法，章程，身体素质"]}, {"name": "construct", "usphone": "kənˈstrʌkt", "ukphone": "", "trans": ["v. 构筑；建造，建设"]}, {"name": "construction", "usphone": "kənˈstrʌkʃ(ə)n", "ukphone": "", "trans": ["n.建造,建设,建筑物"]}, {"name": "consult", "usphone": "kənˈsʌlt", "ukphone": "", "trans": ["v. 咨询，商量"]}, {"name": "consultant", "usphone": "kənˈsʌltənt", "ukphone": "", "trans": ["n. 顾问"]}, {"name": "consume", "usphone": "kənˈsʌltənt", "ukphone": "", "trans": ["v. 消耗，耗费（燃料，能量，时间等）"]}, {"name": "contain", "usphone": "kənˈteɪn", "ukphone": "", "trans": ["v. 包含；包括；能容纳"]}, {"name": "container", "usphone": "kənˈteɪnə(r)", "ukphone": "", "trans": ["n. 容器"]}, {"name": "contemporary", "usphone": "kənˈtempərərɪ; (US) kənˈtempərerɪ", "ukphone": "", "trans": ["a.属同时期的，同一时代的"]}, {"name": "content", "usphone": "kənˈtent", "ukphone": "", "trans": ["a.甘愿的,满意的 n.内容"]}, {"name": "continent", "usphone": "ˈkɔntɪnənt", "ukphone": "", "trans": ["n. 大陆，大洲；陆地"]}, {"name": "continue", "usphone": "kənˈtɪnjuː", "ukphone": "", "trans": ["vi. 继续"]}, {"name": "contradict", "usphone": "kɔntrəˈdɪkt", "ukphone": "", "trans": ["v. 反驳，驳斥，批驳"]}, {"name": "contradictory", "usphone": "ˌkɔntrəˈdiktəri", "ukphone": "", "trans": ["a.相互矛盾,对立的"]}, {"name": "contrary", "usphone": "ˈkɔntrərɪ; (US) ˈkɔntrerɪ", "ukphone": "", "trans": ["n. / a. 相反 相反的"]}, {"name": "contribute", "usphone": "kənˈtrɪbjuːt", "ukphone": "", "trans": ["v. 贡献"]}, {"name": "contribution", "usphone": "kɔnˈtrɪbjuːt", "ukphone": "", "trans": ["n. 贡献"]}, {"name": "control", "usphone": "kənˈtrol", "ukphone": "", "trans": ["vt.& n. 控制"]}, {"name": "controversial", "usphone": "kɔntrəˈvɜːʃ(ə)l", "ukphone": "", "trans": ["a.引起争论的,有争议的"]}, {"name": "convenience", "usphone": "kənˈviːnɪəns", "ukphone": "", "trans": ["n. 便利"]}, {"name": "convenient", "usphone": "kənˈviːnɪənt", "ukphone": "", "trans": ["a. 便利的，方便的"]}, {"name": "conventional", "usphone": "kənˈvenʃən(ə)l", "ukphone": "", "trans": ["a. 依照惯例的，习惯的"]}, {"name": "conversation", "usphone": "kɔnvəˈseɪʃ(ə)n", "ukphone": "", "trans": ["n. 谈话，交谈"]}, {"name": "convey", "usphone": "kənˈveɪ", "ukphone": "", "trans": ["v. 表达，传递（思想，感情等）"]}, {"name": "convince", "usphone": "kənˈvɪns", "ukphone": "", "trans": ["v. 使确信，使信服"]}, {"name": "cook", "usphone": "kʊk", "ukphone": "", "trans": ["n.炊事员,厨师 v.烹调,做饭"]}, {"name": "cooker", "usphone": "ˈkʊkə(r)", "ukphone": "", "trans": ["n. 炊具(锅、炉灶、烤炉等)"]}, {"name": "cookie", "usphone": "ˈkʊkɪ", "ukphone": "", "trans": ["n. 小甜饼"]}, {"name": "cool", "usphone": "kuːl", "ukphone": "", "trans": ["a. 凉的，凉爽的；酷"]}, {"name": "copy", "usphone": "ˈkɔpɪ", "ukphone": "", "trans": ["n. 抄本，副本；一本（份，册……） v. 抄写；复印；（计算机用语）拷（备 份盘）"]}, {"name": "coral", "usphone": "ˈkɔr(ə)l; (US) ˈkɔːrəl", "ukphone": "", "trans": ["n. 珊瑚；珊瑚虫"]}, {"name": "cordless", "usphone": "ˈkɔːdlɪs", "ukphone": "", "trans": ["a. 无线的"]}, {"name": "corn", "usphone": "kɔːn", "ukphone": "", "trans": ["n. 玉米，谷物"]}, {"name": "corner", "usphone": "ˈkɔːnə(r)", "ukphone": "", "trans": ["n. 角；角落；拐角"]}, {"name": "corporation", "usphone": "kɔːpəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n. （大）公司"]}, {"name": "correct", "usphone": "kəˈrekt", "ukphone": "", "trans": ["v. 改正；纠正 a. 正确的，对的；恰当的"]}, {"name": "correction", "usphone": "kəˈrekʃ(ə)n", "ukphone": "", "trans": ["n. 改正"]}, {"name": "correspond", "usphone": "kɔrɪˈspɔnd; (US) kɔːrəˈspɔnd", "ukphone": "", "trans": ["vi. 一致；与……相当；(与人)通信，有书信往来"]}, {"name": "corrupt", "usphone": "kəˈrʌpt", "ukphone": "", "trans": ["a. / v. 贪污的，腐败的，使腐化，堕落"]}, {"name": "cost (cost, cost)", "usphone": "kɔst; (US) kɔːst", "ukphone": "", "trans": ["v.值（钱），花费 n. 价格"]}, {"name": "cosy", "usphone": "ˈkəuzi", "ukphone": "", "trans": ["a.暖和舒适的,亲密无间的"]}, {"name": "cottage", "usphone": "ˈkɔtɪdʒ", "ukphone": "", "trans": ["n. (郊外)小屋,村舍,别墅"]}, {"name": "cotton", "usphone": "ˈkɔt(ə)n", "ukphone": "", "trans": ["n. 棉花 a. 棉花的"]}, {"name": "cough", "usphone": "kɔf; (US) kɔːf", "ukphone": "", "trans": ["n.& vi. 咳嗽"]}, {"name": "could modal", "usphone": "kʊdˈməʊd(ə)l", "ukphone": "", "trans": ["v.（can的过去式）可以…；（表示许可或请求）可以…，行"]}, {"name": "count", "usphone": "kaʊnt", "ukphone": "", "trans": ["vt. 数，点数"]}, {"name": "counter", "usphone": "ˈkaʊntə(r)", "ukphone": "", "trans": ["n. 柜台，结账处"]}, {"name": "country", "usphone": "ˈkʌntrɪ", "ukphone": "", "trans": ["n. 国家；农村，乡下"]}, {"name": "countryside", "usphone": "ˈkʌntrɪsaɪd", "ukphone": "", "trans": ["n. 乡下，农村"]}, {"name": "couple", "usphone": "ˈkʌp(ə)l", "ukphone": "", "trans": ["n. 夫妇，一对"]}, {"name": "courage", "usphone": "ˈkʌrɪdʒ", "ukphone": "", "trans": ["n. 勇气； 胆略"]}, {"name": "course", "usphone": "kɔːs", "ukphone": "", "trans": ["n. 过程；经过；课程"]}, {"name": "court", "usphone": "kɔːt", "ukphone": "", "trans": ["n. 法庭；法院"]}, {"name": "courtyard", "usphone": "ˈkɔːtjɑːd", "ukphone": "", "trans": ["n. 庭院，院子"]}, {"name": "cousin", "usphone": "ˈkʌz(ə)n", "ukphone": "", "trans": ["n. 堂（表）兄弟，堂（表）姐妹"]}, {"name": "cover", "usphone": "ˈkʌvə(r)", "ukphone": "", "trans": ["n. 盖子；罩 v. 覆盖，遮盖；掩盖"]}, {"name": "cow", "usphone": "kaʊ", "ukphone": "", "trans": ["n. 母牛，奶牛"]}, {"name": "cowboy", "usphone": "ˈkaʊbɔɪ", "ukphone": "", "trans": ["n.（美国）牛仔;牧场骑士"]}, {"name": "co-worker", "usphone": "ˈkəʊ ˈwɜːkə(r)", "ukphone": "", "trans": ["n. 合作者；同事"]}, {"name": "crash", "usphone": "kræʃ", "ukphone": "", "trans": ["v. / n. 碰撞，撞击"]}, {"name": "crayon", "usphone": "ˈkreɪən", "ukphone": "", "trans": ["n 蜡笔；蜡笔画"]}, {"name": "crazy", "usphone": "ˈkreɪzɪ", "ukphone": "", "trans": ["a. 疯狂的"]}, {"name": "cream", "usphone": "kriːm", "ukphone": "", "trans": ["n. 奶油，乳脂"]}, {"name": "create", "usphone": "kriːˈeɪt", "ukphone": "", "trans": ["vt. 创造； 造成"]}, {"name": "creature", "usphone": "ˈkriːtʃə(r)", "ukphone": "", "trans": ["n. 生物，动物"]}, {"name": "credit", "usphone": "ˈkredɪt", "ukphone": "", "trans": ["n. 信用；信赖；信誉"]}, {"name": "crime", "usphone": "kraɪm", "ukphone": "", "trans": ["n. （法律上的）罪，犯罪"]}, {"name": "criminal", "usphone": "ˈkrɪmɪn(ə)l", "ukphone": "", "trans": ["n. 罪犯"]}, {"name": "crew", "usphone": "kruː", "ukphone": "", "trans": ["n. 全体船员"]}, {"name": "criterion (pl. criteria)", "usphone": "kraɪˈtɪərɪən", "ukphone": "", "trans": ["n. 标准，准则，原则"]}, {"name": "crop", "usphone": "krɔp", "ukphone": "", "trans": ["n. 庄稼；收成"]}, {"name": "cross", "usphone": "krɔs", "ukphone": "", "trans": ["a. 脾气不好的，易怒的 n. 十字形的东西 vt. 越过；穿过"]}, {"name": "crossing", "usphone": "ˈkrɔsɪŋ", "ukphone": "", "trans": ["n. 十字路口，人行横道"]}, {"name": "crossroads", "usphone": "ˈkrɔsrəʊd", "ukphone": "", "trans": ["n. 交叉路口"]}, {"name": "crowd", "usphone": "kraʊd", "ukphone": "", "trans": ["n. 人群 vt. 拥挤，群聚"]}, {"name": "crowded", "usphone": "ˈkraʊdɪd", "ukphone": "", "trans": ["a. 拥挤的"]}, {"name": "cruel", "usphone": "ˈkruːəl", "ukphone": "", "trans": ["a. 残忍的，残酷的；无情的"]}, {"name": "cry", "usphone": "kraɪ", "ukphone": "", "trans": ["n. 叫喊；哭声 v. 喊叫；哭"]}, {"name": "cube", "usphone": "kjuːb", "ukphone": "", "trans": ["n. 立方体"]}, {"name": "cubic", "usphone": "ˈkjuːbɪk", "ukphone": "", "trans": ["a.立方体的，立方形的"]}, {"name": "cuisine", "usphone": "kwɪˈziːn", "ukphone": "", "trans": ["n. 饭菜，佳肴"]}, {"name": "culture", "usphone": "ˈkʌltʃə(r)", "ukphone": "", "trans": ["n. 文化"]}, {"name": "cup", "usphone": "kʌp", "ukphone": "", "trans": ["n. 茶杯"]}, {"name": "cupboard", "usphone": "ˈkʌbəd", "ukphone": "", "trans": ["n. 碗柜；橱柜"]}, {"name": "cure", "usphone": "kjʊə(r)", "ukphone": "", "trans": ["n. & vt. 治疗；医好"]}, {"name": "curious", "usphone": "ˈkjʊərɪəs", "ukphone": "", "trans": ["a. 好奇的；奇异的"]}, {"name": "currency", "usphone": "ˈkʌrənsɪ", "ukphone": "", "trans": ["n. 货币；现金"]}, {"name": "curriculum", "usphone": "kəˈrɪkjʊləm", "ukphone": "", "trans": ["n.（学校的）全部课程"]}, {"name": "curtain", "usphone": "ˈkɜːt(ə)n", "ukphone": "", "trans": ["n. 窗帘"]}, {"name": "cushion", "usphone": "ˈkʊʃ(ə)n", "ukphone": "", "trans": ["n. 垫子"]}, {"name": "custom", "usphone": "ˈkʌstəm", "ukphone": "", "trans": ["n. 习惯，习俗，风俗习惯"]}, {"name": "customer", "usphone": "ˈkʌstəmə(r)", "ukphone": "", "trans": ["n. （商店）顾客，主顾"]}, {"name": "customs", "usphone": "ˈkʌstəm", "ukphone": "", "trans": ["n. 海关，关税"]}, {"name": "cut (cut, cut)", "usphone": "kʌt", "ukphone": "", "trans": ["v. / n. 切，剪，削，割, 伤口"]}, {"name": "cycle", "usphone": "ˈsaɪk(ə)l", "ukphone": "", "trans": ["vi. 骑自行车"]}, {"name": "cyclist", "usphone": "ˈsaɪklɪst", "ukphone": "", "trans": ["n. 骑自行车的人"]}, {"name": "dad = daddy", "usphone": "dæd", "ukphone": "", "trans": ["n.（口）爸爸，爹爹"]}, {"name": "daily", "usphone": "ˈdeɪlɪ", "ukphone": "", "trans": ["a. 每日的；日常的 ad. 每天 n. 日报"]}, {"name": "dam", "usphone": "dæm", "ukphone": "", "trans": ["n. 水坝，堰堤"]}, {"name": "damage", "usphone": "ˈdæmɪdʒ", "ukphone": "", "trans": ["n.& vt. 毁坏，损害"]}, {"name": "damp", "usphone": "dæmp", "ukphone": "", "trans": ["a. & n. 潮湿（的）"]}, {"name": "dance", "usphone": "dɑːns; (US) dæns", "ukphone": "", "trans": ["n.& vi. 跳舞"]}, {"name": "danger", "usphone": "ˈdeɪndʒə(r)", "ukphone": "", "trans": ["n. 危险"]}, {"name": "dangerous", "usphone": "ˈdeɪndʒərəs", "ukphone": "", "trans": ["a. 危险的"]}, {"name": "dare", "usphone": "deə(r)", "ukphone": "", "trans": ["v.& aux..（后接不带to的不定式；主要用于疑问，否定或条件句）敢，敢于"]}, {"name": "dark", "usphone": "dɑːk", "ukphone": "", "trans": ["n. 黑暗；暗处；日暮 a. 黑暗的；暗淡的；深色的"]}, {"name": "darkness", "usphone": "ˈdɑːknɪs", "ukphone": "", "trans": ["n. 黑暗，阴暗"]}, {"name": "dash", "usphone": "dæʃ", "ukphone": "", "trans": ["v. & n. 快跑，冲刺，短跑"]}, {"name": "data", "usphone": "ˈdeɪtə, ˈdɑːtə; (US) ˈdætə", "ukphone": "", "trans": ["n. 资料，数据"]}, {"name": "database", "usphone": "ˈdeɪtbeɪs", "ukphone": "", "trans": ["n. 资料库，数据库"]}, {"name": "date", "usphone": "deɪt", "ukphone": "", "trans": ["n. 日期；约会 n.枣"]}, {"name": "daughter", "usphone": "ˈdɔːtə(r)", "ukphone": "", "trans": ["n. 女儿"]}, {"name": "dawn", "usphone": "dɔːn", "ukphone": "", "trans": ["n. 黎明，拂晓"]}, {"name": "day", "usphone": "deɪ", "ukphone": "", "trans": ["n.（一）天，（一）日；白天"]}, {"name": "daylight", "usphone": "ˈdeɪlaɪt", "ukphone": "", "trans": ["n. 日光，白昼； 黎明"]}, {"name": "dead", "usphone": "ded", "ukphone": "", "trans": ["a. 死的；无生命的"]}, {"name": "deadline", "usphone": "ˈdedlaɪn", "ukphone": "", "trans": ["n.最后期限，截止日期"]}, {"name": "deaf", "usphone": "def", "ukphone": "", "trans": ["a. 聋的"]}, {"name": "deal", "usphone": "diːl", "ukphone": "", "trans": ["n. 量，数额；交易"]}, {"name": "dear", "usphone": "dɪə(r)", "ukphone": "", "trans": ["int.（表示惊愕）哎呀！唷！ a. 亲爱的；贵的"]}, {"name": "death", "usphone": "deθ", "ukphone": "", "trans": ["n. 死"]}, {"name": "debate", "usphone": "dɪˈbeɪt", "ukphone": "", "trans": ["n. & v.讨论，辩论"]}, {"name": "debt", "usphone": "det", "ukphone": "", "trans": ["n. 债务；欠款"]}, {"name": "decade", "usphone": "ˈdekeɪd", "ukphone": "", "trans": ["n. 十年期"]}, {"name": "December", "usphone": "dɪˈsembə(r)", "ukphone": "", "trans": ["n. 12月"]}, {"name": "decide", "usphone": "dɪˈsaɪd", "ukphone": "", "trans": ["v. 决定；下决心"]}, {"name": "decision", "usphone": "dɪˈsɪʒ(ə)n", "ukphone": "", "trans": ["n. 决定；决心"]}, {"name": "declare", "usphone": "dɪˈkleə(r)", "ukphone": "", "trans": ["vt. 声明；断言"]}, {"name": "decline", "usphone": "dɪˈklaɪn", "ukphone": "", "trans": ["v. 减少,下降,衰退,谢绝"]}, {"name": "decorate", "usphone": "ˈdekəreɪt", "ukphone": "", "trans": ["vt.装饰…，修饰…"]}, {"name": "decoration", "usphone": "dekəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n.装饰，修饰"]}, {"name": "decrease", "usphone": "dɪˈkriːs", "ukphone": "", "trans": ["v.减少，减小，降低"]}, {"name": "deed", "usphone": "diːd", "ukphone": "", "trans": ["n. 行为；事迹"]}, {"name": "deep", "usphone": "diːp", "ukphone": "", "trans": ["a. 深 ad. 深；深厚"]}, {"name": "deeply", "usphone": "ˈdiːplɪ", "ukphone": "", "trans": ["ad. 深深地"]}, {"name": "deer", "usphone": "dɪə(r)", "ukphone": "", "trans": ["n. 鹿"]}, {"name": "defeat", "usphone": "dɪˈfiːt", "ukphone": "", "trans": ["vt. 击败；战胜"]}, {"name": "defence (美defense)", "usphone": "diˈfens", "ukphone": "", "trans": ["n. & v. 防御；防务"]}, {"name": "defend", "usphone": "dɪˈfend", "ukphone": "", "trans": ["vt. 防守；保卫"]}, {"name": "degree", "usphone": "dɪˈɡriː", "ukphone": "", "trans": ["n. 程度；度数；学位"]}, {"name": "delay", "usphone": "dɪˈleɪ", "ukphone": "", "trans": ["v.& n. 拖延，延误，延迟，延期；耽搁"]}, {"name": "delete", "usphone": "dɪˈliːt", "ukphone": "", "trans": ["v. 删去"]}, {"name": "deliberately", "usphone": "dɪˈlɪbərətlɪ", "ukphone": "", "trans": ["ad.故意,蓄意,存心"]}, {"name": "delicate", "usphone": "ˈdelɪkət", "ukphone": "", "trans": ["a.易损的，易碎的"]}, {"name": "delicious", "usphone": "dɪˈlɪʃəs", "ukphone": "", "trans": ["a. 美味的，可口的"]}, {"name": "delight", "usphone": "dɪˈlaɪt", "ukphone": "", "trans": ["n. 快乐；乐事"]}, {"name": "delighted", "usphone": "diˈlaitid", "ukphone": "", "trans": ["a. 高兴的，快乐的"]}, {"name": "deliver", "usphone": "dɪˈlɪvə(r)", "ukphone": "", "trans": ["vt. 投递（信件，邮包等）"]}, {"name": "demand", "usphone": "dɪˈmɑːnd; (US) dɪˈmænd", "ukphone": "", "trans": ["vt. 要求"]}, {"name": "dentist", "usphone": "ˈdentɪst", "ukphone": "", "trans": ["n. 牙科医生 "]}, {"name": "department(缩Dept.)", "usphone": "dɪˈpɑːtmənt", "ukphone": "", "trans": ["n. 部门；（机关的）司，处；（大学的）系"]}, {"name": "department -store", "usphone": "dɪˈpɑːtmənt-stɔː(r)", "ukphone": "", "trans": ["n. 百货商场"]}, {"name": "departure", "usphone": "dɪˈpɑːtʃə(r)", "ukphone": "", "trans": ["n. 离开，启程"]}, {"name": "depend", "usphone": "dɪˈpend", "ukphone": "", "trans": ["vi. 依靠，依赖，指望；取决于"]}, {"name": "deposit", "usphone": "dɪˈpɔzɪt", "ukphone": "", "trans": ["v. / n. 订金，押金，放下，放置，储存"]}, {"name": "depth", "usphone": "depθ", "ukphone": "", "trans": ["n. 深，深度"]}, {"name": "describe", "usphone": "dɪˈskraɪb", "ukphone": "", "trans": ["vt. 描写，叙述"]}, {"name": "description", "usphone": "dɪˈskrɪpʃ(ə)n", "ukphone": "", "trans": ["n. 描述，描写"]}, {"name": "desert", "usphone": "dɪˈzɜːt", "ukphone": "", "trans": ["n. 沙漠 vt. 舍弃； 遗弃"]}, {"name": "deserve", "usphone": "dɪˈzɜːv", "ukphone": "", "trans": ["v.（不用于进行时态）应得，应受"]}, {"name": "design", "usphone": "dɪˈzaɪn", "ukphone": "", "trans": ["n.& vt. n. 设计，策划 图案，图样，样式"]}, {"name": "desire", "usphone": "dɪˈzaɪə(r)", "ukphone": "", "trans": ["vt. & n. 要求；期望"]}, {"name": "desk", "usphone": "desk", "ukphone": "", "trans": ["n. 书桌，写字台"]}, {"name": "desperate", "usphone": "ˈdespərət", "ukphone": "", "trans": ["a.（因绝望而）不惜冒险的，不顾一切的，拼命的"]}, {"name": "dessert", "usphone": "dɪˈzɜːt", "ukphone": "", "trans": ["n. 甜点"]}, {"name": "destination", "usphone": "destɪˈneɪʃ(ə)n", "ukphone": "", "trans": ["n.目的地，终点"]}, {"name": "destroy", "usphone": "dɪˈstrɔɪ", "ukphone": "", "trans": ["vt. 破坏，毁坏"]}, {"name": "detective", "usphone": "dɪˈtektɪv", "ukphone": "", "trans": ["n. 侦探"]}, {"name": "determination", "usphone": "dɪtɜːmɪˈneɪʃ(ə)n", "ukphone": "", "trans": ["n. 决心"]}, {"name": "determine", "usphone": "dɪˈtɜːmɪn", "ukphone": "", "trans": ["vt. 决定；决心"]}, {"name": "develop", "usphone": "dɪˈveləp", "ukphone": "", "trans": ["v. （使）发展；（使）发达；（使）发育；开发 vt. 冲洗（照片）"]}, {"name": "development", "usphone": "dɪˈveləpmənt", "ukphone": "", "trans": ["n. 发展，发达，发育，开发"]}, {"name": "devote", "usphone": "dɪˈvəʊt", "ukphone": "", "trans": ["vt. 把…奉献, 把…专用（于）"]}, {"name": "devotion", "usphone": "dɪˈvəʊʃ(ə)n", "ukphone": "", "trans": ["n. 奉献，奉献精神"]}, {"name": "diagram", "usphone": "ˈdaɪəɡræm", "ukphone": "", "trans": ["n. 图表，图样"]}, {"name": "dial", "usphone": "ˈdaɪ(ə)l", "ukphone": "", "trans": ["vt. 拨（电话号码）"]}, {"name": "dialogue (美 dialog)", "usphone": "ˈdaɪəlɔɡ; (US) ˈdaɪəlɔːɡ", "ukphone": "", "trans": ["n. 对话"]}, {"name": "diamond", "usphone": "ˈdaɪəmənd", "ukphone": "", "trans": ["n. 钻石，金刚石；纸牌中的方块"]}, {"name": "diary", "usphone": "ˈdaɪərɪ", "ukphone": "", "trans": ["n. 日记；日记簿"]}, {"name": "dictation", "usphone": "dɪkˈteɪʃ(ə)n", "ukphone": "", "trans": ["n. 听写"]}, {"name": "dictionary", "usphone": "ˈdɪkʃənərɪ; (US) ˈdɪkʃənerɪ", "ukphone": "", "trans": ["n. 词典，字典"]}, {"name": "die", "usphone": "daɪ", "ukphone": "", "trans": ["v. 死"]}, {"name": "diet", "usphone": "daɪ", "ukphone": "", "trans": ["n. 饮食"]}, {"name": "differ", "usphone": "ˈdɪfə(r)", "ukphone": "", "trans": ["v. 相异，有区别"]}, {"name": "difference", "usphone": "ˈdɪfrəns", "ukphone": "", "trans": ["n. 不同"]}, {"name": "different", "usphone": "ˈdɪfrənt", "ukphone": "", "trans": ["a. 不同的，有差异的"]}, {"name": "difficult", "usphone": "ˈdɪfɪkəlt", "ukphone": "", "trans": ["a.难；艰难；不易相处"]}, {"name": "difficulty", "usphone": "ˈdɪfɪkəltɪ", "ukphone": "", "trans": ["n. 困难，费力"]}, {"name": "dig (dug, dug)", "usphone": "dɪɡ", "ukphone": "", "trans": ["v. 挖（洞沟）,掘"]}, {"name": "digest", "usphone": "dɪˈdʒest, daɪˈdʒest", "ukphone": "", "trans": ["v.消化, 领会"]}, {"name": "digital", "usphone": "ˈdɪdʒɪt(ə)l", "ukphone": "", "trans": ["a. .数字的，数码的"]}, {"name": "dignity", "usphone": "ˈdɪɡnɪtɪ", "ukphone": "", "trans": ["n. 庄重，庄严，尊严。尊贵，高尚"]}, {"name": "dilemma", "usphone": "daɪˈlemə", "ukphone": "", "trans": ["n. （进退两难的）窘境，困境"]}, {"name": "dimension", "usphone": "dɪˈmenʃ(ə)n", "ukphone": "", "trans": ["n.量度，尺寸，面积，程度，范围"]}, {"name": "dine", "usphone": "daɪn", "ukphone": "", "trans": ["v. 吃饭；（指正式）进餐"]}, {"name": "dining-room", "usphone": "ˈdainiŋ-rʊm", "ukphone": "", "trans": ["食堂，饭厅"]}, {"name": "dinner", "usphone": "ˈdɪnə(r)", "ukphone": "", "trans": ["n. 正餐，宴会"]}, {"name": "dinosaur", "usphone": "ˈdaɪnəsɔː(r)", "ukphone": "", "trans": ["n. 恐龙"]}, {"name": "dioxide", "usphone": "daɪˈɔksaɪd", "ukphone": "", "trans": ["n.二氧化物"]}, {"name": "dip", "usphone": "dɪp", "ukphone": "", "trans": ["vt. 浸，蘸；把…放入又取出"]}, {"name": "diploma", "usphone": "dɪˈpləʊmə", "ukphone": "", "trans": ["n.毕业文凭；学位证书"]}, {"name": "direct", "usphone": "dɪˈrekt, daɪˈrekt", "ukphone": "", "trans": ["a. / vt. 直接的；直达的；直截了当的 指挥；指导；监督；管理；指挥（演奏）；导演（电影）"]}, {"name": "direction", "usphone": "dɪˈrekʃ(ə)n, daɪˈrekʃ(ə)n", "ukphone": "", "trans": ["n. 方向；方位"]}, {"name": "director", "usphone": "dɪˈrektə(r)", "ukphone": "", "trans": ["n. 所长，处长，主任；董事；导演"]}, {"name": "directory", "usphone": "dɪˈrektərɪ", "ukphone": "", "trans": ["n. 姓名地址录"]}, {"name": "dirt", "usphone": "dɜːt", "ukphone": "", "trans": ["n. 污物；脏物"]}, {"name": "dirty", "usphone": "ˈdɜːtɪ", "ukphone": "", "trans": ["a. 脏的"]}, {"name": "disability", "usphone": "dɪsəˈbɪlɪtɪ", "ukphone": "", "trans": ["n.. 残疾；无能"]}, {"name": "disabled", "usphone": "dɪsˈeɪb(ə)ld", "ukphone": "", "trans": ["a. 残废的，残疾的"]}, {"name": "disadvantage", "usphone": "dɪsədˈvɑːntɪdʒ", "ukphone": "", "trans": ["n. 不利条件；弱点"]}, {"name": "disagree", "usphone": "dɪsəˈɡriː", "ukphone": "", "trans": ["vi. 意见不一致，持不同意见"]}, {"name": "disagreement", "usphone": "dɪsəˈɡriːmənt", "ukphone": "", "trans": ["n. 意见不一致；相违；争论"]}, {"name": "disappear", "usphone": "dɪsəˈpɪə(r)", "ukphone": "", "trans": ["vi. 消失"]}, {"name": "disappoint", "usphone": "dɪsəˈpɔɪnt", "ukphone": "", "trans": ["vt. 使失望"]}, {"name": "disappointment", "usphone": "dɪsəˈpɔɪntmənt", "ukphone": "", "trans": ["n. 失望；沮丧"]}, {"name": "disaster", "usphone": "dɪˈzɑːstə(r); (US) dɪzˈæstər", "ukphone": "", "trans": ["n. 灾难；祸患"]}, {"name": "discount", "usphone": "ˈdɪskaʊnt", "ukphone": "", "trans": ["n. 折扣"]}, {"name": "discourage", "usphone": "dɪˈskʌrɪdʒ", "ukphone": "", "trans": ["vt. （使）气馁；打消（做…的念头）"]}, {"name": "discover", "usphone": "dɪˈskʌvə(r)", "ukphone": "", "trans": ["vt. 发现"]}, {"name": "discovery", "usphone": "dɪˈskʌvərɪ", "ukphone": "", "trans": ["n. 发现"]}, {"name": "discrimination", "usphone": "dɪskrɪmɪˈneɪʃ(ə)n", "ukphone": "", "trans": ["n. 歧视"]}, {"name": "discuss", "usphone": "dɪsˈkʌs", "ukphone": "", "trans": ["vt. 讨论，议论"]}, {"name": "discussion", "usphone": "dɪsˈkʌʃ(ə)n", "ukphone": "", "trans": ["n. 讨论，辩论"]}, {"name": "disease", "usphone": "dɪˈziːz", "ukphone": "", "trans": ["n. 病，疾病"]}, {"name": "disgusting", "usphone": "dɪsˈɡʌstɪŋ", "ukphone": "", "trans": ["a.极糟的，令人不快的，令人厌恶的"]}, {"name": "dish", "usphone": "dɪʃ", "ukphone": "", "trans": ["n. 盘，碟；盘装菜；盘形物"]}, {"name": "disk =disc", "usphone": "dɪsk", "ukphone": "", "trans": ["n. 磁盘"]}, {"name": "dislike", "usphone": "dɪsˈlaɪk", "ukphone": "", "trans": ["vt. 不喜爱；厌恶"]}, {"name": "dismiss", "usphone": "dɪsˈmɪs", "ukphone": "", "trans": ["vt. 让……离开；遣散；解散；解雇"]}, {"name": "disobey", "usphone": "dɪsəˈbeɪ", "ukphone": "", "trans": ["vt. 不服从"]}, {"name": "distance", "usphone": "ˈdɪstəns", "ukphone": "", "trans": ["n. 距离"]}, {"name": "distant", "usphone": "ˈdɪst(ə)nt", "ukphone": "", "trans": ["a. 远的，遥远的"]}, {"name": "distinction", "usphone": "dɪˈstɪŋkʃ(ə)n", "ukphone": "", "trans": ["n.差别,区别,优秀,卓越"]}, {"name": "distinguish", "usphone": "dɪˈstɪŋɡwɪʃ", "ukphone": "", "trans": ["v. 区分，辨别，分清"]}, {"name": "distribute", "usphone": "dɪˈstrɪbjuːt", "ukphone": "", "trans": ["v. 分发，分配"]}, {"name": "district", "usphone": "ˈdɪstrɪkt", "ukphone": "", "trans": ["n. 区；地区；区域"]}, {"name": "disturb", "usphone": "dɪˈstɜːb", "ukphone": "", "trans": ["vt. 扰乱；打扰"]}, {"name": "disturbing", "usphone": "dɪˈstɜːbɪŋ", "ukphone": "", "trans": ["a. 令人不安的，引起恐慌的"]}, {"name": "dive", "usphone": "daɪv", "ukphone": "", "trans": ["vi. 跳水"]}, {"name": "diverse", "usphone": "daɪˈvɜːs", "ukphone": "", "trans": ["v. 不同的，多种多样，形形色色的"]}, {"name": "divide", "usphone": "dɪˈvaɪd", "ukphone": "", "trans": ["vt. 分，划分"]}, {"name": "division", "usphone": "dɪˈvɪʒ(ə)n", "ukphone": "", "trans": ["n. （算术用语）除"]}, {"name": "divorce", "usphone": "dɪˈvɔːs", "ukphone": "", "trans": ["v. 离婚"]}, {"name": "dizzy", "usphone": "ˈdɪzɪ", "ukphone": "", "trans": ["a. 头眩目晕的"]}, {"name": "do (did, done) donˈt=do not", "usphone": "dʊ, duː", "ukphone": "", "trans": ["v. & aux. 做，干（用以构成疑问句及否定句。第三人称单数现在时用does） 不做，不干"]}, {"name": "doctor", "usphone": "ˈdɔktə(r)", "ukphone": "", "trans": ["n. 医生，大夫；博士"]}, {"name": "document", "usphone": "ˈdɔkjʊmənt", "ukphone": "", "trans": ["n. 文件；文献"]}, {"name": "does doesnˈt = does not", "usphone": "", "ukphone": "", "trans": ["v. 动词do的第三人称单数现在式"]}, {"name": "dog", "usphone": "dɔɡ; (US) dɔːɡ", "ukphone": "", "trans": ["n. 狗"]}, {"name": "doll", "usphone": "dɔl; (US) dɔːl", "ukphone": "", "trans": ["n. 玩偶，玩具娃娃"]}, {"name": "dollar", "usphone": "dɔl; (US) dɔːl", "ukphone": "", "trans": ["n. 元（美国、加拿大、澳大利亚等国货币单位）"]}, {"name": "door", "usphone": "dɔː(r)", "ukphone": "", "trans": ["n. 门"]}, {"name": "dormitory", "usphone": "ˈdɔːmɪtərɪ; (US) ˈdɔːrmɪtɔːrɪ", "ukphone": "", "trans": ["n. 学生宿舍（缩写式dorm）"]}, {"name": "dot", "usphone": "dɔt", "ukphone": "", "trans": ["n. 点，小点，圆点"]}, {"name": "double", "usphone": "ˈdʌb(ə)l", "ukphone": "", "trans": ["a. 两倍.双的 n. 两个.双"]}, {"name": "doubt", "usphone": "daʊt", "ukphone": "", "trans": ["n.& v. 怀疑，疑惑"]}, {"name": "down", "usphone": "daʊn", "ukphone": "", "trans": ["prep. 沿着，沿…而下 ad. 向下"]}, {"name": "download", "usphone": "ˈdaunləud", "ukphone": "", "trans": ["n.& v. 下载"]}, {"name": "downstairs", "usphone": "ˈdaʊnsteəz", "ukphone": "", "trans": ["ad. 在楼下；到楼下"]}, {"name": "downtown", "usphone": "ˈdaʊntaʊn", "ukphone": "", "trans": ["ad. 往或在城市的商业区（或中心区、闹市区） n. 城市的商业区，中心区，闹市区 a.城市的商业区的，中心区的，闹市区的"]}, {"name": "downward", "usphone": "ˈdaʊnwəd", "ukphone": "", "trans": ["ad. 向下"]}, {"name": "dozen", "usphone": "ˈdaʊnwəd", "ukphone": "", "trans": ["n. 十二个；几十，许多"]}, {"name": "Dr(缩) = Doctor", "usphone": "", "ukphone": "", "trans": ["n. 医生，大夫；博士"]}, {"name": "draft", "usphone": "drɑːft; (US) dræft", "ukphone": "", "trans": ["n. / v. 草稿，草案，起草，草拟"]}, {"name": "drag", "usphone": "dræɡ", "ukphone": "", "trans": ["v. 拖；拽"]}, {"name": "draw (drew, drawn)", "usphone": "drɔː", "ukphone": "", "trans": ["v. 绘画；绘制；拉，拖；提取（金钱）"]}, {"name": "drawback", "usphone": "ˈdrɔːbæk", "ukphone": "", "trans": ["n.缺点，不利条件"]}, {"name": "drawer", "usphone": "ˈdrɔːə(r)", "ukphone": "", "trans": ["n. 抽屉"]}, {"name": "drawing", "usphone": "ˈdrɔːɪŋ", "ukphone": "", "trans": ["n. 图画，素描,绘画"]}, {"name": "dream (dreamt, dreamt 或--ed, --ed)", "usphone": "driːm", "ukphone": "", "trans": ["n.& vt. 梦，梦想"]}, {"name": "dress", "usphone": "dres", "ukphone": "", "trans": ["n. 女服，连衣裙；(统指)服装；童装 v. 穿衣；穿着"]}, {"name": "drier =dryer", "usphone": "ˈdraɪə(r)", "ukphone": "", "trans": ["n. 烘干机；吹风机"]}, {"name": "drill", "usphone": "drɪl", "ukphone": "", "trans": ["n. 钻头；（反复的）训练 vt. 钻(孔)， 在…上钻孔；重复训练"]}, {"name": "drink", "usphone": "drɪŋk", "ukphone": "", "trans": ["n. 饮料；喝酒 "]}, {"name": "drink(drank,drunk)", "usphone": "drɪŋk", "ukphone": "", "trans": ["v. 喝，饮"]}, {"name": "drive(drove,driven)", "usphone": "draɪv", "ukphone": "", "trans": ["v. 驾驶，开（车）；驱赶"]}, {"name": "driver", "usphone": "ˈdraɪvə(r)", "ukphone": "", "trans": ["n. 司机，驾驶员"]}, {"name": "drop", "usphone": "drɔp", "ukphone": "", "trans": ["n.滴 v.掉下.落下.投递.放弃"]}, {"name": "drown", "usphone": "draʊn", "ukphone": "", "trans": ["vi. 溺死；淹没"]}, {"name": "drug", "usphone": "drʌɡ", "ukphone": "", "trans": ["n. 药，药物；毒品"]}, {"name": "drum", "usphone": "drʌm", "ukphone": "", "trans": ["n. 鼓"]}, {"name": "drunk", "usphone": "drʌŋk", "ukphone": "", "trans": ["a. 醉的"]}, {"name": "dry", "usphone": "draɪ", "ukphone": "", "trans": ["v. 使…干；弄干；擦干 a. 干的；干燥的"]}, {"name": "duck", "usphone": "dʌk", "ukphone": "", "trans": ["n. 鸭子"]}, {"name": "due", "usphone": "djuː; (US) duː", "ukphone": "", "trans": ["a. 预期的；约定的"]}, {"name": "dull", "usphone": "dʌl", "ukphone": "", "trans": ["a. 阴暗的；单调无味"]}, {"name": "dumpling", "usphone": "ˈdʌmplɪŋ", "ukphone": "", "trans": ["n. 饺子"]}, {"name": "during", "usphone": "ˈdjʊərɪŋ; (US) ˈdʊərɪŋ", "ukphone": "", "trans": ["prep. 在…期间；在…过程中"]}, {"name": "dusk", "usphone": "dʌsk", "ukphone": "", "trans": ["n. 黄昏"]}, {"name": "dust", "usphone": "dʌst", "ukphone": "", "trans": ["n. 灰尘，尘土"]}, {"name": "dustbin", "usphone": "ˈdʌstbɪn", "ukphone": "", "trans": ["n. 垃圾箱"]}, {"name": "dusty", "usphone": "ˈdʌstɪ", "ukphone": "", "trans": ["a. 尘土般的，尘土多的"]}, {"name": "duty", "usphone": "ˈdjuːtɪ; (US) ˈduːtɪ", "ukphone": "", "trans": ["n. 责任，义务"]}, {"name": "DVD", "usphone": "ˈdi:ˈvi:ˈdi:", "ukphone": "", "trans": ["数码影碟(digital versatile disk)"]}, {"name": "Dynamic", "usphone": "daɪˈnæmɪk", "ukphone": "", "trans": ["a.充满活力,精力充沛的"]}, {"name": "Dynasty", "usphone": "ˈdɪnəstɪ; (US) ˈdaɪnəstɪ", "ukphone": "", "trans": ["n.王朝，朝代"]}, {"name": "each", "usphone": "iːtʃ", "ukphone": "", "trans": ["a.& pron.每人.每个.每件"]}, {"name": "eager", "usphone": "ˈiːɡə(r)", "ukphone": "", "trans": ["a. 渴望的，热切的"]}, {"name": "eagle", "usphone": "ˈiːɡ(ə)l", "ukphone": "", "trans": ["n. 鹰"]}, {"name": "ear", "usphone": "ɪə(r)", "ukphone": "", "trans": ["n.耳朵.耳状物；听力，听觉"]}, {"name": "early", "usphone": "ɜːlɪ", "ukphone": "", "trans": ["a. 早的 ad. 早地"]}, {"name": "earn", "usphone": "ɜːn", "ukphone": "", "trans": ["vt. 挣得，赚得"]}, {"name": "earth", "usphone": "ɜːθ", "ukphone": "", "trans": ["n. 地球；土，泥；大地"]}, {"name": "earthquake", "usphone": "ˈɜːθkweɪk", "ukphone": "", "trans": ["n. 地震"]}, {"name": "ease", "usphone": "iːz", "ukphone": "", "trans": ["v. 减轻；缓解（难度或严重程度）"]}, {"name": "easily", "usphone": "ˈiːzɪlɪ", "ukphone": "", "trans": ["ad. 容易地"]}, {"name": "east", "usphone": "iːst", "ukphone": "", "trans": ["a. 东方；东部的；朝东的；从东方来 ad. 在东方；向东方；从东方 n. 东，东方；东部"]}, {"name": "Easter", "usphone": "ˈiːstə(r)", "ukphone": "", "trans": ["n. 复活节"]}, {"name": "eastern", "usphone": "ˈiːst(ə)n", "ukphone": "", "trans": ["a. 东方的；东部的"]}, {"name": "eastwards", "usphone": "ˈiːstwədz", "ukphone": "", "trans": ["ad. 向东"]}, {"name": "easy", "usphone": "ˈiːzɪ", "ukphone": "", "trans": ["a. 容易的，不费力的"]}, {"name": "easy--going", "usphone": "ˈiːzɪ-ˈɡəʊɪŋ", "ukphone": "", "trans": ["a. 随和的"]}, {"name": "eat (ate, eaten)", "usphone": "iːt", "ukphone": "", "trans": ["v. 吃"]}, {"name": "ecology", "usphone": "ɪˈkɔlədʒɪ", "ukphone": "", "trans": ["n. 生态，生态学"]}, {"name": "edge", "usphone": "edʒ", "ukphone": "", "trans": ["n. 边缘"]}, {"name": "edition", "usphone": "ɪˈdɪʃ(ə)n", "ukphone": "", "trans": ["n.（发行物的）版，版（本）"]}, {"name": "editor", "usphone": "ˈedɪtə(r)", "ukphone": "", "trans": ["n. 编辑"]}, {"name": "educate", "usphone": "ˈedjʊkeɪt", "ukphone": "", "trans": ["vt. 教育，培养"]}, {"name": "educator", "usphone": "ˈedju:keitə(r)", "ukphone": "", "trans": ["n. 教育家"]}, {"name": "education", "usphone": "edjʊˈkeɪʃ(ə)n", "ukphone": "", "trans": ["n. 教育，培养"]}, {"name": "effect", "usphone": "ɪˈfekt", "ukphone": "", "trans": ["n. 效果；作用"]}, {"name": "effort", "usphone": "ˈefət", "ukphone": "", "trans": ["n. 努力，艰难的尝试"]}, {"name": "egg", "usphone": "eɡ", "ukphone": "", "trans": ["n. 蛋；卵"]}, {"name": "eggplant", "usphone": "ˈeɡplɑːnt", "ukphone": "", "trans": ["n. 茄子"]}, {"name": "Egypt*", "usphone": "ˈiːdʒɪpt", "ukphone": "", "trans": ["n. 埃及"]}, {"name": "Egyptian", "usphone": "ɪˈdʒɪpʃ(ə)n", "ukphone": "", "trans": ["a. 埃及的；埃及人的；埃及语的 n. 埃及人"]}, {"name": "eight", "usphone": "eɪt", "ukphone": "", "trans": ["num. 八"]}, {"name": "eighteen", "usphone": "ˈeɪˈtiːn", "ukphone": "", "trans": ["num. 十八"]}, {"name": "eighth", "usphone": "eɪtθ", "ukphone": "", "trans": ["num. 第八"]}, {"name": "eighty", "usphone": "ˈeɪtɪ", "ukphone": "", "trans": ["num. 八十"]}, {"name": "either", "usphone": "ˈaɪðə(r)", "ukphone": "", "trans": ["a. 两方任一方的；二者之一 conj. 二者之一；要么……"]}, {"name": "ad.", "usphone": "æd", "ukphone": "", "trans": ["(用于否定句或短语后)也"]}, {"name": "elder", "usphone": "ˈeldə(r)", "ukphone": "", "trans": ["n. 长者；前辈"]}, {"name": "elect", "usphone": "ɪˈlekt", "ukphone": "", "trans": ["vt. （投票）选举"]}, {"name": "electric", "usphone": "ɪˈlektrɪk", "ukphone": "", "trans": ["a. 电的"]}, {"name": "electrical", "usphone": "ɪˈlektrɪk(ə)l", "ukphone": "", "trans": ["a. 电的；电器的"]}, {"name": "electricity", "usphone": "ɪlekˈtrɪsɪtɪ", "ukphone": "", "trans": ["n. 电；电流"]}, {"name": "electronic", "usphone": "ɪlekˈtrɔnɪk", "ukphone": "", "trans": ["a. 电子的"]}, {"name": "elegant", "usphone": "ˈelɪɡənt", "ukphone": "", "trans": ["a.文雅的,漂亮的,精美的"]}, {"name": "elephant", "usphone": "ˈelɪfənt", "ukphone": "", "trans": ["n. 象"]}, {"name": "eleven", "usphone": "ɪˈlev(ə)n", "ukphone": "", "trans": ["num. 十一"]}, {"name": "else", "usphone": "els", "ukphone": "", "trans": ["ad. 别的，其他的"]}, {"name": "e-mail/email", "usphone": "iː- meɪl", "ukphone": "", "trans": ["n. 电子邮件"]}, {"name": "embarrass", "usphone": "ɪmˈbærəs", "ukphone": "", "trans": ["v.使窘迫，尴尬"]}, {"name": "embassy", "usphone": "ˈembəsɪ", "ukphone": "", "trans": ["n. 大使馆"]}, {"name": "emergency", "usphone": "ɪˈmɜːdʒənsɪ", "ukphone": "", "trans": ["n.紧急情况或状态"]}, {"name": "emperor", "usphone": "ˈempərə(r)", "ukphone": "", "trans": ["n. 皇帝"]}, {"name": "empire", "usphone": "ˈempaɪə(r)", "ukphone": "", "trans": ["n. 帝国"]}, {"name": "employ", "usphone": "ɪmˈplɔɪ", "ukphone": "", "trans": ["vt. 雇佣"]}, {"name": "empty", "usphone": "ˈemptɪ", "ukphone": "", "trans": ["a. 空的"]}, {"name": "encourage", "usphone": "ɪnˈkʌrɪdʒ", "ukphone": "", "trans": ["vt. 鼓励"]}, {"name": "encouragement", "usphone": "ɪnˈkʌrɪdʒmənt", "ukphone": "", "trans": ["n. 鼓励"]}, {"name": "end", "usphone": "end", "ukphone": "", "trans": ["n. 末尾；终点；结束 v. 结束，终止"]}, {"name": "ending", "usphone": "ˈendɪŋ", "ukphone": "", "trans": ["n. 结局；结尾，最后"]}, {"name": "endless", "usphone": "ˈendlɪs", "ukphone": "", "trans": ["a. 无止境的； 没完的"]}, {"name": "enemy", "usphone": "ˈenɪmɪ", "ukphone": "", "trans": ["n. 敌人；敌军"]}, {"name": "energetic", "usphone": "enəˈdʒetɪk", "ukphone": "", "trans": ["a. 精力旺盛的"]}, {"name": "energ", "usphone": "ˈenədʒɪ", "ukphone": "", "trans": ["y n. 精力，能量"]}, {"name": "engine", "usphone": "ˈendʒɪn", "ukphone": "", "trans": ["n. 发动机，引擎"]}, {"name": "engineer", "usphone": "endʒɪˈnɪə(r)", "ukphone": "", "trans": ["n. 工程师；技师"]}, {"name": "England*", "usphone": "ˈɪŋɡlənd", "ukphone": "", "trans": ["n. 英格兰"]}, {"name": "English", "usphone": "ˈɪŋɡlɪʃ", "ukphone": "", "trans": ["a. 英国的，英国人的，英语的 n. 英语"]}, {"name": "English -speaking", "usphone": "ˈɪŋɡlɪʃ-spiːk", "ukphone": "", "trans": ["a.说英语的"]}, {"name": "enjoy", "usphone": "ɪnˈdʒɔɪ", "ukphone": "", "trans": ["vt.欣赏；享受乐趣；喜欢"]}, {"name": "enjoyable", "usphone": "ɪnˈdʒɔɪəb(ə)l", "ukphone": "", "trans": ["a. 愉快的；有趣的"]}, {"name": "enlarge", "usphone": "ɪnˈlɑːdʒ", "ukphone": "", "trans": ["vt. 扩大"]}, {"name": "enough", "usphone": "ɪˈnʌf", "ukphone": "", "trans": ["n. 足够；充足 a. 足够；充分的 ad. 足够地；充分地"]}, {"name": "enquiry", "usphone": "ɪnˈkwaɪərɪ", "ukphone": "", "trans": ["n. 询问"]}, {"name": "enter", "usphone": "ˈentə(r)", "ukphone": "", "trans": ["vt. 进入"]}, {"name": "enterprise", "usphone": "ˈentəpraɪz", "ukphone": "", "trans": ["n.公司，企，事业单位"]}, {"name": "entertainment", "usphone": "entəˈteɪnmənt", "ukphone": "", "trans": ["n. 娱乐"]}, {"name": "enthusiastic", "usphone": "ɪnθjuːzɪˈæstɪk", "ukphone": "", "trans": ["a.热情的，热心的"]}, {"name": "entire", "usphone": "ɪnˈtaɪə(r)", "ukphone": "", "trans": ["a. 整个的，全部的"]}, {"name": "entrance", "usphone": "ˈentrəns", "ukphone": "", "trans": ["n. 入口；入场；进入的权利;入学许可"]}, {"name": "entry", "usphone": "ˈentrɪ", "ukphone": "", "trans": ["n. 进入"]}, {"name": "envelope", "usphone": "ˈenvələʊp", "ukphone": "", "trans": ["n. 信封"]}, {"name": "environment", "usphone": "ɪnˈvaɪərənmənt", "ukphone": "", "trans": ["n.环境"]}, {"name": "envy", "usphone": "ˈenvɪ", "ukphone": "", "trans": ["vt.& n. 忌妒； 羡慕"]}, {"name": "equal", "usphone": "ˈiːkw(ə)l", "ukphone": "", "trans": ["a.平等的 vt.等于，使等于"]}, {"name": "equality", "usphone": "iːˈkwɔlətɪ", "ukphone": "", "trans": ["n. 平等"]}, {"name": "equip", "usphone": "ɪˈkwɪp", "ukphone": "", "trans": ["vt. 提供设备；装备；配备"]}, {"name": "equipment", "usphone": "ɪˈkwɪpmənt", "ukphone": "", "trans": ["n. 装备，设备"]}, {"name": "eraser", "usphone": "ɪˈreɪzə(r)", "ukphone": "", "trans": ["n. 橡皮擦；黑板擦"]}, {"name": "error", "usphone": "ˈerə(r)", "ukphone": "", "trans": ["n. 错误；差错"]}, {"name": "erupt", "usphone": "ɪˈrʌpt", "ukphone": "", "trans": ["v.（火山）爆发，喷发"]}, {"name": "escape", "usphone": "ɪˈskeɪp", "ukphone": "", "trans": ["n.& vi. 逃跑；逃脱"]}, {"name": "especially", "usphone": "ɪˈspeʃəlɪ", "ukphone": "", "trans": ["ad. 特别，尤其"]}, {"name": "essay", "usphone": "ˈeseɪ", "ukphone": "", "trans": ["n. 散文；文章；随笔"]}, {"name": "Europe*", "usphone": "ˈjʊərəp", "ukphone": "", "trans": ["n. 欧洲"]}, {"name": "European", "usphone": "jʊərəˈpiːən", "ukphone": "", "trans": ["a. 欧洲的，欧洲人的 n. 欧洲人"]}, {"name": "evaluate", "usphone": "ɪˈvæljʊeɪt", "ukphone": "", "trans": ["v.估值，评价，评估"]}, {"name": "even", "usphone": "ˈiːv(ə)n", "ukphone": "", "trans": ["ad. 甚至，连（…都）；更"]}, {"name": "evening", "usphone": "ˈiːvnɪŋ", "ukphone": "", "trans": ["n. 傍晚，晚上"]}, {"name": "event", "usphone": " ɪˈvent", "ukphone": "", "trans": ["n. 事件，大事"]}, {"name": "eventually", "usphone": "ɪˈventjʊəlɪ", "ukphone": "", "trans": ["ad.最终地"]}, {"name": "ever", "usphone": "ˈevə(r)", "ukphone": "", "trans": ["ad. 曾经；无论何时"]}, {"name": "every", "usphone": "ˈevrɪ", "ukphone": "", "trans": ["a. 每一，每个的"]}, {"name": "everybody", "usphone": "", "ukphone": "", "trans": ["pron.每人，人人"]}, {"name": "everyday", "usphone": "ˈevrɪbɔdɪ", "ukphone": "", "trans": ["a. 每日的；日常的"]}, {"name": "everyone", "usphone": "ˈevrɪwʌn", "ukphone": "", "trans": ["pron. 每人，人人"]}, {"name": "everything", "usphone": "ˈevrɪθɪŋ", "ukphone": "", "trans": ["pron. 每件事，事事"]}, {"name": "everywhere", "usphone": "ˈevrɪweə(r)", "ukphone": "", "trans": ["ad. 到处"]}, {"name": "evidence", "usphone": "ˈevɪdəns", "ukphone": "", "trans": ["n. 证据，证明"]}, {"name": "evident", "usphone": "ˈevɪdənt", "ukphone": "", "trans": ["a.清楚的，显而易见的"]}, {"name": "evolution", "usphone": "iːvəˈluːʃ(ə)n; (US) ev-", "ukphone": "", "trans": ["n. 进化，演变"]}, {"name": "exact", "usphone": "ɪɡˈzækt", "ukphone": "", "trans": ["a. 精确的；确切的"]}, {"name": "exactly", "usphone": "exˈact·ly", "ukphone": "", "trans": ["ad. 精确地；确切地"]}, {"name": "exam = examination", "usphone": "ɪɡzæmɪˈneɪʃ(ə)n", "ukphone": "", "trans": ["n. 考试，测试；检查；审查"]}, {"name": "examine", "usphone": "ɪɡˈzæmɪn", "ukphone": "", "trans": ["vt. 检查；诊察"]}, {"name": "example", "usphone": "ɪɡˈzɑːmp(ə)l; (US) ɪɡˈzæmpl", "ukphone": "", "trans": ["n. 例子；榜样"]}, {"name": "excellent", "usphone": "ˈeksələnt", "ukphone": "", "trans": ["a. 极好的，优秀的"]}, {"name": "except", "usphone": "ɪkˈsept", "ukphone": "", "trans": ["prep. 除……之外"]}, {"name": "exchange", "usphone": "ɪksˈtʃeɪndʒ", "ukphone": "", "trans": ["n. 交换，掉换；交流"]}, {"name": "excite", "usphone": "ɪkˈsaɪt", "ukphone": "", "trans": ["vt. 使兴奋，使激动"]}, {"name": "excuse", "usphone": "ɪkˈskjuːz", "ukphone": "", "trans": ["n.借口.辩解 vt.原谅.宽恕"]}, {"name": "exercise", "usphone": "ˈeksəsaɪz", "ukphone": "", "trans": ["n. 锻炼，做操；练习，习题 vi. 锻炼"]}, {"name": "exhibition", "usphone": "eksɪˈbɪʃ(ə)n", "ukphone": "", "trans": ["n. 展览；展览会"]}, {"name": "exist", "usphone": "ɪgˈzɪst", "ukphone": "", "trans": ["vi. 存在"]}, {"name": "existence", "usphone": "ɪɡˈzɪst(ə)ns", "ukphone": "", "trans": ["n.存在；生存；存在物"]}, {"name": "exit", "usphone": "ˈeksɪt", "ukphone": "", "trans": ["n. 出口，太平门"]}, {"name": "expand", "usphone": "ɪkˈspænd", "ukphone": "", "trans": ["v.扩大，增加，扩展"]}, {"name": "expect", "usphone": "ɪkˈspekt", "ukphone": "", "trans": ["vt. 预料；盼望；认为"]}, {"name": "expectation", "usphone": "ekspekˈteɪʃ(ə)n", "ukphone": "", "trans": ["n. 预料；期望"]}, {"name": "expense", "usphone": "ɪkˈspens", "ukphone": "", "trans": ["n. 消费； 支出"]}, {"name": "expensive", "usphone": "ɪkˈspensɪv", "ukphone": "", "trans": ["a. 昂贵的"]}, {"name": "experience", "usphone": "ɪkˈspɪərɪəns", "ukphone": "", "trans": ["n. 经验；经历"]}, {"name": "experiment", "usphone": "ɪkˈsperɪmənt", "ukphone": "", "trans": ["n. 实验"]}, {"name": "expert", "usphone": "ˈekspɜːt", "ukphone": "", "trans": ["n. 专家，能手"]}, {"name": "explain", "usphone": "ɪksˈpleɪn", "ukphone": "", "trans": ["vt. 解释，说明"]}, {"name": "explanation", "usphone": "ekspləˈneɪʃ(ə)n", "ukphone": "", "trans": ["n. 解释，说明"]}, {"name": "explicit", "usphone": "ɪkˈsplɪsɪt", "ukphone": "", "trans": ["a.清楚明白,易于理解的"]}, {"name": "explode", "usphone": "ɪkˈspləʊd", "ukphone": "", "trans": ["v. （使）爆炸"]}, {"name": "exploit", "usphone": "", "ukphone": "", "trans": ["vt.开采.开发.利用.剥削"]}, {"name": "explore", "usphone": "ɪkˈsplɔː(r)", "ukphone": "", "trans": ["v. 探险"]}, {"name": "explorer", "usphone": "ɪkˈsplɔːrə(r)", "ukphone": "", "trans": ["n. 探险者"]}, {"name": "export", "usphone": "ɪkˈspɔːt", "ukphone": "", "trans": ["n. / v.出口，输出"]}, {"name": "expose", "usphone": "ɪkˈspəʊz; (US) ekspəˈzeɪ", "ukphone": "", "trans": ["vt. 揭露"]}, {"name": "express", "usphone": "ɪkˈspres", "ukphone": "", "trans": ["vt. 表达；表示；表情 n. 快车，特快专递"]}, {"name": "expression", "usphone": "ɪkˈspreʃ(ə)n", "ukphone": "", "trans": ["n. 表达；词句；表示，说法；表情"]}, {"name": "extension", "usphone": "ɪkˈstenʃ(ə)n", "ukphone": "", "trans": ["n.扩大，延伸"]}, {"name": "extra", "usphone": "ˈekstrə", "ukphone": "", "trans": ["a. 额外的，外加的"]}, {"name": "extraordinary", "usphone": "ɪkˈstrɔːdɪnərɪ; (US) -dənerɪ", "ukphone": "", "trans": ["a. 离奇的；使人惊奇的"]}, {"name": "extreme", "usphone": "ɪkˈstriːm", "ukphone": "", "trans": ["a. 极其的，非常的"]}, {"name": "extremely", "usphone": "ɪkˈstriːmlɪ", "ukphone": "", "trans": ["ad. 极其，非常"]}, {"name": "eye", "usphone": "aɪ", "ukphone": "", "trans": ["n. 眼睛"]}, {"name": "eyesight", "usphone": "ˈaɪsaɪt", "ukphone": "", "trans": ["n. 视力；视觉"]}, {"name": "eyewitness", "usphone": "ˈaɪwɪtnɪs", "ukphone": "", "trans": ["n. 目击证人"]}, {"name": "f (缩) =female (或 =foot,feet)", "usphone": "ef", "ukphone": "", "trans": ["n. 女(的)；雌(的)； 英尺"]}, {"name": "face", "usphone": "feɪs", "ukphone": "", "trans": ["n. 脸 vt. 面向；面对"]}, {"name": "facial", "usphone": "ˈfeɪʃ(ə)l", "ukphone": "", "trans": ["a. 面部用的"]}, {"name": "fact", "usphone": "fækt", "ukphone": "", "trans": ["n. 事实，现实"]}, {"name": "factory", "usphone": "", "ukphone": "", "trans": ["n. 工厂"]}, {"name": "fade", "usphone": "feɪd", "ukphone": "", "trans": ["vi. 褪色，（颜色）消退"]}, {"name": "fail", "usphone": "feɪl", "ukphone": "", "trans": ["v. 失败；不及格；衰退"]}, {"name": "failure", "usphone": "ˈfeɪljə(r)", "ukphone": "", "trans": ["n. 失败"]}, {"name": "fair", "usphone": "feə(r)", "ukphone": "", "trans": ["a. 公平的，合理的 a. (肤色)白皙的； （人）白肤金发的 n. 集市；庙会；展览会"]}, {"name": "fairly", "usphone": "ˈfeəlɪ", "ukphone": "", "trans": ["ad. 公正地，正当地；相当（程度）地"]}, {"name": "fairness", "usphone": "ˈfɛənis", "ukphone": "", "trans": ["n. 公平；公正"]}, {"name": "faith", "usphone": "feɪθ", "ukphone": "", "trans": ["n. 信仰；信念"]}, {"name": "fall", "usphone": "fɔːl", "ukphone": "", "trans": ["n. （美）秋季"]}, {"name": "fall", "usphone": "fɔːl", "ukphone": "", "trans": ["(fell, fallen) vi. 落（下），降落；倒"]}, {"name": "false", "usphone": "fɔːls", "ukphone": "", "trans": ["a. 不正确的；假的"]}, {"name": "familiar", "usphone": "fəˈmɪlɪə(r)", "ukphone": "", "trans": ["a. 熟悉的"]}, {"name": "family", "usphone": "ˈfæmɪlɪ", "ukphone": "", "trans": ["n. 家庭；家族；子女"]}, {"name": "family name", "usphone": "", "ukphone": "", "trans": ["姓氏"]}, {"name": "famous", "usphone": "ˈfeɪməs", "ukphone": "", "trans": ["a. 著名的"]}, {"name": "fan", "usphone": "fæn", "ukphone": "", "trans": ["n. （电影、运动等的）迷；热心的爱好者（支持者） n. 风扇"]}, {"name": "fancy", "usphone": "ˈfænsɪ", "ukphone": "", "trans": ["a.花式；装饰的；奇特的"]}, {"name": "fantastic", "usphone": "", "ukphone": "", "trans": ["a. (口语)极好的，美妙的，很棒的"]}, {"name": "fantasy", "usphone": "ˈfæntəsɪ", "ukphone": "", "trans": ["n 幻想，梦想"]}, {"name": "far", "usphone": "fɑː(r)", "ukphone": "", "trans": ["(farther, farthest 或further , furthest) a.& ad. 远的；远地"]}, {"name": "fare", "usphone": "feə(r)", "ukphone": "", "trans": ["n.（车或船的）费用，票（价）"]}, {"name": "farm", "usphone": "fɑːm", "ukphone": "", "trans": ["n. 农场；农庄"]}, {"name": "farmer", "usphone": "ˈfɑːmə(r)", "ukphone": "", "trans": ["n. 农民"]}, {"name": "fast", "usphone": "fɑːst; (US) fæst", "ukphone": "", "trans": ["a. 快的，迅速的；紧密的 ad. 快地，迅速地；紧密地"]}, {"name": "fasten", "usphone": "ˈfɑːs(ə)n; (US) fæsn", "ukphone": "", "trans": ["vt. 扎牢；扣住"]}, {"name": "fat", "usphone": "fæt", "ukphone": "", "trans": ["n. 脂肪 a. 胖的；肥的"]}, {"name": "father", "usphone": "ˈfɑːðə(r)", "ukphone": "", "trans": ["n. 父亲"]}, {"name": "fault", "usphone": "fɔːlt", "ukphone": "", "trans": ["n. 缺点，毛病"]}, {"name": "favour", "usphone": "ˈfeivə", "ukphone": "", "trans": ["(美favor) n. 恩惠；好意；帮助"]}, {"name": "favourite", "usphone": "ˈfeivərit", "ukphone": "", "trans": ["(美 favorite) a. 喜爱的 n. 特别喜爱的人（或物）"]}, {"name": "fax", "usphone": "fæks", "ukphone": "", "trans": ["n. 传真"]}, {"name": "fear", "usphone": "fɪə(r)", "ukphone": "", "trans": ["n. 害怕；恐惧； 担忧"]}, {"name": "feast", "usphone": "fiːst", "ukphone": "", "trans": ["n.盛宴，宴会，（宗教的）节日"]}, {"name": "feather", "usphone": "ˈfeðə(r)", "ukphone": "", "trans": ["n. 羽毛"]}, {"name": "February", "usphone": "ˈfebruəri", "ukphone": "", "trans": ["n. 2月"]}, {"name": "federa", "usphone": "ˈfedər(ə)l", "ukphone": "", "trans": ["l a.中央的（政府）联邦的"]}, {"name": "fee", "usphone": "fiː", "ukphone": "", "trans": ["n. 费，费用"]}, {"name": "feed (fed, fed)", "usphone": "fiːd", "ukphone": "", "trans": ["vt. 喂（养）；饲（养）"]}, {"name": "feel (felt, felt)", "usphone": "fiːl", "ukphone": "", "trans": ["v.& link 感觉，觉得；摸，触"]}, {"name": "feeling", "usphone": "ˈfiːlɪŋ", "ukphone": "", "trans": ["n. 感情；感觉"]}, {"name": "fellow", "usphone": "ˈfeləʊ", "ukphone": "", "trans": ["n. 同伴；伙伴"]}, {"name": "female", "usphone": "ˈfiːmeɪl", "ukphone": "", "trans": ["a. 女的；女性的；雌性的"]}, {"name": "fence", "usphone": "fens", "ukphone": "", "trans": ["n. 栅栏；围栏；篱笆"]}, {"name": "ferry", "usphone": "ˈferɪ", "ukphone": "", "trans": ["n. 渡船"]}, {"name": "festival", "usphone": "ˈfestɪvəl", "ukphone": "", "trans": ["a. 节日的，喜庆的"]}, {"name": "fetch", "usphone": "fetʃ", "ukphone": "", "trans": ["vt. （去）取（物）来，（去）带（人）来"]}, {"name": "fever", "usphone": "ˈfiːvə(r)", "ukphone": "", "trans": ["n. 发烧；发热"]}, {"name": "few", "usphone": "fjuː", "ukphone": "", "trans": ["pron. 不多；少数 不多的；少数的"]}, {"name": "fibre", "usphone": "ˈfaibə", "ukphone": "", "trans": ["(美fiber) n. 纤维质"]}, {"name": "fiction", "usphone": "ˈfɪkʃ(ə)n", "ukphone": "", "trans": ["n.小说，虚构的事"]}, {"name": "field", "usphone": "fiːld", "ukphone": "", "trans": ["n. 田地；牧场；场地"]}, {"name": "fierce", "usphone": "ˈfɪəs", "ukphone": "", "trans": ["a. 猛烈的"]}, {"name": "fifteen", "usphone": "fɪfˈtiːn", "ukphone": "", "trans": ["num. 十五"]}, {"name": "fifth", "usphone": "fɪfθ", "ukphone": "", "trans": ["num. 第五"]}, {"name": "fifty", "usphone": "ˈfɪftɪ", "ukphone": "", "trans": ["num. 五十"]}, {"name": "fight", "usphone": "faɪt", "ukphone": "", "trans": ["n. 打仗（架），争论"]}, {"name": "fight", "usphone": "faɪt", "ukphone": "", "trans": ["(fought, fought) n. 打仗（架），与……打仗（架）"]}, {"name": "fighter", "usphone": "ˈfaɪtə(r)", "ukphone": "", "trans": ["v. 战士；斗士"]}, {"name": "figure", "usphone": "ˈfɪɡə(r); (US) ˈfɪgjər", "ukphone": "", "trans": ["n.数字；数目；图；图形；（人的）身型；人物；（绘画、雕刻）人物像 vt.（美口语）认为，判断.（在心里）想像，描绘"]}, {"name": "file", "usphone": "faɪl", "ukphone": "", "trans": ["n.公文柜；档案(计算机)文档"]}, {"name": "fill", "usphone": "fɪl", "ukphone": "", "trans": ["vt. 填空，装满"]}, {"name": "film", "usphone": "fɪlm", "ukphone": "", "trans": ["n. 电影；影片；胶卷vt. 拍摄，把……拍成电影"]}, {"name": "final", "usphone": "ˈfaɪn(ə)l", "ukphone": "", "trans": ["a. 最后的；终极的"]}, {"name": "finance", "usphone": "ˈfaɪnæns", "ukphone": "", "trans": ["n.资金，财政，财务"]}, {"name": "find", "usphone": "faɪnd", "ukphone": "", "trans": ["(found, found) vt. 找到，发现，感到"]}, {"name": "fine", "usphone": "faɪn", "ukphone": "", "trans": ["a. 细的；晴朗的；美好的；（身体）健康的 n.& v. 罚款"]}, {"name": "finger", "usphone": "ˈfɪŋɡə(r)", "ukphone": "", "trans": ["n. 手指"]}, {"name": "fingernail", "usphone": "ˈfɪŋɡəneɪl", "ukphone": "", "trans": ["n. 指甲"]}, {"name": "finish", "usphone": "ˈfɪnɪʃ", "ukphone": "", "trans": ["v. 结束；做完"]}, {"name": "fire", "usphone": "ˈfaɪə(r)", "ukphone": "", "trans": ["n. 火；火炉；火灾 vi. 开火，开（枪，炮等），射击"]}, {"name": "firefighter", "usphone": "", "ukphone": "", "trans": ["n. 消防人员"]}, {"name": "fireplace", "usphone": "ˈfaɪəpleɪs", "ukphone": "", "trans": ["n. 壁炉"]}, {"name": "firewood", "usphone": "ˈfairwud", "ukphone": "", "trans": ["n. 木柴"]}, {"name": "firework", "usphone": "ˈfaɪəwɜːk", "ukphone": "", "trans": ["n. 焰火"]}, {"name": "firm", "usphone": "fɜːm", "ukphone": "", "trans": ["n.公司;企业 a.坚固的,坚定的"]}, {"name": "firmly", "usphone": "ˈfɜːmlɪ", "ukphone": "", "trans": ["ad. 牢牢地"]}, {"name": "first", "usphone": "fɜːst", "ukphone": "", "trans": ["num. 第一 a.& ad. 第一；首次；最初 n. 开始；开端"]}, {"name": "fish", "usphone": "fɪʃ", "ukphone": "", "trans": ["n. 鱼；鱼肉 vi. 钓鱼；捕鱼"]}, {"name": "fisherman", "usphone": "ˈfɪʃəmən", "ukphone": "", "trans": ["n. 渔民；钓鱼健身者"]}, {"name": "fist", "usphone": "fɪst", "ukphone": "", "trans": ["n. 拳(头)"]}, {"name": "fit", "usphone": "fɪt", "ukphone": "", "trans": ["a. 健康的, 适合的 v. （使）适合，安装"]}, {"name": "fitting room", "usphone": "ˈfɪtɪŋ-rʊm", "ukphone": "", "trans": ["试衣间"]}, {"name": "five", "usphone": "faɪv", "ukphone": "", "trans": ["num. 五"]}, {"name": "fix", "usphone": "fɪks", "ukphone": "", "trans": ["vt. 修理；安装；确定，决定"]}, {"name": "flag", "usphone": "flæɡ", "ukphone": "", "trans": ["n. 旗；标志；旗舰"]}, {"name": "flame", "usphone": "fleɪm", "ukphone": "", "trans": ["n. 火焰，光辉"]}, {"name": "flaming", "usphone": "ˈfleɪmɪŋ", "ukphone": "", "trans": ["a. 火红的；火焰般的"]}, {"name": "flash", "usphone": "flæʃ", "ukphone": "", "trans": ["n. 闪；闪光； 转瞬间"]}, {"name": "flashlight", "usphone": "flæʃ", "ukphone": "", "trans": ["n. 手电"]}, {"name": "flat", "usphone": "flæt", "ukphone": "", "trans": ["a. 平的 n. 楼中一套房间； 公寓(常用复数)"]}, {"name": "flee", "usphone": "fliː", "ukphone": "", "trans": ["(fled, fled) v. 逃走；逃跑"]}, {"name": "flexible", "usphone": "ˈfleksəbl", "ukphone": "", "trans": ["a.灵活的，可变动的"]}, {"name": "flesh", "usphone": "fleʃ", "ukphone": "", "trans": ["n. 肉"]}, {"name": "flight", "usphone": "flaɪt", "ukphone": "", "trans": ["n. 航班 n. 楼梯的一段"]}, {"name": "float", "usphone": "fləʊt", "ukphone": "", "trans": ["vi. 漂浮，浮动"]}, {"name": "flood", "usphone": "flʌd", "ukphone": "", "trans": ["n. 洪水 vt. 淹没，使泛滥"]}, {"name": "floor", "usphone": "flɔː(r)", "ukphone": "", "trans": ["n.地面，地板.（楼房的）层"]}, {"name": "flour", "usphone": "ˈflaʊə(r)", "ukphone": "", "trans": ["n. 面粉，粉"]}, {"name": "flow", "usphone": "fləʊ", "ukphone": "", "trans": ["vi. 流动"]}, {"name": "flower", "usphone": "ˈflaʊə(r)", "ukphone": "", "trans": ["n. 花"]}, {"name": "flu", "usphone": "fluː", "ukphone": "", "trans": ["n. 流行性感冒"]}, {"name": "fluency", "usphone": "ˈfluənsi", "ukphone": "", "trans": ["n.（外语）流利，流畅"]}, {"name": "fluent", "usphone": "ˈfluːənt", "ukphone": "", "trans": ["a. （外语）流利的，流畅"]}, {"name": "fly", "usphone": "ˈfluːənt", "ukphone": "", "trans": ["n. 飞行；苍蝇"]}, {"name": "fly (flew, flown)", "usphone": "flaɪ", "ukphone": "", "trans": ["vi. （鸟、飞机）飞；（人乘飞机）飞行；（旗子等）飘动 vt. 空运（乘客，货物等）；放（风筝、飞机模型等）"]}, {"name": "focus", "usphone": "ˈfəʊkəs", "ukphone": "", "trans": ["v. / n.集中（注意力，精力）于，焦点，中心点"]}, {"name": "fog", "usphone": "fɔɡ", "ukphone": "", "trans": ["n. 雾"]}, {"name": "foggy", "usphone": "ˈfɔɡɪ", "ukphone": "", "trans": ["a. 多雾的"]}, {"name": "fold", "usphone": "fəʊld", "ukphone": "", "trans": ["vt. 折叠；合拢"]}, {"name": "folk", "usphone": "fəʊk", "ukphone": "", "trans": ["a. 民间的"]}, {"name": "follow", "usphone": "ˈfɔləʊ", "ukphone": "", "trans": ["vt. 跟随；仿效；跟得上"]}, {"name": "following", "usphone": "ˈfɔləʊwɪŋ", "ukphone": "", "trans": ["a. 接着的；以下的"]}, {"name": "fond", "usphone": "fɔnd", "ukphone": "", "trans": ["a. 喜爱的，爱好的"]}, {"name": "food", "usphone": "fɔnd", "ukphone": "", "trans": ["n. 食物，食品"]}, {"name": "fool", "usphone": "fuːl", "ukphone": "", "trans": ["n. 傻子，蠢人"]}, {"name": "foolish", "usphone": "ˈfuːlɪʃ", "ukphone": "", "trans": ["a. 愚蠢的，傻的"]}, {"name": "foot (复 feet)", "usphone": "fʊt", "ukphone": "", "trans": ["n. 足，脚；英尺"]}, {"name": "football", "usphone": "ˈfʊtbɔːl", "ukphone": "", "trans": ["n. （英式）足球；（美式）橄榄球"]}, {"name": "for", "usphone": "fə(r), fɔː(r)", "ukphone": "", "trans": ["prep. 为了…；向…，往…；与…交换；防备…；适合…；因为…；在…期 间；对于…；对…来说 conj. 因为，由于"]}, {"name": "forbid", "usphone": "fəˈbɪd", "ukphone": "", "trans": ["(forbade, forbidden) vt. 禁止，不许"]}, {"name": "force", "usphone": "fɔːs", "ukphone": "", "trans": ["vt. 强迫，迫使"]}, {"name": "forecast", "usphone": "ˈfɔːkɑːst; (US) ˈfɔrkæst", "ukphone": "", "trans": ["n. & vt. 预告"]}, {"name": "forehead", "usphone": "ˈfɔrɪd; (US) ˈfɔːrɪd", "ukphone": "", "trans": ["n. 前额"]}, {"name": "foreign", "usphone": "ˈfɔrən; (US) ˈfɔːrɪn", "ukphone": "", "trans": ["a. 外国的"]}, {"name": "foreigner", "usphone": "ˈfɔrənə(r)", "ukphone": "", "trans": ["n. 外国人"]}, {"name": "foresee", "usphone": "fɔːˈsiː", "ukphone": "", "trans": ["(foresaw, foreseen) vt.预见.预知"]}, {"name": "forest", "usphone": "ˈfɔrɪst; (US) ˈfɔːrɪst", "ukphone": "", "trans": ["n. 森林"]}, {"name": "forever", "usphone": "fəˈrevə(r)", "ukphone": "", "trans": ["ad. 永远；永恒的"]}, {"name": "forget", "usphone": "fəˈrevə(r)", "ukphone": "", "trans": ["(forgot, forgotten) v. 忘记；忘掉"]}, {"name": "forgetful", "usphone": "fəˈɡetfʊl", "ukphone": "", "trans": ["a. 健忘的，不留心的"]}, {"name": "forgive", "usphone": "fəˈɡɪv", "ukphone": "", "trans": ["(forgave, forgiven) vt. 原谅，宽恕"]}, {"name": "fork", "usphone": "fɔːk", "ukphone": "", "trans": ["n. 叉，餐叉"]}, {"name": "form", "usphone": "fɔːm", "ukphone": "", "trans": ["n. 表格；形式；结构"]}, {"name": "format", "usphone": "ˈfɔːmæt", "ukphone": "", "trans": ["n.安排，计划，设计"]}, {"name": "former", "usphone": "ˈfɔːmə(r)", "ukphone": "", "trans": ["a. 以前的，从前的；（两者之中的）前者"]}, {"name": "fortnight", "usphone": "ˈfɔːtnaɪt", "ukphone": "", "trans": ["n. 十四日，两星期"]}, {"name": "fortunate", "usphone": "ˈfɔːtʃənət", "ukphone": "", "trans": ["a. 幸运的； 侥幸的"]}, {"name": "fortune", "usphone": "ˈfɔːtjuːn, ˈfɔːtʃuːn", "ukphone": "", "trans": ["n. 财产；运气"]}, {"name": "forty", "usphone": "ˈfɔːtɪ", "ukphone": "", "trans": ["num. 四十"]}, {"name": "forward", "usphone": "ˈfɔːwəd", "ukphone": "", "trans": ["ad.将来.今后.向前，前进"]}, {"name": "found", "usphone": "faʊnd", "ukphone": "", "trans": ["vt. 成立，建立"]}, {"name": "founding", "usphone": "ˈfaundiŋ", "ukphone": "", "trans": ["n. 成立，建立"]}, {"name": "fountain", "usphone": "ˈfaʊntɪn; (US) ˈfaʊntn", "ukphone": "", "trans": ["n. 喷泉"]}, {"name": "four", "usphone": "fɔː(r)", "ukphone": "", "trans": ["num. 四"]}, {"name": "fourteen", "usphone": "ˈfɔːˈtiːn", "ukphone": "", "trans": ["num. 十四"]}, {"name": "fourth", "usphone": "ˈfɔːˈtiːn", "ukphone": "", "trans": ["num. 第四"]}, {"name": "fox", "usphone": "fɔks", "ukphone": "", "trans": ["n. 狐狸"]}, {"name": "franc", "usphone": "fræŋk", "ukphone": "", "trans": ["n. 法郎"]}, {"name": "France*", "usphone": "fræns", "ukphone": "", "trans": ["n. 法国"]}, {"name": "fragile", "usphone": "ˈfrædʒaɪl; (US) ˈfrædʒl", "ukphone": "", "trans": ["a.易碎的，易损的"]}, {"name": "fragrant", "usphone": "ˈfreɪɡrənt", "ukphone": "", "trans": ["a. 香的，芳香的"]}, {"name": "framework", "usphone": "ˈfreɪmwɜːk", "ukphone": "", "trans": ["n.（建筑物）框架，结构"]}, {"name": "free", "usphone": "friː", "ukphone": "", "trans": ["a. 自由，空闲的；免费的"]}, {"name": "freedom", "usphone": "ˈfriːdəm", "ukphone": "", "trans": ["n. 自由"]}, {"name": "freeway", "usphone": "ˈfriːweɪ", "ukphone": "", "trans": ["n. 高速公路"]}, {"name": "freeze", "usphone": "friːz", "ukphone": "", "trans": ["(froze, frozen) vi. 结冰"]}, {"name": "freezing", "usphone": "ˈfri:ziŋ", "ukphone": "", "trans": ["a. 冻结的；极冷的"]}, {"name": "French", "usphone": "frentʃ", "ukphone": "", "trans": ["n. 法语 a法国的；法国人的；法语的"]}, {"name": "Frenchman", "usphone": "ˈfrentʃmən", "ukphone": "", "trans": ["(复 Frenchmen) n. 法国人（男）"]}, {"name": "frequent", "usphone": "ˈfriːkwənt", "ukphone": "", "trans": ["a. 经常的；频繁的"]}, {"name": "fresh", "usphone": "freʃ", "ukphone": "", "trans": ["a. 新鲜的"]}, {"name": "Friday", "usphone": "ˈfraɪdɪ", "ukphone": "", "trans": ["n. 星期五"]}, {"name": "friction", "usphone": "ˈfrɪkʃ(ə)n", "ukphone": "", "trans": ["n. 摩擦"]}, {"name": "fridge =refrigerator", "usphone": "rɪˈfrɪdʒəreɪtə(r)", "ukphone": "", "trans": ["n. 冰箱"]}, {"name": "fried", "usphone": "fraid", "ukphone": "", "trans": ["a. 油煎的"]}, {"name": "friend", "usphone": "frend", "ukphone": "", "trans": ["n. 朋友"]}, {"name": "friendly", "usphone": "ˈfrendlɪ", "ukphone": "", "trans": ["a. 友好的"]}, {"name": "friendship", "usphone": "ˈfrendʃɪp", "ukphone": "", "trans": ["n. 友谊，友情"]}, {"name": "fright", "usphone": "fraɪt", "ukphone": "", "trans": ["n. 惊恐；恐吓"]}, {"name": "frighten", "usphone": "ˈfraɪt(ə)n", "ukphone": "", "trans": ["vt. 使惊恐，吓唬"]}, {"name": "frog", "usphone": "frɔɡ; (US) frɔːɡ", "ukphone": "", "trans": ["n. 青蛙"]}, {"name": "from", "usphone": "frəm, frɔm", "ukphone": "", "trans": ["prep.从；从…起.距.来自"]}, {"name": "front", "usphone": "frʌnt", "ukphone": "", "trans": ["a. 前面的；前部的 n. 前面；前部；前线"]}, {"name": "frontier", "usphone": "ˈfrʌntɪə(r); (US) frʌnˈtɪər", "ukphone": "", "trans": ["n. 前沿 ，边界；前线"]}, {"name": "frost", "usphone": "frɔst; (US) frɔːst", "ukphone": "", "trans": ["n. 霜"]}, {"name": "fruit", "usphone": "fruːt", "ukphone": "", "trans": ["n. 水果；果实"]}, {"name": "fruit juice", "usphone": "fruːt dʒuːs", "ukphone": "", "trans": ["n. 果汁"]}, {"name": "fry", "usphone": "fraɪ", "ukphone": "", "trans": ["vt. 用油煎；用油炸"]}, {"name": "fuel", "usphone": "fjuːəl", "ukphone": "", "trans": ["n. 燃料"]}, {"name": "full", "usphone": "fʊl", "ukphone": "", "trans": ["a. 满的，充满的；完全的"]}, {"name": "fun", "usphone": "fʌn", "ukphone": "", "trans": ["n. 有趣的事，娱乐，玩笑"]}, {"name": "function", "usphone": "ˈfʌŋkʃən", "ukphone": "", "trans": ["n. / v. 作用,功能,运转"]}, {"name": "fundamental", "usphone": "fʌndəˈment(ə)l", "ukphone": "", "trans": ["a. 十分重大的，根本的"]}, {"name": "funeral", "usphone": "ˈfjuːˈnər(ə)l", "ukphone": "", "trans": ["n. 葬礼"]}, {"name": "funny", "usphone": "ˈfʌnɪ", "ukphone": "", "trans": ["a. 有趣的，滑稽可笑的"]}, {"name": "fur", "usphone": "fɜː(r)", "ukphone": "", "trans": ["n. 毛皮；皮子"]}, {"name": "furnished", "usphone": "ˈfə:niʃt", "ukphone": "", "trans": ["a. 配备了家具的"]}, {"name": "furniture", "usphone": "ˈfɜːnɪtʃə(r)", "ukphone": "", "trans": ["n. （总称）家具"]}, {"name": "future", "usphone": "ˈfjuːtʃə(r)", "ukphone": "", "trans": ["n. 将来"]}, {"name": "gain", "usphone": "ɡeɪn", "ukphone": "", "trans": ["vt. 赢得；挣得"]}, {"name": "gale", "usphone": "ɡeɪl", "ukphone": "", "trans": ["n. 强风（约每小时60英里）"]}, {"name": "gallery", "usphone": "ˈɡælərɪ", "ukphone": "", "trans": ["n. 画廊；美术品陈列室"]}, {"name": "gallon", "usphone": "ˈɡælən", "ukphone": "", "trans": ["n. 加仑"]}, {"name": "game", "usphone": "ɡeɪm", "ukphone": "", "trans": ["n. 游戏；运动；比赛"]}, {"name": "garage", "usphone": "ˈɡærɑːʒ, -rɪdʒ; (US) ɡəˈrɑːʒ", "ukphone": "", "trans": ["n. 汽车间（库）"]}, {"name": "garbage", "usphone": "ˈɡɑːbɪdʒ", "ukphone": "", "trans": ["n. 垃圾"]}, {"name": "garden", "usphone": "ˈɡɑːd(ə)n", "ukphone": "", "trans": ["n. 花园，果园，菜园"]}, {"name": "gardening", "usphone": "ˈɡɑːdnɪŋ", "ukphone": "", "trans": ["n. 园艺学"]}, {"name": "garlic", "usphone": "ˈɡɑːlɪk", "ukphone": "", "trans": ["n. 大蒜"]}, {"name": "garment", "usphone": "ˈɡɑːmənt", "ukphone": "", "trans": ["n. （一件）衣服"]}, {"name": "gas", "usphone": "ɡæs", "ukphone": "", "trans": ["n. 煤气"]}, {"name": "gate", "usphone": "ɡeɪt", "ukphone": "", "trans": ["n. 大门"]}, {"name": "gather", "usphone": "ˈɡæðə(r)", "ukphone": "", "trans": ["v. 聚集；采集"]}, {"name": "gay", "usphone": "ɡeɪ", "ukphone": "", "trans": ["a. （男）同性恋的；快活的，愉快的"]}, {"name": "general", "usphone": "ˈdʒenər(ə)l", "ukphone": "", "trans": ["a. 大体，笼统的，总的"]}, {"name": "generation", "usphone": "dʒenəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n. 代，一代"]}, {"name": "generous", "usphone": "ˈdʒenərəs", "ukphone": "", "trans": ["a. 慷慨大方的"]}, {"name": "gentle", "usphone": "ˈdʒent(ə)l", "ukphone": "", "trans": ["a. 温柔的，轻轻的"]}, {"name": "gentleman", "usphone": "ˈdʒent(ə)lmən", "ukphone": "", "trans": ["n. 绅士，先生；有身份、有教养的人"]}, {"name": "geography", "usphone": "dʒɪˈɔɡrəfɪ", "ukphone": "", "trans": ["n. 地理学"]}, {"name": "geometry", "usphone": "dʒɪˈɑmɪtrɪ", "ukphone": "", "trans": ["n. 几何学"]}, {"name": "German", "usphone": "ˈdʒɜːmən", "ukphone": "", "trans": ["a. 德国的，德国人的，德语的 n. 德国人，德语"]}, {"name": "Germany", "usphone": "ˈdʒɜːmənɪ", "ukphone": "", "trans": ["* n. 德国"]}, {"name": "gesture", "usphone": "ˈdʒestʃə(r)", "ukphone": "", "trans": ["n. 姿势，手势"]}, {"name": "get (got , got)", "usphone": "ɡet", "ukphone": "", "trans": ["vt. 成为；得到；具有；到达"]}, {"name": "get--together", "usphone": "ɡet-təˈɡeðə(r)", "ukphone": "", "trans": ["n. 聚会"]}, {"name": "gift", "usphone": "ɡɪft", "ukphone": "", "trans": ["n. 赠品；礼物"]}, {"name": "gifted", "usphone": "ˈɡɪftɪd", "ukphone": "", "trans": ["a. 有天赋的；有才华的"]}, {"name": "giraffe", "usphone": "dʒɪˈrɑːf; (US) dʒəˈræf", "ukphone": "", "trans": ["n. 长颈鹿"]}, {"name": "girl", "usphone": "ɡɜːl", "ukphone": "", "trans": ["n. 女孩"]}, {"name": "give (gave, given)", "usphone": "ɡɪv", "ukphone": "", "trans": ["vt. 给,递给,付出,给予"]}, {"name": "glad", "usphone": "ɡlæd", "ukphone": "", "trans": ["a. 高兴的；乐意的"]}, {"name": "glance", "usphone": "glæns /glɑːns", "ukphone": "", "trans": ["vi. 匆匆一看；一瞥"]}, {"name": "glare", "usphone": "ɡleə(r)", "ukphone": "", "trans": ["v. 瞪眼,怒目而视,闪耀"]}, {"name": "glass", "usphone": "ɡlɑːs; (US) ɡlæs", "ukphone": "", "trans": ["n.玻璃杯,玻璃；(复)眼镜"]}, {"name": "glasshouse", "usphone": "ˈɡlɑːshaʊs", "ukphone": "", "trans": ["n. 温室，暖房"]}, {"name": "globe", "usphone": "ɡləʊb", "ukphone": "", "trans": ["n. 地球仪,地球"]}, {"name": "glory", "usphone": "ˈɡlɔːrɪ", "ukphone": "", "trans": ["n.巨大的光荣; 荣誉;赞美"]}, {"name": "glove", "usphone": "ɡlʌv", "ukphone": "", "trans": ["n. 手套"]}, {"name": "glue", "usphone": "ɡluː", "ukphone": "", "trans": ["n. 胶水"]}, {"name": "go (went, gone)", "usphone": "ɡəʊ", "ukphone": "", "trans": ["vi. 去；走；驶；通到；到达 n. 尝试（做某事）"]}, {"name": "goal", "usphone": "ɡəʊl", "ukphone": "", "trans": ["n. （足球）球门，目标"]}, {"name": "goat", "usphone": "ɡəʊt", "ukphone": "", "trans": ["n. 山羊"]}, {"name": "god", "usphone": "ɡɔd", "ukphone": "", "trans": ["n. 神，（大写）上帝"]}, {"name": "gold", "usphone": "ɡəʊld", "ukphone": "", "trans": ["n. 黄金 a 金的，黄金的"]}, {"name": "golden", "usphone": "ˈɡəʊld(ə)n", "ukphone": "", "trans": ["a. 金(黄)色的"]}, {"name": "goldfish", "usphone": "ˈɡəʊldfɪʃ", "ukphone": "", "trans": ["n. 金鱼"]}, {"name": "golf", "usphone": "ɡɔlf", "ukphone": "", "trans": ["n. 高尔夫球"]}, {"name": "good (better ,best)", "usphone": "ɡʊd", "ukphone": "", "trans": ["a. 好；良好"]}, {"name": "good-bye", "usphone": "ɡʊd- baɪ", "ukphone": "", "trans": ["int. 再见；再会"]}, {"name": "goodness", "usphone": "ˈɡʊdnɪs", "ukphone": "", "trans": ["n. 善良，美德"]}, {"name": "goods", "usphone": "ɡʊd", "ukphone": "", "trans": ["n. 商品，货物"]}, {"name": "goose (复 geese)", "usphone": "ɡuːs", "ukphone": "", "trans": ["n. 鹅"]}, {"name": "govern", "usphone": "ˈɡʌv(ə)n", "ukphone": "", "trans": ["v. 统治；管理"]}, {"name": "government", "usphone": "ˈɡʌvənmənt", "ukphone": "", "trans": ["n. 政府"]}, {"name": "gown", "usphone": "ɡaʊn", "ukphone": "", "trans": ["n. 礼服，长外衣，睡衣"]}, {"name": "grade", "usphone": "ɡreɪd", "ukphone": "", "trans": ["n. 等级；（中小学的）学年；成绩，分数"]}, {"name": "gradually", "usphone": "ˈɡrædjʊəlɪ", "ukphone": "", "trans": ["ad. 逐渐地"]}, {"name": "graduate", "usphone": "ˈɡrædjʊət", "ukphone": "", "trans": ["v. 毕业"]}, {"name": "graduation", "usphone": "ɡrædjʊˈeɪʃ(ə)n", "ukphone": "", "trans": ["n. 毕业，毕业典礼"]}, {"name": "grain", "usphone": "ɡreɪn", "ukphone": "", "trans": ["n. 谷物，谷类"]}, {"name": "gram", "usphone": "ɡræm", "ukphone": "", "trans": ["n. 克(重量单位)"]}, {"name": "grammar", "usphone": "ˈɡræmə(r)", "ukphone": "", "trans": ["n. 语法"]}, {"name": "grand", "usphone": "ɡrænd", "ukphone": "", "trans": ["a. 宏伟的"]}, {"name": "grandchild", "usphone": "ˈgræntʃaɪld", "ukphone": "", "trans": ["n.(外)孙或孙女.孙辈"]}, {"name": "granddaughter", "usphone": "ˈɡrændɔːtə(r)", "ukphone": "", "trans": ["n. （外）孙女"]}, {"name": "grandma = grandmother", "usphone": "ˈɡrænmɑː, ˈɡrændmɑː", "ukphone": "", "trans": ["n. 奶奶；外婆"]}, {"name": "grandpa = grandfather", "usphone": "ˈɡrænpɑː, ˈɡrændpɑː", "ukphone": "", "trans": ["n.爷爷,外公"]}, {"name": "grandparents", "usphone": "ˈɡrændpeərənt", "ukphone": "", "trans": ["n.祖父母.外祖父母"]}, {"name": "grandson", "usphone": "ˈɡrændsʌn", "ukphone": "", "trans": ["n. （外）孙子"]}, {"name": "granny", "usphone": "ˈɡrænɪ", "ukphone": "", "trans": ["n. 老奶奶；祖母；外婆"]}, {"name": "grape", "usphone": "ɡreɪp", "ukphone": "", "trans": ["n. 葡萄"]}, {"name": "graph", "usphone": "ɡrɑːf; (US) ɡræf", "ukphone": "", "trans": ["n. 图表，曲线图"]}, {"name": "grasp", "usphone": "ɡrɑːsp; (US) ɡræsp", "ukphone": "", "trans": ["v. 抓住；紧握"]}, {"name": "grass", "usphone": "ɡrɑːs; (US) ɡræs", "ukphone": "", "trans": ["n. 草；草场；牧草"]}, {"name": "grateful", "usphone": "ˈɡreɪtfʊl", "ukphone": "", "trans": ["a. 感激的，感谢的"]}, {"name": "gravity", "usphone": "ˈɡrævɪtɪ", "ukphone": "", "trans": ["n. 重力，地球引力"]}, {"name": "great", "usphone": "ɡreɪt", "ukphone": "", "trans": ["a. 伟大的,重要的,好极了 ad. （口语）好极了，很好"]}, {"name": "Greece", "usphone": "ɡriːs", "ukphone": "", "trans": ["* n. 希腊"]}, {"name": "greedy", "usphone": "ˈɡriːdɪ", "ukphone": "", "trans": ["a. 贪婪的"]}, {"name": "Greek", "usphone": "ɡriːk", "ukphone": "", "trans": ["a. / n. 希腊的，希腊人的，希腊语的 ; 希腊人，希腊语"]}, {"name": "green", "usphone": "ɡriːn", "ukphone": "", "trans": ["a. 绿色的；青的 n. 绿色"]}, {"name": "greengrocer", "usphone": "ˈɡriːnɡrəʊsə(r)", "ukphone": "", "trans": ["n.（英）蔬菜水果商"]}, {"name": "greet", "usphone": "ɡriːt", "ukphone": "", "trans": ["vt. 问候；向……致敬"]}, {"name": "greeting", "usphone": "ˈɡriːtɪŋ", "ukphone": "", "trans": ["n. 祝贺"]}, {"name": "grey / gray", "usphone": "ɡreɪ", "ukphone": "", "trans": ["a. 灰色的； 灰白的"]}, {"name": "grill", "usphone": "ɡrɪl", "ukphone": "", "trans": ["n. （烧食物的）烤架"]}, {"name": "grocer", "usphone": "ˈɡrəʊsə(r)", "ukphone": "", "trans": ["n. 零售商人；食品店"]}, {"name": "ground", "usphone": "ɡraʊnd", "ukphone": "", "trans": ["n. 地面"]}, {"name": "group", "usphone": "ɡruːp", "ukphone": "", "trans": ["n. 组，群"]}, {"name": "grow (grew, grown)", "usphone": "ɡrəʊ", "ukphone": "", "trans": ["v. 生长；发育；种植；变成"]}, {"name": "growth", "usphone": "ɡrəʊθ", "ukphone": "", "trans": ["n. 生长，增长"]}, {"name": "gruel", "usphone": "ɡrʊəl", "ukphone": "", "trans": ["n. 粥"]}, {"name": "guarantee", "usphone": "ɡærənˈtiː", "ukphone": "", "trans": ["v. 保证，担保"]}, {"name": "guard", "usphone": "ɡɑːd", "ukphone": "", "trans": ["n. 防护装置，警戒"]}, {"name": "guess", "usphone": "ɡes", "ukphone": "", "trans": ["vi. 猜"]}, {"name": "guest", "usphone": "ɡest", "ukphone": "", "trans": ["n. 客人，宾客"]}, {"name": "guidance", "usphone": "ˈɡaɪdəns", "ukphone": "", "trans": ["n. 引导，指导"]}, {"name": "guide", "usphone": "ɡaɪd", "ukphone": "", "trans": ["n. 向导，导游者"]}, {"name": "guilty", "usphone": "ˈɡɪltɪ", "ukphone": "", "trans": ["a.有罪,犯法的,做错事的"]}, {"name": "guitar", "usphone": "ɡɪˈtɑː(r)", "ukphone": "", "trans": ["n. 吉他，六弦琴"]}, {"name": "gun", "usphone": "ɡʌn", "ukphone": "", "trans": ["n. 枪，炮"]}, {"name": "gym =gymnasium", "usphone": "dʒɪm", "ukphone": "", "trans": ["n. 体操；体育馆；健身房"]}, {"name": "gymnastics", "usphone": "dʒɪmˈnæstɪks", "ukphone": "", "trans": ["n. 体操"]}, {"name": "ha", "usphone": "hɑː", "ukphone": "", "trans": ["int. 哈(笑声)"]}, {"name": "habit", "usphone": "ˈhæbɪt", "ukphone": "", "trans": ["n. 习惯，习性"]}, {"name": "hair", "usphone": "heə(r)", "ukphone": "", "trans": ["n. 头发"]}, {"name": "haircut", "usphone": "ˈheəkʌt", "ukphone": "", "trans": ["n. （男子）理发"]}, {"name": "half", "usphone": "hɑːf; (US) hæf", "ukphone": "", "trans": ["a.& n. 半，一半，半个"]}, {"name": "hall", "usphone": "hɔːl", "ukphone": "", "trans": ["n. 大厅,会堂,礼堂;过道"]}, {"name": "ham", "usphone": "hæm", "ukphone": "", "trans": ["n. 火腿"]}, {"name": "hamburger", "usphone": "ˈhæmbɜːɡə(r)", "ukphone": "", "trans": ["n. 汉堡包"]}, {"name": "hammer", "usphone": "ˈhæmə(r)", "ukphone": "", "trans": ["n. 锤子，锣锤"]}, {"name": "hand", "usphone": "hænd", "ukphone": "", "trans": ["n. 手；指针 v. 递；给；交付 交上；交进"]}, {"name": "handbag", "usphone": "ˈhændbæɡ", "ukphone": "", "trans": ["n. 女用皮包，手提包"]}, {"name": "handful", "usphone": "ˈhændfʊl", "ukphone": "", "trans": ["n.(一)把；少数，少量"]}, {"name": "handkerchief", "usphone": "ˈhæŋkətʃɪf", "ukphone": "", "trans": ["n. 手帕"]}, {"name": "handle", "usphone": "ˈhænd(ə)l", "ukphone": "", "trans": ["n. 柄，把柄 v. 处理"]}, {"name": "handsome", "usphone": "ˈhænsəm", "ukphone": "", "trans": ["a. 英俊的"]}, {"name": "handtruck", "usphone": "ˈhændtrʌk", "ukphone": "", "trans": ["n.手推运货车"]}, {"name": "handwriting", "usphone": "ˈhændraɪtɪŋ", "ukphone": "", "trans": ["n. 书法"]}, {"name": "handy", "usphone": "ˈhændɪ", "ukphone": "", "trans": ["a. 便利的，顺手的 hang(hanged,hanged) v. 处（人）绞刑；上吊"]}, {"name": "hang (hung, hung)", "usphone": "hæŋ", "ukphone": "", "trans": ["v.悬挂，吊着；把……吊起"]}, {"name": "happen", "usphone": "ˈhæpən", "ukphone": "", "trans": ["vi.（偶然）发生"]}, {"name": "happily", "usphone": "ˈhæpɪlɪ", "ukphone": "", "trans": ["ad. 幸福地，快乐地"]}, {"name": "happiness", "usphone": "ˈhæpɪnɪs", "ukphone": "", "trans": ["n. 幸福，愉快"]}, {"name": "happy", "usphone": "ˈhæpɪ", "ukphone": "", "trans": ["a.幸福；快乐的，高兴的"]}, {"name": "harbour (美harbor)", "usphone": "ˈhɑ:bə", "ukphone": "", "trans": ["n. 港口"]}, {"name": "hard", "usphone": "hɑːd", "ukphone": "", "trans": ["ad. 努力地；使劲；猛烈地 a.硬的；困难的；艰难的"]}, {"name": "hardly", "usphone": "ˈhɑːdlɪ", "ukphone": "", "trans": ["ad. 几乎不"]}, {"name": "hardship", "usphone": "ˈhɑːdʃɪp", "ukphone": "", "trans": ["n. 困难"]}, {"name": "hardworking", "usphone": "ˈha:dˈwə:kiŋ", "ukphone": "", "trans": ["a. 努力工作的"]}, {"name": "harm", "usphone": "hɑːm", "ukphone": "", "trans": ["n.&v. 伤害；损伤"]}, {"name": "harmful", "usphone": "ˈhɑːmfʊl", "ukphone": "", "trans": ["a.有害的；致伤的"]}, {"name": "harmless", "usphone": "ˈhɑːmlɪs", "ukphone": "", "trans": ["a. 无害的;不致伤的"]}, {"name": "harmony", "usphone": "ˈhɑːmənɪ", "ukphone": "", "trans": ["n. 融洽，和睦"]}, {"name": "harvest", "usphone": "ˈhɑːvɪst", "ukphone": "", "trans": ["n.& vt. 收割，收获（物）"]}, {"name": "hat", "usphone": "hæt", "ukphone": "", "trans": ["n.帽子(一般指有边的)；礼帽"]}, {"name": "hatch", "usphone": "hætʃ", "ukphone": "", "trans": ["v. （鸟、鸡）孵蛋"]}, {"name": "hate", "usphone": "heɪt", "ukphone": "", "trans": ["vt.& n. 恨，讨厌"]}, {"name": "have (has, had, had)", "usphone": "hæv", "ukphone": "", "trans": ["vt.有；吃；喝；进行；经受"]}, {"name": "hawk", "usphone": "hɔːk", "ukphone": "", "trans": ["n. 鹰"]}, {"name": "hay", "usphone": "heɪ", "ukphone": "", "trans": ["n. 作饲料用的干草"]}, {"name": "he", "usphone": "heɪ", "ukphone": "", "trans": ["pron. 他"]}, {"name": "head", "usphone": "hed", "ukphone": "", "trans": ["n. 头；头脑(像)；才智；首脑；源头；标题 a. 头部的；主要的；首席的 v. 率领；加标题；用头顶；出发；(船等)驶向"]}, {"name": "headache", "usphone": "ˈhedeɪk", "ukphone": "", "trans": ["n. 头疼"]}, {"name": "headline", "usphone": "ˈhedlaɪn", "ukphone": "", "trans": ["n. （报刊的）大字标题"]}, {"name": "headmaster", "usphone": "hedˈmɑːstə(r)", "ukphone": "", "trans": ["n. （英）中小学校长"]}, {"name": "headmistress", "usphone": "ˈhedˈmistrɪs", "ukphone": "", "trans": ["n. 女校长"]}, {"name": "headteacher", "usphone": "", "ukphone": "", "trans": ["n. 中小学班主任"]}, {"name": "health", "usphone": "helθ", "ukphone": "", "trans": ["n. 健康，卫生"]}, {"name": "healthy", "usphone": "ˈhelθɪ", "ukphone": "", "trans": ["a. 健康的，健壮的"]}, {"name": "heap", "usphone": "hiːp", "ukphone": "", "trans": ["n. 堆 v. 堆起来"]}, {"name": "hear (heard, heard)", "usphone": "hɪə(r)", "ukphone": "", "trans": ["v. 听见；听说,得知"]}, {"name": "hearing", "usphone": "ˈhɪərɪŋ", "ukphone": "", "trans": ["n. 听力"]}, {"name": "heart", "usphone": "hɑːt", "ukphone": "", "trans": ["n.心.心脏, 纸牌中的红桃"]}, {"name": "heat", "usphone": "hiːt", "ukphone": "", "trans": ["n. 热 vt. 把……加热"]}, {"name": "heaven", "usphone": "ˈhev(ə)n", "ukphone": "", "trans": ["n. 天，天空"]}, {"name": "heavy", "usphone": "ˈhevɪ", "ukphone": "", "trans": ["a. 重的"]}, {"name": "heavily", "usphone": "ˈhevɪlɪ", "ukphone": "", "trans": ["ad. 重地，大量地"]}, {"name": "heel", "usphone": "hiːl", "ukphone": "", "trans": ["n. 脚后跟"]}, {"name": "height", "usphone": "haɪt", "ukphone": "", "trans": ["n. 高，高度"]}, {"name": "helicopter", "usphone": "ˈhelɪkɔptə(r)", "ukphone": "", "trans": ["n. 直升飞机"]}, {"name": "hello", "usphone": "həˈləʊ", "ukphone": "", "trans": ["int. 喂；你好（表示打招呼，问候或唤起注意）"]}, {"name": "helmet", "usphone": "ˈhelmɪt", "ukphone": "", "trans": ["n. 头盔"]}, {"name": "help", "usphone": "help", "ukphone": "", "trans": ["n. & vt. 帮助，帮忙"]}, {"name": "helpful", "usphone": "ˈhelpfʊl", "ukphone": "", "trans": ["a. 有帮助的，有益的"]}, {"name": "hen", "usphone": "hen", "ukphone": "", "trans": ["n. 母鸡"]}, {"name": "her", "usphone": "hɜː(r)", "ukphone": "", "trans": ["pron. 她(宾格),她的"]}, {"name": "herb", "usphone": "hɜːb; (US) ɜːrb", "ukphone": "", "trans": ["n. 草药"]}, {"name": "here", "usphone": "hɪə(r)", "ukphone": "", "trans": ["ad. 这里，在这里；向这里"]}, {"name": "hero", "usphone": "ˈhɪərəʊ", "ukphone": "", "trans": ["n. 英雄，勇士，男主角"]}, {"name": "heroine", "usphone": "ˈherəʊɪn", "ukphone": "", "trans": ["n. 女英雄，女主角"]}, {"name": "hers", "usphone": "hɜːz", "ukphone": "", "trans": ["pron. 她的"]}, {"name": "herself", "usphone": "hɜːˈself", "ukphone": "", "trans": ["pron. 她自己"]}, {"name": "hey", "usphone": "heɪ", "ukphone": "", "trans": ["int. 嘿！"]}, {"name": "hi", "usphone": "haɪ", "ukphone": "", "trans": ["int. 你好（表示打招呼、问候或唤起注 意）"]}, {"name": "hibernate", "usphone": "ˈhaɪbəneɪt", "ukphone": "", "trans": ["vi. 冬眠"]}, {"name": "hibernation", "usphone": "haɪbə(r)ˈneɪʃn", "ukphone": "", "trans": ["n. 冬眠"]}, {"name": "hide (hid, hidden)", "usphone": "haɪd", "ukphone": "", "trans": ["v. 把…藏起来，隐藏"]}, {"name": "hide and seek", "usphone": "haɪd-ənd-siːk", "ukphone": "", "trans": ["捉迷藏"]}, {"name": "high", "usphone": "haɪ", "ukphone": "", "trans": ["a. 高的;高度的 ad. 高地"]}, {"name": "highway", "usphone": "ˈhaɪweɪ", "ukphone": "", "trans": ["n.公路,主要交通道路"]}, {"name": "hill", "usphone": "hɪl", "ukphone": "", "trans": ["n. 小山;丘陵;土堆;斜坡"]}, {"name": "hillside", "usphone": "ˈhɪlsaɪd", "ukphone": "", "trans": ["n. （小山）山腰，山坡"]}, {"name": "hilly", "usphone": "ˈhɪlɪ", "ukphone": "", "trans": ["a. 丘陵的； 多小山的"]}, {"name": "him", "usphone": "hɪm", "ukphone": "", "trans": ["pron. 他（宾格）"]}, {"name": "himself", "usphone": "hɪmˈself", "ukphone": "", "trans": ["pron. 他自己"]}, {"name": "hire", "usphone": "ˈhaɪə(r)", "ukphone": "", "trans": ["vt. 租用"]}, {"name": "his", "usphone": "hɪz", "ukphone": "", "trans": ["pron. 他的"]}, {"name": "history", "usphone": "ˈhɪstərɪ", "ukphone": "", "trans": ["n. 历史，历史学"]}, {"name": "hit (hit, hit)", "usphone": "hɪt", "ukphone": "", "trans": ["n.& vt. 打,撞,击中"]}, {"name": "hive", "usphone": "haɪv", "ukphone": "", "trans": ["n. 蜂房；蜂箱"]}, {"name": "hobby", "usphone": "ˈhɔbɪ", "ukphone": "", "trans": ["n. 业余爱好，嗜好"]}, {"name": "hold (held, held)", "usphone": "həʊld", "ukphone": "", "trans": ["vt.拿；抱；握住；举行；进行"]}, {"name": "hole", "usphone": "həʊl", "ukphone": "", "trans": ["n. 洞，坑"]}, {"name": "holiday", "usphone": "ˈhɔlɪdɪ", "ukphone": "", "trans": ["n. 假日；假期"]}, {"name": "holy", "usphone": "ˈhəʊlɪ", "ukphone": "", "trans": ["a. 神圣的"]}, {"name": "home", "usphone": "həʊm", "ukphone": "", "trans": ["n. 家 ad. 到家；回家"]}, {"name": "homeland", "usphone": "ˈhəʊmlænd", "ukphone": "", "trans": ["n. 祖国"]}, {"name": "hometown", "usphone": "ˈhəʊmtaʊn", "ukphone": "", "trans": ["n. 故乡"]}, {"name": "homework", "usphone": "ˈhəʊmwɜːk", "ukphone": "", "trans": ["n. 家庭作业"]}, {"name": "honest", "usphone": "ˈɔnɪst", "ukphone": "", "trans": ["a. 诚实的，正直的"]}, {"name": "honey", "usphone": "ˈɔnɪst", "ukphone": "", "trans": ["n. 蜂蜜"]}, {"name": "Hong Kong", "usphone": "hɔŋ kɔŋ", "ukphone": "", "trans": ["* n. 香港"]}, {"name": "honour (美honor)", "usphone": "ˈɔnə", "ukphone": "", "trans": ["n. 荣誉，光荣 vt. 尊敬，给予荣誉"]}, {"name": "hook", "usphone": "hʊk", "ukphone": "", "trans": ["n.& v. 钩子；衔接，连接"]}, {"name": "hooray", "usphone": "hʊˈreɪ", "ukphone": "", "trans": ["int. 好哇！（欢呼声）"]}, {"name": "hope", "usphone": "həʊp", "ukphone": "", "trans": ["n.& v. 希望"]}, {"name": "hopeful", "usphone": "ˈhəʊpfʊl", "ukphone": "", "trans": ["a. 有希望的；有前途的"]}, {"name": "hopeless", "usphone": "", "ukphone": "", "trans": ["a.没有希望,不可救药的"]}, {"name": "horrible", "usphone": "ˈhɔrɪb(ə)l", "ukphone": "", "trans": ["a. 令人恐惧；恐怖的"]}, {"name": "horse", "usphone": "hɔːs", "ukphone": "", "trans": ["n. 马"]}, {"name": "hospital", "usphone": "ˈhɔspɪt(ə)l", "ukphone": "", "trans": ["n. 医院"]}, {"name": "host", "usphone": "həʊst", "ukphone": "", "trans": ["n. 主人；节目主持人 v. 做主人招待"]}, {"name": "hostess", "usphone": "ˈhəʊstɪs", "ukphone": "", "trans": ["n. 女主人"]}, {"name": "hot", "usphone": "hɔt,hɑt", "ukphone": "", "trans": ["a. 热的"]}, {"name": "hot dog", "usphone": "hɔt- dɔɡ", "ukphone": "", "trans": ["n. 热狗(红肠面包)"]}, {"name": "hotel", "usphone": "həʊˈtel", "ukphone": "", "trans": ["n. 旅馆，饭店，宾馆"]}, {"name": "hour", "usphone": "ˈaʊə(r)", "ukphone": "", "trans": ["n. 小时"]}, {"name": "house", "usphone": "haʊs", "ukphone": "", "trans": ["n. 房子；住宅"]}, {"name": "housewife", "usphone": "ˈhaʊswaɪf", "ukphone": "", "trans": ["n. 家庭主妇"]}, {"name": "housework", "usphone": "ˈhaʊswɜːk", "ukphone": "", "trans": ["n. 家务劳动"]}, {"name": "how", "usphone": "haʊ", "ukphone": "", "trans": ["ad.怎样,如何；多少；多么"]}, {"name": "however", "usphone": "haʊˈevə(r)", "ukphone": "", "trans": ["ad. 可是 conj. 然而，可是，尽管如此"]}, {"name": "howl", "usphone": "haʊl", "ukphone": "", "trans": ["vi. 嚎叫，嚎哭"]}, {"name": "hug", "usphone": "hʌɡ", "ukphone": "", "trans": ["v. 拥抱"]}, {"name": "huge", "usphone": "hjuːdʒ", "ukphone": "", "trans": ["a. 巨大的，庞大的"]}, {"name": "human", "usphone": "ˈhjuːmən", "ukphone": "", "trans": ["a. 人的，人类的"]}, {"name": "human being", "usphone": "ˈhjuːmən ˈbiːɪŋ", "ukphone": "", "trans": ["人"]}, {"name": "humorous", "usphone": "ˈhjuːmərəs", "ukphone": "", "trans": ["a. 富于幽默的"]}, {"name": "humour (美humor)", "usphone": "ˈhju:mə", "ukphone": "", "trans": ["n.幽默,幽默感"]}, {"name": "hundred", "usphone": "ˈhʌndrəd", "ukphone": "", "trans": ["num. 百"]}, {"name": "hunger", "usphone": "ˈhʌŋɡə(r)", "ukphone": "", "trans": ["n. 饥饿"]}, {"name": "hungry", "usphone": "ˈhʌŋɡrɪ", "ukphone": "", "trans": ["a. （饥）饿的"]}, {"name": "hunt", "usphone": "hʌnt", "ukphone": "", "trans": ["vt. 寻找；狩猎，猎取"]}, {"name": "hunter", "usphone": "ˈhʌntə(r)", "ukphone": "", "trans": ["n. 猎人"]}, {"name": "hurricane", "usphone": "ˈhʌrɪkən", "ukphone": "", "trans": ["n. 飓风，十二级风"]}, {"name": "hurry", "usphone": "ˈhʌrɪ", "ukphone": "", "trans": ["vi. 赶快；急忙"]}, {"name": "hurt (hurt, hurt)", "usphone": "hɜːt", "ukphone": "", "trans": ["vt. 伤害，受伤；伤人感情"]}, {"name": "husband", "usphone": "ˈhʌzbənd", "ukphone": "", "trans": ["n. 丈夫"]}, {"name": "hydrogen", "usphone": "ˈhaɪdrədʒ(ə)n", "ukphone": "", "trans": ["n. 氢"]}, {"name": "I", "usphone": "aɪ", "ukphone": "", "trans": ["pron. 我"]}, {"name": "ice", "usphone": "aɪs", "ukphone": "", "trans": ["n. 冰"]}, {"name": "ice--cream", "usphone": "aɪs- kriːm", "ukphone": "", "trans": ["n. 冰淇淋"]}, {"name": "Iceland", "usphone": "ˈaɪslənd", "ukphone": "", "trans": ["* n. 冰岛"]}, {"name": "idea", "usphone": "aɪˈdɪə", "ukphone": "", "trans": ["n. 主意,意见,打算,想法"]}, {"name": "identity", "usphone": "aɪˈdentɪtɪ", "ukphone": "", "trans": ["n. 身份，特征"]}, {"name": "identification", "usphone": "aɪdentɪfɪˈkeɪʃ(ə)n", "ukphone": "", "trans": ["n. 鉴定，辨别"]}, {"name": "idiom", "usphone": "ˈɪdɪəm", "ukphone": "", "trans": ["n. 习语，成语"]}, {"name": "if", "usphone": "ɪf", "ukphone": "", "trans": ["conj.如果,假使,是否,是不是"]}, {"name": "ignore", "usphone": "ɪɡˈnɔː(r)", "ukphone": "", "trans": ["v. 忽视，对…不理会"]}, {"name": "ill", "usphone": "ɪl", "ukphone": "", "trans": ["a. 有病的；不健康的"]}, {"name": "illegal", "usphone": "ɪˈliːɡ(ə)l", "ukphone": "", "trans": ["a. 非法的"]}, {"name": "illness", "usphone": "ˈɪlnɪs", "ukphone": "", "trans": ["n. 疾病"]}, {"name": "imagine", "usphone": "ɪˈmædʒɪn", "ukphone": "", "trans": ["vt. 想像，设想"]}, {"name": "immediate", "usphone": "ɪˈmiːdɪət", "ukphone": "", "trans": ["a. 立即的，马上"]}, {"name": "immediately", "usphone": "ɪˈmiːdɪətlɪ", "ukphone": "", "trans": ["ad. 立即"]}, {"name": "immigration", "usphone": "ɪmɪˈgreɪʃn", "ukphone": "", "trans": ["n. 移民"]}, {"name": "import", "usphone": "ɪmˈpɔːt", "ukphone": "", "trans": ["v.& n. 进口，输入"]}, {"name": "importance", "usphone": "ɪmˈpɔːt(ə)ns", "ukphone": "", "trans": ["n. 重要性"]}, {"name": "important", "usphone": "ɪmˈpɔːtənt", "ukphone": "", "trans": ["a. 重要的"]}, {"name": "impossible", "usphone": "ɪmˈpɔsɪb(ə)l", "ukphone": "", "trans": ["a. 不可能的"]}, {"name": "impress", "usphone": "ɪmˈpres", "ukphone": "", "trans": ["vt. 留下极深的印象"]}, {"name": "impression", "usphone": "ɪmˈpreʃ(ə)n", "ukphone": "", "trans": ["n. 印象，感觉"]}, {"name": "improve", "usphone": "ɪmˈpruːv", "ukphone": "", "trans": ["vt. 改进，更新"]}, {"name": "in", "usphone": "ɪn", "ukphone": "", "trans": ["prep. 在…里(内)；在…；以… ad. 在家，在内，向内"]}, {"name": "inch", "usphone": "ɪntʃ", "ukphone": "", "trans": ["n. 英寸"]}, {"name": "incident", "usphone": "ˈɪnsɪd(ə)nt", "ukphone": "", "trans": ["n. 事件"]}, {"name": "include", "usphone": "ɪnˈkluːd", "ukphone": "", "trans": ["vt. 包含，包括"]}, {"name": "income", "usphone": "ˈɪnkʌm", "ukphone": "", "trans": ["n. 收入，所得"]}, {"name": "incorrect", "usphone": "ɪnkəˈrekt", "ukphone": "", "trans": ["a. 不正确的，错误的"]}, {"name": "increase", "usphone": "ɪnˈkriːs", "ukphone": "", "trans": ["v. & n. 增加，繁殖"]}, {"name": "indeed", "usphone": "ɪnˈdiːd", "ukphone": "", "trans": ["a. 确实；实在"]}, {"name": "independence", "usphone": "ɪndɪˈpendəns", "ukphone": "", "trans": ["n. 独立"]}, {"name": "independent", "usphone": "ɪndɪˈpendənt", "ukphone": "", "trans": ["a.独立的,有主见的"]}, {"name": "India", "usphone": "ˈɪndɪə", "ukphone": "", "trans": ["* n. 印度"]}, {"name": "Indian", "usphone": "ˈɪndɪən", "ukphone": "", "trans": ["a. （美洲）印地安人的； 印度人的 n. 印地安人；印度人"]}, {"name": "Indicate", "usphone": "ˈɪndɪkeɪt", "ukphone": "", "trans": ["v.表明，象征，暗示"]}, {"name": "industry", "usphone": "ˈɪndəstrɪ", "ukphone": "", "trans": ["n. 工业，产业"]}, {"name": "influence", "usphone": "ˈɪnflʊəns", "ukphone": "", "trans": ["n.& v. 影响"]}, {"name": "inform", "usphone": "ɪnˈfɔːm", "ukphone": "", "trans": ["vt. 告诉； 通知"]}, {"name": "information", "usphone": "ɪnfəˈmeɪʃ(ə)n", "ukphone": "", "trans": ["n. 信息"]}, {"name": "information desk", "usphone": "ɪnfəˈmeɪʃ(ə)n desk", "ukphone": "", "trans": ["问讯处"]}, {"name": "initial", "usphone": "ɪˈnɪʃ(ə)l", "ukphone": "", "trans": ["a. 开始的，最初的"]}, {"name": "injure", "usphone": "ˈɪndʒə(r)", "ukphone": "", "trans": ["vt. 损害，伤害"]}, {"name": "injury", "usphone": "ˈɪndʒərɪ", "ukphone": "", "trans": ["n. 受伤处"]}, {"name": "ink", "usphone": "ɪŋk", "ukphone": "", "trans": ["n. 墨水，油墨"]}, {"name": "inland", "usphone": "ˈɪnlənd, ˈɪnlænd", "ukphone": "", "trans": ["a. 内陆的；内地的"]}, {"name": "inn", "usphone": "ɪn", "ukphone": "", "trans": ["n. 小旅店；小饭店"]}, {"name": "innocent", "usphone": "ˈɪnəsənt", "ukphone": "", "trans": ["a.无辜的，清白的"]}, {"name": "insect", "usphone": "ˈɪnsekt", "ukphone": "", "trans": ["n. 昆虫"]}, {"name": "insert", "usphone": "ɪnˈsɜːt", "ukphone": "", "trans": ["vt. 插入"]}, {"name": "inside", "usphone": "ɪnˈsaɪd", "ukphone": "", "trans": ["prep.在…里面 ad.在里面"]}, {"name": "insist", "usphone": "ɪnˈsɪst", "ukphone": "", "trans": ["vi. 坚持；坚决认为"]}, {"name": "inspect", "usphone": "ɪnˈspekt", "ukphone": "", "trans": ["vt. 检查；检验；审视"]}, {"name": "inspire", "usphone": "ɪnˈspaɪə(r)", "ukphone": "", "trans": ["vt. 鼓舞； 激励"]}, {"name": "instant", "usphone": "ˈɪnst(ə)nt", "ukphone": "", "trans": ["a. 瞬间；刹那"]}, {"name": "instead", "usphone": "ɪnˈsted", "ukphone": "", "trans": ["ad. 代替，顶替"]}, {"name": "institute", "usphone": "ˈɪnstɪtjuːt; (US) ˈɪnstətuːt", "ukphone": "", "trans": ["n. (研究)所, 院，学院"]}, {"name": "institution", "usphone": "ɪnstɪˈtjuːʃ(ə)n; (US) ɪnstəˈtuːʃn", "ukphone": "", "trans": ["n. (慈善、宗教等性质的)公共机构； 学校"]}, {"name": "instruct", "usphone": "ɪnˈstrʌkt", "ukphone": "", "trans": ["vt. 通知；指示；教"]}, {"name": "instruction", "usphone": "ɪnˈstrʌkʃ(ə)n", "ukphone": "", "trans": ["n. 说明,须知;教导"]}, {"name": "instrument", "usphone": "ˈɪnstrʊmənt", "ukphone": "", "trans": ["n. 乐器;工具,器械"]}, {"name": "insurance", "usphone": "ɪnˈʃʊərəns", "ukphone": "", "trans": ["n. 保险"]}, {"name": "insure", "usphone": "ɪnˈʃʊə(r)", "ukphone": "", "trans": ["vt. 给……保险"]}, {"name": "intelligence", "usphone": "ɪnˈtelɪdʒəns", "ukphone": "", "trans": ["n.智力,才智,智慧"]}, {"name": "intend", "usphone": "ɪnˈtend", "ukphone": "", "trans": ["vt. 想要，打算"]}, {"name": "intention", "usphone": "ɪnˈtenʃ(ə)n", "ukphone": "", "trans": ["n. 打算,计划,意图"]}, {"name": "interest", "usphone": "ˈɪntrəst", "ukphone": "", "trans": ["n. 兴趣，趣味;利息"]}, {"name": "interesting", "usphone": "ˈɪntrətɪŋ", "ukphone": "", "trans": ["a. 有趣的"]}, {"name": "international", "usphone": "ɪntəˈnæʃən(ə)l", "ukphone": "", "trans": ["a. 国际的"]}, {"name": "internet", "usphone": "ˈɪntənet", "ukphone": "", "trans": ["n. 互联网，英特网"]}, {"name": "interpreter", "usphone": "ɪnˈtɜːprɪtə(r)", "ukphone": "", "trans": ["n.翻译"]}, {"name": "interrupt", "usphone": "ɪntəˈrʌpt", "ukphone": "", "trans": ["v. 打扰，打断"]}, {"name": "interval", "usphone": "ˈɪntəv(ə)l", "ukphone": "", "trans": ["n. 间歇；间隔"]}, {"name": "interview", "usphone": "ˈɪntəvjuː", "ukphone": "", "trans": ["n.& vt.采访,会见,面试"]}, {"name": "into", "usphone": "ˈɪntʊ, ˈɪntə", "ukphone": "", "trans": ["prep. 到…里;向内；变成"]}, {"name": "introduce", "usphone": "ɪntrəˈdjuːs; (US) -duːs", "ukphone": "", "trans": ["vt. 介绍"]}, {"name": "introduction", "usphone": "ɪntrəˈdʌkʃ(ə)n", "ukphone": "", "trans": ["n. 引进，介绍"]}, {"name": "invent", "usphone": "ɪnˈvent", "ukphone": "", "trans": ["vt. 发明，创造"]}, {"name": "invention", "usphone": "ɪnˈvenʃ(ə)n", "ukphone": "", "trans": ["n. 发明，创造"]}, {"name": "inventor", "usphone": "ɪnˈventə(r)", "ukphone": "", "trans": ["n. 发明者，创造者"]}, {"name": "invitation", "usphone": "ɪnvɪˈteɪʃ(ə)n", "ukphone": "", "trans": ["n. 邀请，请帖"]}, {"name": "invite", "usphone": "ɪnˈvaɪt", "ukphone": "", "trans": ["vt. 邀请，招待"]}, {"name": "Ireland", "usphone": "ˈaɪələnd", "ukphone": "", "trans": ["* n. 爱尔兰"]}, {"name": "Irish", "usphone": "ˈaɪərɪʃ", "ukphone": "", "trans": ["a. 爱尔兰的，爱尔兰人的"]}, {"name": "iron", "usphone": "ˈaɪən; (US) ˈaɪərn", "ukphone": "", "trans": ["n. 铁，熨斗 vt. 熨烫"]}, {"name": "irrigate", "usphone": "ˈɪrɪɡeɪt", "ukphone": "", "trans": ["vt. 灌溉"]}, {"name": "irrigation", "usphone": "ɪrɪˈɡeɪʃ(ə)n", "ukphone": "", "trans": ["n. 灌溉"]}, {"name": "island", "usphone": "ˈaɪlənd", "ukphone": "", "trans": ["n. 岛"]}, {"name": "it", "usphone": "ɪt", "ukphone": "", "trans": ["pron. 它"]}, {"name": "Italian", "usphone": "ɪˈtæljən", "ukphone": "", "trans": ["a. 意大利(人)的；意大利语的 n. 意大利人；意大利语"]}, {"name": "Italy", "usphone": "ˈɪtəlɪ", "ukphone": "", "trans": ["* n. 意大利"]}, {"name": "its", "usphone": "ɪts", "ukphone": "", "trans": ["pron. 它的"]}, {"name": "itself", "usphone": "ɪtˈself", "ukphone": "", "trans": ["pron. 它自己"]}, {"name": "jacket", "usphone": "ˈdʒækɪt", "ukphone": "", "trans": ["n. 短上衣，夹克衫"]}, {"name": "jam", "usphone": "dʒæm", "ukphone": "", "trans": ["n. 果酱；阻塞"]}, {"name": "January", "usphone": "ˈdʒænjʊərɪ; (US) ˈdʒænjʊerɪ", "ukphone": "", "trans": ["n. 1月"]}, {"name": "Japan", "usphone": "dʒæˈpæn", "ukphone": "", "trans": ["* n. 日本"]}, {"name": "Japanese", "usphone": "dʒæpəˈniːz", "ukphone": "", "trans": ["a. 日本的，日本人的，日语的 n. 日本人，日语"]}, {"name": "jar", "usphone": "dʒɑː(r)", "ukphone": "", "trans": ["n. 罐子；坛子"]}, {"name": "jaw", "usphone": "dʒɔː", "ukphone": "", "trans": ["n. 下巴"]}, {"name": "jazz", "usphone": "dʒæz", "ukphone": "", "trans": ["n. 爵士音乐，爵士舞曲"]}, {"name": "jeans", "usphone": "dʒiːns", "ukphone": "", "trans": ["n. 牛仔裤"]}, {"name": "jeep", "usphone": "dʒiːp", "ukphone": "", "trans": ["n. 吉普车"]}, {"name": "jet", "usphone": "dʒet", "ukphone": "", "trans": ["n. 喷气式飞机；喷射（器）"]}, {"name": "jewel", "usphone": "ˈdʒuːəl", "ukphone": "", "trans": ["n. 宝石"]}, {"name": "jewelry", "usphone": "ˈdʒuːəlrɪ", "ukphone": "", "trans": ["n. （总称）珠宝"]}, {"name": "job", "usphone": "dʒɔb", "ukphone": "", "trans": ["n. （一份）工作"]}, {"name": "jog", "usphone": "dʒɔɡ", "ukphone": "", "trans": ["v. 慢跑"]}, {"name": "join", "usphone": "dʒɔɪn", "ukphone": "", "trans": ["v.参加,加入;连接;会合"]}, {"name": "joke", "usphone": "dʒəʊk", "ukphone": "", "trans": ["n. 笑话"]}, {"name": "journalist", "usphone": "ˈdʒɜːnəlɪzt", "ukphone": "", "trans": ["n. 记者，新闻工作者"]}, {"name": "journey", "usphone": "ˈdʒɜːnɪ", "ukphone": "", "trans": ["n. 旅行，路程"]}, {"name": "joy", "usphone": "dʒɔɪ", "ukphone": "", "trans": ["n. 欢乐，高兴，乐趣"]}, {"name": "judge", "usphone": "dʒʌdʒ", "ukphone": "", "trans": ["n. 裁判；审判员；法官vt. 判断，断定"]}, {"name": "judgement", "usphone": "ˈdʒʌdʒmənt", "ukphone": "", "trans": ["n. 裁判"]}, {"name": "juice", "usphone": "dʒuːs", "ukphone": "", "trans": ["n. 汁、液"]}, {"name": "juicy", "usphone": "dʒuːsɪ", "ukphone": "", "trans": ["a. 多汁的；水分多的"]}, {"name": "July", "usphone": "dʒʊˈlaɪ", "ukphone": "", "trans": ["n. 7月"]}, {"name": "jump", "usphone": "dʒʌmp", "ukphone": "", "trans": ["n. 跳跃；跳变 v. 跳跃；惊起；猛扑"]}, {"name": "June", "usphone": "dʒuːn", "ukphone": "", "trans": ["n. 6月"]}, {"name": "jungle", "usphone": "ˈdʒʌŋɡ(ə)l", "ukphone": "", "trans": ["n. 丛林，密林"]}, {"name": "junior", "usphone": "ˈdʒuːnɪə(r)", "ukphone": "", "trans": ["a. 初级的；年少的"]}, {"name": "junk", "usphone": "dʒʌŋk", "ukphone": "", "trans": ["n. （口语）废品，破烂货"]}, {"name": "junk mail", "usphone": "dʒʌŋk meɪl", "ukphone": "", "trans": ["塞到邮箱的广告宣传品"]}, {"name": "junk food", "usphone": "dʒʌŋk fuːd", "ukphone": "", "trans": ["没有营养的垃圾食品"]}, {"name": "just", "usphone": "dʒʌst", "ukphone": "", "trans": ["ad. 刚才；恰好；不过；仅 a. 公正的"]}, {"name": "justice", "usphone": "ˈdʒʌstɪs", "ukphone": "", "trans": ["n. 正义；公正；司法"]}, {"name": "kangaroo", "usphone": "kæŋɡəˈruː", "ukphone": "", "trans": ["n. 大袋鼠"]}, {"name": "keep (kept, kept)", "usphone": "kiːp", "ukphone": "", "trans": ["v. 保持；保存；继续不断 vt. 培育，饲养"]}, {"name": "keeper", "usphone": "ˈkiːpə(r)", "ukphone": "", "trans": ["n. （动物园中的）饲养员，看守人"]}, {"name": "kettle", "usphone": "ˈket(ə)l", "ukphone": "", "trans": ["n. (烧水用的)水壶"]}, {"name": "key", "usphone": "kiː", "ukphone": "", "trans": ["n. 钥匙;答案;键;关键"]}, {"name": "keyboard", "usphone": "kiːbɔːd", "ukphone": "", "trans": ["n. 键盘"]}, {"name": "kick", "usphone": "kɪk", "ukphone": "", "trans": ["v.& n. 踢"]}, {"name": "kid", "usphone": "kɪd", "ukphone": "", "trans": ["n. 小孩"]}, {"name": "kill", "usphone": "kɪl", "ukphone": "", "trans": ["v. 杀死，弄死"]}, {"name": "kilo", "usphone": "ˈkiːləʊ", "ukphone": "", "trans": ["n. 千克；千米"]}, {"name": "kilogram", "usphone": "ˈkɪləɡræm", "ukphone": "", "trans": ["n. 千克"]}, {"name": "kilometr", "usphone": "ˈkiləʊmi:tə(r)", "ukphone": "", "trans": ["e n. 千米（公里）"]}, {"name": "kind", "usphone": "kaɪnd", "ukphone": "", "trans": ["n. 种;类 a. 善良,友好的"]}, {"name": "kindergarten", "usphone": "kɪndəˈɡɑːt(ə)n", "ukphone": "", "trans": ["n. 幼儿园"]}, {"name": "kind-hearted", "usphone": "kaɪnd- ˈhɑ:tid", "ukphone": "", "trans": ["a. 好心的"]}, {"name": "kindness", "usphone": "ˈkaɪndnɪs", "ukphone": "", "trans": ["n. 仁慈；善良"]}, {"name": "king", "usphone": "kɪŋ", "ukphone": "", "trans": ["n. 国王"]}, {"name": "kingdom", "usphone": "ˈkɪŋdəm", "ukphone": "", "trans": ["n. 王国"]}, {"name": "kiss", "usphone": "kɪs", "ukphone": "", "trans": ["n.& vt. 吻，亲吻"]}, {"name": "kitchen", "usphone": "ˈkɪtʃɪn", "ukphone": "", "trans": ["n. 厨房"]}, {"name": "kite", "usphone": "kaɪt", "ukphone": "", "trans": ["n. 风筝"]}, {"name": "knee", "usphone": "niː", "ukphone": "", "trans": ["n. 膝盖"]}, {"name": "knife", "usphone": "naɪf", "ukphone": "", "trans": ["(复 knives) n.小刀;匕首;刀片"]}, {"name": "knock", "usphone": "nɔk", "ukphone": "", "trans": ["n.& v. 敲；打；击 "]}, {"name": "know(knew,known)", "usphone": "nəʊ", "ukphone": "", "trans": ["v. 知道，了解；认识；懂得"]}, {"name": "knowledge", "usphone": "ˈnɔlɪdʒ", "ukphone": "", "trans": ["n. 知识，学问"]}, {"name": "lab", "usphone": "ˈnɔlɪdʒ", "ukphone": "", "trans": ["= laboratory n. 实验室"]}, {"name": "labour (美labor)", "usphone": "ˈleɪbə(r)", "ukphone": "", "trans": ["n. 劳动"]}, {"name": "labourer (laborer)", "usphone": "ˈleibərə", "ukphone": "", "trans": ["n.体力劳动者"]}, {"name": "lack", "usphone": "læk", "ukphone": "", "trans": ["n.& vt. 缺乏，缺少"]}, {"name": "ladder", "usphone": "ˈlædə(r)", "ukphone": "", "trans": ["r n. 梯子"]}, {"name": "lady", "usphone": "ˈleɪdɪ", "ukphone": "", "trans": ["n. 女士，夫人"]}, {"name": "lake", "usphone": "leɪk", "ukphone": "", "trans": ["n. 湖"]}, {"name": "lamb", "usphone": "læm", "ukphone": "", "trans": ["n. 羔羊"]}, {"name": "lame", "usphone": "leɪm", "ukphone": "", "trans": ["a. 跛的，瘸的，残废的"]}, {"name": "lamp", "usphone": "læmp", "ukphone": "", "trans": ["n. 灯，油灯；光源"]}, {"name": "land", "usphone": "lænd", "ukphone": "", "trans": ["n.陆地,土地v.登岸(陆)降落"]}, {"name": "language", "usphone": "ˈlæŋɡwɪdʒ", "ukphone": "", "trans": ["n. 语言"]}, {"name": "lantern", "usphone": "ˈlæntən", "ukphone": "", "trans": ["n. 灯笼；提灯"]}, {"name": "lap", "usphone": "læp", "ukphone": "", "trans": ["n. (人坐时)膝部.(跑道的)一圈"]}, {"name": "large", "usphone": "lɑːdʒ", "ukphone": "", "trans": ["a. 大的；巨大的"]}, {"name": "laser", "usphone": "ˈleɪzə(r)", "ukphone": "", "trans": ["n. 激光"]}, {"name": "last", "usphone": "lɑːst; (US) læst", "ukphone": "", "trans": ["a.最近刚过去;最后的ad.最近刚过去;最后地 n.最后v.持续"]}, {"name": "late", "usphone": "leɪt", "ukphone": "", "trans": ["a.晚的,迟的ad.晚地,迟地"]}, {"name": "lately", "usphone": "ˈleɪtlɪ", "ukphone": "", "trans": ["ad. 最近，不久前"]}, {"name": "later", "usphone": "ˈleɪtə(r)", "ukphone": "", "trans": ["a. 晚些的，迟些的"]}, {"name": "latest", "usphone": "ˈleɪtɪst", "ukphone": "", "trans": ["a.最近，最新的；最晚的"]}, {"name": "latter", "usphone": "ˈlætə(r)", "ukphone": "", "trans": ["n.（两者之中的）后者"]}, {"name": "laugh", "usphone": "lɑːf", "ukphone": "", "trans": ["n.& v. 笑，大笑；嘲笑"]}, {"name": "laughter", "usphone": "ˈlɑːftə(r); (US) ˈlæftər", "ukphone": "", "trans": ["n. 笑； 笑声"]}, {"name": "laundry", "usphone": "ˈlɔːndrɪ", "ukphone": "", "trans": ["n. 洗衣店;要洗的衣服"]}, {"name": "lavatory", "usphone": "ˈlævətrɪ; (US) ˈlævətɔːrɪ", "ukphone": "", "trans": ["n. 便所，厕所"]}, {"name": "law", "usphone": "lɔː", "ukphone": "", "trans": ["n. 法律，法令；定律"]}, {"name": "lawyer", "usphone": "ˈlɔːjə(r), ˈlɔɪə(r)", "ukphone": "", "trans": ["n. 律师"]}, {"name": "lay (laid, laid)", "usphone": "leɪ", "ukphone": "", "trans": ["vt. 放，搁"]}, {"name": "lazy", "usphone": "ˈleɪzɪ", "ukphone": "", "trans": ["a. 懒惰的"]}, {"name": "lead (led, led)", "usphone": "liːd", "ukphone": "", "trans": ["v. 领导，带领 n. 铅"]}, {"name": "leader", "usphone": "ˈliːdə(r)", "ukphone": "", "trans": ["n. 领袖，领导人"]}, {"name": "leading", "usphone": "ˈliːdɪŋ", "ukphone": "", "trans": ["a. 最主要的，第一位的"]}, {"name": "leaf (复 leaves)", "usphone": "liːf", "ukphone": "", "trans": ["n. （树，菜）叶"]}, {"name": "league", "usphone": "liːɡ", "ukphone": "", "trans": ["n. 联盟，社团"]}, {"name": "leak", "usphone": "liːk", "ukphone": "", "trans": ["vi. 漏； 渗"]}, {"name": "learn (learnt, learnt；--ed --ed)", "usphone": "lɜːn", "ukphone": "", "trans": ["vt. 学，学习，学会"]}, {"name": "learned", "usphone": "ˈlɜːnɪd", "ukphone": "", "trans": ["a. 有才华的；博学的"]}, {"name": "least", "usphone": "liːst", "ukphone": "", "trans": ["n.最少，最少量"]}, {"name": "leather", "usphone": "ˈleðə(r)", "ukphone": "", "trans": ["n. 皮革"]}, {"name": "leave (left, left)", "usphone": "liːv", "ukphone": "", "trans": ["v. 离开;把…留下，剩下"]}, {"name": "lecture", "usphone": "ˈlektʃə(r)", "ukphone": "", "trans": ["n. 讲课，演讲"]}, {"name": "left", "usphone": "left", "ukphone": "", "trans": ["a.左边的 ad.向左 n.左,左边"]}, {"name": "left-handed", "usphone": "left- ˈ hændid", "ukphone": "", "trans": ["a. 惯用左手的"]}, {"name": "leftover", "usphone": "ˈleftˌəuvə", "ukphone": "", "trans": ["a.剩余,剩下的n.剩饭菜"]}, {"name": "left-wing", "usphone": "left-wɪŋ", "ukphone": "", "trans": ["n. 左翼的"]}, {"name": "leg", "usphone": "leɡ", "ukphone": "", "trans": ["n. 腿；腿脚；支柱"]}, {"name": "legal", "usphone": "ˈliːɡ(ə)l", "ukphone": "", "trans": ["a.与法律有关的，法律的"]}, {"name": "lemon", "usphone": "ˈlemən", "ukphone": "", "trans": ["n. 柠檬 a. 柠檬色(味)的"]}, {"name": "lemonade", "usphone": "leməˈneɪd", "ukphone": "", "trans": ["n. 柠檬水"]}, {"name": "lend (lent, lent)", "usphone": "lend", "ukphone": "", "trans": ["vt.借(出),把…借给"]}, {"name": "length", "usphone": "leŋθ", "ukphone": "", "trans": ["n. 长，长度，段，节"]}, {"name": "less（little的比较级）", "usphone": "les", "ukphone": "", "trans": ["a.& ad. 少于,小于"]}, {"name": "lesson", "usphone": "ˈles(ə)n", "ukphone": "", "trans": ["n. 课；功课；教训"]}, {"name": "let (let, let)", "usphone": "let", "ukphone": "", "trans": ["vt. 让"]}, {"name": "letter", "usphone": "ˈletə(r)", "ukphone": "", "trans": ["n. 信；字母"]}, {"name": "letter-box", "usphone": "ˈletə(r)- bɔks", "ukphone": "", "trans": ["n. 信箱"]}, {"name": "level", "usphone": "ˈlev(ə)l", "ukphone": "", "trans": ["n. 水平线，水平"]}, {"name": "liberty", "usphone": "ˈlɪbətɪ", "ukphone": "", "trans": ["n. 自由"]}, {"name": "liberate", "usphone": "ˈlɪbəreɪt", "ukphone": "", "trans": ["vt. 解放，使获自由"]}, {"name": "liberation", "usphone": "lɪbəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n. 解放"]}, {"name": "librarian", "usphone": "laɪˈbreərɪən", "ukphone": "", "trans": ["n. 图书管理员；（西方的）图书馆馆长"]}, {"name": "library", "usphone": "ˈlaɪbrərɪ; (US) ˈlaɪbrerɪ", "ukphone": "", "trans": ["n. 图书馆，图书室"]}, {"name": "license", "usphone": "ˈlaɪsəns", "ukphone": "", "trans": ["n. 执照，许可证"]}, {"name": "lid", "usphone": "lɪd", "ukphone": "", "trans": ["n. 盖子"]}, {"name": "lie (lay, lain)", "usphone": "laɪ", "ukphone": "", "trans": ["v. 躺;卧;平放;位于n.& vi. 谎言; 说谎"]}, {"name": "life (复lives)", "usphone": "laɪf", "ukphone": "", "trans": ["n. 生命；生涯；生活；人生；生物"]}, {"name": "lifetime", "usphone": "ˈlaɪftaɪm", "ukphone": "", "trans": ["n. 一生，终生"]}, {"name": "lift", "usphone": "lɪft", "ukphone": "", "trans": ["v. 举起，抬起；（云、烟等）消散 n. （英）电梯"]}, {"name": "light", "usphone": "laɪt", "ukphone": "", "trans": ["n. 光，光亮；灯，灯光 vt. 点（火），点燃 a. 明亮的；轻的；浅色的"]}, {"name": "lightning", "usphone": "ˈlaɪtnɪŋ", "ukphone": "", "trans": ["n.闪电"]}, {"name": "like", "usphone": "laɪk", "ukphone": "", "trans": ["prep. 像，跟…一样 vt. 喜欢，喜爱"]}, {"name": "likely", "usphone": "ˈlaɪklɪ", "ukphone": "", "trans": ["a.很可能的"]}, {"name": "limit", "usphone": "ˈlɪmɪt", "ukphone": "", "trans": ["vt. 限制；减少"]}, {"name": "line", "usphone": "laɪn", "ukphone": "", "trans": ["n. 绳索，线，排，行，线路 v. 画线于，（使）成行"]}, {"name": "link", "usphone": "lɪŋk", "ukphone": "", "trans": ["v. 连接； 联系"]}, {"name": "lion", "usphone": "ˈlaɪən", "ukphone": "", "trans": ["n. 狮子"]}, {"name": "lip", "usphone": "lɪp", "ukphone": "", "trans": ["n. 嘴唇"]}, {"name": "liquid", "usphone": "ˈlɪkwɪd", "ukphone": "", "trans": ["n. & a. 液体；液体的"]}, {"name": "list", "usphone": "lɪst", "ukphone": "", "trans": ["n. 一览表，清单"]}, {"name": "listen", "usphone": "ˈlɪs(ə)n", "ukphone": "", "trans": ["vi. 听,仔细听"]}, {"name": "literature", "usphone": "ˈlɪtərətʃə(r); (US) ˈlɪtrətʃʊər", "ukphone": "", "trans": ["n. 文学"]}, {"name": "literary", "usphone": "ˈlɪtərərɪ; (US) ˈlɪtərerɪ", "ukphone": "", "trans": ["a. 文学的"]}, {"name": "litre (美liter)", "usphone": "liːtə(r)", "ukphone": "", "trans": ["n. 升； 公升"]}, {"name": "litter", "usphone": "ˈlɪtə(r)", "ukphone": "", "trans": ["v. 乱丢杂物"]}, {"name": "little (less, least)", "usphone": "ˈlɪt(ə)l", "ukphone": "", "trans": ["a.小的,少的 ad. 很少地, 稍许 n.没有多少,一点"]}, {"name": "live", "usphone": "lɪv", "ukphone": "", "trans": ["vi. 生活;居住;活着 a. 活的,活着的;实况,现场（直播）的"]}, {"name": "lively", "usphone": "ˈlaɪvlɪ", "ukphone": "", "trans": ["a. 活泼的;充满生气的"]}, {"name": "living", "usphone": "ˈlɪvɪŋ", "ukphone": "", "trans": ["a. 活着的 n. 生计"]}, {"name": "load", "usphone": "ləʊd", "ukphone": "", "trans": ["n. 担子，货物"]}, {"name": "loaf", "usphone": "ləʊf", "ukphone": "", "trans": ["n. 一个面包"]}, {"name": "local", "usphone": "ˈləʊk(ə)l", "ukphone": "", "trans": ["a. 当地的；地方的"]}, {"name": "lock", "usphone": "lɔk", "ukphone": "", "trans": ["n. 锁 vt. 锁，锁上"]}, {"name": "locust", "usphone": "ˈləʊkəst", "ukphone": "", "trans": ["n. 蝗虫"]}, {"name": "London", "usphone": "ˈlʌnd(ə)n", "ukphone": "", "trans": ["n. 伦敦"]}, {"name": "lonely", "usphone": "ˈləʊnlɪ", "ukphone": "", "trans": ["a. 孤独的，寂寞的"]}, {"name": "long", "usphone": "lɔŋ; (US) lɔːŋ", "ukphone": "", "trans": ["a. 长的，远 ad. 长久"]}, {"name": "look", "usphone": "lʊk", "ukphone": "", "trans": ["n. 看，瞧 v. 看，观看 v. link 看起来"]}, {"name": "loose", "usphone": "luːs", "ukphone": "", "trans": ["a. 松散的； 宽松的"]}, {"name": "lorry", "usphone": "ˈlɔrɪ; (US) ˈlɔːrɪ", "ukphone": "", "trans": ["n.（英）运货汽车，卡车"]}, {"name": "loss", "usphone": "lɔs; (US) lɔːs", "ukphone": "", "trans": ["n. 丧失；损耗"]}, {"name": "lose (lost, lost)", "usphone": "luːz", "ukphone": "", "trans": ["vt. 失去，丢失"]}, {"name": "Lost & Found", "usphone": "lɔst; (US) lɔːst", "ukphone": "", "trans": ["失物招领处"]}, {"name": "lot", "usphone": "lɔt", "ukphone": "", "trans": ["n. 许多，好些"]}, {"name": "loud", "usphone": "laʊd", "ukphone": "", "trans": ["a. 大声的"]}, {"name": "loudly", "usphone": "laʊdlɪ", "ukphone": "", "trans": ["ad. 大声地"]}, {"name": "loudspeaker", "usphone": "laʊdˈspiːkə(r)", "ukphone": "", "trans": ["n. 扬声器，喇叭"]}, {"name": "lounge", "usphone": "laʊndʒ", "ukphone": "", "trans": ["n. 休息厅；休息室"]}, {"name": "love", "usphone": "lʌv", "ukphone": "", "trans": ["n.& vt. 爱；热爱;很喜欢"]}, {"name": "lovely", "usphone": "ˈlʌvlɪ", "ukphone": "", "trans": ["a. 美好的，可爱的"]}, {"name": "low", "usphone": "ləʊ", "ukphone": "", "trans": ["a.& ad. 低；矮"]}, {"name": "luck", "usphone": "lʌk", "ukphone": "", "trans": ["n. 运气，好运"]}, {"name": "lucky", "usphone": "ˈlʌkɪ", "ukphone": "", "trans": ["a. 运气好，侥幸"]}, {"name": "luggage", "usphone": "ˈlʌɡɪdʒ", "ukphone": "", "trans": ["n. (总称)行李"]}, {"name": "lunch", "usphone": "lʌntʃ", "ukphone": "", "trans": ["n. 午餐，午饭"]}, {"name": "lung", "usphone": "lʌŋ", "ukphone": "", "trans": ["n. 肺；肺脏"]}, {"name": "machine", "usphone": "məˈʃiːn", "ukphone": "", "trans": ["n. 机器"]}, {"name": "mad", "usphone": "", "ukphone": "", "trans": ["a. 发疯的；生气的"]}, {"name": "madam/ madame", "usphone": "ˈmædəm", "ukphone": "", "trans": ["n. 夫人,女士"]}, {"name": "magazine", "usphone": "mæɡəˈziːn", "ukphone": "", "trans": ["n. 杂志"]}, {"name": "magic", "usphone": "ˈmædʒɪk", "ukphone": "", "trans": ["a. 有魔力的"]}, {"name": "maid", "usphone": "meɪd", "ukphone": "", "trans": ["n. 女仆；侍女"]}, {"name": "mail", "usphone": "meɪl", "ukphone": "", "trans": ["n. 邮政,邮递 v. (美)邮寄"]}, {"name": "mailbox", "usphone": "ˈmeɪlbɒks", "ukphone": "", "trans": ["n. 邮筒；邮箱"]}, {"name": "main", "usphone": "meɪn", "ukphone": "", "trans": ["a. 主要的"]}, {"name": "mainland", "usphone": "ˈmeɪnlənd", "ukphone": "", "trans": ["n. 大陆"]}, {"name": "major", "usphone": "ˈmeɪdʒə(r)", "ukphone": "", "trans": ["a. 较大的；主要的"]}, {"name": "majority", "usphone": "məˈdʒɔrɪtɪ", "ukphone": "", "trans": ["n. 大多数 "]}, {"name": "make (made,made)", "usphone": "meɪk", "ukphone": "", "trans": ["vt.制造,做;使得 n. 样式；制造"]}, {"name": "male", "usphone": "meɪl", "ukphone": "", "trans": ["a. 男（性）的；雄的"]}, {"name": "man (复men)", "usphone": "mæn", "ukphone": "", "trans": ["n. 成年男人;人类"]}, {"name": "manage", "usphone": "ˈmænɪdʒ", "ukphone": "", "trans": ["v. 管理；设法对付"]}, {"name": "manager", "usphone": "ˈmænɪdʒə(r)", "ukphone": "", "trans": ["n. 经理"]}, {"name": "mankind", "usphone": "mænˈkaɪnd", "ukphone": "", "trans": ["n. 人类;（总称）人"]}, {"name": "man-made", "usphone": "mæn- meɪd", "ukphone": "", "trans": ["a. 人造的，人工的"]}, {"name": "manner", "usphone": "ˈmænə(r)", "ukphone": "", "trans": ["n. 方式，态度，举止"]}, {"name": "table manners", "usphone": "ˈteɪb(ə)l ˈmænə(r) z", "ukphone": "", "trans": ["餐桌礼节，用餐的规矩"]}, {"name": "many (more, most)", "usphone": "ˈmenɪ", "ukphone": "", "trans": ["pron. 许多人（或物）a. 许多的"]}, {"name": "map", "usphone": "mæp", "ukphone": "", "trans": ["n. 地图"]}, {"name": "maple", "usphone": "ˈmeɪp(ə)l", "ukphone": "", "trans": ["n. 枫树"]}, {"name": "maple leaves", "usphone": "ˈmeɪp(ə)l-li:vz", "ukphone": "", "trans": ["枫叶"]}, {"name": "marathon", "usphone": "ˈmærəθ(ə)n", "ukphone": "", "trans": ["n. 马拉松"]}, {"name": "marble", "usphone": "ˈmɑːb(ə)l", "ukphone": "", "trans": ["n. 大理石；玻璃弹子"]}, {"name": "march", "usphone": "mɑːtʃ", "ukphone": "", "trans": ["n. 游行，行进"]}, {"name": "March", "usphone": "mɑːtʃ", "ukphone": "", "trans": ["n. 3月"]}, {"name": "mark", "usphone": "mɑːk", "ukphone": "", "trans": ["n.标记 vt.标明,作记号于"]}, {"name": "market", "usphone": "ˈmɑːkɪt", "ukphone": "", "trans": ["n. 市场，集市"]}, {"name": "marriage", "usphone": "ˈmærɪdʒ", "ukphone": "", "trans": ["n. 结婚，婚姻"]}, {"name": "married", "usphone": "ˈmærɪd", "ukphone": "", "trans": ["a. 已婚的"]}, {"name": "marry", "usphone": "ˈmærɪ", "ukphone": "", "trans": ["v.（使）成婚，结婚"]}, {"name": "mask", "usphone": "mɑːsk; (US) mæsk", "ukphone": "", "trans": ["n. 口罩；面罩(具)；遮盖物 v. 戴面具；掩饰；伪装"]}, {"name": "mass", "usphone": "mæs", "ukphone": "", "trans": ["n. 众多;大量;（复）群众"]}, {"name": "master", "usphone": "ˈmɑːstə(r); (US) ˈmæstər", "ukphone": "", "trans": ["vt. 精通，掌握"]}, {"name": "mat", "usphone": "mæt", "ukphone": "", "trans": ["n. 垫子"]}, {"name": "match", "usphone": "mætʃ", "ukphone": "", "trans": ["vt. 使相配，使成对 n. 比赛，竞赛 n. 火柴"]}, {"name": "material", "usphone": "məˈtɪərɪəl", "ukphone": "", "trans": ["n. 材料，原料"]}, {"name": "mathematics =math / maths", "usphone": "mæθəˈmætɪks", "ukphone": "", "trans": ["n.（常作单数用）数学, (英美口语) 数学"]}, {"name": "matter", "usphone": "ˈmætə(r)", "ukphone": "", "trans": ["n. 要紧事，要紧, 事情；问题 vi. 要紧，有重大关系"]}, {"name": "mature", "usphone": "məˈtjʊə(r); (US) məˈtʊər", "ukphone": "", "trans": ["a. 成熟的"]}, {"name": "maximum", "usphone": "ˈmæksɪməm", "ukphone": "", "trans": ["a.& n. 最大量(的)； 最大限度(的)"]}, {"name": "may modal", "usphone": "meɪ ˈməʊd(ə)l", "ukphone": "", "trans": ["v. 可以;也许,可能"]}, {"name": "May", "usphone": "meɪ", "ukphone": "", "trans": ["n. 5月"]}, {"name": "maybe", "usphone": "ˈmeɪbiː", "ukphone": "", "trans": ["ad. 可能，大概，也许"]}, {"name": "me", "usphone": "miː, mɪ", "ukphone": "", "trans": ["pron. 我（宾格）"]}, {"name": "meal", "usphone": "miːl", "ukphone": "", "trans": ["n. 一餐（饭） "]}, {"name": "mean(meant,meant)", "usphone": "miːn", "ukphone": "", "trans": ["vt.意思,意指"]}, {"name": "meaning", "usphone": "ˈmiːnɪŋ", "ukphone": "", "trans": ["n. 意思，含意"]}, {"name": "means", "usphone": "miːnz", "ukphone": "", "trans": ["n. 方法，手段；财产"]}, {"name": "meanwhile", "usphone": "ˈmiːnwaɪl; (US) ˈmɪnhwaɪl", "ukphone": "", "trans": ["ad. 同时"]}, {"name": "measure", "usphone": "ˈmeʒə(r)", "ukphone": "", "trans": ["v. 量"]}, {"name": "meat", "usphone": "miːt", "ukphone": "", "trans": ["n.（猪、牛、羊等的）肉"]}, {"name": "medal", "usphone": "ˈmed(ə)l", "ukphone": "", "trans": ["n. 奖牌"]}, {"name": "gold medal", "usphone": "ɡəʊld ˈmed(ə)l", "ukphone": "", "trans": ["金牌"]}, {"name": "media", "usphone": "ˈmiːdɪə", "ukphone": "", "trans": ["n. 大众传播媒介"]}, {"name": "medical", "usphone": "ˈmedɪk(ə)l", "ukphone": "", "trans": ["a. 医学的，医疗的"]}, {"name": "medicine", "usphone": "ˈmeds(ə)n; (US) ˈmedɪsn", "ukphone": "", "trans": ["n. 药"]}, {"name": "medium", "usphone": "ˈmiːdɪəm", "ukphone": "", "trans": ["n.媒体,中间的,中等的"]}, {"name": "meet (met, met)", "usphone": "miːt", "ukphone": "", "trans": ["vt./ n. 遇见，见到 会；集会"]}, {"name": "meeting", "usphone": "ˈmiːtɪŋ", "ukphone": "", "trans": ["n.会,集会,会见,汇合点"]}, {"name": "melon", "usphone": "ˈmelən", "ukphone": "", "trans": ["n. （甜）瓜；瓜状物"]}, {"name": "member", "usphone": "ˈmembə(r)", "ukphone": "", "trans": ["n. 成员，会员"]}, {"name": "memorial", "usphone": "mɪˈmɔːrɪəl", "ukphone": "", "trans": ["n. 纪念馆"]}, {"name": "memory", "usphone": "ˈmemərɪ", "ukphone": "", "trans": ["n. 回忆，记忆"]}, {"name": "memorize", "usphone": "ˈmeməraɪz", "ukphone": "", "trans": ["v. 记忆"]}, {"name": "mend", "usphone": "mend", "ukphone": "", "trans": ["v. 修理，修补"]}, {"name": "mental", "usphone": "ˈment(ə)l", "ukphone": "", "trans": ["a. 精神的；脑力的"]}, {"name": "mentally", "usphone": "ˈmentəlɪ", "ukphone": "", "trans": ["ad. 精神上；智力上"]}, {"name": "mention", "usphone": "ˈmenʃ(ə)n", "ukphone": "", "trans": ["n. 提及；记载 vt. 提到，说起；提名表扬"]}, {"name": "menu", "usphone": "ˈmenʃ(ə)n", "ukphone": "", "trans": ["n. 菜单"]}, {"name": "merchant", "usphone": "ˈmɜːtʃənt", "ukphone": "", "trans": ["a. 商业的；商人的 n. 商人；生意人"]}, {"name": "merciful", "usphone": "ˈmɜːsɪfʊl", "ukphone": "", "trans": ["a. 仁慈的；宽大的"]}, {"name": "mercy", "usphone": "ˈmɜːsɪ", "ukphone": "", "trans": ["n. 怜悯"]}, {"name": "merely", "usphone": "ˈmɪəlɪ", "ukphone": "", "trans": ["ad. 仅仅，只不过"]}, {"name": "merry", "usphone": "ˈmerɪ", "ukphone": "", "trans": ["a. 高兴的，愉快的"]}, {"name": "mess", "usphone": "mes", "ukphone": "", "trans": ["n. 凌乱"]}, {"name": "message", "usphone": "ˈmesɪdʒ", "ukphone": "", "trans": ["n. 消息，音信"]}, {"name": "messy", "usphone": "ˈmesɪ", "ukphone": "", "trans": ["a. 乱七八糟的"]}, {"name": "metal", "usphone": "ˈmet(ə)l", "ukphone": "", "trans": ["n. 金属 a. 金属制成的"]}, {"name": "method", "usphone": "ˈmeθəd", "ukphone": "", "trans": ["n. 方法，办法"]}, {"name": "metre (美meter)", "usphone": "ˈmi:tə", "ukphone": "", "trans": ["n. 米，公尺"]}, {"name": "Mexican", "usphone": "ˈmeksɪkən", "ukphone": "", "trans": ["a. 墨西哥的"]}, {"name": "Mexico", "usphone": "ˈmeksɪkəʊ", "ukphone": "", "trans": ["* n. 墨西哥"]}, {"name": "microcomputer", "usphone": "ˈmaɪkrəʊkəmpjuːtə(r)", "ukphone": "", "trans": ["n. 微机"]}, {"name": "microscope", "usphone": "ˈmaɪkrəskəʊp", "ukphone": "", "trans": ["n. 显微镜"]}, {"name": "microwave", "usphone": "ˈmaɪkrəʊweɪv", "ukphone": "", "trans": ["n. 微波"]}, {"name": "mid-autumn", "usphone": "mɪd- ˈɔːtəm", "ukphone": "", "trans": ["n. 中秋"]}, {"name": "midday", "usphone": "ˈmɪddeɪ", "ukphone": "", "trans": ["n. 中午, 正午"]}, {"name": "middle", "usphone": "ˈmɪd(ə)l", "ukphone": "", "trans": ["n. 中间;当中;中级的"]}, {"name": "Middle East", "usphone": "ˈmɪd(ə)l iːst", "ukphone": "", "trans": ["n. 中东"]}, {"name": "midnight", "usphone": "ˈmɪdnaɪt", "ukphone": "", "trans": ["n. 午夜"]}, {"name": "might", "usphone": "maɪt", "ukphone": "", "trans": ["v. aux. (may的过去式，助动词) 可能，也许，或许"]}, {"name": "mild", "usphone": "maɪld", "ukphone": "", "trans": ["a. 温和,暖和的,凉爽的"]}, {"name": "mile", "usphone": "maɪl", "ukphone": "", "trans": ["n. 英里"]}, {"name": "milk", "usphone": "mɪlk", "ukphone": "", "trans": ["n. 牛奶 vt. 挤奶"]}, {"name": "million", "usphone": "ˈmɪlɪən", "ukphone": "", "trans": ["num. 百万 n. 百万个（人或物）"]}, {"name": "millionaire", "usphone": "mɪljəˈneə(r)", "ukphone": "", "trans": ["n. 百万富翁"]}, {"name": "mind", "usphone": "maɪnd", "ukphone": "", "trans": ["n. 思想,想法 v.介意,关心"]}, {"name": "mine", "usphone": "maɪn", "ukphone": "", "trans": ["n.矿藏,矿山vt.开采(矿物) pron. 我的"]}, {"name": "mineral", "usphone": "ˈmɪnər(ə)l", "ukphone": "", "trans": ["n. 矿物质，矿物"]}, {"name": "minibus", "usphone": "ˈmɪnɪbʌs", "ukphone": "", "trans": ["n. 小型公共汽车"]}, {"name": "minimum", "usphone": "ˈmɪnɪməm", "ukphone": "", "trans": ["a.最小的"]}, {"name": "miniskirt", "usphone": "ˈmɪnɪskɜːt", "ukphone": "", "trans": ["n. 超短裙"]}, {"name": "minister", "usphone": "ˈmɪnɪstə(r)", "ukphone": "", "trans": ["n. 部长；牧师"]}, {"name": "ministry", "usphone": "ˈmɪnɪstrɪ", "ukphone": "", "trans": ["n.（政府的）部"]}, {"name": "minority", "usphone": "maɪˈnɔrɪtɪ; (US) -ˈnɔːr-", "ukphone": "", "trans": ["n. 少数；少数民族"]}, {"name": "minus", "usphone": "ˈmaɪnəs", "ukphone": "", "trans": ["prep. & a.负的，减去的"]}, {"name": "minute", "usphone": "ˈmɪnɪt", "ukphone": "", "trans": ["n. 分钟;一会儿，瞬间"]}, {"name": "mirror", "usphone": "ˈmɪrə(r)", "ukphone": "", "trans": ["n. 镜子"]}, {"name": "miss", "usphone": "mɪs", "ukphone": "", "trans": ["vt. 失去，错过，缺"]}, {"name": "Miss.", "usphone": "mɪs", "ukphone": "", "trans": ["n.小姐,女士(称呼未婚妇女)"]}, {"name": "missile", "usphone": "ˈmɪsaɪl", "ukphone": "", "trans": ["n 导弹"]}, {"name": "mist", "usphone": "mɪst", "ukphone": "", "trans": ["n. 雾"]}, {"name": "mistake (mistook, mistaken)", "usphone": "mɪsˈteɪk", "ukphone": "", "trans": ["n. 错误 vt. 弄错"]}, {"name": "mistaken", "usphone": "mɪsˈteɪkən", "ukphone": "", "trans": ["a. 错误的"]}, {"name": "misunderstand (-stood, -stood)", "usphone": "mɪsʌndəˈstænd", "ukphone": "", "trans": ["v. 误会；不理解"]}, {"name": "mix", "usphone": "mɪks", "ukphone": "", "trans": ["v. 混合，搅拌"]}, {"name": "mixture", "usphone": "ˈmɪkstʃə(r)", "ukphone": "", "trans": ["n. 混合物"]}, {"name": "mm (缩) = millimetre", "usphone": "ˈmiliˌmi:tə(r)", "ukphone": "", "trans": ["n. 毫米"]}, {"name": "mobile", "usphone": "ˈməʊbaɪl; (US) məʊbl", "ukphone": "", "trans": ["a. 活动的，可移动的"]}, {"name": "mobile phone", "usphone": "ˈməʊbaɪl fəʊn", "ukphone": "", "trans": ["手提电话，手机"]}, {"name": "model", "usphone": "ˈmɔd(ə)l", "ukphone": "", "trans": ["n.模型,原形,范例,模范"]}, {"name": "modem", "usphone": "ˈməʊdem", "ukphone": "", "trans": ["n. 调制解调器"]}, {"name": "modern", "usphone": "ˈmɔd(ə)n", "ukphone": "", "trans": ["a. 现代的"]}, {"name": "modest", "usphone": "ˈmɔdɪst", "ukphone": "", "trans": ["a. 谦虚的；谦逊的"]}, {"name": "Mom =Mum", "usphone": "mɒm", "ukphone": "", "trans": ["n. 妈妈"]}, {"name": "moment", "usphone": "ˈməʊmənt", "ukphone": "", "trans": ["n. 片刻，瞬间"]}, {"name": "mommy = mummy", "usphone": "ˈmɔmɪ", "ukphone": "", "trans": ["n. 妈妈（美）"]}, {"name": "Monday", "usphone": "ˈmʌndeɪ, ˈmʌndɪ", "ukphone": "", "trans": ["n. 星期一"]}, {"name": "money", "usphone": "ˈmʌnɪ", "ukphone": "", "trans": ["n. 钱；货币"]}, {"name": "monitor", "usphone": "ˈmɔnɪtə(r)", "ukphone": "", "trans": ["n. （班级内的）班长；纠察生；监视器"]}, {"name": "monkey", "usphone": "ˈmʌŋkɪ", "ukphone": "", "trans": ["n. 猴子"]}, {"name": "month", "usphone": "mʌnθ", "ukphone": "", "trans": ["n. 月，月份"]}, {"name": "monument", "usphone": "ˈmɔnjʊmənt", "ukphone": "", "trans": ["n. 纪念碑，纪念物"]}, {"name": "moon", "usphone": "muːn", "ukphone": "", "trans": ["n. 月球；月光；月状物"]}, {"name": "moon cake", "usphone": "muːn keɪk", "ukphone": "", "trans": ["n. 月饼"]}, {"name": "mop", "usphone": "mɔp", "ukphone": "", "trans": ["n. / v. 拖把 拖地"]}, {"name": "moral", "usphone": "ˈmɔr(ə)l; (US) ˈmɔːrəl", "ukphone": "", "trans": ["a.道德的 n.寓意,道德启示"]}, {"name": "more（much或many 的比较级）", "usphone": "mɔː(r)", "ukphone": "", "trans": ["a./ ad.另外的；附加的；较多的再；另外；而且；更 n. 更多的量；另外的一些"]}, {"name": "morning", "usphone": "ˈmɔːnɪŋ", "ukphone": "", "trans": ["n. 早晨，上午"]}, {"name": "Moscow", "usphone": "ˈmɔskəʊ", "ukphone": "", "trans": ["n. 莫斯科"]}, {"name": "Moslem", "usphone": "ˈmɔzləm", "ukphone": "", "trans": ["n. 伊斯兰教徒,回教徒"]}, {"name": "Mosquito", "usphone": "məˈskiːtəʊ", "ukphone": "", "trans": ["n.蚊子"]}, {"name": "most (much或many 的最高级)", "usphone": "məʊst; (US) mɔːst", "ukphone": "", "trans": ["a. & ad.最多 n.大部分,大多数"]}, {"name": "mother", "usphone": "ˈmʌðə(r)", "ukphone": "", "trans": ["n. 母亲"]}, {"name": "motherland", "usphone": "ˈmʌðəlænd", "ukphone": "", "trans": ["n. 祖国"]}, {"name": "motivation", "usphone": "məʊtɪˈveɪʃn", "ukphone": "", "trans": ["n. （做事的）动机"]}, {"name": "motor", "usphone": "ˈməʊtə(r)", "ukphone": "", "trans": ["n. 发动机，马达"]}, {"name": "motorbike", "usphone": "ˈməʊtəbaɪk", "ukphone": "", "trans": ["n. 摩托车"]}, {"name": "motorcycle", "usphone": "ˈməʊtəsaikl", "ukphone": "", "trans": ["n. 摩托车"]}, {"name": "motto", "usphone": "ˈmɔtəʊ", "ukphone": "", "trans": ["n. 箴言，格言"]}, {"name": "mountain(s)", "usphone": "ˈmaʊntɪn(z)", "ukphone": "", "trans": ["n. 山，山脉"]}, {"name": "mountainous", "usphone": "ˈmaʊntɪnəs", "ukphone": "", "trans": ["a. 多山的"]}, {"name": "mourn", "usphone": "mɔːn", "ukphone": "", "trans": ["vt. 哀痛； 哀悼"]}, {"name": "mouse (复mice)", "usphone": "maʊs", "ukphone": "", "trans": ["n. 鼠，耗子；（计算机）鼠标"]}, {"name": "moustache", "usphone": "məsˈtɑ:ʃ", "ukphone": "", "trans": ["n. 小胡子"]}, {"name": "mouth", "usphone": "maʊθ", "ukphone": "", "trans": ["n. 嘴，口"]}, {"name": "mouthful", "usphone": "ˈmaʊθfʊl", "ukphone": "", "trans": ["n. 满口，一口"]}, {"name": "from mouth to mouth", "usphone": "", "ukphone": "", "trans": ["ad. 口口相传；人传人地"]}, {"name": "move", "usphone": "muːv", "ukphone": "", "trans": ["v. 移动，搬动，搬家"]}, {"name": "movement", "usphone": "ˈmuːvmənt", "ukphone": "", "trans": ["n. 运动，活动"]}, {"name": "movie", "usphone": "ˈmuːvɪ", "ukphone": "", "trans": ["n.（口语）电影"]}, {"name": "Mr. (mister)", "usphone": "ˈmɪstə(r)", "ukphone": "", "trans": ["n. 先生（用于姓名前）"]}, {"name": "Mrs. (mistress)", "usphone": "ˈmɪsɪz", "ukphone": "", "trans": ["n. 夫人, 太太（称呼已婚妇女）"]}, {"name": "Ms.", "usphone": "mɪz", "ukphone": "", "trans": ["n. 女士(用在婚姻状况不明的女子姓名前)"]}, {"name": "much (more，most)", "usphone": "mʌtʃ", "ukphone": "", "trans": ["a. 许多的，大量的 ad. 非常；更加 n. 许多，大量，非常"]}, {"name": "mud", "usphone": "mʌd", "ukphone": "", "trans": ["n. 泥, 泥浆"]}, {"name": "muddy", "usphone": "ˈmʌdɪ", "ukphone": "", "trans": ["a. 泥泞的"]}, {"name": "multiply", "usphone": "ˈmʌltɪplaɪ", "ukphone": "", "trans": ["vt. 乘；使相乘"]}, {"name": "murder", "usphone": "ˈmɜːdə(r)", "ukphone": "", "trans": ["vt. 谋杀"]}, {"name": "museum", "usphone": "mjuːˈzɪəm", "ukphone": "", "trans": ["n. 博物馆，博物院"]}, {"name": "mushroom", "usphone": "ˈmʌʃrʊm", "ukphone": "", "trans": ["n. 蘑菇"]}, {"name": "music", "usphone": "ˈmjuːzɪk", "ukphone": "", "trans": ["n. 音乐，乐曲"]}, {"name": "musical", "usphone": "ˈmjuːzɪk(ə)l", "ukphone": "", "trans": ["a. 音乐的，爱好音乐的 n. 音乐片"]}, {"name": "musician", "usphone": "mjuːˈzɪʃ(ə)n", "ukphone": "", "trans": ["n. 音乐家，乐师"]}, {"name": "must modal", "usphone": "mʌst ˈməʊd(ə)l", "ukphone": "", "trans": ["v.必须,应当;必定是"]}, {"name": "mustard", "usphone": "ˈmʌstəd", "ukphone": "", "trans": ["n. 芥末，芥子粉"]}, {"name": "mutton", "usphone": "ˈmʌt(ə)n", "ukphone": "", "trans": ["n. 羊肉"]}, {"name": "my", "usphone": "maɪ", "ukphone": "", "trans": ["pron. 我的"]}, {"name": "myself", "usphone": "maɪˈself", "ukphone": "", "trans": ["pron. 我自己"]}, {"name": "nail", "usphone": "neɪl", "ukphone": "", "trans": ["n. 钉，钉子"]}, {"name": "name", "usphone": "neɪm", "ukphone": "", "trans": ["n. 名字,姓名,名称 vt. 命名,名叫"]}, {"name": "narrow", "usphone": "ˈnærəʊ", "ukphone": "", "trans": ["a. 狭窄的"]}, {"name": "nation", "usphone": "ˈneɪʃ(ə)n", "ukphone": "", "trans": ["n. 民族，国家"]}, {"name": "national", "usphone": "ˈnæʃən(ə)l", "ukphone": "", "trans": ["a. 国家的,全国性的，民族的"]}, {"name": "nationality", "usphone": "næʃəˈnælətɪ", "ukphone": "", "trans": ["n. 国籍"]}, {"name": "nationwide", "usphone": "ˈneɪʃ(ə)nwaɪd", "ukphone": "", "trans": ["ad.全国范围内的,全国性的"]}, {"name": "native", "usphone": "ˈneɪtɪv", "ukphone": "", "trans": ["a. 本土的，本国的"]}, {"name": "natural", "usphone": "ˈnætʃər(ə)l", "ukphone": "", "trans": ["a. 自然的"]}, {"name": "nature", "usphone": "ˈneɪtʃə(r)", "ukphone": "", "trans": ["n. 自然, 性质，种类"]}, {"name": "navy", "usphone": "ˈneɪvɪ", "ukphone": "", "trans": ["n. 海军"]}, {"name": "near", "usphone": "nɪə(r)", "ukphone": "", "trans": ["a. 近的 ad. 附近，邻近 prep. 在……附近，靠近"]}, {"name": "nearby", "usphone": "ˈnɪəbaɪ", "ukphone": "", "trans": ["a. 附近的"]}, {"name": "nearly", "usphone": "ˈnɪəlɪ", "ukphone": "", "trans": ["ad. 将近，几乎"]}, {"name": "neat", "usphone": "niːt", "ukphone": "", "trans": ["a. 整洁的；灵巧的"]}, {"name": "necessary", "usphone": "ˈnesəsərɪ; (US) ˈnesəserɪ", "ukphone": "", "trans": ["a. 必需的，必要的"]}, {"name": "neck", "usphone": "nek", "ukphone": "", "trans": ["n. 颈，脖子"]}, {"name": "necklace", "usphone": "ˈneklɪs", "ukphone": "", "trans": ["n. 项链"]}, {"name": "necktie", "usphone": "ˈnektaɪ", "ukphone": "", "trans": ["n. 领带，领花"]}, {"name": "need", "usphone": "niːd", "ukphone": "", "trans": ["n. 需要,需求aux.& v.需要,必须"]}, {"name": "needle", "usphone": "niːd(ə)l", "ukphone": "", "trans": ["n. 针"]}, {"name": "negotiate", "usphone": "nɪˈɡəʊʃɪeɪt", "ukphone": "", "trans": ["v.谈判，协商"]}, {"name": "neighbour (美neighbor)", "usphone": "ˈneɪbə(r)", "ukphone": "", "trans": ["n. 邻居，邻人"]}, {"name": "neighbourhood (美neighborhood)", "usphone": "ˈneibəhud", "ukphone": "", "trans": ["n. 四邻；邻近地区"]}, {"name": "neither", "usphone": "ˈnaɪðə(r), ˈniːðə(r)", "ukphone": "", "trans": ["a. （两者）都不;也不"]}, {"name": "nephew", "usphone": "ˈnefjuː, ˈnevjuː", "ukphone": "", "trans": ["n. 侄子，外甥"]}, {"name": "nervous", "usphone": "ˈnɜːvəs", "ukphone": "", "trans": ["a. 紧张不安的"]}, {"name": "nest", "usphone": "nest", "ukphone": "", "trans": ["n. 巢；窝"]}, {"name": "net", "usphone": "net", "ukphone": "", "trans": ["n. 网"]}, {"name": "network", "usphone": "ˈnetwɜːk", "ukphone": "", "trans": ["n. 网络，网状系统"]}, {"name": "never", "usphone": "ˈnevə(r)", "ukphone": "", "trans": ["ad. 决不，从来没有"]}, {"name": "new", "usphone": "njuː; (US) nuː", "ukphone": "", "trans": ["a. 新的；新鲜的"]}, {"name": "New York", "usphone": "njuː jɔːk", "ukphone": "", "trans": ["n. 纽约"]}, {"name": "New Zealand", "usphone": "njuː ˈzi:lənd", "ukphone": "", "trans": ["* n. 新西兰"]}, {"name": "New Zealander", "usphone": "njuː ˈzi:ləndə", "ukphone": "", "trans": ["n. 新西兰人"]}, {"name": "news", "usphone": "njuːz; (US) nuːz", "ukphone": "", "trans": ["n. 新闻，消息"]}, {"name": "newspaper", "usphone": "njuːz; (US) nuːz", "ukphone": "", "trans": ["n. 报纸"]}, {"name": "next", "usphone": "nekst", "ukphone": "", "trans": ["a. 最近的，紧挨着的，隔壁的；下一次 ad. 随后，然后，下一步 n. 下一个人（东西）"]}, {"name": "nice", "usphone": "naɪs", "ukphone": "", "trans": ["a.令人愉快;好的漂亮的"]}, {"name": "niece", "usphone": "niːs", "ukphone": "", "trans": ["n. 侄女，甥女"]}, {"name": "night", "usphone": "naɪt", "ukphone": "", "trans": ["n. 夜；夜间"]}, {"name": "night-club", "usphone": "naɪt-klʌb", "ukphone": "", "trans": ["n. 夜总会"]}, {"name": "nine", "usphone": "naɪn", "ukphone": "", "trans": ["num. 九"]}, {"name": "nineteen", "usphone": "naɪnˈtiːn", "ukphone": "", "trans": ["num. 十九"]}, {"name": "ninety", "usphone": "ˈnaɪntɪ", "ukphone": "", "trans": ["num. 九十"]}, {"name": "ninth", "usphone": "naɪnθ", "ukphone": "", "trans": ["num. 第九"]}, {"name": "no", "usphone": "nəʊ", "ukphone": "", "trans": ["ad. 不,不是 a.没有,无,不"]}, {"name": "No.(缩) = number", "usphone": "ˈnʌmbə(r)", "ukphone": "", "trans": ["n.数字;号码"]}, {"name": "noble", "usphone": "ˈnəʊb(ə)l", "ukphone": "", "trans": ["a. 高贵的，贵族的"]}, {"name": "nobody", "usphone": "ˈnəʊbədɪ", "ukphone": "", "trans": ["n. 渺小人物 pron. 没有人，谁也不"]}, {"name": "nod", "usphone": "nɔd", "ukphone": "", "trans": ["vi. 点头"]}, {"name": "noise", "usphone": "nɔɪz", "ukphone": "", "trans": ["n. 声音，噪声，喧闹声"]}, {"name": "noisily", "usphone": "ˈnɔɪzɪlɪ", "ukphone": "", "trans": ["ad. 喧闹地"]}, {"name": "noisy", "usphone": "ˈnɔɪzɪ", "ukphone": "", "trans": ["a. 喧闹的，嘈杂的"]}, {"name": "none", "usphone": "nʌn", "ukphone": "", "trans": ["pron.无任何东西, 无一人"]}, {"name": "non-stop", "usphone": "nʌn-stɔp", "ukphone": "", "trans": ["a.& ad.不停的,不断地"]}, {"name": "non-violent", "usphone": "nɔn-ˈvaɪələnt", "ukphone": "", "trans": ["a. 非暴力的"]}, {"name": "noodle", "usphone": "ˈnuːd(ə)l", "ukphone": "", "trans": ["n. 面条"]}, {"name": "noon", "usphone": "nuːn", "ukphone": "", "trans": ["n. 中午，正午"]}, {"name": "nor", "usphone": "nɔː(r)", "ukphone": "", "trans": ["conj. 也不"]}, {"name": "normal", "usphone": "ˈnɔːm(ə)l", "ukphone": "", "trans": ["n.& a. 正常的（状态）"]}, {"name": "north", "usphone": "nɔːθ", "ukphone": "", "trans": ["a.北的;朝北的;从北来的 ad.向（在,从）北方 n.北;北方;北部"]}, {"name": "northeast", "usphone": "nɒ:θˈi:st", "ukphone": "", "trans": ["n. 东北（部）"]}, {"name": "northern", "usphone": "ˈnɔːð(ə)n", "ukphone": "", "trans": ["a. 北方的，北部的"]}, {"name": "northwards", "usphone": "ˈnɔːθwədz", "ukphone": "", "trans": ["ad. 向北"]}, {"name": "northwest", "usphone": "nɒ:θˈwest", "ukphone": "", "trans": ["n. 西北"]}, {"name": "nose", "usphone": "nəʊz", "ukphone": "", "trans": ["n. 鼻"]}, {"name": "not", "usphone": "nɔt", "ukphone": "", "trans": ["ad. 不，没"]}, {"name": "note", "usphone": "nəʊt", "ukphone": "", "trans": ["n. 便条，笔记，注释；钞票，纸币；音符，音调 vt. 记下，记录；注意，留意"]}, {"name": "notebook", "usphone": "ˈnəʊtbʊk", "ukphone": "", "trans": ["n. 笔记簿"]}, {"name": "nothing", "usphone": "ˈnʌθɪŋ", "ukphone": "", "trans": ["n. 没有东西,没有什么 adv.一点也不；并不"]}, {"name": "notice", "usphone": "ˈnəʊtɪs", "ukphone": "", "trans": ["n. 布告，通告；注意 vt. 注意，注意到"]}, {"name": "novel", "usphone": "ˈnɔv(ə)l", "ukphone": "", "trans": ["n. （长篇）小说"]}, {"name": "novelist", "usphone": "ˈnɔvəlɪst", "ukphone": "", "trans": ["n. 小说家"]}, {"name": "November", "usphone": "nəʊˈvembə(r)", "ukphone": "", "trans": ["n. 11月"]}, {"name": "now", "usphone": "naʊ", "ukphone": "", "trans": ["ad. 现在"]}, {"name": "nowadays", "usphone": "ˈnaʊədeɪz", "ukphone": "", "trans": ["ad. 当今，现在"]}, {"name": "nowhere", "usphone": "ˈnəʊweə(r); (US) ˈnəʊhweər", "ukphone": "", "trans": ["ad.任何地方都不,无处"]}, {"name": "nuclear", "usphone": "ˈnjuːklɪə(r)", "ukphone": "", "trans": ["a. 原子核的，原子能的，核动力的"]}, {"name": "numb", "usphone": "nʌm", "ukphone": "", "trans": ["a. 麻木的，失去知觉的，迟钝的"]}, {"name": "number", "usphone": "ˈnʌmbə(r)", "ukphone": "", "trans": ["n. 数,数字,号码,数量"]}, {"name": "nurse", "usphone": "nɜːs", "ukphone": "", "trans": ["n. 护士；保育员"]}, {"name": "nursery", "usphone": "ˈnɜːsərɪ", "ukphone": "", "trans": ["n. 托儿所"]}, {"name": "nursing", "usphone": "nɜːsɪŋ", "ukphone": "", "trans": ["n.(职业性的）保育,护理"]}, {"name": "nut", "usphone": "nʌt", "ukphone": "", "trans": ["n.坚果,果仁(胡桃,栗子等)"]}, {"name": "nutrition", "usphone": "njuːˈtrɪʃ(ə)n", "ukphone": "", "trans": ["n. 营养，滋养"]}, {"name": "nylon", "usphone": "ˈnaɪlɔn", "ukphone": "", "trans": ["n. 尼龙"]}, {"name": "obey", "usphone": "əʊˈbeɪ", "ukphone": "", "trans": ["v. 服从，顺从，听从"]}, {"name": "object", "usphone": "ˈɔbdʒɪkt", "ukphone": "", "trans": ["n. 物，物体；宾语"]}, {"name": "observe", "usphone": "əbˈzɜːv", "ukphone": "", "trans": ["v. 观察，监视，观测"]}, {"name": "obtain", "usphone": "əbˈteɪn", "ukphone": "", "trans": ["vt. 获得；得到"]}, {"name": "obvious", "usphone": "ˈɔbvɪəs", "ukphone": "", "trans": ["a. 显然"]}, {"name": "occupation", "usphone": "ɔkjʊˈpeɪʃ(ə)n", "ukphone": "", "trans": ["n. 职业，工作"]}, {"name": "occur", "usphone": "əˈkɜː(r)", "ukphone": "", "trans": ["vi. 发生"]}, {"name": "ocean", "usphone": "ˈəʊʃ(ə)n", "ukphone": "", "trans": ["n. 海洋"]}, {"name": "Oceania*", "usphone": "", "ukphone": "", "trans": ["n. 大洋洲"]}, {"name": "oˈclock", "usphone": "əˈklɔk", "ukphone": "", "trans": ["n. 点钟"]}, {"name": "October", "usphone": "ɔkˈtəʊbə(r)", "ukphone": "", "trans": ["n. 10月"]}, {"name": "of", "usphone": "ɔv, əv; (US) ɔːf", "ukphone": "", "trans": ["prep.(表所属,数量,) ….的"]}, {"name": "off", "usphone": "ˈɔf; (US) ɔːf", "ukphone": "", "trans": ["prep. 离开,脱离,（走）开"]}, {"name": "ad", "usphone": "æd", "ukphone": "", "trans": [".离开；（电自来水）停了,中断"]}, {"name": "offence", "usphone": "of·fence || əˈfens", "ukphone": "", "trans": ["n. 违法行为，犯罪"]}, {"name": "offer", "usphone": "ˈɔfə(r); (US) ɔːfər", "ukphone": "", "trans": ["n.& vt. 提供；建议"]}, {"name": "office", "usphone": "ˈɔfɪs; (US) ˈɔːfɪs", "ukphone": "", "trans": ["n. 办公室"]}, {"name": "officer", "usphone": "ˈɔfɪsə(r); (US) ˈɔːfɪsər", "ukphone": "", "trans": ["n. 军官;公务员,官员；警察，警官"]}, {"name": "official", "usphone": "əˈfɪʃ(ə)l; (US) ˈɔːf-", "ukphone": "", "trans": ["n.（公司、团体或政府）官员 ,高级职员 a.官方,政府的"]}, {"name": "offshore", "usphone": "ˈɔfʃɔː(r); (US) ˈɔːf-", "ukphone": "", "trans": ["a. 近海的"]}, {"name": "often", "usphone": "ˈɔf(ə)n; (US) ˈɔːfn", "ukphone": "", "trans": ["ad. 经常，常常"]}, {"name": "oh", "usphone": "əʊ", "ukphone": "", "trans": ["int. 哦！啊！"]}, {"name": "oil", "usphone": "ɔɪl", "ukphone": "", "trans": ["n. 油"]}, {"name": "oilfield", "usphone": "ˈɔɪlfiːld", "ukphone": "", "trans": ["n.油田"]}, {"name": "OK", "usphone": "əʊˈkeɪ", "ukphone": "", "trans": ["ad. （口语）好,对,不错"]}, {"name": "old", "usphone": "əʊld", "ukphone": "", "trans": ["a. 老的，旧的"]}, {"name": "Olympic(s)", "usphone": "əˈlɪmpɪk", "ukphone": "", "trans": ["a. & n. 奥林匹克"]}, {"name": "Olympic Games", "usphone": "əˈlɪmpɪk ɡeɪms", "ukphone": "", "trans": ["n. 奥运会"]}, {"name": "omelette", "usphone": "ˈɔmlɪt", "ukphone": "", "trans": ["n. 煎蛋卷；煎蛋饼"]}, {"name": "on", "usphone": "ɔn", "ukphone": "", "trans": ["prep. 在…上（时），关于 ad. （穿，放…）上；接通；进行下  去；（电灯）开"]}, {"name": "once", "usphone": "wʌns", "ukphone": "", "trans": ["n.& ad. 一次,一度,从前 conj. 一旦"]}, {"name": "one", "usphone": "wʌn", "ukphone": "", "trans": ["pron. 一（个，只…）(pl. ones) num. 一"]}, {"name": "oneself", "usphone": "wʌnˈself", "ukphone": "", "trans": ["pron. 自己；自身"]}, {"name": "onion", "usphone": "ˈʌnjən", "ukphone": "", "trans": ["n. 洋葱；洋葱头"]}, {"name": "only", "usphone": "ˈəʊnlɪ", "ukphone": "", "trans": ["a. 惟一的，仅有的 ad. 仅仅，只，才"]}, {"name": "onto", "usphone": "ˈɔntʊ", "ukphone": "", "trans": ["prep. 到…的上面"]}, {"name": "open", "usphone": "ˈəʊpən", "ukphone": "", "trans": ["a.开着的,开的 vt.开,打开"]}, {"name": "opener", "usphone": "ˈəʊpənə(r)", "ukphone": "", "trans": ["n. 开具，启子"]}, {"name": "opening", "usphone": "ˈəʊpənɪŋ", "ukphone": "", "trans": ["n. 开放，口子"]}, {"name": "opera", "usphone": "ˈɔpərə", "ukphone": "", "trans": ["n. 歌剧"]}, {"name": "opera house", "usphone": "ˈɔpərə haʊs", "ukphone": "", "trans": ["n.歌剧院,艺术剧院"]}, {"name": "operate", "usphone": "ˈɔpəreɪt", "ukphone": "", "trans": ["v. 做手术，运转；实施，负责, 经营，管理"]}, {"name": "operation", "usphone": "ɔpəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n. 手术，操作"]}, {"name": "operator", "usphone": "ˈɔpəreɪtə(r)", "ukphone": "", "trans": ["n. 接线员"]}, {"name": "opinion", "usphone": "əˈpɪnjən", "ukphone": "", "trans": ["n. 看法，见解"]}, {"name": "oppose", "usphone": "əˈpəʊz", "ukphone": "", "trans": ["vt. 反对；反抗"]}, {"name": "opposite", "usphone": "ˈɔpəzɪt", "ukphone": "", "trans": ["n. 相反，对面 a. 相反的，对面的"]}, {"name": "optimistic", "usphone": "ɔptɪˈmɪstɪk", "ukphone": "", "trans": ["a. 乐观的"]}, {"name": "optional", "usphone": "ˈɔpʃən(ə)l", "ukphone": "", "trans": ["a. 可选择的，选修的"]}, {"name": "or", "usphone": "ə(r), ɔː(r)", "ukphone": "", "trans": ["conj. 或；就是；否则"]}, {"name": "oral", "usphone": "ˈɔːrəl", "ukphone": "", "trans": ["a. 口述的，口头上的"]}, {"name": "orange", "usphone": "ˈɔrɪndʒ; (US) ˈɔːr-", "ukphone": "", "trans": ["n. 橘子，橙子，橘汁 a. 橘色的，橙色的"]}, {"name": "orbit", "usphone": "ˈɔːbɪt", "ukphone": "", "trans": ["n.（天体等的）运行轨道"]}, {"name": "order", "usphone": "ˈɔːdə(r)", "ukphone": "", "trans": ["n. 顺序"]}, {"name": "order", "usphone": "ˈɔːdə(r)", "ukphone": "", "trans": ["vt. 定购，定货；点菜"]}, {"name": "ordinary", "usphone": "ˈɔːdɪnərɪ; (US) ˈɔːrdənerɪ", "ukphone": "", "trans": ["a. 普通的，平常的"]}, {"name": "organ", "usphone": "ˈɔːɡən", "ukphone": "", "trans": ["n. （人，动物）器官"]}, {"name": "organise(美organize)", "usphone": "ˈɔ:gənaiz", "ukphone": "", "trans": ["vt. 组织"]}, {"name": "organiser (organizer)", "usphone": "ˈɔ:gənaizə", "ukphone": "", "trans": ["n. 组织者"]}, {"name": "organization", "usphone": "ɔːɡənaɪˈzeɪʃ(ə)n", "ukphone": "", "trans": ["n. 组织，机构"]}, {"name": "origin", "usphone": "ˈɔrɪdʒɪn", "ukphone": "", "trans": ["n. 起源，由来"]}, {"name": "other", "usphone": "ˈʌðə(r)", "ukphone": "", "trans": ["pron. 别人，别的东西 a. 别的,另外的"]}, {"name": "otherwise", "usphone": "ˈʌðəwaɪz", "ukphone": "", "trans": ["ad.要不然,否则,另样"]}, {"name": "Ottawa", "usphone": "ˈɔtəwə", "ukphone": "", "trans": ["n. 渥太华"]}, {"name": "ouch", "usphone": "aʊtʃ", "ukphone": "", "trans": ["int（突然受痛时叫声）哎哟"]}, {"name": "ought", "usphone": "ɔːt", "ukphone": "", "trans": ["v.& aux.应该，应当"]}, {"name": "our", "usphone": "ˈaʊə(r)", "ukphone": "", "trans": ["pron.我们的"]}, {"name": "ours", "usphone": "ˈaʊəz", "ukphone": "", "trans": ["pron.我们的"]}, {"name": "ourselves", "usphone": "aʊəˈselvz", "ukphone": "", "trans": ["pron. 我们自己"]}, {"name": "out", "usphone": "aʊt", "ukphone": "", "trans": ["ad. 出外;在外,向外;熄"]}, {"name": "outcome", "usphone": "ˈaʊtkʌm", "ukphone": "", "trans": ["n. 结果，效果"]}, {"name": "outdoors", "usphone": "aʊtˈdɔːz", "ukphone": "", "trans": ["ad. 在户外, 在野外"]}, {"name": "outer", "usphone": "ˈaʊtə(r)", "ukphone": "", "trans": ["a. 外部的，外面的"]}, {"name": "outgoing", "usphone": "ˈaʊtɡəʊɪŋ", "ukphone": "", "trans": ["a. 爱交际的,外向的"]}, {"name": "outing", "usphone": "ˈaʊtɪŋ", "ukphone": "", "trans": ["n. 郊游，远足"]}, {"name": "outline", "usphone": "ˈaʊtlaɪn", "ukphone": "", "trans": ["n. 概述，略述"]}, {"name": "output", "usphone": "ˈaʊtpʊt", "ukphone": "", "trans": ["n. 产量，输出量"]}, {"name": "outside", "usphone": "aʊtˈsaɪd", "ukphone": "", "trans": ["n. 外面 ad. 在外面；向外面 prep. 在…外面"]}, {"name": "outspoken", "usphone": "aʊtˈspəʊkən", "ukphone": "", "trans": ["a. 直率，坦诚"]}, {"name": "outstanding", "usphone": "aʊtˈstændɪŋ", "ukphone": "", "trans": ["a. 优秀的，杰出的"]}, {"name": "outward(s)", "usphone": "ˈaʊtwəd", "ukphone": "", "trans": ["ad. 向外的，外出的"]}, {"name": "oval", "usphone": "ˈəʊv(ə)l", "ukphone": "", "trans": ["n.& adj.椭圆；椭圆形的"]}, {"name": "over", "usphone": "ˈəʊvə(r)", "ukphone": "", "trans": ["prep. 在…上方,越过,遍及 ad. 翻倒,遍布,越过,结束"]}, {"name": "overcoat", "usphone": "ˈəʊvəkəʊt", "ukphone": "", "trans": ["n. 大衣"]}, {"name": "overcome", "usphone": "əʊvəˈkʌm", "ukphone": "", "trans": ["v. 克服，解决"]}, {"name": "overhead", "usphone": "əʊvəˈhed", "ukphone": "", "trans": ["a.在头顶上;架空的"]}, {"name": "overlook", "usphone": "əʊvəˈlʊk", "ukphone": "", "trans": ["v. 忽略,不予理会"]}, {"name": "overweight", "usphone": "əʊvəˈweɪt", "ukphone": "", "trans": ["a. 太胖的,超重的"]}, {"name": "owe", "usphone": "əʊ", "ukphone": "", "trans": ["vt. 欠（债等）"]}, {"name": "own", "usphone": "əʊn", "ukphone": "", "trans": ["a. 自己的 v. 拥有,所有"]}, {"name": "owner", "usphone": "ˈəʊnə(r)", "ukphone": "", "trans": ["n. 物主，所有人"]}, {"name": "ownership", "usphone": "ˈəʊnəʃɪp", "ukphone": "", "trans": ["n. 所有制"]}, {"name": "ox (复oxen)", "usphone": "ɔks", "ukphone": "", "trans": ["n. 牛；公牛"]}, {"name": "oxygen", "usphone": "ˈɔksɪdʒ(ə)n", "ukphone": "", "trans": ["n. 氧；氧气"]}, {"name": "pace", "usphone": "peɪs", "ukphone": "", "trans": ["n. 步子；节奏"]}, {"name": "Pacific", "usphone": "pəˈsɪfɪk", "ukphone": "", "trans": ["a. 太平洋的"]}, {"name": "the Pacific Ocean", "usphone": "ðə pəˈsɪfɪkˈəʊʃ(ə)n", "ukphone": "", "trans": ["太平洋"]}, {"name": "pack", "usphone": "pæk", "ukphone": "", "trans": ["n. 包,捆;（猎犬、野兽的）一群 v.(为运输或储存而)打包"]}, {"name": "package", "usphone": "ˈpækɪdʒ", "ukphone": "", "trans": ["n. （尤指包装好或密封的容器）一包，一袋，一盒"]}, {"name": "packet", "usphone": "ˈpækɪt", "ukphone": "", "trans": ["n. 小包裹，袋"]}, {"name": "paddle", "usphone": "ˈpæd(ə)l", "ukphone": "", "trans": ["n. 桨状物，蹼"]}, {"name": "page", "usphone": "peɪdʒ", "ukphone": "", "trans": ["n. 页，页码"]}, {"name": "pain", "usphone": "peɪn", "ukphone": "", "trans": ["n. 疼痛，疼"]}, {"name": "painful", "usphone": "ˈpeɪnfʊl", "ukphone": "", "trans": ["a. 使痛的，使痛苦的"]}, {"name": "paint", "usphone": "peɪnt", "ukphone": "", "trans": ["n.油漆 vt.油漆,粉刷,绘画"]}, {"name": "painter", "usphone": "ˈpeɪntə(r)", "ukphone": "", "trans": ["n. 绘画者,（油）画家"]}, {"name": "painting", "usphone": "ˈpeɪntɪŋ", "ukphone": "", "trans": ["n. 油画，水彩画"]}, {"name": "pair", "usphone": "peə(r)", "ukphone": "", "trans": ["n. 一双，一对"]}, {"name": "palace", "usphone": "ˈpælɪs", "ukphone": "", "trans": ["n. 宫，宫殿"]}, {"name": "pale", "usphone": "peɪl", "ukphone": "", "trans": ["a. 苍白的，灰白的"]}, {"name": "pan", "usphone": "pæn", "ukphone": "", "trans": ["n. 平底锅"]}, {"name": "pancake", "usphone": "ˈpænkeɪk", "ukphone": "", "trans": ["n. 薄煎饼"]}, {"name": "panda", "usphone": "ˈpændə", "ukphone": "", "trans": ["n. 熊猫"]}, {"name": "panic", "usphone": "ˈpænɪk", "ukphone": "", "trans": ["a./ v.惊慌,恐慌,惶恐不安"]}, {"name": "paper", "usphone": "ˈpeɪpə(r)", "ukphone": "", "trans": ["n. 纸；报纸"]}, {"name": "paperwork", "usphone": "ˈpeɪpəwɜːk", "ukphone": "", "trans": ["n. 日常文书工作"]}, {"name": "paragraph", "usphone": "ˈpærəɡrɑːf; (US) ˈpærəgræf", "ukphone": "", "trans": ["n. （文章的）段落"]}, {"name": "parallel", "usphone": "", "ukphone": "", "trans": ["n. 极其相似的人,纬线"]}, {"name": "parcel", "usphone": "ˈpɑːs(ə)l", "ukphone": "", "trans": ["n. 包裹"]}, {"name": "pardon", "usphone": "ˈpɑːd(ə)n", "ukphone": "", "trans": ["n. 原谅,宽恕,对不起"]}, {"name": "parent", "usphone": "ˈpeərənt", "ukphone": "", "trans": ["n. 父(母)，双亲"]}, {"name": "Paris", "usphone": "ˈpærɪs", "ukphone": "", "trans": ["n. 巴黎"]}, {"name": "park", "usphone": "ˈpærɪs", "ukphone": "", "trans": ["n. 公园"]}, {"name": "park", "usphone": "pɑːk", "ukphone": "", "trans": ["vt. 停放（汽车）"]}, {"name": "parking", "usphone": "ˈpɑːkɪŋ", "ukphone": "", "trans": ["n. 停车"]}, {"name": "parrot", "usphone": "ˈpærət", "ukphone": "", "trans": ["n. 鹦鹉"]}, {"name": "part", "usphone": "pɑːt", "ukphone": "", "trans": ["n. 部分；成分；角色；部件；零件 a. 局部的；部分的 v. 分离；分开；分割"]}, {"name": "participate", "usphone": "pɑːˈtɪsɪpeɪt", "ukphone": "", "trans": ["v. 参加，参与"]}, {"name": "particular", "usphone": "pəˈtɪkjʊlə(r)", "ukphone": "", "trans": ["a. 特殊的，个别的"]}, {"name": "partly", "usphone": "ˈpɑːtlɪ", "ukphone": "", "trans": ["ad.部分地,在一定程度上"]}, {"name": "partner", "usphone": "ˈpɑːtnə(r)", "ukphone": "", "trans": ["n. 搭档，合作者"]}, {"name": "part-time", "usphone": "pɑːt -taɪm", "ukphone": "", "trans": ["a.& ad. 兼职的； 部分时间的（地）"]}, {"name": "party", "usphone": "ˈpɑːtɪ", "ukphone": "", "trans": ["n. 聚会，晚会；党派"]}, {"name": "pass", "usphone": "pɑːs; (US) pæs", "ukphone": "", "trans": ["vt. 传，递；经过；通过"]}, {"name": "passage", "usphone": "ˈpæsɪdʒ", "ukphone": "", "trans": ["n. （文章等的）一节，一段；通道；走廊"]}, {"name": "passenger", "usphone": "ˈpæsɪndʒə(r)", "ukphone": "", "trans": ["n. 乘客，旅客"]}, {"name": "passer-by", "usphone": "ˈpɑ:sə-baɪ", "ukphone": "", "trans": ["n. 过客，过路人"]}, {"name": "passive", "usphone": "ˈpæsɪv", "ukphone": "", "trans": ["a. 被动的"]}, {"name": "passport", "usphone": "ˈpɑːspɔːt; (US) ˈpæ-", "ukphone": "", "trans": ["n. 护照"]}, {"name": "past", "usphone": "pɑːst; (US) pæst", "ukphone": "", "trans": ["ad. 过 n.过去，昔日，往事 prep. 过…，走过某处"]}, {"name": "patent", "usphone": "ˈpeɪt(ə)nt; (US) ˈpætnt", "ukphone": "", "trans": ["n.专利权，专利证书"]}, {"name": "path", "usphone": "pɑːθ; (US) pæθ", "ukphone": "", "trans": ["n. 小道，小径"]}, {"name": "patience", "usphone": "", "ukphone": "", "trans": ["n. 容忍；耐心"]}, {"name": "patient", "usphone": "ˈpeɪʃ(ə)nt", "ukphone": "", "trans": ["n. 病人"]}, {"name": "pattern", "usphone": "ˈpæt(ə)n", "ukphone": "", "trans": ["n. 式样"]}, {"name": "pause", "usphone": "pɔːz", "ukphone": "", "trans": ["n.& vi. 中止，暂停；停止"]}, {"name": "pay", "usphone": "peɪ", "ukphone": "", "trans": ["(paid, paid) v. 付钱，给…报酬 n. 工资"]}, {"name": "P.E.(缩) =physical education", "usphone": "piːiː", "ukphone": "", "trans": ["体育"]}, {"name": "P.C.(缩) =personal computer", "usphone": "piːsiː", "ukphone": "", "trans": ["个人电脑"]}, {"name": "pea", "usphone": "piː", "ukphone": "", "trans": ["n. 豌豆"]}, {"name": "peace", "usphone": "piːs", "ukphone": "", "trans": ["n. 和平"]}, {"name": "peaceful", "usphone": "ˈpiːsfʊl", "ukphone": "", "trans": ["a. 和平的，安宁的"]}, {"name": "peach", "usphone": "piːtʃ", "ukphone": "", "trans": ["n. 桃子"]}, {"name": "pear", "usphone": "peə(r)", "ukphone": "", "trans": ["n. 梨子，梨树"]}, {"name": "peasant", "usphone": "ˈpezənt", "ukphone": "", "trans": ["n. 农民；佃农"]}, {"name": "pedestrian", "usphone": "pɪˈdestrɪən", "ukphone": "", "trans": ["n. 步行者，行人"]}, {"name": "pen", "usphone": "pen", "ukphone": "", "trans": ["n. 钢笔，笔"]}, {"name": "pencil", "usphone": "ˈpens(ə)l", "ukphone": "", "trans": ["n. 铅笔"]}, {"name": "pencil-box", "usphone": "ˈpens(ə)l -bɔks", "ukphone": "", "trans": ["n. 铅笔盒"]}, {"name": "pen-friend", "usphone": "pen- friend", "ukphone": "", "trans": ["n. 笔友"]}, {"name": "penny", "usphone": "ˈpenɪ", "ukphone": "", "trans": ["(英复pence) n. （英）便士；美分"]}, {"name": "pension", "usphone": "ˈpenʃ(ə)n", "ukphone": "", "trans": ["n. 养老金"]}, {"name": "people", "usphone": "ˈpiːp(ə)l", "ukphone": "", "trans": ["n. 人，人们；人民"]}, {"name": "pepper", "usphone": "ˈpepə(r)", "ukphone": "", "trans": ["n. 胡椒粉"]}, {"name": "per", "usphone": "pə(r)", "ukphone": "", "trans": ["prep. 每，每一"]}, {"name": "percent", "usphone": "pəˈsent", "ukphone": "", "trans": ["n. 百分之……"]}, {"name": "percentage", "usphone": "pəˈsentədʒ", "ukphone": "", "trans": ["n. 百分率"]}, {"name": "perfect", "usphone": "kwestʃəˈneə(r)", "ukphone": "", "trans": ["a. 完美的，极好的"]}, {"name": "perform", "usphone": "pəˈfɔːm", "ukphone": "", "trans": ["v. 表演，履行；行动"]}, {"name": "performance", "usphone": "pəˈfɔːm", "ukphone": "", "trans": ["n. 演出，表演"]}, {"name": "performer", "usphone": "pəˈfɔːmə(r)", "ukphone": "", "trans": ["n. 表演者，执行者"]}, {"name": "perfume", "usphone": "ˈpɜːfjuːm", "ukphone": "", "trans": ["n. 香水"]}, {"name": "perhaps", "usphone": "pəˈhæps", "ukphone": "", "trans": ["ad. 可能，或"]}, {"name": "period", "usphone": "ˈpɪərɪəd", "ukphone": "", "trans": ["n. 时期，时代"]}, {"name": "permanent", "usphone": "ˈpɜːmənənt", "ukphone": "", "trans": ["a. 永久的，永恒的"]}, {"name": "permission", "usphone": "pəˈmɪʃ(ə)n", "ukphone": "", "trans": ["n. 允许,许可,同意"]}, {"name": "permit", "usphone": "pəˈmɪt", "ukphone": "", "trans": ["vt.许可,允许;执照 n.许可证"]}, {"name": "person", "usphone": "ˈpɜːs(ə)n", "ukphone": "", "trans": ["n. 人"]}, {"name": "personal", "usphone": "ˈpɜːsən(ə)l", "ukphone": "", "trans": ["a. 个人的，私人的"]}, {"name": "personnel", "usphone": "pɜːsəˈnel", "ukphone": "", "trans": ["n. 全体人员，职员"]}, {"name": "personally", "usphone": "ˈpɜːsənəlɪ", "ukphone": "", "trans": ["ad. 就自己而言"]}, {"name": "persuade", "usphone": "ˈpɜːsənəlɪ", "ukphone": "", "trans": ["vt. 说服，劝说"]}, {"name": "pest", "usphone": "pest", "ukphone": "", "trans": ["n. 害虫"]}, {"name": "pet", "usphone": "pet", "ukphone": "", "trans": ["n. 宠物，爱畜"]}, {"name": "petrol", "usphone": "ˈpetr(ə)l", "ukphone": "", "trans": ["n. 石油"]}, {"name": "phenomenon (pl. phenomena)", "usphone": "fɪˈnɔmɪnən; (US) -nɔn-", "ukphone": "", "trans": ["n. 现象"]}, {"name": "phone = telephone", "usphone": "fəʊn", "ukphone": "", "trans": ["v. 打电话 n. 电话，电话机"]}, {"name": "phone-booth", "usphone": "fəʊn-buːð", "ukphone": "", "trans": ["n. 公用电话间"]}, {"name": "photo =photograph", "usphone": "ˈfəʊtəʊ", "ukphone": "", "trans": ["n. 照片"]}, {"name": "photograph", "usphone": "ˈfəʊtəɡrɑːf; (US) -ɡræf", "ukphone": "", "trans": ["n. 照片"]}, {"name": "photographer", "usphone": "fəˈtɔɡrəfə(r)", "ukphone": "", "trans": ["n. 摄影师"]}, {"name": "phrase", "usphone": "freɪz", "ukphone": "", "trans": ["n. 短语；习惯用语"]}, {"name": "physical", "usphone": "ˈfɪzɪk(ə)l", "ukphone": "", "trans": ["a. 身体的；物理的"]}, {"name": "physician", "usphone": "fɪˈzɪʃ(ə)n", "ukphone": "", "trans": ["n.(有行医执照的)医生"]}, {"name": "physicist", "usphone": "ˈfɪzɪsɪst", "ukphone": "", "trans": ["n. 物理学家"]}, {"name": "physics", "usphone": "ˈfɪzɪks", "ukphone": "", "trans": ["n. 物理（学）"]}, {"name": "pianist", "usphone": "ˈfɪzɪks", "ukphone": "", "trans": ["n. 钢琴家"]}, {"name": "piano", "usphone": "pɪˈænəʊ", "ukphone": "", "trans": ["n. 钢琴"]}, {"name": "pick", "usphone": "pɪk", "ukphone": "", "trans": ["v. 拾起，采集；挑选"]}, {"name": "picnic", "usphone": "ˈpɪknɪk", "ukphone": "", "trans": ["n.& v. 野餐"]}, {"name": "picture", "usphone": "ˈpɪktʃə(r)", "ukphone": "", "trans": ["n. 图片，画片，照片"]}, {"name": "pie", "usphone": "paɪ", "ukphone": "", "trans": ["n. 甜馅饼"]}, {"name": "piece", "usphone": "paɪ", "ukphone": "", "trans": ["n. 一块（片，张，件…）"]}, {"name": "pig", "usphone": "paɪ", "ukphone": "", "trans": ["n. 猪"]}, {"name": "pile", "usphone": "paɪ", "ukphone": "", "trans": ["n. 堆"]}, {"name": "pill", "usphone": "pɪl", "ukphone": "", "trans": ["n. 药丸，药片"]}, {"name": "pillow", "usphone": "pɪl", "ukphone": "", "trans": ["n. 枕头"]}, {"name": "pilot", "usphone": "ˈpaɪlət", "ukphone": "", "trans": ["n. 飞行员"]}, {"name": "pin", "usphone": "pɪn", "ukphone": "", "trans": ["n. 别针 v. 别住, 钉住"]}, {"name": "pine", "usphone": "paɪn", "ukphone": "", "trans": ["n. 松树"]}, {"name": "pineapple", "usphone": "ˈpaɪnæp(ə)l", "ukphone": "", "trans": ["n. 菠萝"]}, {"name": "ping-pong", "usphone": "pɪŋ-pɔɡ", "ukphone": "", "trans": ["n. 乒乓球"]}, {"name": "pink", "usphone": "", "ukphone": "", "trans": ["a. 粉红色的"]}, {"name": "pint", "usphone": "paɪnt", "ukphone": "", "trans": ["n.（液量单位）品脱"]}, {"name": "pioneer", "usphone": "paɪəˈnɪə(r)", "ukphone": "", "trans": ["n. 先锋，开拓者"]}, {"name": "pipe", "usphone": "paɪp", "ukphone": "", "trans": ["n. 管子，输送管"]}, {"name": "pity", "usphone": "ˈpɪtɪ", "ukphone": "", "trans": ["n. 怜悯，同情"]}, {"name": "place", "usphone": "pleɪs", "ukphone": "", "trans": ["n. 地方，处所 v. 放置，安置，安排"]}, {"name": "plain", "usphone": "pleɪn", "ukphone": "", "trans": ["a. 家常的； 普通的"]}, {"name": "plan", "usphone": "plæn", "ukphone": "", "trans": ["n.& v. 计划，打算"]}, {"name": "plane", "usphone": "pleɪn", "ukphone": "", "trans": ["n. 飞机"]}, {"name": "planet", "usphone": "ˈplænɪt", "ukphone": "", "trans": ["n. 行星"]}, {"name": "plant", "usphone": "plɑːnt; (US) ˈplænt", "ukphone": "", "trans": ["vt. 种植，播种 n. 植物"]}, {"name": "plastic", "usphone": "ˈplæstɪk", "ukphone": "", "trans": ["a. 塑料的"]}, {"name": "plate", "usphone": "pleɪt", "ukphone": "", "trans": ["n. 板；片；牌；盘子；盆子"]}, {"name": "platform", "usphone": "ˈplætfɔːm", "ukphone": "", "trans": ["n. 讲台,(车站的)月台"]}, {"name": "play", "usphone": "pleɪ", "ukphone": "", "trans": ["v. 玩；打（球）；游戏；播放 n. 玩耍，戏剧"]}, {"name": "playroom", "usphone": "", "ukphone": "", "trans": ["n. 游戏室"]}, {"name": "player", "usphone": "ˈpleɪə(r)", "ukphone": "", "trans": ["n. 比赛者，选手"]}, {"name": "playground", "usphone": "ˈpleɪgraʊnd", "ukphone": "", "trans": ["n. 操场，运动场"]}, {"name": "playmate", "usphone": "ˈpleɪmeɪt", "ukphone": "", "trans": ["n. 玩伴"]}, {"name": "pleasant", "usphone": "ˈplezənt", "ukphone": "", "trans": ["a. 令人愉快的，舒适的"]}, {"name": "please", "usphone": "pliːz", "ukphone": "", "trans": ["v. 请,使人高兴,使人满意"]}, {"name": "pleased", "usphone": "pliːzd", "ukphone": "", "trans": ["a. 高兴的"]}, {"name": "pleasure", "usphone": "pliːzd", "ukphone": "", "trans": ["n. 高兴，愉快"]}, {"name": "plenty", "usphone": "pliːzd", "ukphone": "", "trans": ["n. 充足，大量"]}, {"name": "plot", "usphone": "plɔt", "ukphone": "", "trans": ["v. / n. 故事情节，密谋"]}, {"name": "plug", "usphone": "plʌɡ", "ukphone": "", "trans": ["n. 塞子 vt.（用塞子）把…塞住"]}, {"name": "plus", "usphone": "plʌs", "ukphone": "", "trans": ["prep.加，加上"]}, {"name": "p.m./pm, P.M. /PM", "usphone": "piːem", "ukphone": "", "trans": ["n. 下午,午后"]}, {"name": "pocket", "usphone": "ˈpɔkɪt", "ukphone": "", "trans": ["n. （衣服的）口袋"]}, {"name": "poem", "usphone": "ˈpəʊɪm", "ukphone": "", "trans": ["n. 诗"]}, {"name": "poet", "usphone": "ˈpəʊɪt", "ukphone": "", "trans": ["n. 诗人"]}, {"name": "point", "usphone": "pɔɪnt", "ukphone": "", "trans": ["v. 指，指向 n. 点；分数"]}, {"name": "poison", "usphone": "ˈpɔɪz(ə)n", "ukphone": "", "trans": ["n. 毒药"]}, {"name": "poisonous", "usphone": "ˈpɔɪzənəs", "ukphone": "", "trans": ["a. 有毒的，致命的"]}, {"name": "pole", "usphone": "pəʊl", "ukphone": "", "trans": ["n. 杆，电线杆；"]}, {"name": "the North (South) Pole", "usphone": "ðə nɔːθpəʊ", "ukphone": "", "trans": ["（地球的）极，极地 北（南）极"]}, {"name": "police", "usphone": "pəˈliːs", "ukphone": "", "trans": ["n. 警察，警务人员"]}, {"name": "policeman (复-men)", "usphone": "pəˈliːsmən", "ukphone": "", "trans": ["n.警察,巡警policewoman ( -women) n.女警察"]}, {"name": "policy", "usphone": "ˈpɔlɪsɪ", "ukphone": "", "trans": ["n. 政策，方针，原则"]}, {"name": "polish", "usphone": "ˈpɔlɪsɪ", "ukphone": "", "trans": ["v.擦亮 n.擦光剂,亮光剂"]}, {"name": "polite", "usphone": "pəˈlaɪt", "ukphone": "", "trans": ["a. 有礼貌的,有教养的"]}, {"name": "political", "usphone": "pəˈlɪtɪk(ə)l", "ukphone": "", "trans": ["a. 政治的"]}, {"name": "politician", "usphone": "pɔlɪˈtɪʃ(ə)n", "ukphone": "", "trans": ["n. 政治家"]}, {"name": "politics", "usphone": "ˈpɔlɪtɪks", "ukphone": "", "trans": ["n. 政治"]}, {"name": "pollute", "usphone": "pəˈluːt", "ukphone": "", "trans": ["vt. 污染"]}, {"name": "pollution", "usphone": "pəˈluːʃ(ə)n", "ukphone": "", "trans": ["n. 污染"]}, {"name": "pond", "usphone": "pɔnd", "ukphone": "", "trans": ["n. 池塘"]}, {"name": "pool", "usphone": "puːl", "ukphone": "", "trans": ["n. 水塘，水池"]}, {"name": "poor", "usphone": "pʊə(r)", "ukphone": "", "trans": ["a.贫穷；可怜；不好的,差的"]}, {"name": "pop = popular", "usphone": "pɔp", "ukphone": "", "trans": ["a. (口语) （音乐、艺术等）大众的，通俗的"]}, {"name": "popcorn", "usphone": "ˈpɔpkɔːn", "ukphone": "", "trans": ["n. 爆米花"]}, {"name": "popular", "usphone": "ˈpɔpjʊlə(r)", "ukphone": "", "trans": ["a. 流行,大众,受欢迎的"]}, {"name": "population", "usphone": "pɔpjʊˈleɪʃ(ə)n", "ukphone": "", "trans": ["n. 人口，人数"]}, {"name": "pork", "usphone": "pɔːk", "ukphone": "", "trans": ["n. 猪肉"]}, {"name": "porridge", "usphone": "ˈpɔrɪdʒ; (US) ˈpɔːrɪdʒ", "ukphone": "", "trans": ["n. 稀饭，粥"]}, {"name": "port", "usphone": "pɔːt", "ukphone": "", "trans": ["n. 港口，码头"]}, {"name": "portable", "usphone": "ˈpɔːtəb(ə)l", "ukphone": "", "trans": ["a.手提的，便携式的"]}, {"name": "porter", "usphone": "ˈpɔːtə(r)", "ukphone": "", "trans": ["n. （火车站或旅馆处的）搬运工"]}, {"name": "position", "usphone": "pəˈzɪʃ(ə)n", "ukphone": "", "trans": ["n. 位置"]}, {"name": "possess", "usphone": "pəˈzɪʃ(ə)n", "ukphone": "", "trans": ["vt. 占有；拥有"]}, {"name": "possession", "usphone": "pəˈzeʃ(ə)n", "ukphone": "", "trans": ["n. 所有，拥有；财产，所有物"]}, {"name": "possibility", "usphone": "pɔsɪˈbɪlɪtɪ", "ukphone": "", "trans": ["vn. 可能，可能性"]}, {"name": "possible", "usphone": "ˈpɔsɪb(ə)l", "ukphone": "", "trans": ["a. 可能的"]}, {"name": "possibly", "usphone": "", "ukphone": "", "trans": ["adv. 可能地，也许"]}, {"name": "post", "usphone": "pəʊst", "ukphone": "", "trans": ["n. 邮政，邮寄，邮件 v. 投寄； 邮寄"]}, {"name": "postage", "usphone": "ˈpəʊstɪdʒ", "ukphone": "", "trans": ["n. 邮费"]}, {"name": "postbox", "usphone": "ˈpəʊstbɔks", "ukphone": "", "trans": ["n. 邮箱"]}, {"name": "postcard", "usphone": "ˈpəʊstkɑːd", "ukphone": "", "trans": ["n. 明信片"]}, {"name": "postcode", "usphone": "ˈpəʊstkəʊd", "ukphone": "", "trans": ["n. （英）邮政编码"]}, {"name": "poster", "usphone": "ˈpəʊstə(r)", "ukphone": "", "trans": ["n. (贴在公共场所的大型)招贴；广告(画)"]}, {"name": "postman", "usphone": "ˈpəʊstmən", "ukphone": "", "trans": ["n. 邮递员"]}, {"name": "postpone", "usphone": "pəʊstˈpəʊn", "ukphone": "", "trans": ["vt. 推迟，延期"]}, {"name": "pot", "usphone": "pɔt", "ukphone": "", "trans": ["n. 锅，壶，瓶，罐"]}, {"name": "potato", "usphone": "pəˈteɪtəʊ", "ukphone": "", "trans": ["n. 土豆，马铃薯"]}, {"name": "potential", "usphone": "pəˈtenʃ(ə)l", "ukphone": "", "trans": ["a. 潜在的，可能的"]}, {"name": "pound", "usphone": "pəˈtenʃ(ə)l", "ukphone": "", "trans": ["n. 磅；英镑"]}, {"name": "pour", "usphone": "pɔː(r)", "ukphone": "", "trans": ["vi. 倾泻，不断流出"]}, {"name": "powder", "usphone": "ˈpaʊdə(r)", "ukphone": "", "trans": ["n. 粉，粉末"]}, {"name": "power", "usphone": "ˈpaʊdə(r)", "ukphone": "", "trans": ["n. 力，动力，电力"]}, {"name": "powerful", "usphone": "ˈpaʊəfʊl", "ukphone": "", "trans": ["a. 效力大的，强有力的，强大的"]}, {"name": "practical", "usphone": "ˈpræktɪk(ə)l", "ukphone": "", "trans": ["a. 实际的，适用的"]}, {"name": "practice(s)e", "usphone": "ˈpræktɪs", "ukphone": "", "trans": ["n. 练习"]}, {"name": "prairie", "usphone": "ˈpreərɪ", "ukphone": "", "trans": ["n. 大草原"]}, {"name": "praise", "usphone": "preɪz", "ukphone": "", "trans": ["n.& vt.赞扬，表扬"]}, {"name": "pray", "usphone": "preɪ", "ukphone": "", "trans": ["v. 祈祷；祈求"]}, {"name": "prayer", "usphone": "preə(r)", "ukphone": "", "trans": ["n. 祈祷"]}, {"name": "precious", "usphone": "ˈpreʃəs", "ukphone": "", "trans": ["a. 宝贵的, 珍贵的"]}, {"name": "precise", "usphone": "prɪˈsaɪs", "ukphone": "", "trans": ["a. 准确,精确的,确切的"]}, {"name": "predict", "usphone": "prɪˈdɪkt", "ukphone": "", "trans": ["v. 预言，预告，预报"]}, {"name": "prefer", "usphone": "prɪˈfɜː(r)", "ukphone": "", "trans": ["vt.宁愿（选择）,更喜欢"]}, {"name": "preference", "usphone": "ˈprefərəns", "ukphone": "", "trans": ["n. 选择，趋向"]}, {"name": "pregnant", "usphone": "ˈpreɡnənt", "ukphone": "", "trans": ["a. 怀孕的"]}, {"name": "prejudice", "usphone": "ˈpredʒʊdɪs", "ukphone": "", "trans": ["n. 偏见，成见"]}, {"name": "premier", "usphone": "ˈpremɪə(r); (US) priːˈmɪər", "ukphone": "", "trans": ["n. 首相，总理"]}, {"name": "preparation", "usphone": "prepəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n. 准备"]}, {"name": "prepare", "usphone": "prɪˈpeə(r)", "ukphone": "", "trans": ["vt. 准备,预备,调制,配制"]}, {"name": "prescription", "usphone": "prɪˈskrɪpʃ(ə)n", "ukphone": "", "trans": ["n. 处方，药方"]}, {"name": "present", "usphone": "ˈprez(ə)nt", "ukphone": "", "trans": ["a. 出现的，出席的 n. 礼物，赠品 vt. 呈奉，奉送"]}, {"name": "presentation", "usphone": "prezənˈteɪʃ(ə)n; (US) priːzenˈteʃn", "ukphone": "", "trans": ["n. 演示，演出"]}, {"name": "preserve", "usphone": "prezənˈteɪʃ(ə)n; (US) priːzenˈteʃn", "ukphone": "", "trans": ["v.保护，保留，保存"]}, {"name": "president", "usphone": "ˈprezɪdənt", "ukphone": "", "trans": ["n. 总统；主席"]}, {"name": "press", "usphone": "ˈprezɪdənt", "ukphone": "", "trans": ["vt.压,按 n.新闻界,出版社"]}, {"name": "pressure", "usphone": "ˈpreʃə(r)", "ukphone": "", "trans": ["n. 压迫,压力,压强"]}, {"name": "pretend", "usphone": "ˈpreʃə(r)", "ukphone": "", "trans": ["vi. 假装，装作"]}, {"name": "pretty", "usphone": "ˈprɪtɪ", "ukphone": "", "trans": ["a. 漂亮的，俊俏的"]}, {"name": "prevent", "usphone": "prɪˈvent", "ukphone": "", "trans": ["vt. 防止, 预防"]}, {"name": "preview", "usphone": "ˈpriːvjuː", "ukphone": "", "trans": ["vt. 预习;试演;预展"]}, {"name": "price", "usphone": "praɪs", "ukphone": "", "trans": ["n. 价格，价钱"]}, {"name": "pride", "usphone": "praɪd", "ukphone": "", "trans": ["n. 自豪，骄傲"]}, {"name": "primary", "usphone": "ˈpraɪmərɪ", "ukphone": "", "trans": ["a. 初等的；初级的"]}, {"name": "primary school", "usphone": "ˈpraɪmərɪ skuːl", "ukphone": "", "trans": ["小学"]}, {"name": "primitive", "usphone": "ˈprɪmɪtɪv", "ukphone": "", "trans": ["a. 原始的，远古的"]}, {"name": "principle", "usphone": "ˈprɪnsɪp(ə)l", "ukphone": "", "trans": ["n. 道德原则，法则"]}, {"name": "print", "usphone": "prɪnt", "ukphone": "", "trans": ["vt. 印刷"]}, {"name": "printer", "usphone": "ˈprɪntə(r)", "ukphone": "", "trans": ["n. 打印机"]}, {"name": "printing", "usphone": "ˈprɪntɪŋ", "ukphone": "", "trans": ["n. 印刷，印刷术"]}, {"name": "prison", "usphone": "ˈprɪz(ə)n", "ukphone": "", "trans": ["n. 监狱"]}, {"name": "prisoner", "usphone": "ˈprɪznə(r)", "ukphone": "", "trans": ["n. 囚犯"]}, {"name": "private", "usphone": "ˈpraɪvɪt", "ukphone": "", "trans": ["a. 私人的"]}, {"name": "privilege", "usphone": "ˈprɪvɪlɪdʒ", "ukphone": "", "trans": ["特权，特殊待遇"]}, {"name": "prize", "usphone": "praɪz", "ukphone": "", "trans": ["n. 奖赏，奖品"]}, {"name": "probable", "usphone": "ˈprɔbəb(ə)l", "ukphone": "", "trans": ["a.很可能,很有希望的"]}, {"name": "probably", "usphone": "ˈprɔbəb(ə)lɪ", "ukphone": "", "trans": ["ad. 很可能，大概"]}, {"name": "problem", "usphone": "ˈprɔbləm", "ukphone": "", "trans": ["n. 问题，难题"]}, {"name": "procedure", "usphone": "prəˈsiːdʒə(r)", "ukphone": "", "trans": ["n. 程序,手续,待遇"]}, {"name": "process", "usphone": "ˈprəʊses; (US) ˈprɔses", "ukphone": "", "trans": ["n./ v. 过程,加工,处理"]}, {"name": "produce", "usphone": "prəˈdjuːs; (US) -ˈduːs", "ukphone": "", "trans": ["vt. 生产；制造"]}, {"name": "product", "usphone": "ˈprɔdʌkt", "ukphone": "", "trans": ["n. 产品，制品"]}, {"name": "production", "usphone": "prəˈdʌkʃ(ə)n", "ukphone": "", "trans": ["n. 生产；制造"]}, {"name": "profession", "usphone": "prəˈfeʃ(ə)n", "ukphone": "", "trans": ["n.（需要有高等教育学位的）职业（如医生或律师）"]}, {"name": "professor", "usphone": "prəˈfesə(r)", "ukphone": "", "trans": ["n. 教授"]}, {"name": "profit", "usphone": "ˈprɔfɪt", "ukphone": "", "trans": ["n. 利润，收益"]}, {"name": "programme (美program)", "usphone": "", "ukphone": "", "trans": ["n. 节目；项目"]}, {"name": "progress", "usphone": "ˈprəʊɡres; (US) ˈprɔɡres", "ukphone": "", "trans": ["n.进步,上进vi.进展,进行"]}, {"name": "prohibit", "usphone": "prəˈhɪbɪt", "ukphone": "", "trans": ["v. 禁止"]}, {"name": "project", "usphone": "ˈprɔdʒekt", "ukphone": "", "trans": ["n. 工程"]}, {"name": "promise", "usphone": "ˈprɔmɪs", "ukphone": "", "trans": ["n.& vi. 答应，允诺"]}, {"name": "promote", "usphone": "prəˈməʊt", "ukphone": "", "trans": ["v.促进,推动,促销,晋升"]}, {"name": "pronounce", "usphone": "prəˈnaʊns", "ukphone": "", "trans": ["vt. 发音"]}, {"name": "pronunciation", "usphone": "prənʌnsɪˈeɪʃ(ə)n", "ukphone": "", "trans": ["n. 发音"]}, {"name": "proper", "usphone": "ˈprɔpə(r)", "ukphone": "", "trans": ["a. 恰当的，合适的"]}, {"name": "properly", "usphone": "ˈprɔpəlɪ", "ukphone": "", "trans": ["ad. 适当地"]}, {"name": "protect", "usphone": "prəˈtekt", "ukphone": "", "trans": ["vt. 保护"]}, {"name": "protection", "usphone": "prəˈtekʃ(ə)n", "ukphone": "", "trans": ["n. 保护"]}, {"name": "proud", "usphone": "praʊd", "ukphone": "", "trans": ["a. 自豪的；骄傲的"]}, {"name": "prove", "usphone": "pruːv", "ukphone": "", "trans": ["vt. 证明"]}, {"name": "provide", "usphone": "prəˈvaɪd", "ukphone": "", "trans": ["vt. 提供"]}, {"name": "province", "usphone": "ˈprɔvɪns", "ukphone": "", "trans": ["n. 省"]}, {"name": "psychology", "usphone": "saɪˈkɔlədʒɪ", "ukphone": "", "trans": ["n. 心理学"]}, {"name": "pub", "usphone": "pʌb", "ukphone": "", "trans": ["n. 酒店，酒吧"]}, {"name": "public", "usphone": "ˈpʌblɪk", "ukphone": "", "trans": ["a.公共,公众的 n. 公众"]}, {"name": "publicly", "usphone": "ˈpʌblɪklɪ", "ukphone": "", "trans": ["ad. 当众；公开地"]}, {"name": "publish", "usphone": "ˈpʌblɪʃ", "ukphone": "", "trans": ["t. 出版，发行"]}, {"name": "pull", "usphone": "pʊl", "ukphone": "", "trans": ["拉，拖 n. 拉力，引力"]}, {"name": "pulse", "usphone": "pʌls", "ukphone": "", "trans": ["n. 脉搏，（光、能量、波等的）脉动，搏动"]}, {"name": "pump", "usphone": "ˈpʌmp", "ukphone": "", "trans": ["t. 用泵抽水"]}, {"name": "punctual", "usphone": "ˈpʌŋktjʊəl", "ukphone": "", "trans": ["a. 准时的"]}, {"name": "punctuate", "usphone": "ˈpʌŋktjʊeɪt", "ukphone": "", "trans": ["v. 加标点"]}, {"name": "punctuation", "usphone": "", "ukphone": "", "trans": ["n. 标点符号"]}, {"name": "punish", "usphone": "ˈpʌnɪʃ", "ukphone": "", "trans": ["v. 惩罚，处罚"]}, {"name": "punishment", "usphone": "ˈpʌnɪʃmənt", "ukphone": "", "trans": ["n. 惩罚"]}, {"name": "pupil", "usphone": "ˈpjuːpɪl", "ukphone": "", "trans": ["n. （小）学生"]}, {"name": "purchase", "usphone": "ˈpɜːtʃəs", "ukphone": "", "trans": ["v. 购买，采购"]}, {"name": "pure", "usphone": "pjʊə(r)", "ukphone": "", "trans": ["a. 纯的, 不掺杂的"]}, {"name": "purple", "usphone": "ˈpɜːp(ə)l", "ukphone": "", "trans": ["n. / a. 紫色"]}, {"name": "purpose", "usphone": "ˈpɜːpəs", "ukphone": "", "trans": ["n. 目的，意图"]}, {"name": "purse", "usphone": "pɜːs", "ukphone": "", "trans": ["n. 钱包"]}, {"name": "push", "usphone": "pʊʃ", "ukphone": "", "trans": ["n.& v. 推"]}, {"name": "put (put, put)", "usphone": "pʊt", "ukphone": "", "trans": ["vt. 放，摆"]}, {"name": "puzzle", "usphone": "ˈpʌz(ə)l", "ukphone": "", "trans": ["n. 难题,（字、画）谜"]}, {"name": "puzzled", "usphone": "ˈpʌz(ə)l", "ukphone": "", "trans": ["a. 迷惑的，困惑的"]}, {"name": "pyramid", "usphone": "ˈpɪrəmɪd", "ukphone": "", "trans": ["n. 角锥形，金字塔"]}, {"name": "quake", "usphone": "kweɪk", "ukphone": "", "trans": ["n.& v. 震动，颤抖"]}, {"name": "qualification", "usphone": "kwɔlɪfɪˈkeɪʃ(ə)n", "ukphone": "", "trans": ["n. 资格，学历"]}, {"name": "quality", "usphone": "ˈkwɔlɪtɪ", "ukphone": "", "trans": ["n. 质量，性质"]}, {"name": "quantity", "usphone": "ˈkwɔntətɪ", "ukphone": "", "trans": ["n. 量，数"]}, {"name": "quarrel", "usphone": "ˈkwɔrəl; (US) ˈkwɔːrəl", "ukphone": "", "trans": ["vi. 争吵，吵架"]}, {"name": "quarter", "usphone": "ˈkwɔːtə(r)", "ukphone": "", "trans": ["n. 四分之一，一刻钟"]}, {"name": "queen", "usphone": "kwiːn", "ukphone": "", "trans": ["n. 皇后，女王"]}, {"name": "question", "usphone": "ˈkwestʃ(ə)n", "ukphone": "", "trans": ["vt. 询问 n. 问题"]}, {"name": "questionnaire", "usphone": "kwestʃəˈneə(r)", "ukphone": "", "trans": ["n. 调查表，问卷"]}, {"name": "queue", "usphone": "kjuː", "ukphone": "", "trans": ["n. 行列，长队"]}, {"name": "quick", "usphone": "kwɪk", "ukphone": "", "trans": ["a. 快；敏捷的；急剧的 ad. 快地；敏捷地；急剧地"]}, {"name": "quiet", "usphone": "ˈkwaɪət", "ukphone": "", "trans": ["a. 安静的；寂静的"]}, {"name": "quilt", "usphone": "kwɪlt", "ukphone": "", "trans": ["n. 被子；被状物"]}, {"name": "quit", "usphone": "kwɪt", "ukphone": "", "trans": ["v. 离任，离校，戒掉"]}, {"name": "quite", "usphone": "kwaɪt", "ukphone": "", "trans": ["ad. 完全，十分"]}, {"name": "quiz", "usphone": "kwɪz", "ukphone": "", "trans": ["n. 测验，小型考试"]}, {"name": "rabbit", "usphone": "ˈræbɪt", "ukphone": "", "trans": ["n. 兔，家兔"]}, {"name": "race", "usphone": "reɪs", "ukphone": "", "trans": ["n. 种族，民族 v. （速度）竞赛，比赛 n. 赛跑，竞赛"]}, {"name": "racial", "usphone": "ˈreɪʃ(ə)l", "ukphone": "", "trans": ["a. 种族的"]}, {"name": "radiation", "usphone": "reɪdɪˈeɪʃ(ə)n", "ukphone": "", "trans": ["n. 放射，放射物"]}, {"name": "radio", "usphone": "reɪdɪəʊ", "ukphone": "", "trans": ["n. 无线电，收音机"]}, {"name": "radioactive", "usphone": "reɪdɪəʊˈæktɪv", "ukphone": "", "trans": ["a. 放射性的"]}, {"name": "radium", "usphone": "ˈreɪdɪəm", "ukphone": "", "trans": ["n. 镭"]}, {"name": "rag", "usphone": "ræɡ", "ukphone": "", "trans": ["n. 破布，抹布"]}, {"name": "rail", "usphone": "reɪl", "ukphone": "", "trans": ["n. 铁路"]}, {"name": "railway", "usphone": "ˈreɪlweɪ", "ukphone": "", "trans": ["n. 铁路；铁道"]}, {"name": "rain", "usphone": "reɪn", "ukphone": "", "trans": ["n. 雨，雨水 vi. 下雨"]}, {"name": "rainbow", "usphone": "ˈreɪnbəʊ", "ukphone": "", "trans": ["n. 虹，彩虹"]}, {"name": "raincoat", "usphone": "ˈreɪnkəʊt", "ukphone": "", "trans": ["n. 雨衣"]}, {"name": "rainfall", "usphone": "ˈreɪnfɔːl", "ukphone": "", "trans": ["n. 一场雨； 降雨量"]}, {"name": "rainy", "usphone": "ˈreɪnɪ", "ukphone": "", "trans": ["a. 下雨的；多雨的"]}, {"name": "raise", "usphone": "reɪz", "ukphone": "", "trans": ["vt. 使升高； 饲养"]}, {"name": "random", "usphone": "ˈrændəm", "ukphone": "", "trans": ["a.随意,未经事先考虑的"]}, {"name": "range", "usphone": "reɪndʒ", "ukphone": "", "trans": ["n./ v. 变化，变动，排序"]}, {"name": "rank", "usphone": "ræŋk", "ukphone": "", "trans": ["n. 职衔，军衔"]}, {"name": "rapid", "usphone": "ˈræpɪd", "ukphone": "", "trans": ["a. 快的，迅速的"]}, {"name": "rare", "usphone": "reə(r)", "ukphone": "", "trans": ["a. 罕见的，稀有的"]}, {"name": "rat", "usphone": "ræt", "ukphone": "", "trans": ["n. 老鼠"]}, {"name": "rate", "usphone": "reɪt", "ukphone": "", "trans": ["n./ v. 率，评估，评价"]}, {"name": "rather", "usphone": "ˈrɑːðə; (US) ˈræðər", "ukphone": "", "trans": ["ad. 相当，宁可"]}, {"name": "raw", "usphone": "rɔː", "ukphone": "", "trans": ["a.生的,未煮过的,未加工的"]}, {"name": "raw material", "usphone": "rɔː məˈtɪərɪəl", "ukphone": "", "trans": ["原料"]}, {"name": "ray", "usphone": "reɪ", "ukphone": "", "trans": ["n. 光辉，光线"]}, {"name": "razor", "usphone": "ˈreɪzə(r)", "ukphone": "", "trans": ["n. 剃须刀"]}, {"name": "reach", "usphone": "riːtʃ", "ukphone": "", "trans": ["v. 到达，伸手(脚)够到"]}, {"name": "react", "usphone": "riːˈækt", "ukphone": "", "trans": ["v. 回应，过敏，起物理，化学反应"]}, {"name": "read (read, read)", "usphone": "riːd", "ukphone": "", "trans": ["v. 读；朗读"]}, {"name": "reading", "usphone": "ʃɜːt", "ukphone": "", "trans": ["n. 阅读；朗读"]}, {"name": "ready", "usphone": "ˈredɪ", "ukphone": "", "trans": ["a. 准备好的"]}, {"name": "real", "usphone": "riːl", "ukphone": "", "trans": ["a. 真实的，确实的"]}, {"name": "reality", "usphone": "rɪˈælɪtɪ", "ukphone": "", "trans": ["n. 现实"]}, {"name": "realise (美realize)", "usphone": "ˈrɪəlaɪz", "ukphone": "", "trans": ["vt.认识到,实现"]}, {"name": "really", "usphone": "ˈrɪəlɪ", "ukphone": "", "trans": ["adv. 真正地；到底；确实"]}, {"name": "reason", "usphone": "ˈriːz(ə)n", "ukphone": "", "trans": ["vi.评理,劝说n.理由,原因"]}, {"name": "reasonable", "usphone": "ˈriːzənəb(ə)l", "ukphone": "", "trans": ["a. 合乎情理的"]}, {"name": "rebuild", "usphone": "riːˈbɪld", "ukphone": "", "trans": ["vt. 重建"]}, {"name": "receipt", "usphone": "rɪˈsiːt", "ukphone": "", "trans": ["n. 收据"]}, {"name": "receive", "usphone": "rɪˈsiːv", "ukphone": "", "trans": ["v. 收到，得到"]}, {"name": "receiver", "usphone": "rɪˈsiːvə(r)", "ukphone": "", "trans": ["n. 电话听筒"]}, {"name": "recent", "usphone": "ˈriːsənt", "ukphone": "", "trans": ["a. 近来的，最近的"]}, {"name": "reception", "usphone": "rɪˈsepʃ(ə)n", "ukphone": "", "trans": ["n. 接待"]}, {"name": "receptionist", "usphone": "rɪˈsepʃənɪst", "ukphone": "", "trans": ["n. 接待员"]}, {"name": "recipe", "usphone": "ˈresɪpɪ", "ukphone": "", "trans": ["n. 烹饪法，食谱"]}, {"name": "recite", "usphone": "rɪˈsaɪt", "ukphone": "", "trans": ["v. 背诵"]}, {"name": "recognise (美recognize)", "usphone": "ˈrekəɡnaɪz", "ukphone": "", "trans": ["vt.认出"]}, {"name": "recommend", "usphone": "rekəˈmend", "ukphone": "", "trans": ["v. 推荐"]}, {"name": "record", "usphone": "ˈrekɔːd; (US) ˈrekərd", "ukphone": "", "trans": ["n. 记录；唱片"]}, {"name": "record holder", "usphone": "ˈrekɔːd ˈhəʊldə(r)", "ukphone": "", "trans": ["记录保持者"]}, {"name": "record", "usphone": "ˈrekɔːd; (US) ˈrekərd", "ukphone": "", "trans": ["v. 录制，记录"]}, {"name": "recorder", "usphone": "rɪˈkɔːdə(r)", "ukphone": "", "trans": ["n. 录音机"]}, {"name": "recover", "usphone": "rɪˈkʌvə(r)", "ukphone": "", "trans": ["vi. 痊愈；恢复"]}, {"name": "recreation", "usphone": "rekrɪˈeɪʃ(ə)n", "ukphone": "", "trans": ["n. 娱乐，消遣"]}, {"name": "recycle", "usphone": "riːˈsaɪk(ə)l", "ukphone": "", "trans": ["vt. 回收；再循环"]}, {"name": "rectangle", "usphone": "ˈrektæŋɡ(ə)l", "ukphone": "", "trans": ["n. & a.长方形,长方形的"]}, {"name": "red", "usphone": "red", "ukphone": "", "trans": ["n. 红色 a.红色的"]}, {"name": "redirect", "usphone": "riːdaɪˈrekt", "ukphone": "", "trans": ["vt. 使改变，使转移"]}, {"name": "reduce", "usphone": "rɪˈdjuːs; (US) -ˈduːs", "ukphone": "", "trans": ["vt. 减少，缩减"]}, {"name": "refer", "usphone": "rɪˈfɜː(r)", "ukphone": "", "trans": ["vi. 谈到,提到,涉及,有关"]}, {"name": "referee", "usphone": "refəˈriː", "ukphone": "", "trans": ["n. 裁判，仲裁，调解员"]}, {"name": "reference", "usphone": "ˈref(ə)rəns", "ukphone": "", "trans": ["n.提到,涉及,谈及,查询"]}, {"name": "reflect", "usphone": "rɪˈflekt", "ukphone": "", "trans": ["v. 反映，反射"]}, {"name": "reform", "usphone": "rɪˈfɔːm", "ukphone": "", "trans": ["v./ n. 改革，改进，改良"]}, {"name": "refresh", "usphone": "rɪˈfreʃ", "ukphone": "", "trans": ["v. 使恢复精力，提醒"]}, {"name": "refreshments", "usphone": "rɪˈfreʃmənt", "ukphone": "", "trans": ["n. 点心，便餐；(会议后的)简单茶点招待"]}, {"name": "refrigerator", "usphone": "rɪˈfrɪdʒəreɪtə(r)", "ukphone": "", "trans": ["n. 冰箱"]}, {"name": "refusal", "usphone": "rɪˈfjuːz(ə)l", "ukphone": "", "trans": ["n. 拒绝"]}, {"name": "refuse", "usphone": "rɪˈfjuːz", "ukphone": "", "trans": ["vi. 拒绝，不愿"]}, {"name": "regard", "usphone": "rɪˈɡɑːd", "ukphone": "", "trans": ["v. 把……看作"]}, {"name": "regards", "usphone": "rɪˈɡɑːd", "ukphone": "", "trans": ["n. 问候，致意"]}, {"name": "regardless", "usphone": "rɪˈɡɑːdlɪs", "ukphone": "", "trans": ["a. 不顾，不加理会"]}, {"name": "register", "usphone": "ˈredʒɪstə(r)", "ukphone": "", "trans": ["n. 登记簿，花名册，注册员 v. 登记，注册"]}, {"name": "regret", "usphone": "rɪˈɡret", "ukphone": "", "trans": ["n./ vt.可惜,遗憾;痛惜;哀悼"]}, {"name": "regular", "usphone": "ˈreɡjʊlə(r)", "ukphone": "", "trans": ["a. 规则的，经常"]}, {"name": "regulation", "usphone": "reɡjʊˈleɪʃ(ə)n", "ukphone": "", "trans": ["n. 规则，规章"]}, {"name": "reject", "usphone": "rɪˈdʒekt", "ukphone": "", "trans": ["v. 拒绝"]}, {"name": "relate", "usphone": "rɪˈleɪt", "ukphone": "", "trans": ["vi. 有关； 涉及"]}, {"name": "relation", "usphone": "rɪˈleɪʃ(ə)n", "ukphone": "", "trans": ["n. 关系； 亲属"]}, {"name": "relationship", "usphone": "rɪˈleɪʃənʃɪp", "ukphone": "", "trans": ["n. 关系"]}, {"name": "relative", "usphone": "ˈrelətɪv", "ukphone": "", "trans": ["n. 亲属，亲戚"]}, {"name": "relax", "usphone": "rɪˈlæks", "ukphone": "", "trans": ["v. （使）放松，轻松"]}, {"name": "relay", "usphone": "ˈriːleɪ", "ukphone": "", "trans": ["n. 接力，接替人，中转 v. 接替，补充；转运"]}, {"name": "relevant", "usphone": "", "ukphone": "", "trans": ["a. 紧密相关,有意义的"]}, {"name": "reliable", "usphone": "rɪˈlaɪəb(ə)l", "ukphone": "", "trans": ["a. 可信赖的，可依靠的"]}, {"name": "relief", "usphone": "rɪˈliːf", "ukphone": "", "trans": ["n. 轻松,解脱,缓和,救济"]}, {"name": "religion", "usphone": "rɪˈlɪdʒən", "ukphone": "", "trans": ["n. 宗教"]}, {"name": "religious", "usphone": "rɪˈlɪdʒəs", "ukphone": "", "trans": ["a. 宗教的"]}, {"name": "rely", "usphone": "rɪˈlaɪ", "ukphone": "", "trans": ["v. 依赖，依靠"]}, {"name": "remain", "usphone": "rɪˈmeɪn", "ukphone": "", "trans": ["vt.余下,留下vi.保持,仍是"]}, {"name": "remark", "usphone": "rɪˈmɑːk", "ukphone": "", "trans": ["n. 陈述；话；议论"]}, {"name": "remember", "usphone": "rɪˈmembə(r)", "ukphone": "", "trans": ["v. 记得，想起"]}, {"name": "remind", "usphone": "rɪˈmaɪnd", "ukphone": "", "trans": ["vt. 提醒，使记起"]}, {"name": "remote", "usphone": "rɪˈməʊt", "ukphone": "", "trans": ["a. 偏远的，偏僻的"]}, {"name": "remove", "usphone": "rɪˈmuːv", "ukphone": "", "trans": ["vt. 移动，拿走，脱掉（衣服等）"]}, {"name": "rent", "usphone": "rent", "ukphone": "", "trans": ["n.& v. 租金"]}, {"name": "repair", "usphone": "rɪˈpeə(r)", "ukphone": "", "trans": ["n.& vt. 修理；修补"]}, {"name": "repairs", "usphone": "rɪˈpeə(r)", "ukphone": "", "trans": ["n. 修理工作"]}, {"name": "repeat", "usphone": "rɪˈpiːt", "ukphone": "", "trans": ["vt. 重说，重做"]}, {"name": "replace", "usphone": "rɪˈpleɪs", "ukphone": "", "trans": ["vt. 取代"]}, {"name": "reply", "usphone": "rɪˈplaɪ", "ukphone": "", "trans": ["n. 回答，答复"]}, {"name": "report", "usphone": "rɪˈpɔːt", "ukphone": "", "trans": ["n.& v. 报道，报告"]}, {"name": "reporter", "usphone": "rɪˈpɔːtə(r)", "ukphone": "", "trans": ["n. 记者，新闻通讯员"]}, {"name": "represent", "usphone": "reprɪˈzent", "ukphone": "", "trans": ["vt. 代表"]}, {"name": "representative", "usphone": "reprɪˈzentətɪv", "ukphone": "", "trans": ["n.代表,典型人物"]}, {"name": "republic", "usphone": "rɪˈpʌblɪk", "ukphone": "", "trans": ["n. 共和国"]}, {"name": "reputation", "usphone": "repjʊˈteɪʃ(ə)n", "ukphone": "", "trans": ["n. 名声，名誉"]}, {"name": "request", "usphone": "rɪˈkwest", "ukphone": "", "trans": ["n. 请求，要求的事物"]}, {"name": "require", "usphone": "rɪˈkwaɪə(r)", "ukphone": "", "trans": ["vt. 需求；要求"]}, {"name": "requirement", "usphone": "rɪˈkwaɪəmənt", "ukphone": "", "trans": ["n. 需要； 要求； 必要的条件"]}, {"name": "rescue", "usphone": "ˈreskjuː", "ukphone": "", "trans": ["vt. 营救，援救"]}, {"name": "research", "usphone": "rɪˈsɜːtʃ", "ukphone": "", "trans": ["n. 研究，调查"]}, {"name": "resemble", "usphone": "rɪˈzemb(ə)l", "ukphone": "", "trans": ["v. （不用进行时）像，看起来像"]}, {"name": "reservation", "usphone": "rezəˈveɪʃ(ə)n", "ukphone": "", "trans": ["n. 预定"]}, {"name": "reserve", "usphone": "rɪˈzɜːv", "ukphone": "", "trans": ["n. & v. 储备；预定"]}, {"name": "resign", "usphone": "rɪˈzaɪn", "ukphone": "", "trans": ["v. 辞职"]}, {"name": "resist", "usphone": "rɪˈzɪst", "ukphone": "", "trans": ["v. 抵抗；挡开"]}, {"name": "respect", "usphone": "rɪˈspekt", "ukphone": "", "trans": ["vt.& n. 尊敬，尊重"]}, {"name": "respond", "usphone": "rɪˈspekt", "ukphone": "", "trans": ["v.回答,回应,作出反应"]}, {"name": "responsibility", "usphone": "rɪspɔnsɪˈbɪlɪtɪ", "ukphone": "", "trans": ["n. 责任，负责"]}, {"name": "rest", "usphone": "rest", "ukphone": "", "trans": ["n. 休息；剩余的部分，其余的人（物） vi. 休息，歇息"]}, {"name": "restaurant", "usphone": "ˈrestərɔnt; (US) ˈrestərənt", "ukphone": "", "trans": ["n. 饭馆, 饭店"]}, {"name": "restrict", "usphone": "rɪˈstrɪkt", "ukphone": "", "trans": ["v. 限制"]}, {"name": "restriction", "usphone": "rɪˈstrɪkʃ(ə)n", "ukphone": "", "trans": ["n. 限制，约束"]}, {"name": "result", "usphone": "rɪˈzʌlt", "ukphone": "", "trans": ["n. 结果，效果"]}, {"name": "retell", "usphone": "riːˈtel", "ukphone": "", "trans": ["vt. 重讲，重复，复述"]}, {"name": "retire", "usphone": "rɪˈtaɪə(r)", "ukphone": "", "trans": ["v. 退休"]}, {"name": "return", "usphone": "rɪˈtɜːn", "ukphone": "", "trans": ["v. 归还"]}, {"name": "reuse", "usphone": "riːˈjuːz", "ukphone": "", "trans": ["vt. 重新使用；循环使用"]}, {"name": "review", "usphone": "rɪˈvjuː", "ukphone": "", "trans": ["vt. 重新调查； 回顾； 复习 n. 复查；复习；评论"]}, {"name": "reviewer", "usphone": "rɪˈvjuːə(r)", "ukphone": "", "trans": ["n. 评论者；书评家"]}, {"name": "revision", "usphone": "rɪˈvɪʒ(ə)n", "ukphone": "", "trans": ["n. 复习，温习"]}, {"name": "revolution", "usphone": "revəˈluːʃ(ə)n", "ukphone": "", "trans": ["n. 革命，变革"]}, {"name": "reward", "usphone": "rɪˈwɔːd", "ukphone": "", "trans": ["n. 奖赏"]}, {"name": "rewind", "usphone": "riːˈwaɪnd", "ukphone": "", "trans": ["v. 回转（磁带等）"]}, {"name": "rewrite", "usphone": "riːˈraɪt", "ukphone": "", "trans": ["vt. 重写"]}, {"name": "rhyme", "usphone": "raɪm", "ukphone": "", "trans": ["n./ v. 押韵"]}, {"name": "rice", "usphone": "raɪs", "ukphone": "", "trans": ["n. 稻米；米饭"]}, {"name": "rich", "usphone": "rɪtʃ", "ukphone": "", "trans": ["a. 富裕的，有钱的"]}, {"name": "rid (rid, rid / ridded, ridded)", "usphone": "rɪd", "ukphone": "", "trans": ["vt. 使摆脱"]}, {"name": "riddle", "usphone": "ˈrɪd(ə)l", "ukphone": "", "trans": ["n. 谜(语)"]}, {"name": "ridiculous", "usphone": "rɪˈdɪkjʊləs", "ukphone": "", "trans": ["a. 荒谬的，愚蠢的"]}, {"name": "ride (rode, ridden)", "usphone": "raɪd", "ukphone": "", "trans": ["v. 骑（马、自行车）；乘车 n. 乘车旅行"]}, {"name": "right", "usphone": "raɪt", "ukphone": "", "trans": ["n.权利 a.对,正确的 ad. 正确地,恰恰,完全地 a. 右,右边的"]}, {"name": "right-handed", "usphone": "raɪt-hænd", "ukphone": "", "trans": ["a. 惯用右手的"]}, {"name": "right-wing", "usphone": "raɪt-wɪŋ", "ukphone": "", "trans": ["n. 右翼"]}, {"name": "ring (rang, rung)", "usphone": "rɪŋ", "ukphone": "", "trans": ["v. （钟、铃等）响；打电话 n. 电话，铃声 n. 环形物（如环、圈、戒指等）"]}, {"name": "ring-road", "usphone": "rɪŋ-rəʊd", "ukphone": "", "trans": ["n. 环形公路"]}, {"name": "rigid", "usphone": "ˈrɪdʒɪd", "ukphone": "", "trans": ["a. 死板的,僵硬的,固执的"]}, {"name": "ripe", "usphone": "raɪp", "ukphone": "", "trans": ["a. 成熟的，熟的"]}, {"name": "ripen", "usphone": "ˈraɪpən", "ukphone": "", "trans": ["v. 成熟"]}, {"name": "rise (rose, risen)", "usphone": "raɪz", "ukphone": "", "trans": ["vi. 上升，上涨"]}, {"name": "risk", "usphone": "rɪsk", "ukphone": "", "trans": ["n./ v. 危险，风险，冒险"]}, {"name": "river", "usphone": "ˈrɪvə(r)", "ukphone": "", "trans": ["n. 江；河；水道；巨流"]}, {"name": "road", "usphone": "rəʊd", "ukphone": "", "trans": ["n. 路，道路"]}, {"name": "roast", "usphone": "rəʊst", "ukphone": "", "trans": ["v. 烤（肉）"]}, {"name": "rob", "usphone": "rɔb", "ukphone": "", "trans": ["v. 抢夺，抢劫"]}, {"name": "robot", "usphone": "ˈrəʊbɔt", "ukphone": "", "trans": ["n. 机器人"]}, {"name": "rock", "usphone": "rɔk", "ukphone": "", "trans": ["n.岩石,大石头vt. 摇,摇晃"]}, {"name": "rocket", "usphone": "", "ukphone": "", "trans": ["n. 火箭"]}, {"name": "role", "usphone": "rəʊl", "ukphone": "", "trans": ["n. 角色"]}, {"name": "roll", "usphone": "rəʊl", "ukphone": "", "trans": ["v. 滚动, 打滚 n. 面包圈，小圆面包；卷状物"]}, {"name": "roller", "usphone": "ˈrəʊlə(r)", "ukphone": "", "trans": ["n. 滚筒； 辊"]}, {"name": "roller skatingn", "usphone": "", "ukphone": "", "trans": ["滑旱冰"]}, {"name": "roof", "usphone": "ruːf", "ukphone": "", "trans": ["n. 屋顶，顶部"]}, {"name": "room", "usphone": "rʊm", "ukphone": "", "trans": ["n. 房间,室;空间;地方"]}, {"name": "rooster", "usphone": "ˈruːstə(r)", "ukphone": "", "trans": ["n. (美)公鸡"]}, {"name": "root", "usphone": "ruːt", "ukphone": "", "trans": ["n. 根，根源，起源"]}, {"name": "rope", "usphone": "rəʊp", "ukphone": "", "trans": ["n. 绳，索"]}, {"name": "rose", "usphone": "rəʊz", "ukphone": "", "trans": ["n. 玫瑰花"]}, {"name": "rot", "usphone": "rɔt", "ukphone": "", "trans": ["vi. 烂； 腐败"]}, {"name": "rough", "usphone": "rʌf", "ukphone": "", "trans": ["a. 粗糙的，粗略的"]}, {"name": "round", "usphone": "raʊnd", "ukphone": "", "trans": ["ad. 转过来 prep. 环绕一周，围着 a.圆的；球形的"]}, {"name": "roundabout", "usphone": "ˈraʊndəbaʊt", "ukphone": "", "trans": ["a. & n. 绕道的，不直接的；转盘路"]}, {"name": "routine", "usphone": "ruːˈtiːn", "ukphone": "", "trans": ["n. 常规,正常顺序,无聊"]}, {"name": "row", "usphone": "rəʊ", "ukphone": "", "trans": ["n.（一）排,（一）行 v.划船"]}, {"name": "royal", "usphone": "ˈrɔɪəl", "ukphone": "", "trans": ["a. 皇家的，王室的，国王的，女王的"]}, {"name": "rubber", "usphone": "ˈrʌbə(r)", "ukphone": "", "trans": ["n. 橡胶； 合成橡胶"]}, {"name": "rubbish", "usphone": "ˈrʌbɪʃ", "ukphone": "", "trans": ["n. 垃圾； 废物"]}, {"name": "rude", "usphone": "ruːd", "ukphone": "", "trans": ["a. 无理的, 粗鲁的"]}, {"name": "rugby", "usphone": "ˈrʌɡbɪ", "ukphone": "", "trans": ["n. （英）橄榄球"]}, {"name": "ruin", "usphone": "ˈruːɪn", "ukphone": "", "trans": ["vt. （使）毁坏；（使） 毁灭 n. (复) 废墟；遗迹"]}, {"name": "rule", "usphone": "ruːl", "ukphone": "", "trans": ["n. 规则,规定 vt.统治,支配"]}, {"name": "ruler", "usphone": "ˈruːlə(r)", "ukphone": "", "trans": ["n. 统治者；直尺"]}, {"name": "run (ran, run)", "usphone": "rʌn", "ukphone": "", "trans": ["vi. 跑，奔跑；（颜色）褪色"]}, {"name": "runner", "usphone": "ˈrʌnə(r)", "ukphone": "", "trans": ["n. 赛跑者；操作者；滑行装置"]}, {"name": "running", "usphone": "ˈrʌnɪŋ", "ukphone": "", "trans": ["n. 跑步"]}, {"name": "rush", "usphone": "rʌʃ", "ukphone": "", "trans": ["vi. 冲，奔跑"]}, {"name": "Russia", "usphone": "ˈrʌʃə", "ukphone": "", "trans": ["* n. 俄罗斯，俄国"]}, {"name": "Russian", "usphone": "ˈrʌʃ(ə)n", "ukphone": "", "trans": ["a. 俄国人的，俄语的 n. 俄国人，俄语"]}, {"name": "sacred", "usphone": "ˈseɪkrɪd", "ukphone": "", "trans": ["a. 害怕，恐惧，担心"]}, {"name": "sacrifice", "usphone": "ˈsækrɪfaɪs", "ukphone": "", "trans": ["vt. 牺牲"]}, {"name": "sad", "usphone": "sæd", "ukphone": "", "trans": ["a. （使人）悲伤的"]}, {"name": "sadness", "usphone": "ˈsædnɪs", "ukphone": "", "trans": ["n. 悲哀，忧伤"]}, {"name": "safe", "usphone": "seɪf", "ukphone": "", "trans": ["a. 安全的 n. 保险柜"]}, {"name": "safety", "usphone": "ˈseɪftɪ", "ukphone": "", "trans": ["n. 安全，保险"]}, {"name": "sail", "usphone": "seɪl", "ukphone": "", "trans": ["n. 航行 v. 航行，开航"]}, {"name": "sailing", "usphone": "ˈseɪlɪŋ", "ukphone": "", "trans": ["n. 航海"]}, {"name": "sailor", "usphone": "ˈseɪlə(r)", "ukphone": "", "trans": ["n. 水手，海员"]}, {"name": "salad", "usphone": "ˈsæləd", "ukphone": "", "trans": ["n. 色拉（西餐中的一种菜）"]}, {"name": "salary", "usphone": "ˈsælərɪ", "ukphone": "", "trans": ["n. 薪金，薪水"]}, {"name": "sale", "usphone": "seɪl", "ukphone": "", "trans": ["n. 卖，出售"]}, {"name": "salesgirl", "usphone": "ˈseɪlzɡɜːl", "ukphone": "", "trans": ["n. 女售货员"]}, {"name": "salesman", "usphone": "ˈseɪlzmən", "ukphone": "", "trans": ["n. 男售货员"]}, {"name": "saleswoman", "usphone": "seɪlz‚wʊmən", "ukphone": "", "trans": ["n. 女售货员"]}, {"name": "salt", "usphone": "sɔːlt, sɔlt", "ukphone": "", "trans": ["n. 盐"]}, {"name": "salty", "usphone": "ˈsɔːltɪ, ˈsɔltɪ", "ukphone": "", "trans": ["a. 盐的，咸的，含盐的"]}, {"name": "salute", "usphone": "səˈluːt, səˈljuːt", "ukphone": "", "trans": ["v.& n. 敬礼"]}, {"name": "same", "usphone": "seɪm", "ukphone": "", "trans": ["n.同样的事a同样的,同一"]}, {"name": "sand", "usphone": "sænd", "ukphone": "", "trans": ["n. 沙，沙子"]}, {"name": "sandwich", "usphone": "ˈsænwɪdʒ", "ukphone": "", "trans": ["n.三明治（夹心面包片）"]}, {"name": "satellite", "usphone": "ˈsætəlaɪt", "ukphone": "", "trans": ["n. 卫星"]}, {"name": "satisfaction", "usphone": "sætɪsˈfækʃ(ə)n", "ukphone": "", "trans": ["n. 满意"]}, {"name": "satisfy", "usphone": "ˈsætɪsfaɪ", "ukphone": "", "trans": ["vt. 满足，使满意"]}, {"name": "Saturday", "usphone": "ˈsætədeɪ, ˈsætədɪ", "ukphone": "", "trans": ["n. 星期六"]}, {"name": "sauce", "usphone": "sɔːs", "ukphone": "", "trans": ["n. 酱汁； 调味汁"]}, {"name": "saucer", "usphone": "ˈsɔːsə(r)", "ukphone": "", "trans": ["n. 茶碟，茶托，小圆盘"]}, {"name": "sausage", "usphone": "ˈsɔsɪdʒ; (US) ˈsɔːsɪdʒ", "ukphone": "", "trans": ["n. 香肠，腊肠"]}, {"name": "savage", "usphone": "ˈsævɪdʒ", "ukphone": "", "trans": ["n. 野蛮人，未开化的人"]}, {"name": "save", "usphone": "seɪv", "ukphone": "", "trans": ["vt. 救，挽救，节省"]}, {"name": "say (said, said)", "usphone": "seɪ", "ukphone": "", "trans": ["vt. 说，讲"]}, {"name": "saying", "usphone": "ˈseɪɪŋ", "ukphone": "", "trans": ["n. 说，俗话，谚语"]}, {"name": "scan", "usphone": "skæn", "ukphone": "", "trans": ["v. 略读，浏览，扫描"]}, {"name": "scar", "usphone": "skɑː(r)", "ukphone": "", "trans": ["n. 伤疤，伤痕"]}, {"name": "scare", "usphone": "skeə(r)", "ukphone": "", "trans": ["v. 使害怕，使恐惧"]}, {"name": "scarf", "usphone": "skɑːf", "ukphone": "", "trans": ["n. 领巾，围巾"]}, {"name": "scene", "usphone": "sɪːn", "ukphone": "", "trans": ["n. （戏剧、电影等的）一场，场景，布景"]}, {"name": "scenery", "usphone": "ˈsiːnərɪ", "ukphone": "", "trans": ["n. 风景，景色，风光"]}, {"name": "sceptical (AmE skeptical)", "usphone": "ˈskeptɪkl", "ukphone": "", "trans": ["a.怀疑的"]}, {"name": "schedule", "usphone": "ˈʃedjuːl; (US) ˈskedʒʊl", "ukphone": "", "trans": ["n. 工作计划，日程安排v. 安排时间，预定"]}, {"name": "school", "usphone": "skuːl", "ukphone": "", "trans": ["n. 学校"]}, {"name": "scholar", "usphone": "ˈskɔlə(r)", "ukphone": "", "trans": ["n. 学者"]}, {"name": "scholarship", "usphone": "ˈskɔləʃɪp", "ukphone": "", "trans": ["n. 奖学金"]}, {"name": "schoolbag", "usphone": "ˈsku:lbæg", "ukphone": "", "trans": ["n. 书包"]}, {"name": "school-leaver", "usphone": "skuːl-", "ukphone": "", "trans": ["n.(英)学校毕业生"]}, {"name": "schoolmate", "usphone": "ˈskuːlmeɪt", "ukphone": "", "trans": ["n. 同校同学"]}, {"name": "science", "usphone": "ˈsaɪəns", "ukphone": "", "trans": ["n. 科学，自然科学"]}, {"name": "scientific", "usphone": "saɪənˈtɪfɪk", "ukphone": "", "trans": ["a. 科学的"]}, {"name": "scientist", "usphone": "ˈsaɪəntɪst", "ukphone": "", "trans": ["n. 科学家"]}, {"name": "scissors", "usphone": "ˈsɪzəz", "ukphone": "", "trans": ["n. 剪刀，剪子"]}, {"name": "scold", "usphone": "skəʊld", "ukphone": "", "trans": ["vt. 责骂"]}, {"name": "score", "usphone": "skɔː(r)", "ukphone": "", "trans": ["n.& v. 得分，分数"]}, {"name": "scores", "usphone": "skɔː(r) z", "ukphone": "", "trans": ["n. 许多，很多"]}, {"name": "Scotland", "usphone": "ˈskɔtlənd", "ukphone": "", "trans": ["* n. 苏格兰"]}, {"name": "Scottish", "usphone": "ˈskɔtɪʃ", "ukphone": "", "trans": ["a. 苏格兰（人）的 n. 苏格兰人"]}, {"name": "Scratch", "usphone": " krætʃ ", "ukphone": "", "trans": ["v./ n. 划破，划痕，划伤"]}, {"name": "scream", "usphone": "skriːm", "ukphone": "", "trans": ["n. 尖叫"]}, {"name": "screen", "usphone": "skriːn", "ukphone": "", "trans": ["n. 幕，荧光屏"]}, {"name": "sculpture", "usphone": "ˈskʌlptʃə(r)", "ukphone": "", "trans": ["n. 雕塑（术），雕刻（术），雕刻作品，雕像"]}, {"name": "sea", "usphone": "siː", "ukphone": "", "trans": ["n. 海，海洋"]}, {"name": "seagull", "usphone": "ˈsiːɡʌl", "ukphone": "", "trans": ["n. 海鸥"]}, {"name": "seal", "usphone": "siːl", "ukphone": "", "trans": ["n. 海豹"]}, {"name": "seaman", "usphone": "ˈsiːmən", "ukphone": "", "trans": ["n. 水手； 海员"]}, {"name": "search", "usphone": "sɜːtʃ", "ukphone": "", "trans": ["n.& v. 搜寻，搜查"]}, {"name": "seashell", "usphone": "ˈsiːʃel", "ukphone": "", "trans": ["n. 海贝"]}, {"name": "seaside", "usphone": "ˈsiːsaɪd", "ukphone": "", "trans": ["n. 海滨"]}, {"name": "season", "usphone": "ˈsiːz(ə)n", "ukphone": "", "trans": ["n. 季；季节"]}, {"name": "seat", "usphone": "siːt", "ukphone": "", "trans": ["n. 座位，座"]}, {"name": "seaweed", "usphone": "ˈsiːwiːd", "ukphone": "", "trans": ["n. 海草,海藻,海带"]}, {"name": "second", "usphone": "ˈsekənd", "ukphone": "", "trans": ["n.秒 num.第二a.第二的"]}, {"name": "secondhand", "usphone": "ˈsekəndˈhænd", "ukphone": "", "trans": ["n. 二手货; 旧货"]}, {"name": "secret", "usphone": "ˈsiːkrɪt", "ukphone": "", "trans": ["n. 秘密，内情"]}, {"name": "secretary", "usphone": "ˈsekrətərɪ", "ukphone": "", "trans": ["n. 秘书；书记"]}, {"name": "section", "usphone": "ˈsekʃ(ə)n", "ukphone": "", "trans": ["n. 段，部分，部门"]}, {"name": "secure", "usphone": "sɪˈkjʊə(r)", "ukphone": "", "trans": ["a.安心的,有把握的,牢靠的"]}, {"name": "security", "usphone": "sɪˈkjʊərɪtɪ", "ukphone": "", "trans": ["n. 安全，平安"]}, {"name": "see (saw, seen)", "usphone": "siː", "ukphone": "", "trans": ["vt. 看见，看到；领会；拜会"]}, {"name": "seed", "usphone": "siːd", "ukphone": "", "trans": ["n. 种子"]}, {"name": "melon seed", "usphone": "ˈmelən siːd", "ukphone": "", "trans": ["瓜子"]}, {"name": "seek (sought, sought)", "usphone": "siːk", "ukphone": "", "trans": ["vt.试图;探寻"]}, {"name": "seem", "usphone": "siːm", "ukphone": "", "trans": ["v. 似乎，好像"]}, {"name": "see-saw", "usphone": "siː-sɔː", "ukphone": "", "trans": ["n. 跷跷板（游戏）"]}, {"name": "seize", "usphone": "siːz", "ukphone": "", "trans": ["vt. 抓住(时机等)"]}, {"name": "seldom", "usphone": "ˈseldəm", "ukphone": "", "trans": ["ad. 很少，不常"]}, {"name": "select", "usphone": "sɪˈlekt", "ukphone": "", "trans": ["vt. 选择，挑选，选拔"]}, {"name": "self", "usphone": "self", "ukphone": "", "trans": ["n. 自己，自我，自身"]}, {"name": "selfish", "usphone": "ˈselfɪʃ", "ukphone": "", "trans": ["a. 自私的"]}, {"name": "self-service", "usphone": "self-ˈsɜːvɪs", "ukphone": "", "trans": ["n.自助,自我服务的"]}, {"name": "sell (sold, sold)", "usphone": "sel", "ukphone": "", "trans": ["v. 卖，售"]}, {"name": "semicircle", "usphone": "ˈsemɪsɜːk(ə)l", "ukphone": "", "trans": ["n. 半圆"]}, {"name": "send (sent, sent)", "usphone": "send", "ukphone": "", "trans": ["v. 打发，派遣；送，邮寄"]}, {"name": "senior", "usphone": "ˈsiːnɪə(r)", "ukphone": "", "trans": ["a. 年长的,资深的,高年级的 n. 上级，长辈，高年级生"]}, {"name": "sense", "usphone": "sens", "ukphone": "", "trans": ["n. 感觉，意识"]}, {"name": "sensitive", "usphone": "ˈsensɪtɪv", "ukphone": "", "trans": ["a.体贴的,善解人意的"]}, {"name": "sentence", "usphone": "ˈsent(ə)ns", "ukphone": "", "trans": ["n. 句子"]}, {"name": "separate", "usphone": "ˈsepərət", "ukphone": "", "trans": ["v. 使分开，使分离a. 单独的，分开的"]}, {"name": "separately", "usphone": "ˈsepərətlɪ", "ukphone": "", "trans": ["ad. 单独地，各自地"]}, {"name": "separation", "usphone": "sepəˈreɪʃ(ə)n", "ukphone": "", "trans": ["n. 分离，隔离"]}, {"name": "September", "usphone": "səpˈtembə(r)", "ukphone": "", "trans": ["n. 9月"]}, {"name": "serious", "usphone": "ˈsɪərɪəs", "ukphone": "", "trans": ["a.严肃的,严重的,认真的"]}, {"name": "servant", "usphone": "ˈsɜːvənt", "ukphone": "", "trans": ["n. 仆人，佣人"]}, {"name": "serve", "usphone": "sɜːv", "ukphone": "", "trans": ["vt. 招待（顾客等）,服务"]}, {"name": "service", "usphone": "ˈsɜːvɪs", "ukphone": "", "trans": ["n. 服务"]}, {"name": "service-charge", "usphone": "ˈsɜːvɪs-tʃɑːdʒ", "ukphone": "", "trans": ["n. 服务费,小费"]}, {"name": "session", "usphone": "ˈseʃ(ə)n", "ukphone": "", "trans": ["n.一场,一节,一段时间"]}, {"name": "set (set, set)", "usphone": "set", "ukphone": "", "trans": ["vt. 释放，安置 n. 装备，设备"]}, {"name": "settle", "usphone": "ˈset(ə)l", "ukphone": "", "trans": ["vi. 安家，定居"]}, {"name": "settlement", "usphone": "ˈsetəlmənt", "ukphone": "", "trans": ["n. 新拓居地；（美）部落，村落"]}, {"name": "settler", "usphone": "ˈsetlə(r)", "ukphone": "", "trans": ["n. 移居者，开拓者"]}, {"name": "seven", "usphone": "ˈsev(ə)n", "ukphone": "", "trans": ["num. 七"]}, {"name": "seventeen", "usphone": "sevənˈtiːn", "ukphone": "", "trans": ["num. 十七"]}, {"name": "seventh", "usphone": "ˈsevənθ", "ukphone": "", "trans": ["num. 第七"]}, {"name": "seventy", "usphone": "ˈsevəntɪ", "ukphone": "", "trans": ["num. 七十"]}, {"name": "several", "usphone": "ˈsevr(ə)l", "ukphone": "", "trans": ["pron. 几个,数个 a.若干"]}, {"name": "severe", "usphone": "sɪˈvɪə(r)", "ukphone": "", "trans": ["a.极为恶劣,十分严重的"]}, {"name": "sew (sewed, sewn 或sewed)", "usphone": "səʊ", "ukphone": "", "trans": ["vi. 缝, 缝制；缝补；缝纫"]}, {"name": "sex", "usphone": "seks", "ukphone": "", "trans": ["n. 性，性别"]}, {"name": "shabby", "usphone": "ˈʃæbɪ", "ukphone": "", "trans": ["a.破旧,破烂,衣衫褴褛的"]}, {"name": "shade", "usphone": "ʃeɪd", "ukphone": "", "trans": ["n. 阴凉处，树荫处"]}, {"name": "shadow", "usphone": "ˈʃædəʊ", "ukphone": "", "trans": ["n. 影子, 阴影"]}, {"name": "shake (shook, shak en)", "usphone": "ʃeɪk", "ukphone": "", "trans": ["v. （使）动摇，震动"]}, {"name": "shall (should)", "usphone": "ʃæl, ʃ(ə)l", "ukphone": "", "trans": ["v. aux. （表示将来）将要，会；……好吗"]}, {"name": "shallow", "usphone": "ˈʃæləʊ", "ukphone": "", "trans": ["a. 浅的,不深的,肤浅的"]}, {"name": "shame", "usphone": "ʃeɪm", "ukphone": "", "trans": ["n. 遗憾的事；羞愧"]}, {"name": "Shanghai", "usphone": "ʃæŋˈhaɪ", "ukphone": "", "trans": ["n. 上海"]}, {"name": "shape", "usphone": "ʃeɪp", "ukphone": "", "trans": ["n. 形状，外形 v. 使成型，制造，塑造"]}, {"name": "share", "usphone": "ʃeə(r)", "ukphone": "", "trans": ["vt. 分享，共同使用"]}, {"name": "shark", "usphone": "ʃɑːk", "ukphone": "", "trans": ["n. 鲨鱼"]}, {"name": "sharp", "usphone": "ʃɑːp", "ukphone": "", "trans": ["a. 锋利的，尖的"]}, {"name": "sharpen", "usphone": "ˈʃɑːpən", "ukphone": "", "trans": ["v. （使）变锐利，削尖"]}, {"name": "sharpener", "usphone": "ˈʃɑːpənə(r)", "ukphone": "", "trans": ["n. 削尖用的器具"]}, {"name": "pencil- sharpener", "usphone": "ˈpens(ə)l-ˈʃɑːpənə(r)", "ukphone": "", "trans": ["转笔刀"]}, {"name": "shave (shaved, shaved 或 shaven)", "usphone": "ʃeɪv", "ukphone": "", "trans": ["v. 刮（脸，胡子）"]}, {"name": "shaver", "usphone": "", "ukphone": "", "trans": ["n. 电动剃须刀"]}, {"name": "she", "usphone": "ʃiː", "ukphone": "", "trans": ["pron. 她"]}, {"name": "sheep (复sheep)", "usphone": "ʃiːp", "ukphone": "", "trans": ["n. （绵）羊；羊皮；驯服者"]}, {"name": "sheet", "usphone": "ʃiːt", "ukphone": "", "trans": ["n. 成幅的薄片，薄板"]}, {"name": "shelf (复 shelves)", "usphone": "ʃelf", "ukphone": "", "trans": ["n. 架子；搁板；格层；礁；陆架"]}, {"name": "shelter", "usphone": "ˈʃeltə(r)", "ukphone": "", "trans": ["n. 掩蔽；隐蔽处"]}, {"name": "shine", "usphone": "ʃaɪn", "ukphone": "", "trans": ["n. 光泽；光彩；阳光；晴天；光(亮)"]}, {"name": "shine (shone, shone 或-d, -d)", "usphone": "ʃaɪn", "ukphone": "", "trans": ["v. 发光；照耀；杰出；擦亮"]}, {"name": "ship", "usphone": "ʃɪp", "ukphone": "", "trans": ["n. 船，轮船 vi. 用船装运"]}, {"name": "shirt", "usphone": "ʃɜːt", "ukphone": "", "trans": ["vn. 男衬衫"]}, {"name": "shock", "usphone": "ʃɔk", "ukphone": "", "trans": ["vt. 使震惊"]}, {"name": "shoe", "usphone": "ʃuː", "ukphone": "", "trans": ["n. 鞋"]}, {"name": "shoot", "usphone": "ʃuːt", "ukphone": "", "trans": ["(shot, shot) vt. 射击，射中，发射 n. 嫩枝；苗；芽"]}, {"name": "shooting", "usphone": "ˈʃuːtɪŋ", "ukphone": "", "trans": ["n. 射击"]}, {"name": "shop", "usphone": "ʃɔp", "ukphone": "", "trans": ["vi. 买东西 n. 商店,车间"]}, {"name": "shop assistant", "usphone": "ʃɔp əˈsɪst(ə)nt", "ukphone": "", "trans": ["(英) 售货员"]}, {"name": "shopkeeper", "usphone": "ˈʃɔpkiːpə(r)", "ukphone": "", "trans": ["n. 店主，零售商人"]}, {"name": "shopping", "usphone": "ˈʃɔpɪŋ", "ukphone": "", "trans": ["n. 买东西"]}, {"name": "shore", "usphone": "ʃɔː(r)", "ukphone": "", "trans": ["n. 滨，岸"]}, {"name": "short", "usphone": "ʃɔːt", "ukphone": "", "trans": ["a. 短的；矮的"]}, {"name": "shortcoming", "usphone": "ˈʃɔːtkʌmɪŋ", "ukphone": "", "trans": ["n. 缺点，短处"]}, {"name": "shortly", "usphone": "ˈʃɔːtlɪ", "ukphone": "", "trans": ["ad. 不久"]}, {"name": "shorts", "usphone": "ʃɔːts", "ukphone": "", "trans": ["n. 短裤；运动短裤"]}, {"name": "short wave", "usphone": "ʃɔːt", "ukphone": "", "trans": [""]}, {"name": "[weɪv]", "usphone": "n. 短波", "ukphone": "", "trans": ["shot"]}, {"name": "[ʃɔt]", "usphone": "n. 射击，开枪，开炮，射击声；子弹", "ukphone": "", "trans": ["should"]}, {"name": "[ʃɔt]", "usphone": "v. mod. 应当，应该，会 v. aux.会,应该（shall的过去时态）", "ukphone": "", "trans": ["shoulder"]}, {"name": "[ˈʃəʊldə(r)]", "usphone": "n. 肩膀,(道路的)路肩", "ukphone": "", "trans": ["shout"]}, {"name": "[ˈʃəʊldə(r)]", "usphone": "n.& v. 喊，高声呼喊", "ukphone": "", "trans": ["show"]}, {"name": "[ʃəʊ]", "usphone": "n. 展示,展览（会）;演出", "ukphone": "", "trans": ["show"]}, {"name": "[ʃəʊ]", "usphone": "(showed, shown 或 showed) v. 给…看,出示,显示", "ukphone": "", "trans": ["shower"]}, {"name": "[ˈʃaʊə(r)]", "usphone": "n. 阵雨；淋浴", "ukphone": "", "trans": ["shrink (shrank, shrunk / shrunk, shrunken)"]}, {"name": "[ʃrɪŋk]", "usphone": "v. 缩小，收缩，减少", "ukphone": "", "trans": ["shut (shut, shut)"]}, {"name": "[ʃʌt]", "usphone": "v. / n. 关上，封闭；禁闭；", "ukphone": "", "trans": ["shuttle"]}, {"name": "[ˈʃʌt(ə)l]", "usphone": "vn. 合拢 （往返与两个定点之间的）（火车汽车飞机）班车/机", "ukphone": "", "trans": ["shyv"]}, {"name": "[ʃaɪ]", "usphone": "a. 害羞的", "ukphone": "", "trans": ["sick"]}, {"name": "[sɪk]", "usphone": "a.有病,患病的,（想）呕吐", "ukphone": "", "trans": ["sickness"]}, {"name": "[ˈsɪknɪs]", "usphone": "n. 疾病", "ukphone": "", "trans": ["side"]}, {"name": "[ˈsɪknɪs]", "usphone": "n. 边，旁边，面，侧面", "ukphone": "", "trans": ["sideroad (AmE sidewalk) n.人行道"]}, {"name": "sideway", "usphone": "ˈsaɪdweɪz", "ukphone": "", "trans": ["n. 岔路，旁路"]}, {"name": "sideways", "usphone": "ˈsaɪdweɪz", "ukphone": "", "trans": ["ad. 斜向一边的"]}, {"name": "sigh", "usphone": "saɪ", "ukphone": "", "trans": ["vi. 叹息；叹气"]}, {"name": "sight", "usphone": "saɪ", "ukphone": "", "trans": ["n. 情景，风景；视力"]}, {"name": "sightseeing", "usphone": "ˈsaɪtsiːɪŋ", "ukphone": "", "trans": ["n. 游览，观光"]}, {"name": "sign", "usphone": "saɪn", "ukphone": "", "trans": ["n. 符号，标记"]}, {"name": "signal", "usphone": "ˈsɪɡn(ə)l", "ukphone": "", "trans": ["n. 信号，暗号"]}, {"name": "signature", "usphone": "ˈsɪɡnətʃə(r)", "ukphone": "", "trans": ["n. 签名"]}, {"name": "significance", "usphone": "ˈsɪɡnətʃə(r)", "ukphone": "", "trans": ["n. 重要性，意义"]}, {"name": "silence", "usphone": "ˈsaɪləns", "ukphone": "", "trans": ["n. 安静，沉默"]}, {"name": "silent", "usphone": "ˈsaɪlənt", "ukphone": "", "trans": ["a. 无声的，无对话的"]}, {"name": "silk", "usphone": "sɪlk", "ukphone": "", "trans": ["n. （蚕）丝，丝织品"]}, {"name": "silly", "usphone": "ˈsɪlɪ", "ukphone": "", "trans": ["a. 傻的，愚蠢的"]}, {"name": "silver", "usphone": "ˈsɪlvə(r)", "ukphone": "", "trans": ["n. 银"]}, {"name": "similar", "usphone": "ˈsɪmɪlə(r)", "ukphone": "", "trans": ["a. 相似的，像"]}, {"name": "simple", "usphone": "ˈsɪmp(ə)l", "ukphone": "", "trans": ["a. 简单的，简易的"]}, {"name": "simple-minded", "usphone": "ˈsɪmp(ə)l maɪndɪ", "ukphone": "", "trans": ["a.纯朴,头脑简单"]}, {"name": "simplify", "usphone": "ˈsɪmplɪfaɪ", "ukphone": "", "trans": ["v. 使简化，使简易"]}, {"name": "simply", "usphone": "ˈsɪmplɪ", "ukphone": "", "trans": ["ad.简单地,(加强语气)的确"]}, {"name": "since", "usphone": "sɪns", "ukphone": "", "trans": ["ad. 从那时以来 conj. 从…以来，…以后，由于 prep. 从…以来"]}, {"name": "sincerely", "usphone": "sɪnˈsɪrlɪ /-ˈsɪəl-", "ukphone": "", "trans": ["ad. 真诚地"]}, {"name": "sing (sang, sung)", "usphone": "sɪŋ", "ukphone": "", "trans": ["v. 唱，唱歌"]}, {"name": "singer", "usphone": "sɪŋ", "ukphone": "", "trans": ["n. 歌唱家，歌手"]}, {"name": "single", "usphone": "ˈsɪŋɡ(ə)l", "ukphone": "", "trans": ["a. 单一的，单个的"]}, {"name": "sink", "usphone": "sɪŋk", "ukphone": "", "trans": ["n. 洗涤槽；污水槽"]}, {"name": "sink (sank, sunk)", "usphone": "sɪŋk", "ukphone": "", "trans": ["vi. 下沉；消沉"]}, {"name": "sir", "usphone": "sɜː(r)", "ukphone": "", "trans": ["n. 先生；阁下"]}, {"name": "sister", "usphone": "ˈsɪstə(r)", "ukphone": "", "trans": ["n. 姐；妹"]}, {"name": "sister-in-law", "usphone": "ˈsɪstə(r) -ɪn-lɔː", "ukphone": "", "trans": ["n. 嫂，弟媳"]}, {"name": "sit (sat, sat)", "usphone": "sɪt", "ukphone": "", "trans": ["vi. 坐"]}, {"name": "situation", "usphone": "sɪtjʊˈeɪʃ(ə)n", "ukphone": "", "trans": ["n. 形势，情况"]}, {"name": "six", "usphone": "sɪks", "ukphone": "", "trans": ["num. 六"]}, {"name": "sixth", "usphone": "sɪksθ", "ukphone": "", "trans": ["num. 第六"]}, {"name": "sixty", "usphone": "ˈsɪkstɪ", "ukphone": "", "trans": ["num. 六十"]}, {"name": "sixteen", "usphone": "ˈsɪkstɪ", "ukphone": "", "trans": ["num. 十六"]}, {"name": "sixteenth", "usphone": "sɪksˈtiːnθ", "ukphone": "", "trans": ["num. 第十六"]}, {"name": "size", "usphone": "sɪksˈtiːnθ", "ukphone": "", "trans": ["n. 尺寸，大小"]}, {"name": "skate", "usphone": "sɪksˈtiːnθ", "ukphone": "", "trans": ["vi. 溜冰，滑冰"]}, {"name": "skateboard", "usphone": "ˈskeɪtbɔːd", "ukphone": "", "trans": ["n. 冰鞋，滑板"]}, {"name": "ski", "usphone": "skiː", "ukphone": "", "trans": ["n.& vi. 滑雪板；滑雪"]}, {"name": "skill", "usphone": "skiː", "ukphone": "", "trans": ["n. 技能，技巧"]}, {"name": "skilled", "usphone": "skiː", "ukphone": "", "trans": ["a. 熟练的；有技能的"]}, {"name": "skillful", "usphone": "ˈskɪlf(ə)l", "ukphone": "", "trans": ["a. 熟练,精湛的,灵巧的"]}, {"name": "skillfully", "usphone": "ˈskilfuli", "ukphone": "", "trans": ["ad. 精湛地,巧妙地"]}, {"name": "skin", "usphone": "skɪn", "ukphone": "", "trans": ["n. 皮，皮肤；兽皮"]}, {"name": "skip", "usphone": "skɪp", "ukphone": "", "trans": ["v. 蹦蹦跳跳；跳绳"]}, {"name": "skipping", "usphone": "skɪpɪŋ", "ukphone": "", "trans": ["rope （跳绳用）绳"]}, {"name": "skirt", "usphone": "skɜːt", "ukphone": "", "trans": ["n. 女裙"]}, {"name": "sky", "usphone": "skaɪ", "ukphone": "", "trans": ["n. 天；天空"]}, {"name": "skyscraper", "usphone": "ˈskaɪskreɪpə(r)", "ukphone": "", "trans": ["n. 摩天楼"]}, {"name": "slave", "usphone": "sleɪv", "ukphone": "", "trans": ["n. 奴隶"]}, {"name": "slavery", "usphone": "ˈsleɪvərɪ", "ukphone": "", "trans": ["n. 奴隶制度"]}, {"name": "sleep", "usphone": "sliːp", "ukphone": "", "trans": ["n. 睡觉"]}, {"name": "sleep (slept, slept)", "usphone": "sliːp", "ukphone": "", "trans": ["vi. 睡觉"]}, {"name": "sleepy", "usphone": "sliːp", "ukphone": "", "trans": ["a. 想睡的,困倦的,瞌睡的"]}, {"name": "sleeve", "usphone": "sliːv", "ukphone": "", "trans": ["n. 袖子，袖套"]}, {"name": "slice", "usphone": "sliːv", "ukphone": "", "trans": ["n. 片，切面（薄）片"]}, {"name": "slide", "usphone": "slaɪd", "ukphone": "", "trans": ["n.幻灯片,滑道 v.滑行,滑动"]}, {"name": "slight", "usphone": "slaɪt", "ukphone": "", "trans": ["a. 轻微的，细小的"]}, {"name": "slim", "usphone": "slɪm", "ukphone": "", "trans": ["a. 苗条的，纤细的"]}, {"name": "slip", "usphone": "slɪp", "ukphone": "", "trans": ["n. 片，条，纸片，纸条"]}, {"name": "slow", "usphone": "slɪp", "ukphone": "", "trans": ["ad. 慢慢地，缓慢地"]}, {"name": "small", "usphone": "smɔːl", "ukphone": "", "trans": ["a. 小的，少的"]}, {"name": "smart", "usphone": "smɑːt", "ukphone": "", "trans": ["a. 灵巧的，伶俐的；（人、服装等）时髦的，帅的"]}, {"name": "smell (smelt, smelt 或-ed,-ed)", "usphone": "smel", "ukphone": "", "trans": ["v. 嗅，闻到；发气味 n. 气味"]}, {"name": "smelly", "usphone": "ˈsmelɪ", "ukphone": "", "trans": ["a. 有臭味的,发出臭味的"]}, {"name": "smile", "usphone": "smaɪl", "ukphone": "", "trans": ["n.& v. 微笑"]}, {"name": "smog", "usphone": "smaɪl", "ukphone": "", "trans": ["n. 烟雾(= smoke + fog)"]}, {"name": "smoke", "usphone": "smaɪl", "ukphone": "", "trans": ["n. 烟 v. 冒烟；吸烟"]}, {"name": "smoke-free", "usphone": "sməʊk-friː", "ukphone": "", "trans": ["a. 非吸烟的,无烟的"]}, {"name": "smoker", "usphone": "ˈsməʊkə(r)", "ukphone": "", "trans": ["n. 吸烟者"]}, {"name": "smoking", "usphone": "ˈsməʊkɪŋ", "ukphone": "", "trans": ["n. 吸烟,抽烟;冒烟"]}, {"name": "smooth", "usphone": "ˈsməʊkɪŋ", "ukphone": "", "trans": ["a. 光滑的;平坦的"]}, {"name": "snack", "usphone": "snæk", "ukphone": "", "trans": ["n. 小吃"]}, {"name": "snack bar", "usphone": "snæk bɑː", "ukphone": "", "trans": ["n. 快餐店"]}, {"name": "snake", "usphone": "sneɪk", "ukphone": "", "trans": ["n.蛇v.蛇般爬行;蜿蜒行进"]}, {"name": "snatch", "usphone": "sneɪk", "ukphone": "", "trans": ["v. 夺，夺得，夺走"]}, {"name": "sneaker", "usphone": "sneɪk", "ukphone": "", "trans": ["n. （复）轻便运动鞋（美）"]}, {"name": "sneeze", "usphone": "sneɪk", "ukphone": "", "trans": ["v. 打喷嚏"]}, {"name": "sniff", "usphone": "snɪf", "ukphone": "", "trans": ["v. 抽鼻子（哭,患感冒时）"]}, {"name": "snow", "usphone": "snəʊ", "ukphone": "", "trans": ["n. 雪 vi.下雪"]}, {"name": "snowball", "usphone": "ˈsnəʊbɔːl", "ukphone": "", "trans": ["n. 雪球"]}, {"name": "snowman", "usphone": "ˈsnəʊmæn", "ukphone": "", "trans": ["n. 雪人"]}, {"name": "snowy", "usphone": "ˈsnəʊɪ", "ukphone": "", "trans": ["a. 雪(白)的；下雪的；多(积)雪的"]}, {"name": "so", "usphone": "səʊ", "ukphone": "", "trans": ["ad. 如此，这么；非常；同样 conj. 因此，所以"]}, {"name": "soap", "usphone": "səʊp", "ukphone": "", "trans": ["n. 肥皂"]}, {"name": "sob", "usphone": "səʊp", "ukphone": "", "trans": ["n.& v. 抽泣，啜泣"]}, {"name": "soccer", "usphone": "ˈsɔkə(r)", "ukphone": "", "trans": ["n.英式足球"]}, {"name": "social", "usphone": "ˈsəʊʃ(ə)l", "ukphone": "", "trans": ["a. 社会的；社交的"]}, {"name": "socialism", "usphone": "ˈsəʊʃəlɪz(ə)m", "ukphone": "", "trans": ["n. 社会主义"]}, {"name": "socialist", "usphone": "ˈsəʊʃəlɪst", "ukphone": "", "trans": ["a. 社会主义的"]}, {"name": "society", "usphone": "səˈsaɪətɪ", "ukphone": "", "trans": ["n. 社会"]}, {"name": "sock", "usphone": "sɔk", "ukphone": "", "trans": ["n. 短袜"]}, {"name": "socket", "usphone": "ˈsɔkɪt", "ukphone": "", "trans": ["n. （电源）插座"]}, {"name": "sofa", "usphone": "ˈsɔkɪt", "ukphone": "", "trans": ["n. （长）沙发"]}, {"name": "soft sɔft; (US) sɔːft]", "usphone": "a. 软的，柔和的", "ukphone": "", "trans": ["software"]}, {"name": "[sɔft; (US) sɔːft]", "usphone": "n. 软件", "ukphone": "", "trans": ["soft drink"]}, {"name": "[sɔft drɪŋk]", "usphone": "n. (不含酒精)清凉饮料", "ukphone": "", "trans": ["softball"]}, {"name": "[ˈsɔftbɔːl]", "usphone": "n. 垒球", "ukphone": "", "trans": ["soil"]}, {"name": "[sɔɪl]", "usphone": "n. 土壤，土地", "ukphone": "", "trans": ["solar"]}, {"name": "[ˈsəʊlə(r)]", "usphone": "a. 太阳的", "ukphone": "", "trans": ["soldier"]}, {"name": "[ˈsəʊldʒə(r)]", "usphone": "n. 士兵，战士", "ukphone": "", "trans": ["solid"]}, {"name": "[ˈsɔlɪd]", "usphone": "a. 结实的,固体的 n.固体", "ukphone": "", "trans": ["some"]}, {"name": "[sʌm]", "usphone": "a. 一些，若干；有些；某一 pron. 若干，一些", "ukphone": "", "trans": ["somebody"]}, {"name": "[ˈsʌmbʌdɪ; ˈsʌmbədɪ]", "usphone": "pron. 某人；有人；有名气的人", "ukphone": "", "trans": ["someone"]}, {"name": "[ˈsʌmwʌn]", "usphone": "pron. 某一个人", "ukphone": "", "trans": ["something"]}, {"name": "[ˈsʌmθɪŋ]", "usphone": "pron. 某事；某物", "ukphone": "", "trans": ["sometimes"]}, {"name": "[ˈsʌmtaɪmz]", "usphone": "ad. 有时", "ukphone": "", "trans": ["somewhere"]}, {"name": "[ˈsʌmtaɪmz]", "usphone": "ad. 在某处", "ukphone": "", "trans": ["son"]}, {"name": "[sʌn]", "usphone": "n. 儿子", "ukphone": "", "trans": ["song"]}, {"name": "[sʌn]", "usphone": "n. 歌唱；歌曲", "ukphone": "", "trans": ["soon"]}, {"name": "[sʌn]", "usphone": "ad. 不久,很快,一会儿", "ukphone": "", "trans": ["sorrow"]}, {"name": "[ˈsɔrəʊ]", "usphone": "n. 悲伤，悲痛", "ukphone": "", "trans": ["sorry"]}, {"name": "[ˈsɔrɪ]", "usphone": "a. 对不起,抱歉;难过的", "ukphone": "", "trans": ["sort"]}, {"name": "[sɔːt]", "usphone": "v", "ukphone": "", "trans": ["t. 把…分类，拣选 n. 种类，类别"]}, {"name": "so-so", "usphone": "səʊ-səʊ", "ukphone": "", "trans": ["a. 一般；不怎么样；凑合"]}, {"name": "soul", "usphone": "səʊl", "ukphone": "", "trans": ["n. 灵魂；心灵；气魄"]}, {"name": "sound", "usphone": "saʊnd", "ukphone": "", "trans": ["vi.听起来,发出声音n.声音"]}, {"name": "soup", "usphone": "suːp", "ukphone": "", "trans": ["n. 汤"]}, {"name": "sour", "usphone": "ˈsaʊə(r)", "ukphone": "", "trans": ["a. 酸的，馊的"]}, {"name": "south", "usphone": "ˈsaʊə(r)", "ukphone": "", "trans": ["a. 南(方)的；向南的；从南来的 ad. 在南方；向南方；自南方 n. 南；南方；南风；南部"]}, {"name": "southeast", "usphone": "‚saʊθˈɪːs", "ukphone": "", "trans": ["n. 东南"]}, {"name": "southern", "usphone": "ˈsʌð(ə)n", "ukphone": "", "trans": ["a. 南部的，南方的"]}, {"name": "southwest", "usphone": "sauθˈwest", "ukphone": "", "trans": ["n. 西南"]}, {"name": "souvenirs", "usphone": "suːvəˈnɪə(r); (US) ˈsuːvənɪər", "ukphone": "", "trans": ["n.旅游纪念品,纪念物"]}, {"name": "sow (sowed, sown 或-ed)", "usphone": "səʊ", "ukphone": "", "trans": ["vt.播种"]}, {"name": "space", "usphone": "speɪs", "ukphone": "", "trans": ["n. 空间"]}, {"name": "spaceship", "usphone": "ˈspeɪsʃɪp", "ukphone": "", "trans": ["n. 宇宙飞船"]}, {"name": "spade", "usphone": "speɪd", "ukphone": "", "trans": ["n. 铲子;纸牌中的黑桃"]}, {"name": "spaghettiv", "usphone": "", "ukphone": "", "trans": ["n. 意大利式面条"]}, {"name": "Spain*", "usphone": "speɪn", "ukphone": "", "trans": ["n. 西班牙"]}, {"name": "Spanish", "usphone": "ˈspænɪʃ", "ukphone": "", "trans": ["a. 西班牙人的，西班牙的，西班牙语的 n. 西班牙语"]}, {"name": "spare", "usphone": "speə(r)", "ukphone": "", "trans": ["a. 空闲,多余的，剩余的"]}, {"name": "sparrow", "usphone": "ˈspærəʊ", "ukphone": "", "trans": ["n. 麻雀，雀型鸟类"]}, {"name": "speak (spoke, spoken)", "usphone": "ˈspærəʊ", "ukphone": "", "trans": ["v. 说，讲；谈话；发言"]}, {"name": "speaker", "usphone": "ˈspiːkə(r)", "ukphone": "", "trans": ["n. 演讲人，演说家"]}, {"name": "spear", "usphone": "spɪə(r)", "ukphone": "", "trans": ["n. 矛，枪，梭镖"]}, {"name": "special", "usphone": "ˈspeʃ(ə)l", "ukphone": "", "trans": ["a. 特别的，专门的"]}, {"name": "specialist", "usphone": "ˈspeʃəlɪst", "ukphone": "", "trans": ["n. （医学）专家，专科医生；专家；专业人员"]}, {"name": "specific", "usphone": "spɪˈsɪfɪk", "ukphone": "", "trans": ["a.明确的,具体的,独特的"]}, {"name": "speech", "usphone": "spiːtʃ", "ukphone": "", "trans": ["n. 演讲"]}, {"name": "speed", "usphone": "spiːd", "ukphone": "", "trans": ["n. 速度 v. （使）加速"]}, {"name": "spell", "usphone": "spiːd", "ukphone": "", "trans": ["vt. 拼写"]}, {"name": "spelling", "usphone": "ˈspelɪŋ", "ukphone": "", "trans": ["n. 拼写，拼读"]}, {"name": "spend (spent, spent)", "usphone": "ˈspelɪŋ", "ukphone": "", "trans": ["v. 度过；花费（钱、时间等）"]}, {"name": "spin", "usphone": "spɪn", "ukphone": "", "trans": ["v.& n. 纺，（使）快速旋转；旋转，旋转运动"]}, {"name": "spirit", "usphone": "ˈspɪrɪt", "ukphone": "", "trans": ["n. 精神"]}, {"name": "spiritual", "usphone": "ˈspɪrɪtʃʊəl", "ukphone": "", "trans": ["a. 精神的； 心灵的"]}, {"name": "spit", "usphone": "spɪt", "ukphone": "", "trans": ["v. 吐唾沫；吐痰"]}, {"name": "splendid", "usphone": "ˈsplendɪd", "ukphone": "", "trans": ["a. 灿烂的，辉煌的；（口语）极好的"]}, {"name": "split", "usphone": "splɪt", "ukphone": "", "trans": ["v. 撕开;切开"]}, {"name": "spoken", "usphone": "ˈspəʊkən", "ukphone": "", "trans": ["a. 口语的"]}, {"name": "spoken man/ woman (pl. spokemen/ women)", "usphone": "ˈspəʊkən mæn", "ukphone": "", "trans": ["n. 发言人"]}, {"name": "sponsor", "usphone": "ˈspɔnsə(r)", "ukphone": "", "trans": ["n. 赞助者，赞助商"]}, {"name": "spoon", "usphone": "spuːn", "ukphone": "", "trans": ["n. 匙, 调羹"]}, {"name": "spoonful", "usphone": "ˈspuːnfʊl", "ukphone": "", "trans": ["n. 一匙（的量）"]}, {"name": "sport", "usphone": "spɔːt", "ukphone": "", "trans": ["vn. 体育运动，锻炼；(复，英)运动会"]}, {"name": "spot", "usphone": "spɔt", "ukphone": "", "trans": ["n. 斑点，污点；场所，地点 v. 沾上污渍，弄脏"]}, {"name": "spray", "usphone": "spreɪ", "ukphone": "", "trans": ["n. / v. 水雾,喷雾(器)喷洒"]}, {"name": "spread", "usphone": "spred", "ukphone": "", "trans": ["v. 延伸； 展开"]}, {"name": "spring", "usphone": "sprɪŋ", "ukphone": "", "trans": ["n. 春天,春季 n. 泉水,泉"]}, {"name": "spy", "usphone": "spaɪ", "ukphone": "", "trans": ["n. 密探,间谍 v.侦探,刺探"]}, {"name": "square", "usphone": "skweə(r)", "ukphone": "", "trans": ["n. 广场 a. 平方的；方形的，宽而结实的（体格，肩膀）"]}, {"name": "squeeze", "usphone": "", "ukphone": "", "trans": ["n. 挤压，捏，塞"]}, {"name": "squid", "usphone": "skwɪd", "ukphone": "", "trans": ["n. 鱿鱼"]}, {"name": "squirrel", "usphone": "ˈskwɪr(ə)l; (US) ˈskwɜːrəl", "ukphone": "", "trans": ["n. 松鼠"]}, {"name": "stable", "usphone": "ˈsteɪb(ə)l", "ukphone": "", "trans": ["a. 稳固的，牢固的"]}, {"name": "stadium", "usphone": "ˈsteɪdɪəm", "ukphone": "", "trans": ["n. （露天）体育场"]}, {"name": "staff", "usphone": "stɑːf", "ukphone": "", "trans": ["n. 全体职工（雇员）"]}, {"name": "stage", "usphone": "steɪdʒ", "ukphone": "", "trans": ["n. 舞台；阶段"]}, {"name": "stain", "usphone": "steɪn", "ukphone": "", "trans": ["n. 污点，污渍，染色剂"]}, {"name": "stainless", "usphone": "ˈsteɪnlɪs", "ukphone": "", "trans": ["a. 无污点的"]}, {"name": "stainless steel", "usphone": "ˈsteɪnlɪs stiːl", "ukphone": "", "trans": ["不锈钢"]}, {"name": "stair", "usphone": "steə(r)", "ukphone": "", "trans": ["n. 楼梯"]}, {"name": "stamp", "usphone": "stæmp", "ukphone": "", "trans": ["n. 邮票"]}, {"name": "stand", "usphone": "stænd", "ukphone": "", "trans": ["n. 站；立；停止；立场；地位；台；坛；摊"]}, {"name": "stand (stood, stood)", "usphone": "stænd", "ukphone": "", "trans": ["v. 站；立；起立；坐落；经受；持久"]}, {"name": "standard", "usphone": "ˈstændəd", "ukphone": "", "trans": ["n. & a. 标准（的）"]}, {"name": "star", "usphone": "stɑː(r)", "ukphone": "", "trans": ["n. 星，恒星"]}, {"name": "stare", "usphone": "steə(r)", "ukphone": "", "trans": ["vi. 盯，凝视"]}, {"name": "start", "usphone": "stɑːt", "ukphone": "", "trans": ["v. 开始，着手；出发"]}, {"name": "starvation", "usphone": "stɑːˈveɪʃ(ə)n", "ukphone": "", "trans": ["n. 饥饿； 饿死"]}, {"name": "starve", "usphone": "stɑːv", "ukphone": "", "trans": ["v. 饿死"]}, {"name": "state", "usphone": "steɪt", "ukphone": "", "trans": ["n. 状态； 情形；国家，（美国的）州"]}, {"name": "station", "usphone": "ˈsteɪʃ(ə)n", "ukphone": "", "trans": ["n. 站，所，车站；电台"]}, {"name": "statement", "usphone": "ˈsteɪtmənt", "ukphone": "", "trans": ["n.声明，陈诉，说法"]}, {"name": "statesman/ woman (pl. statesmen/ women)", "usphone": "ˈsteɪtsmən", "ukphone": "", "trans": ["n. 政治家"]}, {"name": "statistics", "usphone": "stəˈtɪstɪks", "ukphone": "", "trans": ["n. 统计数字，统计资料，统计学"]}, {"name": "statue", "usphone": "ˈstætjuː", "ukphone": "", "trans": ["n. 法令，法规，章程"]}, {"name": "status", "usphone": "ˈsteɪtəs", "ukphone": "", "trans": ["n. 法律地位（身份）"]}, {"name": "stay", "usphone": "steɪ", "ukphone": "", "trans": ["n.& vi. 停留，逗留，呆"]}, {"name": "steady", "usphone": "ˈstedɪ", "ukphone": "", "trans": ["a. 稳固的；平稳的"]}, {"name": "steak", "usphone": "steɪk", "ukphone": "", "trans": ["n. 牛排，肉排，鱼排"]}, {"name": "steal (stole, stolen)", "usphone": "stiːl", "ukphone": "", "trans": ["vt. 偷, 窃取"]}, {"name": "steam", "usphone": "stiːm", "ukphone": "", "trans": ["n. 汽，水蒸气"]}, {"name": "steel", "usphone": "stiːl", "ukphone": "", "trans": ["n. 钢，钢铁"]}, {"name": "steep", "usphone": "stiːp", "ukphone": "", "trans": ["a. 险峻的； 陡峭的"]}, {"name": "step", "usphone": "step", "ukphone": "", "trans": ["n.脚步,台阶,梯级 vi.走,跨步"]}, {"name": "step-mother", "usphone": "step-ˈmʌðə(r)", "ukphone": "", "trans": ["n. 继母"]}, {"name": "steward", "usphone": "ˈstjuːəd; (US) ˈstuːərd", "ukphone": "", "trans": ["n. (火车、飞机、轮船等)男服务员；男乘务员"]}, {"name": "stewardess", "usphone": "stjuːəˈdes, ˈstjuːədɪs", "ukphone": "", "trans": ["n.女乘务员,空中小姐"]}, {"name": "stick (stuck, stuck)", "usphone": "stɪk", "ukphone": "", "trans": ["vi. 粘住，钉住；坚持n. 木棒（棍）,枝条"]}, {"name": "still", "usphone": "stɪl", "ukphone": "", "trans": ["a.不动的,平静的ad.仍然,还"]}, {"name": "stocking", "usphone": "ˈstɔkɪŋ", "ukphone": "", "trans": ["n. 长统袜"]}, {"name": "stomach", "usphone": "ˈstʌmək", "ukphone": "", "trans": ["n. 胃，胃部"]}, {"name": "stomachache", "usphone": "ˈstʌməkeɪk", "ukphone": "", "trans": ["n. 胃疼"]}, {"name": "stone", "usphone": "stəʊn", "ukphone": "", "trans": ["n. 石头，石料"]}, {"name": "stop", "usphone": "stɔp", "ukphone": "", "trans": ["n. 停；（停车）站 v. 停，停止，阻止"]}, {"name": "stopwatch", "usphone": "ˈstɔpwɔtʃ", "ukphone": "", "trans": ["n. 记秒表；跑表"]}, {"name": "storage", "usphone": "ˈstɔːrɪdʒ", "ukphone": "", "trans": ["n. 贮藏； 储存"]}, {"name": "store", "usphone": "stɔː(r)", "ukphone": "", "trans": ["n. 商店 vt. 储藏，存储"]}, {"name": "storm", "usphone": "stɔːm", "ukphone": "", "trans": ["n. 风暴，暴（风）雨"]}, {"name": "story", "usphone": "ˈstɔːrɪ", "ukphone": "", "trans": ["n. 故事，小说"]}, {"name": "stout", "usphone": "staʊt", "ukphone": "", "trans": ["a. 肥壮的，厚实牢固的"]}, {"name": "stove", "usphone": "stəʊv", "ukphone": "", "trans": ["n. （供烹饪用的 ）火炉，煤炉，电炉"]}, {"name": "straight", "usphone": "streɪt", "ukphone": "", "trans": ["a. 一直的，直的 ad. 一直地，直地"]}, {"name": "straightforward", "usphone": "streɪtˈfɔːwəd", "ukphone": "", "trans": ["a./ ad. 简单的，坦率的"]}, {"name": "strait", "usphone": "streɪt", "ukphone": "", "trans": ["n. 海峡"]}, {"name": "strange", "usphone": "streɪndʒ", "ukphone": "", "trans": ["a. 奇怪,奇特的,陌生的"]}, {"name": "stranger", "usphone": "ˈstreɪndʒə(r)", "ukphone": "", "trans": ["n. 陌生人，外人"]}, {"name": "straw", "usphone": "strɔː", "ukphone": "", "trans": ["n. 稻草"]}, {"name": "strawberry", "usphone": "ˈstrɔːbərɪ; (US) -berɪ", "ukphone": "", "trans": ["n. 草莓"]}, {"name": "stream", "usphone": "striːm", "ukphone": "", "trans": ["n. 小河；溪流"]}, {"name": "street", "usphone": "striːt", "ukphone": "", "trans": ["n. 街，街道"]}, {"name": "strength", "usphone": "streŋθ", "ukphone": "", "trans": ["n. 力量，力气"]}, {"name": "strengthen", "usphone": "ˈstreŋθ(ə)n", "ukphone": "", "trans": ["vt. 加强，增强"]}, {"name": "stress", "usphone": "stres", "ukphone": "", "trans": ["n. 精神压力，心理负担 v. 强调，重读"]}, {"name": "strict", "usphone": "strɪkt", "ukphone": "", "trans": ["a. 严格的，严密的"]}, {"name": "strike", "usphone": "straɪk", "ukphone": "", "trans": ["v.（钟）鸣;敲（响）,罢工"]}, {"name": "strike (struck, struck 或stricken)", "usphone": "straɪk", "ukphone": "", "trans": ["vt. 擦（打）火, 侵袭"]}, {"name": "string", "usphone": "strɪŋ", "ukphone": "", "trans": ["n. 细绳，线，带"]}, {"name": "strong", "usphone": "strɔŋ; (US) strɔːɡ", "ukphone": "", "trans": ["a. 强(壮)的；坚固的；强烈的；坚强的"]}, {"name": "struggle", "usphone": "ˈstrʌɡ(ə)l", "ukphone": "", "trans": ["vi. 斗争"]}, {"name": "stubborn", "usphone": "ˈstʌbən", "ukphone": "", "trans": ["a. 固执的，倔强的"]}, {"name": "student", "usphone": "ˈstjuːdənt", "ukphone": "", "trans": ["n. 学生"]}, {"name": "studio", "usphone": "ˈstjuːdɪəʊ", "ukphone": "", "trans": ["n. 工作室，演播室"]}, {"name": "study", "usphone": "ˈstʌdɪ", "ukphone": "", "trans": ["v. 学习；研究 n. 书房"]}, {"name": "stupid", "usphone": "ˈstjuːpɪd", "ukphone": "", "trans": ["a. 愚蠢的，笨的"]}, {"name": "style", "usphone": "staɪl", "ukphone": "", "trans": ["n. 方式，作风，款式"]}, {"name": "subject", "usphone": "ˈsʌbdʒɪkt", "ukphone": "", "trans": ["a. 隶属的；受支配的；易受…的；在…条件下 vt. 使隶属；使服从；使受到 n. 题目；主题；学科；主语；主体"]}, {"name": "subjective", "usphone": "səbˈdʒektɪv", "ukphone": "", "trans": ["a. 主观的"]}, {"name": "submit", "usphone": "səbˈmɪt", "ukphone": "", "trans": ["v. 提交，呈递（文件，建议等）"]}, {"name": "subscribe", "usphone": "səbˈskraɪb", "ukphone": "", "trans": ["v.订阅,订购（报刊等）"]}, {"name": "substitute", "usphone": "ˈsʌbstɪtjuːt", "ukphone": "", "trans": ["v. 代替，取代"]}, {"name": "subtraction", "usphone": "səbˈtrɔkʃ(ə)n", "ukphone": "", "trans": ["n.（算数中的）减"]}, {"name": "succeed", "usphone": "səkˈsiːd", "ukphone": "", "trans": ["vi. 成功"]}, {"name": "success", "usphone": "səkˈses", "ukphone": "", "trans": ["n. 成功"]}, {"name": "successful", "usphone": "səkˈsesfʊl", "ukphone": "", "trans": ["a. 成功的,有成就的"]}, {"name": "such", "usphone": "sʌtʃ", "ukphone": "", "trans": ["ad. 那么 pron. （泛指）人，事物 a.这样的，那样的"]}, {"name": "suck", "usphone": "sʌk", "ukphone": "", "trans": ["vt. 吸吮"]}, {"name": "sudden", "usphone": "ˈsʌd(ə)n", "ukphone": "", "trans": ["a. 突然的"]}, {"name": "suffer", "usphone": "ˈsʌfə(r)", "ukphone": "", "trans": ["vi. 受苦，遭受"]}, {"name": "suffering", "usphone": "ˈsʌfərɪŋ", "ukphone": "", "trans": ["n. 痛苦，苦难"]}, {"name": "sugar", "usphone": "ˈʃʊɡə(r)", "ukphone": "", "trans": ["n. 糖"]}, {"name": "suggest", "usphone": "səˈdʒest; (US) səɡˈdʒest", "ukphone": "", "trans": ["vt. 建议，提议"]}, {"name": "suggestion", "usphone": "səˈdʒestʃ(ə)n", "ukphone": "", "trans": ["n. 建议"]}, {"name": "suit", "usphone": "suːt, sjuːt", "ukphone": "", "trans": ["vt. 适合 n.一套（衣服）"]}, {"name": "suite", "usphone": "swiːt", "ukphone": "", "trans": ["n. 套间；组曲"]}, {"name": "suitable", "usphone": "ˈsjuːtəb(ə)l", "ukphone": "", "trans": ["a. 合适的，适宜的"]}, {"name": "suitcase", "usphone": "ˈsjuːtkeɪs", "ukphone": "", "trans": ["n.(旅行用)小提箱,衣箱"]}, {"name": "summary", "usphone": "ˈsʌmərɪ", "ukphone": "", "trans": ["n. 摘要，概要"]}, {"name": "summer", "usphone": "ˈsʌmə(r)", "ukphone": "", "trans": ["n. 夏天，夏季"]}, {"name": "sun", "usphone": "sʌn", "ukphone": "", "trans": ["n. 太阳，阳光"]}, {"name": "sunburnt", "usphone": "ˈsʌnbɜːnt", "ukphone": "", "trans": ["a. 晒黑的"]}, {"name": "Sunday", "usphone": "ˈsʌndeɪ", "ukphone": "", "trans": ["n. 星期日"]}, {"name": "sunglasses", "usphone": "ˈsʌnɡlɑːsɪs", "ukphone": "", "trans": ["n. 太阳眼镜，墨镜"]}, {"name": "sunlight", "usphone": "ˈsʌnlaɪt", "ukphone": "", "trans": ["n. 日光，阳光"]}, {"name": "sunny", "usphone": "ˈsʌnɪ", "ukphone": "", "trans": ["a. 晴朗的;阳光充足的"]}, {"name": "sunrise", "usphone": "ˈsʌnraɪs", "ukphone": "", "trans": ["n. 黎明，拂晓"]}, {"name": "sunset", "usphone": "ˈsʌnset", "ukphone": "", "trans": ["n. 日落(时分)"]}, {"name": "sunshine", "usphone": "ˈsʌnʃaɪn", "ukphone": "", "trans": ["n. 阳光"]}, {"name": "super", "usphone": "ˈsuːpə(r), ˈsjuːpə(r)", "ukphone": "", "trans": ["a. 顶好的，超级的"]}, {"name": "superb", "usphone": "suːˈpɜːb", "ukphone": "", "trans": ["a. 卓越的,质量极高的"]}, {"name": "superior", "usphone": "suːˈpɪərɪə(r)", "ukphone": "", "trans": ["a. 更胜一筹的 n. 上级，上司"]}, {"name": "superman", "usphone": "ˈsuːpəman", "ukphone": "", "trans": ["n. 超人"]}, {"name": "supermarket", "usphone": "ˈsuːpəmɑːkɪt", "ukphone": "", "trans": ["n. 超级市场"]}, {"name": "supper", "usphone": "ˈsʌpə(r)", "ukphone": "", "trans": ["n. 晚餐，晚饭"]}, {"name": "supply", "usphone": "səˈplaɪ", "ukphone": "", "trans": ["vt.& n. 供给，供应"]}, {"name": "support", "usphone": "səˈpɔːt", "ukphone": "", "trans": ["vt.& n. 支持，赞助"]}, {"name": "suppose", "usphone": "səˈpəʊz", "ukphone": "", "trans": ["vt. 猜想,假定,料想"]}, {"name": "supreme", "usphone": "suːˈpriːm", "ukphone": "", "trans": ["a.至高无上的,最高的"]}, {"name": "sure", "usphone": "ʃʊə(r), ʃɔː(r)", "ukphone": "", "trans": ["a. 确信，肯定 ad. (口语)的确，一定，当然"]}, {"name": "surface", "usphone": "ˈsɜːfɪs", "ukphone": "", "trans": ["n. 表面"]}, {"name": "surgeon", "usphone": "ˈsɜːdʒ(ə)n", "ukphone": "", "trans": ["n. 外科医生"]}, {"name": "surplus", "usphone": "ˈsɜːpləs", "ukphone": "", "trans": ["n. 过剩，剩余"]}, {"name": "surprise", "usphone": "səˈpraɪz", "ukphone": "", "trans": ["vt. 使惊奇,使诧异 n. 惊奇,诧异"]}, {"name": "surround", "usphone": "səˈraʊnd", "ukphone": "", "trans": ["vt. 围绕；包围"]}, {"name": "surrounding", "usphone": "səˈraʊndɪŋ", "ukphone": "", "trans": ["a. 周围的"]}, {"name": "survival", "usphone": "səˈvaɪv(ə)l", "ukphone": "", "trans": ["n. 存活，幸存"]}, {"name": "survive", "usphone": "səˈvaɪv", "ukphone": "", "trans": ["v.生存，存活，幸免于难"]}, {"name": "suspect", "usphone": "səˈspekt", "ukphone": "", "trans": ["n. 犯罪嫌疑人"]}, {"name": "suspension", "usphone": "səˈspenʃ(ə)n", "ukphone": "", "trans": ["n.暂令停职,推迟,延期"]}, {"name": "swallow", "usphone": "ˈswɔləʊ", "ukphone": "", "trans": ["vt. 吞下；咽下"]}, {"name": "swap", "usphone": "swɔp", "ukphone": "", "trans": ["v. 交换（东西）"]}, {"name": "swear (swore, sworn)", "usphone": "sweə(r)", "ukphone": "", "trans": ["v.咒骂.,诅咒"]}, {"name": "sweat", "usphone": "swet", "ukphone": "", "trans": ["n. 汗，汗水"]}, {"name": "sweater", "usphone": "ˈswetə(r)", "ukphone": "", "trans": ["n. 厚运动衫，毛衣 "]}, {"name": "sweep(swept,swept)", "usphone": "swiːp", "ukphone": "", "trans": ["v. 扫除，扫"]}, {"name": "sweet", "usphone": "swiːt", "ukphone": "", "trans": ["n.甜食;蜜饯;甜点;糖果;芳香a.甜的;新鲜的;可爱的;亲切的"]}, {"name": "swell (swelled, swollen)", "usphone": "swel", "ukphone": "", "trans": ["v. 肿胀"]}, {"name": "swift", "usphone": "swɪft", "ukphone": "", "trans": ["a. 快的，迅速的"]}, {"name": "swim", "usphone": "swɪm", "ukphone": "", "trans": ["n. 游泳，游"]}, {"name": "swim (swam, swum)", "usphone": "swɪm", "ukphone": "", "trans": ["vi. 游泳,游"]}, {"name": "swimming", "usphone": "ˈswɪmɪŋ", "ukphone": "", "trans": ["n. 游泳"]}, {"name": "swimming pool", "usphone": "ˈswɪmɪŋ puːl", "ukphone": "", "trans": ["n. 游泳池"]}, {"name": "swing", "usphone": "swɪŋ", "ukphone": "", "trans": ["vt. 挥舞，摆动 n. 秋千"]}, {"name": "Swiss", "usphone": "swɪŋ", "ukphone": "", "trans": ["a. 瑞士人的 n. 瑞士人"]}, {"name": "Switzerland", "usphone": "ˈswɪtsələnd", "ukphone": "", "trans": ["* n. 瑞士"]}, {"name": "switch", "usphone": "swɪtʃ", "ukphone": "", "trans": ["v./ n. 开关,转换,改变"]}, {"name": "sword", "usphone": "sɔːd", "ukphone": "", "trans": ["n. 剑，刀"]}, {"name": "symbol", "usphone": "ˈsɪmb(ə)l", "ukphone": "", "trans": ["n. 象征"]}, {"name": "sympathy", "usphone": "ˈsɪmpəθɪ", "ukphone": "", "trans": ["n. 同情"]}, {"name": "symphony", "usphone": "ˈsɪmfənɪ", "ukphone": "", "trans": ["n. 交响乐"]}, {"name": "symptom", "usphone": "ˈsɪmfənɪ", "ukphone": "", "trans": ["n. 症状"]}, {"name": "system", "usphone": "ˈsɪstəm", "ukphone": "", "trans": ["n. 体系；系统"]}, {"name": "systematic", "usphone": "sɪstəˈmætɪk", "ukphone": "", "trans": ["a.系统的,有条理的"]}, {"name": "table", "usphone": "ˈteɪb(ə)l", "ukphone": "", "trans": ["n. 桌子，表格"]}, {"name": "table tennis", "usphone": "ˈteɪb(ə)l ˈtenɪs", "ukphone": "", "trans": ["n. 乒乓球"]}, {"name": "tablet", "usphone": "", "ukphone": "", "trans": ["n. 药片"]}, {"name": "tail", "usphone": "teɪl", "ukphone": "", "trans": ["n. (动物的)尾巴"]}, {"name": "tailor", "usphone": "ˈteɪlə(r)", "ukphone": "", "trans": ["n. 裁缝"]}, {"name": "take (took, taken)", "usphone": "teɪk", "ukphone": "", "trans": ["vt. 拿；拿走；做；服用；乘坐；花费"]}, {"name": "tale", "usphone": "teɪl", "ukphone": "", "trans": ["n. 故事, 传说"]}, {"name": "talent", "usphone": "ˈtælənt", "ukphone": "", "trans": ["n. 天才，天赋"]}, {"name": "talk", "usphone": "tɔːk", "ukphone": "", "trans": ["n.& v.谈话,讲话,演讲,交谈"]}, {"name": "tall", "usphone": "tɔːl", "ukphone": "", "trans": ["a. 高的"]}, {"name": "tank", "usphone": "tæŋk", "ukphone": "", "trans": ["n. 储水容量；坦克"]}, {"name": "tanker", "usphone": "ˈtæŋkə(r)", "ukphone": "", "trans": ["n. 油船"]}, {"name": "tap", "usphone": "tæp", "ukphone": "", "trans": ["n. (自来水煤气等的)龙头"]}, {"name": "tape", "usphone": "teɪp", "ukphone": "", "trans": ["n. 磁带；录音带"]}, {"name": "tape recorder", "usphone": "teɪp rɪˈkɔːdə(r)", "ukphone": "", "trans": ["n. 磁带录音机"]}, {"name": "target", "usphone": "ˈtɑːɡɪt", "ukphone": "", "trans": ["n./ v. 目标，把…作为攻击目标"]}, {"name": "task", "usphone": "tɑːsk; (US) tæsk", "ukphone": "", "trans": ["n. 任务, 工作"]}, {"name": "taste", "usphone": "teɪst", "ukphone": "", "trans": ["n. 品尝, 尝味；味道 vt. 品尝, 尝味"]}, {"name": "tasteless", "usphone": "ˈteɪstlɪs", "ukphone": "", "trans": ["a. 无滋味的"]}, {"name": "tasty", "usphone": "ˈteɪstɪ", "ukphone": "", "trans": ["a. 味道好的"]}, {"name": "tax", "usphone": "tæks", "ukphone": "", "trans": ["n. 税，税款"]}, {"name": "tax-free", "usphone": "tæks friː", "ukphone": "", "trans": ["免税的"]}, {"name": "taxi", "usphone": "ˈtæksɪ", "ukphone": "", "trans": ["n. 出租汽车"]}, {"name": "taxipayer", "usphone": "", "ukphone": "", "trans": ["n. 纳税人"]}, {"name": "tea", "usphone": "tiː", "ukphone": "", "trans": ["n. 茶；茶叶 "]}, {"name": "teach(taught,taught)", "usphone": "tiː", "ukphone": "", "trans": ["v. 教书,教"]}, {"name": "teacher", "usphone": "ˈtiːtʃə(r)", "ukphone": "", "trans": ["n. 教师，教员"]}, {"name": "team", "usphone": "tiːm", "ukphone": "", "trans": ["n. 队，组"]}, {"name": "teamwork", "usphone": "ˈtiːmwɜːk", "ukphone": "", "trans": ["n. 合作，协同工作"]}, {"name": "teapot", "usphone": "ˈtiːpɔt", "ukphone": "", "trans": ["n. 茶壶"]}, {"name": "tear", "usphone": "teə(r)", "ukphone": "", "trans": ["n. 眼泪 v. 扯破, 撕开"]}, {"name": "tease", "usphone": "tiːz", "ukphone": "", "trans": ["v. 取笑，戏弄，寻开心"]}, {"name": "technical", "usphone": "ˈteknɪk(ə)l", "ukphone": "", "trans": ["a. 技术的，工艺的"]}, {"name": "technique", "usphone": "ˈteknɪk(ə)l", "ukphone": "", "trans": ["n. 技术;技巧,方法"]}, {"name": "technology", "usphone": "tekˈnɔlədʒɪ", "ukphone": "", "trans": ["n. 技术"]}, {"name": "teenager", "usphone": "ˈtiːneɪdʒə(r)", "ukphone": "", "trans": ["n.（13～19岁的）青少年，十几岁的少年"]}, {"name": "telegram", "usphone": "ˈtelɪɡræm", "ukphone": "", "trans": ["n. 电报"]}, {"name": "telegraph", "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf", "ukphone": "", "trans": ["v. (拍) 电报"]}, {"name": "telephone", "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf", "ukphone": "", "trans": ["v. 打电话 n. 电话"]}, {"name": "telephone-booth / telephone-box", "usphone": "", "ukphone": "", "trans": ["n. 公用电话间"]}, {"name": "telescope", "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf", "ukphone": "", "trans": ["n. 望远镜"]}, {"name": "television", "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf", "ukphone": "", "trans": ["n. 电视"]}, {"name": "tell (told, told)", "usphone": "tel", "ukphone": "", "trans": ["vt.告诉,讲述,吩咐"]}, {"name": "temperature", "usphone": "ˈtemprɪtʃə(r)", "ukphone": "", "trans": ["n. 温度"]}, {"name": "temple", "usphone": "ˈtemp(ə)l", "ukphone": "", "trans": ["n. 庙宇，寺院"]}, {"name": "temporary", "usphone": "ˈtempərərɪ", "ukphone": "", "trans": ["a. 短暂的，暂时的"]}, {"name": "temptation", "usphone": "tempˈteɪʃ(ə)n", "ukphone": "", "trans": ["n. 引诱；诱惑"]}, {"name": "tend", "usphone": "tend", "ukphone": "", "trans": ["v. 往往会，常常就，倾向，趋于"]}, {"name": "tendency", "usphone": "ˈtendənsɪ", "ukphone": "", "trans": ["n. 倾向，偏好，性情"]}, {"name": "tennis", "usphone": "ˈtenɪs", "ukphone": "", "trans": ["n. 网球"]}, {"name": "ten", "usphone": "ten", "ukphone": "", "trans": ["num. 十"]}, {"name": "tense", "usphone": "tens", "ukphone": "", "trans": ["a. 心烦意乱的，紧张的"]}, {"name": "tension", "usphone": "ˈtenʃ(ə)n", "ukphone": "", "trans": ["n. 紧张局势，矛盾"]}, {"name": "tent", "usphone": "tent", "ukphone": "", "trans": ["n. 帐篷"]}, {"name": "tentative", "usphone": "tent", "ukphone": "", "trans": ["a. 不确定的，踌躇的"]}, {"name": "term", "usphone": "tɜːm", "ukphone": "", "trans": ["n. 学期;术语;条款;项"]}, {"name": "terminal", "usphone": "tɜːm", "ukphone": "", "trans": ["a.(火车汽车飞机)终点站"]}, {"name": "terrible", "usphone": "ˈterɪb(ə)l", "ukphone": "", "trans": ["a. 可怕的；糟糕的"]}, {"name": "terrify", "usphone": "ˈterɪfaɪ", "ukphone": "", "trans": ["vt. 使人感到恐怖"]}, {"name": "terror", "usphone": "ˈterə(r)", "ukphone": "", "trans": ["n. 恐惧，惊恐"]}, {"name": "test", "usphone": "test", "ukphone": "", "trans": ["vt.& n. 测试, 考查，试验"]}, {"name": "text", "usphone": "tekst", "ukphone": "", "trans": ["n. 文本，课文"]}, {"name": "textbook", "usphone": "", "ukphone": "", "trans": ["n. 课本，教科书"]}, {"name": "than", "usphone": "ðen, ðæn", "ukphone": "", "trans": ["conj. 比"]}, {"name": "thank", "usphone": "θæŋk", "ukphone": "", "trans": ["vt. 感谢，致谢，道谢 n. （复）感谢，谢意"]}, {"name": "thankful", "usphone": "ˈθæŋkfʊl", "ukphone": "", "trans": ["a. 感谢的，感激的"]}, {"name": "that", "usphone": "ðæt", "ukphone": "", "trans": ["a.& pron.那，那个 conj. 那，那个（引导宾语从句等）ad. 那么，那样"]}, {"name": "the", "usphone": "ðə, ðɪ, ðiː", "ukphone": "", "trans": ["art. 这（那）个,这（那）些（用于特定人或物，序数词，最高级，专有名词，世上独一 无二事物前）"]}, {"name": "theatre (美theater)", "usphone": "ˈθiətə", "ukphone": "", "trans": ["n. 剧场，戏院"]}, {"name": "theft", "usphone": "θeft", "ukphone": "", "trans": ["n. 盗窃案"]}, {"name": "their", "usphone": "ðeə(r)", "ukphone": "", "trans": ["pron. 他(她,它)们的"]}, {"name": "theirs", "usphone": "ðeəz", "ukphone": "", "trans": ["pron. 他（她,它）们的"]}, {"name": "them", "usphone": "ð(ə)m, ðem", "ukphone": "", "trans": ["pron. 他/她/它们（宾格）"]}, {"name": "theme", "usphone": "θiːm", "ukphone": "", "trans": ["n. 主题"]}, {"name": "themselves", "usphone": "ðəmˈselvz", "ukphone": "", "trans": ["pron.他/她/它们自己"]}, {"name": "then", "usphone": "ðen", "ukphone": "", "trans": ["ad. 当时,那时,然后,那么"]}, {"name": "theoretical", "usphone": "θɪəˈretɪk(ə)l", "ukphone": "", "trans": ["a. 理论的"]}, {"name": "theory", "usphone": "θɪəˈretɪk(ə)l", "ukphone": "", "trans": ["n. 理论"]}, {"name": "there", "usphone": "ðeə(r)", "ukphone": "", "trans": ["int. 那！你瞧（表示引起注意） n. 那里，那儿 ad. 在那里，往那里；（作引导词）表”存在\""]}, {"name": "therefore", "usphone": "ˈðeəfɔː(r)", "ukphone": "", "trans": ["ad. 因此，所以"]}, {"name": "thermos", "usphone": "ˈθɜːmɔs", "ukphone": "", "trans": ["n. 热水瓶"]}, {"name": "these", "usphone": "ˈθɜːmɔs", "ukphone": "", "trans": ["a. & pron. 这些"]}, {"name": "they", "usphone": "ðeɪ", "ukphone": "", "trans": ["pron. 他（她）们；它们"]}, {"name": "thick", "usphone": "θɪk", "ukphone": "", "trans": ["a. 厚的"]}, {"name": "thief (复thieves)", "usphone": "θiːf", "ukphone": "", "trans": ["n. 窃贼, 小偷"]}, {"name": "thin", "usphone": "θɪn", "ukphone": "", "trans": ["a. 薄的；瘦的；稀的"]}, {"name": "thing", "usphone": "θɪŋ", "ukphone": "", "trans": ["n. 东西；(复)物品，用品；事情，事件"]}, {"name": "think(thought, thought)", "usphone": "θɪŋk", "ukphone": "", "trans": ["v. 想；认为；考虑"]}, {"name": "thinking", "usphone": "ˈθɪŋkɪŋ", "ukphone": "", "trans": ["n. 思索;见解;想法"]}, {"name": "third", "usphone": "θɜːd", "ukphone": "", "trans": ["num. 第三"]}, {"name": "thirst", "usphone": "θɜːd", "ukphone": "", "trans": ["n. 渴； 口渴"]}, {"name": "thirsty", "usphone": "ˈθɜːstɪ", "ukphone": "", "trans": ["a. 渴"]}, {"name": "thirteen", "usphone": "θɜːˈtiːn", "ukphone": "", "trans": ["num. 十三"]}, {"name": "thirty", "usphone": "ˈθɜːtɪ", "ukphone": "", "trans": ["num. 三十"]}, {"name": "this", "usphone": "ðɪs", "ukphone": "", "trans": ["a.& pron.这，这个"]}, {"name": "thorough", "usphone": "ˈθʌrə; (US) ˈθʌrəʊ", "ukphone": "", "trans": ["a. 彻底的"]}, {"name": "those", "usphone": "ðəʊz", "ukphone": "", "trans": ["a.& pron.那些"]}, {"name": "though", "usphone": "ðəʊ", "ukphone": "", "trans": ["conj. 虽然，可是"]}, {"name": "thought", "usphone": "θɔːt", "ukphone": "", "trans": ["n. 思考,思想;念头"]}, {"name": "thousand", "usphone": "ˈθaʊzənd", "ukphone": "", "trans": ["num. 千"]}, {"name": "thread", "usphone": "θred", "ukphone": "", "trans": ["n. 线"]}, {"name": "three", "usphone": "θriː", "ukphone": "", "trans": ["num. 三"]}, {"name": "thrill", "usphone": "θrɪl", "ukphone": "", "trans": ["n./ v. 兴奋，激动"]}, {"name": "thriller", "usphone": "ˈθrɪlə(r)", "ukphone": "", "trans": ["n. 惊险小说"]}, {"name": "throat", "usphone": "θrəʊt", "ukphone": "", "trans": ["n. 喉咙"]}, {"name": "through", "usphone": "θruː", "ukphone": "", "trans": ["prep.穿（通）过;从始至终 ad.穿(通)过;自始至终,全部"]}, {"name": "throughout", "usphone": "θruːˈaʊt", "ukphone": "", "trans": ["prep. 遍及，贯穿"]}, {"name": "throw(threw,thrown)", "usphone": "θrəʊ", "ukphone": "", "trans": ["v.投,掷,扔"]}, {"name": "thunder", "usphone": "ˈθʌndə(r)", "ukphone": "", "trans": ["n.& v. 雷声，打雷"]}, {"name": "thunderstorm", "usphone": "ˈθʌndəstɔːm", "ukphone": "", "trans": ["n.雷电交加暴风雨"]}, {"name": "Thursday", "usphone": "ˈθɜːzdeɪ", "ukphone": "", "trans": ["n. 星期四"]}, {"name": "thus", "usphone": "ðʌs", "ukphone": "", "trans": ["ad. 这样；因而"]}, {"name": "Tibet", "usphone": "tiˈbet", "ukphone": "", "trans": ["n. 西藏"]}, {"name": "Tibeta", "usphone": "tiˈbetən", "ukphone": "", "trans": ["n. 西藏人；西藏语"]}, {"name": "tick", "usphone": "tɪk", "ukphone": "", "trans": ["vt. 作记号"]}, {"name": "ticket", "usphone": "ˈtɪkɪt", "ukphone": "", "trans": ["n. 票；卷"]}, {"name": "tidy", "usphone": "ˈtɪkɪt", "ukphone": "", "trans": ["a. 整洁的，干净的 vt. 弄整洁，弄干净"]}, {"name": "tie", "usphone": "taɪ", "ukphone": "", "trans": ["vt. （用绳，线）系，拴，扎 n. 领带，绳子，结；关系"]}, {"name": "tiger", "usphone": "ˈtaɪɡə(r)", "ukphone": "", "trans": ["n. 老虎"]}, {"name": "tight", "usphone": "taɪt", "ukphone": "", "trans": ["a. 紧的"]}, {"name": "till", "usphone": "tɪl", "ukphone": "", "trans": ["conj.& prep.直到,直到…为止"]}, {"name": "time", "usphone": "taɪm", "ukphone": "", "trans": ["n. 时间;时期;钟点,次,回 vt.测定…的时间,记录…的时间"]}, {"name": "timetable", "usphone": "ˈtaɪmteɪb(ə)l", "ukphone": "", "trans": ["n. （火车、公共汽车等）时间表；（学校）课表"]}, {"name": "tin", "usphone": "tɪn", "ukphone": "", "trans": ["n. （英）罐头，听头"]}, {"name": "tiny", "usphone": "ˈtaɪnɪ", "ukphone": "", "trans": ["adj.  tinier, tiniest  a. 极小的，微小的"]}, {"name": "tip", "usphone": "tɪp", "ukphone": "", "trans": ["n.& v.顶端，尖端；告诫； 提示 (给)小费"]}, {"name": "tire", "usphone": "ˈtaɪə(r)", "ukphone": "", "trans": ["vi. 使疲劳"]}, {"name": "tired", "usphone": "ˈtaɪəd", "ukphone": "", "trans": ["a. 疲劳的，累的"]}, {"name": "tiresomev", "usphone": "", "ukphone": "", "trans": ["a. 令人厌倦的"]}, {"name": "tissue", "usphone": "ˈtɪʃuː, ˈtɪsjuː", "ukphone": "", "trans": ["n. （人，动植物的）组织，纸巾"]}, {"name": "title", "usphone": "ˈtɪʃuː, ˈtɪsjuː", "ukphone": "", "trans": ["n. 标题，题目"]}, {"name": "to", "usphone": "tʊ, tuː", "ukphone": "", "trans": ["prep. （动词不定式符号，无词义）；（表示接受动作的人或物）给；对，向，到；在…之前"]}, {"name": "toast", "usphone": "təʊst", "ukphone": "", "trans": ["v./ n. 烤"]}, {"name": "tobacco", "usphone": "təʊst", "ukphone": "", "trans": ["n. 烟草，烟叶"]}, {"name": "today", "usphone": "təʊst", "ukphone": "", "trans": ["ad.& n.今天;现在,当前"]}, {"name": "together", "usphone": "təʊst", "ukphone": "", "trans": ["ad. 一起，共同"]}, {"name": "toilet", "usphone": "ˈtɔɪlɪt", "ukphone": "", "trans": ["n. 厕所"]}, {"name": "Tokyo", "usphone": "ˈtəʊkjəʊ", "ukphone": "", "trans": ["n. 东京"]}, {"name": "tolerate", "usphone": "ˈtɔləreɪt", "ukphone": "", "trans": ["v. 容许，允许，忍受"]}, {"name": "tomato", "usphone": "təˈmɑːtəʊ; (US) təˈmeɪtəʊ", "ukphone": "", "trans": ["n. 西红柿，番茄"]}, {"name": "tomb", "usphone": "tuːm", "ukphone": "", "trans": ["n. 坟墓"]}, {"name": "tomorrow", "usphone": "təˈmɔrəʊ", "ukphone": "", "trans": ["ad. & n.明天"]}, {"name": "ton", "usphone": "təˈmɔrəʊ", "ukphone": "", "trans": ["n. （重量单位）吨"]}, {"name": "tongue", "usphone": "tʌŋ", "ukphone": "", "trans": ["n. 舌，舌头"]}, {"name": "tonight", "usphone": "təˈnaɪt", "ukphone": "", "trans": ["ad.& n. 今晚，今夜"]}, {"name": "too", "usphone": "təˈnaɪt", "ukphone": "", "trans": ["ad.也,还,又,太,过分,很,非常"]}, {"name": "tool", "usphone": "tuːl", "ukphone": "", "trans": ["n. 工具，器具"]}, {"name": "tooth (复 teeth)", "usphone": "tuːθ", "ukphone": "", "trans": ["n. 牙齿"]}, {"name": "toothache", "usphone": "ˈtuːθeɪk", "ukphone": "", "trans": ["n. 牙痛"]}, {"name": "toothbrush", "usphone": "ˈtuːθbrʌʃ", "ukphone": "", "trans": ["n. 牙刷"]}, {"name": "toothpaste", "usphone": "ˈtuːθpeɪst", "ukphone": "", "trans": ["n. 牙膏"]}, {"name": "top", "usphone": "tɔp", "ukphone": "", "trans": ["n. 顶部,（物体的）上面"]}, {"name": "topic", "usphone": "ˈtɔpɪk", "ukphone": "", "trans": ["n. 题目，话题"]}, {"name": "tortoise", "usphone": "ˈtɔpɪk", "ukphone": "", "trans": ["n. 乌龟"]}, {"name": "total", "usphone": "ˈtəʊt(ə)l", "ukphone": "", "trans": ["a. 总数的;总括的;完全的,全然的 n.合计,总计 v.合计为"]}, {"name": "totally", "usphone": "ˈtɔt(ə)lɪ", "ukphone": "", "trans": ["ad. 总合地，完全地"]}, {"name": "touch", "usphone": "tʌtʃ", "ukphone": "", "trans": ["vt. 触摸，接触"]}, {"name": "tough", "usphone": "ˈtɔt(ə)lɪ", "ukphone": "", "trans": ["a. 坚硬的；结实的；棘手的，难解的"]}, {"name": "tour", "usphone": "tʊə(r)", "ukphone": "", "trans": ["n. 参观, 观光, 旅行"]}, {"name": "tourism", "usphone": "ˈtʊərɪz(ə)m", "ukphone": "", "trans": ["n. 旅游业；观光"]}, {"name": "tourist", "usphone": "ˈtʊərɪst", "ukphone": "", "trans": ["vn. 旅行者，观光者"]}, {"name": "tournament", "usphone": "ˈtʊənəmənt; (US) ˈtɜːrn-", "ukphone": "", "trans": ["n. 锦标赛，联赛"]}, {"name": "toward(s)", "usphone": "təˈwɔːd", "ukphone": "", "trans": ["prep. 向，朝，对于"]}, {"name": "towel", "usphone": "ˈtaʊəl", "ukphone": "", "trans": ["n. 毛巾"]}, {"name": "tower", "usphone": "ˈtaʊə(r)", "ukphone": "", "trans": ["n. 塔"]}, {"name": "town", "usphone": "taʊn", "ukphone": "", "trans": ["n. 城镇，城"]}, {"name": "toy", "usphone": "tɔɪ", "ukphone": "", "trans": ["n. 玩具, 玩物"]}, {"name": "track", "usphone": "træk", "ukphone": "", "trans": ["n. 轨道；田径"]}, {"name": "tractor", "usphone": "ˈtræktə(r)", "ukphone": "", "trans": ["n. 拖拉机"]}, {"name": "trade", "usphone": "treɪd", "ukphone": "", "trans": ["n.贸易 vt.用…进行交换"]}, {"name": "tradition", "usphone": "trəˈdɪʃ(ə)n", "ukphone": "", "trans": ["n. 传统，风俗"]}, {"name": "traditional", "usphone": "trəˈdɪʃ(ə)n", "ukphone": "", "trans": ["a. 传统的，风俗的"]}, {"name": "traffic", "usphone": "ˈtræfɪk", "ukphone": "", "trans": ["n. 交通，来往车辆"]}, {"name": "traffic lights", "usphone": "ˈtræfɪk laɪts", "ukphone": "", "trans": ["n.交通指挥灯红绿灯"]}, {"name": "train", "usphone": "treɪn", "ukphone": "", "trans": ["n. 火车 v. 培训,训练"]}, {"name": "trainer", "usphone": "treɪˈnə(r)", "ukphone": "", "trans": ["n. 训练人；教练"]}, {"name": "training", "usphone": "ˈtreɪnɪŋ", "ukphone": "", "trans": ["n. 培训"]}, {"name": "tram", "usphone": "træm", "ukphone": "", "trans": ["n. 有轨电车"]}, {"name": "transform", "usphone": "trænsˈfɔːm", "ukphone": "", "trans": ["v.使改变形态,使改观"]}, {"name": "translate", "usphone": "trænsˈleɪt", "ukphone": "", "trans": ["vt. 翻译"]}, {"name": "translation", "usphone": "trænsˈleɪʃ(ə)n", "ukphone": "", "trans": ["n. 翻译；译文"]}, {"name": "transparent", "usphone": "trænsˈpærənt", "ukphone": "", "trans": ["a.透明的，清澈的"]}, {"name": "translator", "usphone": "trænsˈleitə", "ukphone": "", "trans": ["n. 翻译家，译者"]}, {"name": "transport", "usphone": "trænsˈpɔːt", "ukphone": "", "trans": ["n.& vt.运输"]}, {"name": "trap", "usphone": "træp", "ukphone": "", "trans": ["n. 陷阱 vt. 使陷入困境"]}, {"name": "travel", "usphone": "ˈtræv(ə)l", "ukphone": "", "trans": ["n.& vi.旅行"]}, {"name": "traveler", "usphone": "ˈtrævələ(r)", "ukphone": "", "trans": ["n. 旅行者"]}, {"name": "treasure", "usphone": "ˈtreʒə(r)", "ukphone": "", "trans": ["n. 金银财宝, 财富"]}, {"name": "treat", "usphone": "triːt", "ukphone": "", "trans": ["vt. 对待，看待"]}, {"name": "treatment", "usphone": "ˈtriːtmənt", "ukphone": "", "trans": ["n. 治疗,疗法"]}, {"name": "tree", "usphone": "triː", "ukphone": "", "trans": ["n. 树"]}, {"name": "tremble", "usphone": "ˈtremb(ə)l", "ukphone": "", "trans": ["v. 颤抖"]}, {"name": "trend", "usphone": "trend", "ukphone": "", "trans": ["n. 趋势，倾向，动态"]}, {"name": "trial", "usphone": "ˈtraɪəl", "ukphone": "", "trans": ["n. 审判；试验；试用"]}, {"name": "triangle", "usphone": "ˈtraɪæŋɡ(ə)l", "ukphone": "", "trans": ["n.& adj.三角形;三角形的"]}, {"name": "trick", "usphone": "trɪk", "ukphone": "", "trans": ["n. 诡计，把戏"]}, {"name": "trip", "usphone": "trɪp", "ukphone": "", "trans": ["n. 旅行，旅程"]}, {"name": "trolley-bus", "usphone": "ˈtrɔlɪ- bʌs", "ukphone": "", "trans": ["n. 无轨电车"]}, {"name": "trooping", "usphone": "", "ukphone": "", "trans": ["vi. 成群结队地走"]}, {"name": "troop", "usphone": "truːp", "ukphone": "", "trans": ["n. 部队"]}, {"name": "trouble", "usphone": "ˈtrʌb(ə)l", "ukphone": "", "trans": ["vt. 使苦恼,使忧虑,使麻烦 n.问题,疾病,烦恼,麻烦"]}, {"name": "troublesome", "usphone": "ˈtrʌb(ə)lsəm", "ukphone": "", "trans": ["a.令人烦恼, 讨厌"]}, {"name": "trousers", "usphone": "ˈtraʊzəz", "ukphone": "", "trans": ["n. 裤子，长裤"]}, {"name": "truck", "usphone": "trʌk", "ukphone": "", "trans": ["n. 卡车, 运货车；车皮 v. 装车；用货车运"]}, {"name": "true", "usphone": "truː", "ukphone": "", "trans": ["a. 真的，真实的；忠诚的"]}, {"name": "truly", "usphone": "ˈtruːlɪ", "ukphone": "", "trans": ["ad. 真正地，真实地"]}, {"name": "trunk", "usphone": "trʌŋk", "ukphone": "", "trans": ["n. 树干；大箱子"]}, {"name": "trust", "usphone": "trʌst", "ukphone": "", "trans": ["vt. 相信，信任，信赖"]}, {"name": "truth", "usphone": "truːθ", "ukphone": "", "trans": ["n. 真理,事实,真相,实际"]}, {"name": "try", "usphone": "truːθ", "ukphone": "", "trans": ["v. 试，试图，努力"]}, {"name": "T-shirt", "usphone": "tiː- ʃɜːt", "ukphone": "", "trans": ["n. T恤衫"]}, {"name": "tube", "usphone": "tjuːb; (US) tuːb", "ukphone": "", "trans": ["n. 管，管状物"]}, {"name": "tune", "usphone": "tjuːn; (US) tuːn", "ukphone": "", "trans": ["n. 曲调，曲子"]}, {"name": "Tuesday", "usphone": "ˈtjuːzdeɪ", "ukphone": "", "trans": ["n. 星期二"]}, {"name": "turkey", "usphone": "ˈtɜːkɪ", "ukphone": "", "trans": ["n. 火鸡"]}, {"name": "turn", "usphone": "tɜːn", "ukphone": "", "trans": ["v. 旋转，翻转，转变，转弯 n. 轮流，（轮流的）顺序"]}, {"name": "turning n", "usphone": "ˈtɜːnɪŋ", "ukphone": "", "trans": [". 拐弯处，拐角处"]}, {"name": "tutor", "usphone": "ˈtjuːtə(r)", "ukphone": "", "trans": ["n. 家庭教师，私人教师，导师"]}, {"name": "TV(缩) = television", "usphone": "‚tiːˈviː", "ukphone": "", "trans": ["n. 电视机"]}, {"name": "twelfth", "usphone": "twelfθ", "ukphone": "", "trans": ["num. 第十二"]}, {"name": "twelve", "usphone": "twelv", "ukphone": "", "trans": ["num. 十二"]}, {"name": "twentieth", "usphone": "", "ukphone": "", "trans": ["vnum.第二十"]}, {"name": "twenty", "usphone": "ˈtwentɪ", "ukphone": "", "trans": ["num. 二十"]}, {"name": "twenty-first", "usphone": "ˈtwentɪ- [fɜːst", "ukphone": "", "trans": ["num. 第二十一"]}, {"name": "twenty-one", "usphone": "ˈtwentɪ- wʌn", "ukphone": "", "trans": ["num. 二十一"]}, {"name": "twice", "usphone": "twaɪs", "ukphone": "", "trans": ["ad. 两次；两倍"]}, {"name": "twin", "usphone": "twɪst", "ukphone": "", "trans": ["n. 双胞胎之一"]}, {"name": "twist", "usphone": "twɪst", "ukphone": "", "trans": ["v./ n. 使弯曲，转动"]}, {"name": "two", "usphone": "tuː", "ukphone": "", "trans": ["num. 二"]}, {"name": "type", "usphone": "ˈtaɪp", "ukphone": "", "trans": ["vt. 打字"]}, {"name": "typewriter", "usphone": "ˈtaɪpraɪtə(r)", "ukphone": "", "trans": ["n. 打字机"]}, {"name": "typical", "usphone": "ˈtɪpɪk(ə)l", "ukphone": "", "trans": ["a. 典型的，有代表性的，特有的"]}, {"name": "typhoon", "usphone": "taɪˈfuːn", "ukphone": "", "trans": ["n. 台风"]}, {"name": "typist", "usphone": "ˈtaɪpɪst", "ukphone": "", "trans": ["n. 打字员"]}, {"name": "tyre (美tire)", "usphone": "taɪə", "ukphone": "", "trans": ["n. 轮胎"]}, {"name": "ugly", "usphone": "ˈʌɡlɪ", "ukphone": "", "trans": ["a. 丑陋的；难看的"]}, {"name": "U.K./ UK(缩) = United Kingdom", "usphone": "juː ˈkeɪ", "ukphone": "", "trans": ["n.英国，联合王国"]}, {"name": "umbrella", "usphone": "ʌmˈbrelə", "ukphone": "", "trans": ["n. 雨伞"]}, {"name": "U.N./ UN(缩) = the United Nations", "usphone": "juː ˈən", "ukphone": "", "trans": ["n. 联合国"]}, {"name": "unable", "usphone": "juː ˈən", "ukphone": "", "trans": ["a.不能的，不能胜任的"]}, {"name": "unbearable", "usphone": "ʌnˈbeərəb(ə)l", "ukphone": "", "trans": ["a.难耐得,无法接受的"]}, {"name": "unbelievable", "usphone": "ʌnbɪˈliːvəb(ə)l", "ukphone": "", "trans": ["a.难以置信的"]}, {"name": "uncertain", "usphone": "ˈsɜːt(ə)n", "ukphone": "", "trans": ["a.不确定的"]}, {"name": "uncle", "usphone": "ˈʌŋk(ə)l", "ukphone": "", "trans": ["n. 叔,伯,舅,姑夫,姨父"]}, {"name": "uncomfortable", "usphone": "ʌnˈkʌmftəb(ə)l", "ukphone": "", "trans": ["a. 令人不舒服的"]}, {"name": "unconditional", "usphone": "ʌnkənˈdɪʃən(ə)l", "ukphone": "", "trans": ["a.无条件，绝对的"]}, {"name": "unconscious", "usphone": "ʌnˈkɔnʃəs", "ukphone": "", "trans": ["a.昏迷,不省人事的"]}, {"name": "under", "usphone": "ˈʌndə(r)", "ukphone": "", "trans": ["ad.& prep.在…下面，向…下面"]}, {"name": "underground", "usphone": "ʌndəˈɡraʊnd", "ukphone": "", "trans": ["a.地下的 n. 地铁"]}, {"name": "underline", "usphone": "ʌndəˈlaɪn", "ukphone": "", "trans": ["v. 在…下划线"]}, {"name": "understand (understood, understood)", "usphone": "ʌndəˈstænd", "ukphone": "", "trans": ["v. 懂得;明白;理解"]}, {"name": "understanding", "usphone": "ʌndəˈstændɪŋ", "ukphone": "", "trans": ["n. 领会;理解"]}, {"name": "undertake (undertook, undertaken)", "usphone": "ʌndəˈteɪk", "ukphone": "", "trans": ["v. 承担，从事，负责"]}, {"name": "underwear", "usphone": "ˈʌndəweə(r)", "ukphone": "", "trans": ["n. 内衣"]}, {"name": "undivided", "usphone": "ʌndɪˈvaɪdɪd", "ukphone": "", "trans": ["a. 没分开的；专一的； 专心的"]}, {"name": "undo", "usphone": "ʌnˈduː", "ukphone": "", "trans": ["v. 解开，松开"]}, {"name": "unemployment", "usphone": "ʌnɪmˈplɔɪmənt", "ukphone": "", "trans": ["n.失业,失业状态"]}, {"name": "unfair", "usphone": "ʌnˈfeə(r)", "ukphone": "", "trans": ["a. 不公平的，不公正的"]}, {"name": "unfit", "usphone": "ʌnˈfɪt", "ukphone": "", "trans": ["a. 不合宜的，不相宜的"]}, {"name": "unfold", "usphone": "ʌnˈfəʊld", "ukphone": "", "trans": ["vt. 展开，打开"]}, {"name": "unfortunate", "usphone": "ʌnˈfəʊld", "ukphone": "", "trans": ["a. 不幸的"]}, {"name": "unfortunately", "usphone": "ʌnˈfɔːtjʊnətlɪ", "ukphone": "", "trans": ["ad. 不幸地"]}, {"name": "unhappy", "usphone": "ʌnˈfɔːtjʊnətlɪ", "ukphone": "", "trans": ["a. 不高兴的,伤心的"]}, {"name": "unhealthy", "usphone": "ʌnˈhelθɪ", "ukphone": "", "trans": ["a.不健康的,不卫生的"]}, {"name": "uniform", "usphone": "ˈjuːnɪfɔːm", "ukphone": "", "trans": ["n. 制服"]}, {"name": "unimportant", "usphone": "ʌnɪmˈpɔːt(e)nt", "ukphone": "", "trans": ["a.不重要的,无意义"]}, {"name": "union", "usphone": "ˈjuːnjən", "ukphone": "", "trans": ["n. 联合,联盟；工会"]}, {"name": "unique", "usphone": "jʊˈniːk", "ukphone": "", "trans": ["a. 惟一的,独一无二的"]}, {"name": "unit", "usphone": "ˈjuːnɪt", "ukphone": "", "trans": ["n. 单元，单位"]}, {"name": "unite", "usphone": "jʊˈnaɪt", "ukphone": "", "trans": ["v. 联合，团结"]}, {"name": "universal", "usphone": "juːnɪˈvɜːs(ə)l", "ukphone": "", "trans": ["a. 普遍的，全体的"]}, {"name": "universe", "usphone": "ˈjuːnɪvɜːs", "ukphone": "", "trans": ["n. 宇宙"]}, {"name": "university", "usphone": "juːnɪˈvɜːsɪtɪ", "ukphone": "", "trans": ["n. 大学"]}, {"name": "unknown", "usphone": "juːnɪˈvɜːsɪtɪ", "ukphone": "", "trans": ["a. 不知道的"]}, {"name": "unless", "usphone": "ʌnˈles", "ukphone": "", "trans": ["conj. 如果不，除非"]}, {"name": "unlike", "usphone": "ʌnˈlaɪk", "ukphone": "", "trans": ["prep. 不像，和…不同"]}, {"name": "unmarried", "usphone": "ʌnˈmærɪd", "ukphone": "", "trans": ["a. 未婚的，独身的"]}, {"name": "unpleasant", "usphone": "ʌnˈplez(ə)nt", "ukphone": "", "trans": ["a. 使人不愉快的"]}, {"name": "unrest", "usphone": "ʌnˈrest", "ukphone": "", "trans": ["n. 不安；骚动"]}, {"name": "unsafe", "usphone": "ʌnˈseɪf", "ukphone": "", "trans": ["a. 不安全的；危险的"]}, {"name": "unsuccessful", "usphone": "ʌnsəkˈsesfʊl", "ukphone": "", "trans": ["a. 不成功,失败的"]}, {"name": "until", "usphone": "ʌnˈtɪl", "ukphone": "", "trans": ["prep.& conj.直到…为止"]}, {"name": "untrue", "usphone": "ʌnˈtruː", "ukphone": "", "trans": ["a. 不真实的，假的"]}, {"name": "unusual", "usphone": "ʌnˈjuːʒʊəl", "ukphone": "", "trans": ["a. 不平常的，异常的"]}, {"name": "unwilling", "usphone": "ʌnˈwɪlɪŋ", "ukphone": "", "trans": ["a. 不愿意的，勉强的"]}, {"name": "up", "usphone": "ʌp", "ukphone": "", "trans": ["ad. 向上；在上方；起来；在…以上 a. 上面的，向上的，上行的 n. 上升；上坡；上行；繁荣 v. 举起；拿起；提高 prep. 向(高处)；向(在)……上(面)游"]}, {"name": "upon", "usphone": "əˈpɔn", "ukphone": "", "trans": ["prep. 在……上面"]}, {"name": "upper", "usphone": "ˈʌpə(r)", "ukphone": "", "trans": ["a. 较高的，较上的"]}, {"name": "upset", "usphone": "ʌpˈset", "ukphone": "", "trans": ["a. 心烦的，苦恼的"]}, {"name": "upstairs", "usphone": "ʌpˈsteəz", "ukphone": "", "trans": ["ad. 在楼上，到楼上"]}, {"name": "upward", "usphone": "ˈʌpwəd", "ukphone": "", "trans": ["ad. 向上；往上"]}, {"name": "urban", "usphone": "ˈɜːbən", "ukphone": "", "trans": ["a. 城市的，都市的"]}, {"name": "urge", "usphone": "ɜːdʒ", "ukphone": "", "trans": ["v. 敦促，催促，力劝"]}, {"name": "urgent", "usphone": "ˈɜːdʒənt", "ukphone": "", "trans": ["a. 紧急的，紧迫的"]}, {"name": "U.S.A./USA(缩) = the United States of America", "usphone": "juː es ˈeɪ", "ukphone": "", "trans": ["n. 美国（美利坚合众国）"]}, {"name": "use", "usphone": "juːz", "ukphone": "", "trans": ["n.& vt.利用,使用,应用"]}, {"name": "used", "usphone": "", "ukphone": "", "trans": ["a. 用过的;旧的;二手的"]}, {"name": "useful", "usphone": "ˈjuːsfʊl", "ukphone": "", "trans": ["a. 有用的，有益的"]}, {"name": "useless", "usphone": "ˈjuːslɪs", "ukphone": "", "trans": ["a. 无用的"]}, {"name": "user", "usphone": "ˈjuːzə", "ukphone": "", "trans": ["n. 使用者；用户"]}, {"name": "usual", "usphone": "ˈjuːʒʊəl", "ukphone": "", "trans": ["a. 通常的，平常的"]}, {"name": "usually", "usphone": "ˈjuːʒʊəlɪ", "ukphone": "", "trans": ["ad. 通常，经常"]}, {"name": "vacation", "usphone": "vəˈkeɪʃ(ə)n", "ukphone": "", "trans": ["n. 假期，休假"]}, {"name": "vacant", "usphone": "ˈveɪkənt", "ukphone": "", "trans": ["a. 空缺的，未被占用的"]}, {"name": "vague", "usphone": "veɪɡ", "ukphone": "", "trans": ["a. 含糊的，紧迫的"]}, {"name": "vain", "usphone": "veɪn", "ukphone": "", "trans": ["n. 自负的，自视过高的，徒劳的，无效的"]}, {"name": "valid", "usphone": "ˈvælɪd", "ukphone": "", "trans": ["a.有效的,合理的,有根据的"]}, {"name": "valley", "usphone": "ˈvælɪ", "ukphone": "", "trans": ["n. 山谷, 溪谷"]}, {"name": "valuable", "usphone": "ˈvæljʊəb(ə)l", "ukphone": "", "trans": ["a. 值钱的，贵重的"]}, {"name": "value", "usphone": "ˈvæljuː", "ukphone": "", "trans": ["n. 价值，益处"]}, {"name": "vanilla", "usphone": "vəˈnɪlə", "ukphone": "", "trans": ["n. 香草"]}, {"name": "variety", "usphone": "vəˈraɪətɪ", "ukphone": "", "trans": ["n. 种种，种类"]}, {"name": "various", "usphone": "ˈveərɪəs", "ukphone": "", "trans": ["a. 各种各样的，不同的"]}, {"name": "vase", "usphone": "vɑːz; (US) veɪs", "ukphone": "", "trans": ["n. （花）瓶；瓶饰"]}, {"name": "vast", "usphone": "vɑːst; (US) væst", "ukphone": "", "trans": ["a. 巨大的，广阔的"]}, {"name": "VCD = versatile compact disk", "usphone": "", "ukphone": "", "trans": ["n. 影碟光盘"]}, {"name": "veal", "usphone": "viːl", "ukphone": "", "trans": ["n. （食用）小牛肉"]}, {"name": "vegetable", "usphone": "ˈvedʒɪtəb(ə)l", "ukphone": "", "trans": ["n. 蔬菜"]}, {"name": "vehicle", "usphone": "ˈviːɪk(ə)l; (US) ˈviːhɪkl", "ukphone": "", "trans": ["n. 交通工具，车辆"]}, {"name": "version", "usphone": "ˈvɜːʃ(ə)n; (US) ˈvərʒn", "ukphone": "", "trans": ["n. 变体，变种，改写本"]}, {"name": "vertical", "usphone": "ˈvɜːtɪk(ə)l", "ukphone": "", "trans": ["a. 垂直的，纵向的"]}, {"name": "very", "usphone": "ˈverɪ", "ukphone": "", "trans": ["vad. 很，非常"]}, {"name": "vest", "usphone": "vest", "ukphone": "", "trans": ["n. 背心，内衣"]}, {"name": "via", "usphone": "ˈvaɪə", "ukphone": "", "trans": ["prep. 经过（某地），通过"]}, {"name": "vice", "usphone": "vaɪs", "ukphone": "", "trans": ["n. 罪行，不道德行为"]}, {"name": "victim", "usphone": "ˈvɪktɪm", "ukphone": "", "trans": ["n. 受害者，牺牲品"]}, {"name": "victory", "usphone": "ˈvɪktərɪ", "ukphone": "", "trans": ["n. 胜利"]}, {"name": "video", "usphone": "ˈvɪdɪəʊ", "ukphone": "", "trans": ["n. 录像，视频"]}, {"name": "videophone", "usphone": "ˈvidiəʊfəʊn", "ukphone": "", "trans": ["n. 可视电话"]}, {"name": "view", "usphone": "vjuː", "ukphone": "", "trans": ["n. 看法,见解;风景,景色"]}, {"name": "viewer", "usphone": "ˈvjuːə(r)", "ukphone": "", "trans": ["n. 观看者"]}, {"name": "village", "usphone": "ˈvɪlɪdʒ", "ukphone": "", "trans": ["n. 村庄，乡村"]}, {"name": "villager", "usphone": "ˈvilidʒə", "ukphone": "", "trans": ["n. 村民"]}, {"name": "vinegar", "usphone": "ˈvilidʒə", "ukphone": "", "trans": ["n. 醋"]}, {"name": "violate", "usphone": "ˈvaɪəleɪt", "ukphone": "", "trans": ["v. 违反（法律、协议等），侵犯"]}, {"name": "violence", "usphone": "ˈvaɪələns", "ukphone": "", "trans": ["n. 暴力行为"]}, {"name": "violent", "usphone": "ˈvaɪələnt", "ukphone": "", "trans": ["a. 暴力的"]}, {"name": "violin", "usphone": "vaɪəˈlɪn", "ukphone": "", "trans": ["n. 小提琴"]}, {"name": "violinist", "usphone": "vaɪəˈlɪnɪst", "ukphone": "", "trans": ["n. 提琴家，提琴手"]}, {"name": "virtue", "usphone": "ˈvɜːtjuː", "ukphone": "", "trans": ["n. 美德,正直的品行,德行"]}, {"name": "virus", "usphone": "ˈvaɪərəs", "ukphone": "", "trans": ["n.病毒"]}, {"name": "visa", "usphone": "ˈviːzə", "ukphone": "", "trans": ["n. 签证，背签"]}, {"name": "visit", "usphone": "ˈviːzə", "ukphone": "", "trans": ["n.& vt. 参观，访问，拜访"]}, {"name": "visitor", "usphone": "ˈvɪzɪtə(r)", "ukphone": "", "trans": ["n. 访问者，参观者"]}, {"name": "visual", "usphone": "ˈvɪʒjʊəl", "ukphone": "", "trans": ["a. 视力的，视觉的"]}, {"name": "vital", "usphone": "ˈvaɪt(ə)l", "ukphone": "", "trans": ["a. 必不可少的，对…极重要的"]}, {"name": "vivid", "usphone": "ˈvɪvɪd", "ukphone": "", "trans": ["a. 生动，逼真的，鲜明的"]}, {"name": "vocabulary", "usphone": "vəˈkæbjʊlərɪ", "ukphone": "", "trans": ["n. 词汇, 词汇表"]}, {"name": "voice", "usphone": "vɔɪs", "ukphone": "", "trans": ["n. 说话声; 语态"]}, {"name": "volcano", "usphone": "vɔlˈkeɪnəʊ", "ukphone": "", "trans": ["n. 火山"]}, {"name": "volleyball", "usphone": "vɔlˈkeɪnəʊ", "ukphone": "", "trans": ["n. 排球"]}, {"name": "voluntary", "usphone": "ˈvɔləntərɪ", "ukphone": "", "trans": ["a. 自愿的，主动的"]}, {"name": "volunteer", "usphone": "vɔlənˈtɪə(r)", "ukphone": "", "trans": ["n./ v. 义工，自愿者，无偿做"]}, {"name": "vote", "usphone": "vəʊt", "ukphone": "", "trans": ["vi. 选举，投票"]}, {"name": "voyage", "usphone": "ˈvɔɪɪdʒ", "ukphone": "", "trans": ["n. 航行，旅行"]}, {"name": "wag", "usphone": "ˈvɔɪɪdʒ", "ukphone": "", "trans": ["v. 摇动；摆动"]}, {"name": "wage", "usphone": "weɪdʒ", "ukphone": "", "trans": ["n. 工资，工钱，报酬"]}, {"name": "waist", "usphone": "weɪst", "ukphone": "", "trans": ["n. 腰，腰部，腰围"]}, {"name": "wait", "usphone": "weɪt", "ukphone": "", "trans": ["vi. 等，等候"]}, {"name": "waiter", "usphone": "ˈweɪtə(r)", "ukphone": "", "trans": ["n. （餐厅）男服务员"]}, {"name": "waiting -room", "usphone": "ˈweɪtɪŋ- rʊm", "ukphone": "", "trans": ["n.候诊室,候车室"]}, {"name": "waitress", "usphone": "tres", "ukphone": "", "trans": ["n. 女服务员"]}, {"name": "wake (woke, woken)", "usphone": "weɪk", "ukphone": "", "trans": ["v.醒来,叫醒"]}, {"name": "walk", "usphone": "wɔːk", "ukphone": "", "trans": ["n.& v. 步行；散步"]}, {"name": "walkman", "usphone": "ˈwɔːkmən", "ukphone": "", "trans": ["n. 随身听"]}, {"name": "wall", "usphone": "wɔːl", "ukphone": "", "trans": ["n. 墙"]}, {"name": "wallet", "usphone": "ˈwɔlɪt", "ukphone": "", "trans": ["n. (放钱,证件等的)皮夹"]}, {"name": "walnut", "usphone": "ˈwɔːlnʌt", "ukphone": "", "trans": ["n. 核桃，胡桃"]}, {"name": "wander", "usphone": "ˈwɔndə(r)", "ukphone": "", "trans": ["vi.漫游,游荡,漫步,流浪"]}, {"name": "want", "usphone": "wɔnt; (US) wɔːnt", "ukphone": "", "trans": ["vt. 想,想要,需要,必要"]}, {"name": "war", "usphone": "wɔː(r)", "ukphone": "", "trans": ["n. 战争"]}, {"name": "ward", "usphone": "wɔːd", "ukphone": "", "trans": ["n. 保卫,看护,病房,收容所"]}, {"name": "warehouse", "usphone": "ˈweəhaʊs", "ukphone": "", "trans": ["n. 仓库，货栈"]}, {"name": "warm", "usphone": "wɔːm", "ukphone": "", "trans": ["a. 暖和的,温暖的;热情的"]}, {"name": "warm-hearted", "usphone": "wɔːm- hɑːt", "ukphone": "", "trans": ["a. 热心的"]}, {"name": "warmth", "usphone": "wɔːmθ", "ukphone": "", "trans": ["n. 暖和，温暖"]}, {"name": "war", "usphone": "wɔː(r)", "ukphone": "", "trans": ["n vt. 警告，预先通知"]}, {"name": "warning", "usphone": "ˈwɔːnɪŋ", "ukphone": "", "trans": ["n. 警报"]}, {"name": "wash", "usphone": "ˈwɔːnɪŋ", "ukphone": "", "trans": ["n.洗(涤)冲洗,洗剂,泼溅,洗的衣服 v.洗(涤),冲洗,流过,弄湿"]}, {"name": "washing -machine", "usphone": "ˈwɔʃɪŋ- məˈʃiːn", "ukphone": "", "trans": ["n. 洗衣机"]}, {"name": "washroom", "usphone": "ˈwɔʃrʊm, ˈwɔʃruːm", "ukphone": "", "trans": ["n. 盥洗室"]}, {"name": "waste", "usphone": "weɪst", "ukphone": "", "trans": ["n.& vt. 浪费"]}, {"name": "watch", "usphone": "wɔtʃ", "ukphone": "", "trans": ["vt. 观看，注视；当心，注意 n. 手表，表"]}, {"name": "water", "usphone": "ˈwɔːtə(r)", "ukphone": "", "trans": ["n. 水v. 浇水"]}, {"name": "watermelon", "usphone": "ˈwɔːtəmelən", "ukphone": "", "trans": ["n. 西瓜"]}, {"name": "wave", "usphone": "weɪv", "ukphone": "", "trans": ["n. （热、光、声等的）波，波浪 v. 挥手，挥动，波动"]}, {"name": "wax", "usphone": "wæks", "ukphone": "", "trans": ["n. 蜡"]}, {"name": "way", "usphone": "weɪ", "ukphone": "", "trans": ["n. 路，路线；方式，手段"]}, {"name": "wayside", "usphone": "weɪ", "ukphone": "", "trans": ["a. 路边的"]}, {"name": "we", "usphone": "wiː, wɪ", "ukphone": "", "trans": ["pron. 我们"]}, {"name": "web", "usphone": "web", "ukphone": "", "trans": ["n. 网，网状物"]}, {"name": "website", "usphone": "websaɪt", "ukphone": "", "trans": ["n. 网络"]}, {"name": "weak", "usphone": "wiːk", "ukphone": "", "trans": ["a. 差的，弱的，淡的"]}, {"name": "weakness", "usphone": "ˈwiːknɪs", "ukphone": "", "trans": ["n. 软弱"]}, {"name": "wealth", "usphone": "welθ", "ukphone": "", "trans": ["n. 财产，财富"]}, {"name": "wealthy", "usphone": "ˈwelθɪ", "ukphone": "", "trans": ["a. 富的"]}, {"name": "wear (wore, worn)", "usphone": "weə(r)", "ukphone": "", "trans": ["v. 穿，戴"]}, {"name": "weather", "usphone": "weə(r)", "ukphone": "", "trans": ["n. 天气"]}, {"name": "weatherman", "usphone": "ˈweath·er·man", "ukphone": "", "trans": ["n.气象员,预报天气的人"]}, {"name": "wedding", "usphone": "ˈwedɪŋ", "ukphone": "", "trans": ["n. 婚礼,结婚"]}, {"name": "Wednesday", "usphone": "ˈwenzdeɪ", "ukphone": "", "trans": ["n. 星期三"]}, {"name": "weed", "usphone": "wiːd", "ukphone": "", "trans": ["n. 杂草，野草"]}, {"name": "week", "usphone": "wiːk", "ukphone": "", "trans": ["n. 星期，周"]}, {"name": "weekday", "usphone": "ˈwiːkdeɪ", "ukphone": "", "trans": ["n. 平日"]}, {"name": "weekend", "usphone": "wiːkˈend, ˈwiːkend", "ukphone": "", "trans": ["n. 周末"]}, {"name": "weekly", "usphone": "ˈwiːklɪ", "ukphone": "", "trans": ["a. 每周的"]}, {"name": "weep", "usphone": "wiːp", "ukphone": "", "trans": ["v. 哭泣，流泪"]}, {"name": "weigh", "usphone": "weɪ", "ukphone": "", "trans": ["vt. 称…的重量，重（若干）"]}, {"name": "weight", "usphone": "weɪt", "ukphone": "", "trans": ["n. 重，重量"]}, {"name": "welcome", "usphone": "ˈwelkəm", "ukphone": "", "trans": ["int.n. & v.欢迎 a. 受欢迎的"]}, {"name": "welfare", "usphone": "ˈwelfeə(r)", "ukphone": "", "trans": ["n. 幸福，福利"]}, {"name": "well", "usphone": "wel", "ukphone": "", "trans": ["(better, best) ad. 好,令人满意地,完全地 a.好的,,健康的int. 表示惊讶同意或犹豫等,亦用于接话语;好吧,那么,哎呀 n. 井"]}, {"name": "well-known", "usphone": "wel- nəʊn", "ukphone": "", "trans": ["a.出名,众所周知的"]}, {"name": "west", "usphone": "west", "ukphone": "", "trans": ["a. (在)西；向西,从西来的 ad. 在西方,向西方 n.西部；西方"]}, {"name": "western", "usphone": "ˈwest(ə)n", "ukphone": "", "trans": ["a. 西方的，西部的"]}, {"name": "westerner", "usphone": "ˈwestənə", "ukphone": "", "trans": ["n. 西方人"]}, {"name": "westwards", "usphone": "ˈwestwədz", "ukphone": "", "trans": ["ad. 向西"]}, {"name": "wet", "usphone": "wet", "ukphone": "", "trans": ["a. 湿的,潮的,多雨的"]}, {"name": "whale", "usphone": "weɪl; (US) hweɪl", "ukphone": "", "trans": ["n. 鲸"]}, {"name": "what", "usphone": "wɔt; (US) hwɑt", "ukphone": "", "trans": ["pron. 什么,怎么样 a. 多么，何等；什么"]}, {"name": "whatever", "usphone": "wɔtˈevə(r)", "ukphone": "", "trans": ["conj. & pron.无论什么，不管什么"]}, {"name": "wheat", "usphone": "wiːt; (US) hwiːt", "ukphone": "", "trans": ["n. 小麦"]}, {"name": "wheel", "usphone": "wiːl; (US) hwiːl", "ukphone": "", "trans": ["n. 轮，机轮"]}, {"name": "when", "usphone": "wen", "ukphone": "", "trans": ["conj. 当…的时候 ad. 什么时候，何时"]}, {"name": "whenever", "usphone": "wenˈevə(r)", "ukphone": "", "trans": ["conj. 每当，无论何时"]}, {"name": "where", "usphone": "weə(r); (US) hweər", "ukphone": "", "trans": ["ad. 在哪里；往哪里"]}, {"name": "wherever", "usphone": "weərˈevə(r)", "ukphone": "", "trans": ["conj. 无论在哪里"]}, {"name": "whether", "usphone": "ˈweðə(r); (US) ˈhweðər", "ukphone": "", "trans": ["conj. 是否"]}, {"name": "which", "usphone": "wɪtʃ; (US) hwɪtʃ", "ukphone": "", "trans": ["pron. 那(哪)一个；那(哪)一些 a.这(哪)个；这(哪)些；无论哪个(些)"]}, {"name": "whichever", "usphone": "wɪtʃˈevə(r)", "ukphone": "", "trans": ["pron. 无论哪个;无论哪些"]}, {"name": "while", "usphone": "waɪl; (US) hwaɪl", "ukphone": "", "trans": ["conj.在…的时候,和…同时 n. 一会儿，一段时间"]}, {"name": "whisper", "usphone": "ˈwɪspə(r)", "ukphone": "", "trans": ["v. 低语，私下说"]}, {"name": "whistle", "usphone": "waɪt; (US) hwaɪt", "ukphone": "", "trans": ["n. 口哨，口哨声"]}, {"name": "white", "usphone": "waɪt; (US) hwaɪt", "ukphone": "", "trans": ["a. 白色的 n. 白色"]}, {"name": "who", "usphone": "huː", "ukphone": "", "trans": ["pron. 谁"]}, {"name": "whole", "usphone": "həʊl", "ukphone": "", "trans": ["a. 整个的"]}, {"name": "whom", "usphone": "huːm", "ukphone": "", "trans": ["pron. (who的宾格 )"]}, {"name": "whose", "usphone": "huːz", "ukphone": "", "trans": ["pron. 谁的"]}, {"name": "why", "usphone": "waɪ; (US) hwaɪ", "ukphone": "", "trans": ["ad./ int. 为什么, 你难道不知道（表示反驳、不耐烦等）"]}, {"name": "wide", "usphone": "weə(r); (US) hweər", "ukphone": "", "trans": ["a. 宽阔的"]}, {"name": "widespread", "usphone": "ˈwaɪdspred, -ˈspred", "ukphone": "", "trans": ["a.分布广的,普遍的"]}, {"name": "wife", "usphone": "waɪf", "ukphone": "", "trans": ["n. 妻子"]}, {"name": "wild", "usphone": "waɪld", "ukphone": "", "trans": ["a. 未开发的，荒凉的；野生的，野的"]}, {"name": "wildlife", "usphone": "ˈwaɪldlaɪf", "ukphone": "", "trans": ["n. 野生动物"]}, {"name": "will", "usphone": "wɪl", "ukphone": "", "trans": ["n. 意志, 遗嘱"]}, {"name": "will (would)", "usphone": "wɪl", "ukphone": "", "trans": ["modal v. 将,会(表示将来)；愿意，要"]}, {"name": "willing", "usphone": "ˈwɪlɪŋ", "ukphone": "", "trans": ["a. 乐意的； 愿意的"]}, {"name": "willingly", "usphone": "ˈwiliŋli", "ukphone": "", "trans": ["ad. 乐意地"]}, {"name": "willingness", "usphone": "ˈwiliŋnis", "ukphone": "", "trans": ["n. 意愿； 愿望"]}, {"name": "win (won, won)", "usphone": "wɪn", "ukphone": "", "trans": ["n. 获胜，赢得"]}, {"name": "wind", "usphone": "wɪnd", "ukphone": "", "trans": ["n. 风 "]}, {"name": "wind(wound,wound)", "usphone": "wɪnd", "ukphone": "", "trans": ["vt. 缠，连带；蜿蜒，弯曲"]}, {"name": "windbreaker", "usphone": "ˈwind,breikә", "ukphone": "", "trans": ["n.风衣,防风(皮)夹克"]}, {"name": "window", "usphone": "ˈwɪndəʊ", "ukphone": "", "trans": ["n. 窗户；计算机的窗"]}, {"name": "windy", "usphone": "ˈwɪndɪ", "ukphone": "", "trans": ["a. 有风的，多风的"]}, {"name": "wine", "usphone": "waɪn", "ukphone": "", "trans": ["n. 酒"]}, {"name": "wing", "usphone": "wɪŋ", "ukphone": "", "trans": ["n. 机翼，翅膀"]}, {"name": "winner", "usphone": "ˈwɪnə(r)", "ukphone": "", "trans": ["n. 获胜者"]}, {"name": "winter", "usphone": "ˈwɪntə(r)", "ukphone": "", "trans": ["n. 冬天，冬季"]}, {"name": "wipe", "usphone": "waɪp", "ukphone": "", "trans": ["v. 擦；擦净；擦干"]}, {"name": "wire", "usphone": "ˈwaɪə(r)", "ukphone": "", "trans": ["n. 电线"]}, {"name": "wisdom", "usphone": "ˈwɪzdəm", "ukphone": "", "trans": ["n. 智慧"]}, {"name": "wise", "usphone": "waɪz", "ukphone": "", "trans": ["a. 聪明,英明的,有见识的"]}, {"name": "wish", "usphone": "wɪʃ", "ukphone": "", "trans": ["n. 愿望，祝愿 vt. 希望，想要，祝愿"]}, {"name": "with", "usphone": "wɪʃ", "ukphone": "", "trans": ["prep.关于,带有,以,和,用,有"]}, {"name": "withdraw", "usphone": "wɪðˈdrɔː", "ukphone": "", "trans": ["v. 撤回，撤离"]}, {"name": "within", "usphone": "wɪˈðɪn", "ukphone": "", "trans": ["prep. 在……里面"]}, {"name": "without", "usphone": "wɪˈðaʊt", "ukphone": "", "trans": ["prep. 没有"]}, {"name": "witness", "usphone": "ˈwɪtnɪs", "ukphone": "", "trans": ["v./ n. 目击者，见证人"]}, {"name": "wolf（复wolves）", "usphone": "wʊlf", "ukphone": "", "trans": ["n. 狼"]}, {"name": "woman ( 复women)", "usphone": "ˈwʊmən", "ukphone": "", "trans": ["n.妇女女人"]}, {"name": "wonder", "usphone": "ˈwʌndə(r)", "ukphone": "", "trans": ["v. 对…疑惑，感到惊奇,想知道 n. 惊讶,惊叹;奇迹"]}, {"name": "wonderful", "usphone": "ˈwʌndəfʊl", "ukphone": "", "trans": ["a. 美妙的，精彩的；了不起的；太好了"]}, {"name": "wood", "usphone": "ˈwʌndəfʊl", "ukphone": "", "trans": ["n.木头,木材,(复)树木,森林"]}, {"name": "wooden", "usphone": "ˈwʊd(ə)n", "ukphone": "", "trans": ["a. 木制的"]}, {"name": "woo", "usphone": "wʊl", "ukphone": "", "trans": ["l n. 羊毛，羊绒"]}, {"name": "woollen", "usphone": "ˈwulin", "ukphone": "", "trans": ["a. 羊毛的，羊毛制的"]}, {"name": "word", "usphone": "wɜːd", "ukphone": "", "trans": ["n. 词，单词；话"]}, {"name": "work", "usphone": "wɜːk", "ukphone": "", "trans": ["n. 工作,劳动,事情 vi. 工作;(机器、器官等)运转,活动"]}, {"name": "workday", "usphone": "ˈwə:kdei", "ukphone": "", "trans": ["n. 工作日"]}, {"name": "worker", "usphone": "ˈwɜːkə(r)", "ukphone": "", "trans": ["n. 工人；工作者"]}, {"name": "workforce", "usphone": "ˈwə:kfɔ:s", "ukphone": "", "trans": ["n. 劳动力"]}, {"name": "workmate", "usphone": "ˈwə:kfɔ:s", "ukphone": "", "trans": ["n. 同事；工友"]}, {"name": "workplace", "usphone": "wɜːkpleɪs", "ukphone": "", "trans": ["n.工作场所，车间"]}, {"name": "works", "usphone": "wɜːks", "ukphone": "", "trans": ["n. 著作，作品"]}, {"name": "world", "usphone": "wɜːld", "ukphone": "", "trans": ["n. 世界"]}, {"name": "world-famous", "usphone": "wɜːld- ˈfeɪməs", "ukphone": "", "trans": ["a. 世界闻名的"]}, {"name": "worldwide", "usphone": "ˈwɜːldwaɪd, -ˈwaɪd", "ukphone": "", "trans": ["a. 遍及全球的，世界范围的"]}, {"name": "worm", "usphone": "wɜːm", "ukphone": "", "trans": ["n. 软体虫,蠕虫(尤指蚯蚓)"]}, {"name": "worn", "usphone": "wɜrn /wɜːm", "ukphone": "", "trans": ["a. 用坏,用旧的,疲惫的"]}, {"name": "worried", "usphone": "ˈwɜrɪd /ˈwʌ-", "ukphone": "", "trans": ["a. 担心的，烦恼的"]}, {"name": "worry", "usphone": "ˈwʌrɪ", "ukphone": "", "trans": ["n.& v.烦恼,担忧,发怒,困扰"]}, {"name": "worse", "usphone": "wɜːs", "ukphone": "", "trans": ["a. (bad的比较级)更坏的"]}, {"name": "worst", "usphone": "wɜːst", "ukphone": "", "trans": ["a. (bad的最高级)最坏的"]}, {"name": "worth", "usphone": "wɜːθ", "ukphone": "", "trans": ["a. 有…的价值,值得…的"]}, {"name": "worthless", "usphone": "ˈwɜːθlɪs", "ukphone": "", "trans": ["a.没有价值,没有用的"]}, {"name": "worthwhile", "usphone": "wɜːθˈwaɪl", "ukphone": "", "trans": ["a. 值得做的"]}, {"name": "worthy", "usphone": "wɜːθˈwaɪl", "ukphone": "", "trans": ["a. 值得的"]}, {"name": "would", "usphone": "wəd, wʊd", "ukphone": "", "trans": ["modal v.（will的过去时）将会，打算，想要，过去常常"]}, {"name": "wound", "usphone": "wuːnd", "ukphone": "", "trans": ["vt.伤,伤害 n.创伤,伤口"]}, {"name": "wounded", "usphone": "wuːndɪd", "ukphone": "", "trans": ["a. 受伤的"]}, {"name": "wrestle", "usphone": "ˈres(ə)l", "ukphone": "", "trans": ["v. 摔跤"]}, {"name": "wrinkle", "usphone": "ˈrɪŋk(ə)l", "ukphone": "", "trans": ["n. 皱纹"]}, {"name": "wrist", "usphone": "rɪst", "ukphone": "", "trans": ["n. 手腕，腕关节"]}, {"name": "write", "usphone": "raɪt", "ukphone": "", "trans": ["(wrote, written) v. 写，书写；写作，著述"]}, {"name": "writing", "usphone": "raɪt", "ukphone": "", "trans": ["n. 书写，写"]}, {"name": "wrong", "usphone": "rɔŋ; (US) rɔːŋ", "ukphone": "", "trans": ["a.错误,不正常,有毛病的"]}, {"name": "X-ray", "usphone": "eks-reɪ", "ukphone": "", "trans": ["n. X射线；X光"]}, {"name": "yard", "usphone": "jɑːd", "ukphone": "", "trans": ["n. 码；院子；场地"]}, {"name": "yawn", "usphone": "jɔːn", "ukphone": "", "trans": ["v. 打哈欠"]}, {"name": "year", "usphone": "jɪə(r), jəː(r)", "ukphone": "", "trans": ["n. 年"]}, {"name": "yell", "usphone": "jel", "ukphone": "", "trans": ["v. 叫喊，吼叫"]}, {"name": "yellow", "usphone": "ˈjeləʊ", "ukphone": "", "trans": ["a. 黄色的"]}, {"name": "yes", "usphone": "jes", "ukphone": "", "trans": ["ad. 是，好，同意"]}, {"name": "yesterday", "usphone": "ˈjestədeɪ", "ukphone": "", "trans": ["n.& ad. 昨天"]}, {"name": "yet", "usphone": "jet", "ukphone": "", "trans": ["ad. 尚，还，仍然"]}, {"name": "yoghurt", "usphone": "ˈjɔgət,ˈjəʊ-", "ukphone": "", "trans": ["n. 酸奶"]}, {"name": "you", "usphone": "juː, jʊ", "ukphone": "", "trans": ["pron. 你；你们"]}, {"name": "young", "usphone": "jʌŋ", "ukphone": "", "trans": ["a. 年轻的"]}, {"name": "your", "usphone": "jʌŋ", "ukphone": "", "trans": ["pron. 你的；你们的"]}, {"name": "yours", "usphone": "jɔːz, jʊəz", "ukphone": "", "trans": ["pron. 你的；你们的"]}, {"name": "yourself", "usphone": "jɔːˈself; (US) jʊərˈself", "ukphone": "", "trans": ["pron. 你自己"]}, {"name": "yourselves", "usphone": "jɔːˈself; (US) jʊərˈself", "ukphone": "", "trans": ["pron. 你们自己"]}, {"name": "youth", "usphone": "juːθ", "ukphone": "", "trans": ["n. 青春；青年"]}, {"name": "yummy", "usphone": "ˈjʌmɪ", "ukphone": "", "trans": ["a. 很好吃的"]}, {"name": "zebra", "usphone": "ˈzebrə, ˈziːbrə", "ukphone": "", "trans": ["n. 斑马"]}, {"name": "zebra -crossing", "usphone": "ˈzebrə-ˈkrɔsɪŋ", "ukphone": "", "trans": ["人行横道线（斑马线）"]}, {"name": "zero", "usphone": "ˈzɪərəʊ", "ukphone": "", "trans": ["n. & num.零,零度,零点"]}, {"name": "zip", "usphone": "zɪp", "ukphone": "", "trans": ["v.& n.拉开(或扣上)……的拉链；拉链"]}, {"name": "zip code(美) =postcode", "usphone": "zɪp kəʊd", "ukphone": "", "trans": ["(英)邮政区号"]}, {"name": "zipper", "usphone": "ˈzɪpə(r)", "ukphone": "", "trans": ["n. 拉链"]}, {"name": "zone", "usphone": "zuː", "ukphone": "", "trans": ["n. 区域；范围"]}, {"name": "zoo", "usphone": "zuː", "ukphone": "", "trans": ["n. 动物园"]}, {"name": "zoom", "usphone": "zuːm", "ukphone": "", "trans": ["v. 快速移动，迅速前往，猛涨"]}]
+[
+  {
+    "name": "a (an)",
+    "usphone": "ə, eɪ(ən)",
+    "ukphone": "",
+    "trans": [
+      "art. 一（个、件……）"
+    ]
+  },
+  {
+    "name": "abandon",
+    "usphone": "əˈbændən",
+    "ukphone": "",
+    "trans": [
+      "v.抛弃，舍弃，放弃"
+    ]
+  },
+  {
+    "name": "ability",
+    "usphone": "əˈbɪlɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 能力；才能"
+    ]
+  },
+  {
+    "name": "able",
+    "usphone": "ˈeɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 能够；有能力的"
+    ]
+  },
+  {
+    "name": "abnormal",
+    "usphone": "æbˈnɔːm(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 反常的，变态的"
+    ]
+  },
+  {
+    "name": "aboard",
+    "usphone": "əˈbɔːd",
+    "ukphone": "",
+    "trans": [
+      "prep. 上（船，飞机，火车，汽车等）"
+    ]
+  },
+  {
+    "name": "abolish",
+    "usphone": "əˈbɔlɪʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 废除，废止"
+    ]
+  },
+  {
+    "name": "abortion",
+    "usphone": "əˈbɔːʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "v. 人工流产，堕胎"
+    ]
+  },
+  {
+    "name": "about",
+    "usphone": "əˈbaʊt",
+    "ukphone": "",
+    "trans": [
+      "ad. 大约；到处；四处 prep. 关于；在各处；四处"
+    ]
+  },
+  {
+    "name": "above",
+    "usphone": "əˈbʌv",
+    "ukphone": "",
+    "trans": [
+      "prep. 在……上面 a. 上面的 ad. 在……之上"
+    ]
+  },
+  {
+    "name": "abroad",
+    "usphone": "əˈbrɔːd",
+    "ukphone": "",
+    "trans": [
+      "ad. 到（在）国外"
+    ]
+  },
+  {
+    "name": "abrupt",
+    "usphone": "əˈbrʌpt",
+    "ukphone": "",
+    "trans": [
+      "a. 突然的，意外的，粗鲁"
+    ]
+  },
+  {
+    "name": "absence",
+    "usphone": "ˈæbsəns",
+    "ukphone": "",
+    "trans": [
+      "n. 不在，缺席"
+    ]
+  },
+  {
+    "name": "absent",
+    "usphone": "ˈæbsənt",
+    "ukphone": "",
+    "trans": [
+      "a. 缺席， 不在"
+    ]
+  },
+  {
+    "name": "absolute",
+    "usphone": "ˈæbsəluːt",
+    "ukphone": "",
+    "trans": [
+      "a. 完全，全部，绝对的"
+    ]
+  },
+  {
+    "name": "absorb",
+    "usphone": "əbˈsɔːb",
+    "ukphone": "",
+    "trans": [
+      "v. 吸收，使全神贯注"
+    ]
+  },
+  {
+    "name": "abstract",
+    "usphone": "ˈæbstrækt",
+    "ukphone": "",
+    "trans": [
+      "a./ n. 抽象的（作品）"
+    ]
+  },
+  {
+    "name": "absurd",
+    "usphone": "əbˈsɜːd",
+    "ukphone": "",
+    "trans": [
+      "a.荒谬的，怪诞不经的"
+    ]
+  },
+  {
+    "name": "abundant",
+    "usphone": "əˈbʌndənt",
+    "ukphone": "",
+    "trans": [
+      "a.大量,丰盛的,充裕的"
+    ]
+  },
+  {
+    "name": "abuse",
+    "usphone": "əˈbjuːz",
+    "ukphone": "",
+    "trans": [
+      "v.（酗酒）滥用,虐待,恶语"
+    ]
+  },
+  {
+    "name": "academic",
+    "usphone": "ækəˈdemɪk",
+    "ukphone": "",
+    "trans": [
+      "a. / n. 学术的，教学的"
+    ]
+  },
+  {
+    "name": "academy",
+    "usphone": "əˈkædəmɪ",
+    "ukphone": "",
+    "trans": [
+      "n.专科学院,（美）私立学校"
+    ]
+  },
+  {
+    "name": "accelerate",
+    "usphone": "əkˈseləreɪt",
+    "ukphone": "",
+    "trans": [
+      "v.（使）加速，加快"
+    ]
+  },
+  {
+    "name": "accent",
+    "usphone": "ˈæksənt",
+    "ukphone": "",
+    "trans": [
+      "n. 口音，音调"
+    ]
+  },
+  {
+    "name": "accept",
+    "usphone": "əkˈsept",
+    "ukphone": "",
+    "trans": [
+      "vt. 接受"
+    ]
+  },
+  {
+    "name": "access",
+    "usphone": "ˈækses",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 通道，入径，存取（计算机文件）"
+    ]
+  },
+  {
+    "name": "accessible",
+    "usphone": "əkˈsesɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 可到达的，可接受的，易相处的）"
+    ]
+  },
+  {
+    "name": "accident",
+    "usphone": "ˈæksɪdənt",
+    "ukphone": "",
+    "trans": [
+      "n. 事故，意外的事"
+    ]
+  },
+  {
+    "name": "accommodation",
+    "usphone": "əkɔməˈdeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.住宿，膳宿"
+    ]
+  },
+  {
+    "name": "accompany",
+    "usphone": "əˈkʌmpənɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 陪同，陪伴，与…同时发生"
+    ]
+  },
+  {
+    "name": "accomplish",
+    "usphone": "əˈkʌmplɪʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 完成"
+    ]
+  },
+  {
+    "name": "according to",
+    "usphone": "əˈkɔːdɪŋ tʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. 按照，根据"
+    ]
+  },
+  {
+    "name": "account",
+    "usphone": "əˈkaʊnt",
+    "ukphone": "",
+    "trans": [
+      "n. 账目;描述"
+    ]
+  },
+  {
+    "name": "accountant",
+    "usphone": "əˈkaʊnt(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "n. 会计，会计师"
+    ]
+  },
+  {
+    "name": "accumulate",
+    "usphone": "əˈkjuːmjʊleɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 积累，积聚"
+    ]
+  },
+  {
+    "name": "accuracy",
+    "usphone": "ˈækjʊrəsɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 准确，精确"
+    ]
+  },
+  {
+    "name": "accuse",
+    "usphone": "əˈkjuːz",
+    "ukphone": "",
+    "trans": [
+      "v. 正确无误的,精确的"
+    ]
+  },
+  {
+    "name": "accustomed",
+    "usphone": "əˈkʌstəmd",
+    "ukphone": "",
+    "trans": [
+      "a. 习惯于,惯常的"
+    ]
+  },
+  {
+    "name": "ache",
+    "usphone": "eɪk",
+    "ukphone": "",
+    "trans": [
+      "vi.& n. 痛，疼痛"
+    ]
+  },
+  {
+    "name": "achieve",
+    "usphone": "əˈtʃiːv",
+    "ukphone": "",
+    "trans": [
+      "vt. 达到，取得"
+    ]
+  },
+  {
+    "name": "achievement",
+    "usphone": "əˈtʃiːvmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 成就,成绩,功绩"
+    ]
+  },
+  {
+    "name": "acid",
+    "usphone": "ˈæsɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 酸的"
+    ]
+  },
+  {
+    "name": "acknowledge",
+    "usphone": "əkˈnɔlɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "v. 承认"
+    ]
+  },
+  {
+    "name": "acquaintance",
+    "usphone": "əˈkweɪntəns",
+    "ukphone": "",
+    "trans": [
+      "n. 熟人，（与某人）认识"
+    ]
+  },
+  {
+    "name": "acquire",
+    "usphone": "əˈkwaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 获得，得到"
+    ]
+  },
+  {
+    "name": "acquisition",
+    "usphone": "ækwɪˈzɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 获得，得到"
+    ]
+  },
+  {
+    "name": "acre",
+    "usphone": "ˈeɪkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 英亩"
+    ]
+  },
+  {
+    "name": "across",
+    "usphone": "əˈkrɔs",
+    "ukphone": "",
+    "trans": [
+      "prep. 横过，穿过"
+    ]
+  },
+  {
+    "name": "act",
+    "usphone": "ækt",
+    "ukphone": "",
+    "trans": [
+      "n. 法令，条例 v. （戏）表演，扮演（角色），演出（戏）；行动，做事"
+    ]
+  },
+  {
+    "name": "action",
+    "usphone": "ˈækʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 行动"
+    ]
+  },
+  {
+    "name": "active",
+    "usphone": "ˈæktɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 积极的，主动的"
+    ]
+  },
+  {
+    "name": "activity",
+    "usphone": "ækˈtɪvɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 活动"
+    ]
+  },
+  {
+    "name": "actor",
+    "usphone": "ˈæktə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 男演员"
+    ]
+  },
+  {
+    "name": "actress",
+    "usphone": "ˈæktrɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 女演员"
+    ]
+  },
+  {
+    "name": "actual",
+    "usphone": "ˈæktʃʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 实际的； 现实的"
+    ]
+  },
+  {
+    "name": "acut",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a.十分严重的,（病）急性的"
+    ]
+  },
+  {
+    "name": "AD",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 公元"
+    ]
+  },
+  {
+    "name": "ad",
+    "usphone": "æd",
+    "ukphone": "",
+    "trans": [
+      "(缩) =advertisement n.广告"
+    ]
+  },
+  {
+    "name": "adapt",
+    "usphone": "əˈdæpt",
+    "ukphone": "",
+    "trans": [
+      "v. 使适应，适合，改编"
+    ]
+  },
+  {
+    "name": "adaptation",
+    "usphone": "ədæpˈteɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 适应，改编本"
+    ]
+  },
+  {
+    "name": "add",
+    "usphone": "æd",
+    "ukphone": "",
+    "trans": [
+      "vt.添加，增加"
+    ]
+  },
+  {
+    "name": "addicted",
+    "usphone": "əˈdɪktɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 上瘾，成瘾，入迷"
+    ]
+  },
+  {
+    "name": "addition",
+    "usphone": "əˈdɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.增加;（算数用语）加"
+    ]
+  },
+  {
+    "name": "address",
+    "usphone": "əˈdres",
+    "ukphone": "",
+    "trans": [
+      "n. 地址"
+    ]
+  },
+  {
+    "name": "adequate",
+    "usphone": "ˈædɪkwət",
+    "ukphone": "",
+    "trans": [
+      "a. 合适的，合乎需要的"
+    ]
+  },
+  {
+    "name": "adjust",
+    "usphone": "əˈdʒʌst",
+    "ukphone": "",
+    "trans": [
+      "v.调整,调节,适应,习惯"
+    ]
+  },
+  {
+    "name": "adjustment",
+    "usphone": "əˈdʒʌstmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 调整，适应"
+    ]
+  },
+  {
+    "name": "administration",
+    "usphone": "ədmɪnɪˈstreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.管理,行政部门"
+    ]
+  },
+  {
+    "name": "admirable",
+    "usphone": "ˈædmərəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.值得赞赏的,可钦佩的"
+    ]
+  },
+  {
+    "name": "admire",
+    "usphone": "ədˈmaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 钦佩；羡慕"
+    ]
+  },
+  {
+    "name": "admission",
+    "usphone": "ədˈmɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 准入, 接纳"
+    ]
+  },
+  {
+    "name": "admit",
+    "usphone": "ədˈmɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 承认，准许（入场，入学，入会）"
+    ]
+  },
+  {
+    "name": "adolescence",
+    "usphone": "ædəʊˈlesns",
+    "ukphone": "",
+    "trans": [
+      "n. 青春，青春期"
+    ]
+  },
+  {
+    "name": "adolescent",
+    "usphone": "ædəˈlesənt",
+    "ukphone": "",
+    "trans": [
+      "n. 青少年"
+    ]
+  },
+  {
+    "name": "adopt",
+    "usphone": "əˈdɔpt",
+    "ukphone": "",
+    "trans": [
+      "v. 收养，领养"
+    ]
+  },
+  {
+    "name": "adore",
+    "usphone": "əˈdɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "v. （不用于进行时）热爱，爱慕某人"
+    ]
+  },
+  {
+    "name": "adult",
+    "usphone": "ˈædʌlt",
+    "ukphone": "",
+    "trans": [
+      "n. 成年人"
+    ]
+  },
+  {
+    "name": "advance",
+    "usphone": "ədˈvɑːns; (US) ədˈvæns",
+    "ukphone": "",
+    "trans": [
+      "v. 推进，促进；前进"
+    ]
+  },
+  {
+    "name": "advantage",
+    "usphone": "ədˈvɑːntɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 优点； 好处"
+    ]
+  },
+  {
+    "name": "adventure",
+    "usphone": "ədˈventʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 冒险； 奇遇"
+    ]
+  },
+  {
+    "name": "advertise",
+    "usphone": "ˈædvətaɪz",
+    "ukphone": "",
+    "trans": [
+      "vt. 为……做广告"
+    ]
+  },
+  {
+    "name": "advertisement",
+    "usphone": "ədˈvɜːtɪsmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 广告"
+    ]
+  },
+  {
+    "name": "advice",
+    "usphone": "ədˈvaɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 忠告，劝告，建议"
+    ]
+  },
+  {
+    "name": "advise",
+    "usphone": "ədˈvaɪz",
+    "ukphone": "",
+    "trans": [
+      "vt. 忠告，劝告，建议"
+    ]
+  },
+  {
+    "name": "advocate",
+    "usphone": "ˈædvəkət",
+    "ukphone": "",
+    "trans": [
+      "v. 拥护，支持，提倡"
+    ]
+  },
+  {
+    "name": "aeroplane",
+    "usphone": "`erə,pleɪn",
+    "ukphone": "",
+    "trans": [
+      "n. (英)飞机"
+    ]
+  },
+  {
+    "name": "affair",
+    "usphone": "əˈfeə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 事，事情"
+    ]
+  },
+  {
+    "name": "affect",
+    "usphone": "əˈfekt",
+    "ukphone": "",
+    "trans": [
+      "vt. 影响"
+    ]
+  },
+  {
+    "name": "affection",
+    "usphone": "əˈfekʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 喜爱，钟爱"
+    ]
+  },
+  {
+    "name": "afford",
+    "usphone": "əˈfɔːd",
+    "ukphone": "",
+    "trans": [
+      "vt. 负担得起（……的费用）；抽得出（时间）；提供"
+    ]
+  },
+  {
+    "name": "afraid",
+    "usphone": "əˈfreɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 害怕的；担心"
+    ]
+  },
+  {
+    "name": "Africa",
+    "usphone": "ˈæfrɪkə",
+    "ukphone": "",
+    "trans": [
+      "* n. 非洲"
+    ]
+  },
+  {
+    "name": "African",
+    "usphone": "ˈæfrɪkən",
+    "ukphone": "",
+    "trans": [
+      "a. 非洲的，非洲人的 n. 非洲人"
+    ]
+  },
+  {
+    "name": "afte",
+    "usphone": "ˈɑːftə(r)",
+    "ukphone": "",
+    "trans": [
+      "r ad. 在后；后来prep. 在…之后；在 后面 conj. 在…以后"
+    ]
+  },
+  {
+    "name": "afternoon",
+    "usphone": "ɑːftəˈnuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 下午，午后"
+    ]
+  },
+  {
+    "name": "afterward(s)",
+    "usphone": "ˈɑːftəwəd(z)",
+    "ukphone": "",
+    "trans": [
+      "ad. 后来"
+    ]
+  },
+  {
+    "name": "again",
+    "usphone": "əˈɡeɪn",
+    "ukphone": "",
+    "trans": [
+      "ad. 再一次；再，又"
+    ]
+  },
+  {
+    "name": "against",
+    "usphone": "əˈɡeɪnst",
+    "ukphone": "",
+    "trans": [
+      "prep. 对着，反对"
+    ]
+  },
+  {
+    "name": "age",
+    "usphone": "eɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 年龄；时代"
+    ]
+  },
+  {
+    "name": "agency",
+    "usphone": "ˈeɪdʒənsɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 代理机构"
+    ]
+  },
+  {
+    "name": "agenda",
+    "usphone": "əˈdʒendə",
+    "ukphone": "",
+    "trans": [
+      "n. （会议）议程表，议事日程"
+    ]
+  },
+  {
+    "name": "agent",
+    "usphone": "ˈeɪdʒənt",
+    "ukphone": "",
+    "trans": [
+      "n. 代理人，经济人"
+    ]
+  },
+  {
+    "name": "aggression",
+    "usphone": "ˈəɡreʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 侵略"
+    ]
+  },
+  {
+    "name": "aggressive",
+    "usphone": "ˈəɡresɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 侵略的；咄咄逼人"
+    ]
+  },
+  {
+    "name": "ago",
+    "usphone": "əˈɡəʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. 以前"
+    ]
+  },
+  {
+    "name": "agree",
+    "usphone": "əˈɡriː",
+    "ukphone": "",
+    "trans": [
+      "v. 同意；应允"
+    ]
+  },
+  {
+    "name": "agreement",
+    "usphone": "əˈɡriːmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 同意，一致；协定，协议"
+    ]
+  },
+  {
+    "name": "agricultural",
+    "usphone": "æɡrɪˈkʌltʃər(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 农业的"
+    ]
+  },
+  {
+    "name": "agriculture",
+    "usphone": "ˈæɡrɪkʌltʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 农业，农学"
+    ]
+  },
+  {
+    "name": "ahead",
+    "usphone": "əˈhed",
+    "ukphone": "",
+    "trans": [
+      "ad. 在前，向前"
+    ]
+  },
+  {
+    "name": "aid",
+    "usphone": "eɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 援助；救护；辅助器具"
+    ]
+  },
+  {
+    "name": "AIDS",
+    "usphone": "eɪdz",
+    "ukphone": "",
+    "trans": [
+      "n. 艾滋病"
+    ]
+  },
+  {
+    "name": "aim",
+    "usphone": "eɪm",
+    "ukphone": "",
+    "trans": [
+      "n.目的；目标 v. 计划，打算；瞄准；针对"
+    ]
+  },
+  {
+    "name": "air",
+    "usphone": "eə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 空气；大气"
+    ]
+  },
+  {
+    "name": "aircraft",
+    "usphone": "ˈeəkrɑːft",
+    "ukphone": "",
+    "trans": [
+      "n. 飞机 (单复数同)"
+    ]
+  },
+  {
+    "name": "airline",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 航空公司；航空系统"
+    ]
+  },
+  {
+    "name": "airmail",
+    "usphone": "ˈeəmeɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 航空邮件"
+    ]
+  },
+  {
+    "name": "airplane",
+    "usphone": "ˈeəpleɪn",
+    "ukphone": "",
+    "trans": [
+      "n. （美）飞机"
+    ]
+  },
+  {
+    "name": "airport",
+    "usphone": "ˈeəpɔːt",
+    "ukphone": "",
+    "trans": [
+      "n. 航空站，飞机场"
+    ]
+  },
+  {
+    "name": "airspace",
+    "usphone": "ˈeəspeɪs",
+    "ukphone": "",
+    "trans": [
+      "n.领空,（某国的）空域"
+    ]
+  },
+  {
+    "name": "alarm",
+    "usphone": "əˈlɑːm",
+    "ukphone": "",
+    "trans": [
+      "n. 警报"
+    ]
+  },
+  {
+    "name": "album",
+    "usphone": "ˈælbəm",
+    "ukphone": "",
+    "trans": [
+      "n. 相册，影集，集邮簿"
+    ]
+  },
+  {
+    "name": "alcohol",
+    "usphone": "ˈælkəhɔl",
+    "ukphone": "",
+    "trans": [
+      "n. 含酒精饮料，酒"
+    ]
+  },
+  {
+    "name": "alcoholic",
+    "usphone": "ælkəˈhɔlɪk",
+    "ukphone": "",
+    "trans": [
+      "a. / n. 含酒精的，酒鬼"
+    ]
+  },
+  {
+    "name": "algebra",
+    "usphone": "ˈældʒɪbrə",
+    "ukphone": "",
+    "trans": [
+      "n. 代数"
+    ]
+  },
+  {
+    "name": "alike",
+    "usphone": "əˈlaɪk",
+    "ukphone": "",
+    "trans": [
+      "ad. 很相似地，同样地"
+    ]
+  },
+  {
+    "name": "alive",
+    "usphone": "əˈlaɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 活着的，存在的"
+    ]
+  },
+  {
+    "name": "all",
+    "usphone": "ɔːl",
+    "ukphone": "",
+    "trans": [
+      "ad. 全部地 a. 全（部）;所有的;总;整 pron.全部;全体人员"
+    ]
+  },
+  {
+    "name": "allergic",
+    "usphone": "əˈlɜːdʒɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 过敏的，厌恶"
+    ]
+  },
+  {
+    "name": "alley",
+    "usphone": "ˈælɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 小巷，胡同"
+    ]
+  },
+  {
+    "name": "allocate",
+    "usphone": "ˈæləkeɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 拨给,划归,分配…给"
+    ]
+  },
+  {
+    "name": "allow",
+    "usphone": "əˈlaʊ",
+    "ukphone": "",
+    "trans": [
+      "vt. 允许，准许"
+    ]
+  },
+  {
+    "name": "allowance",
+    "usphone": "əˈlaʊəns",
+    "ukphone": "",
+    "trans": [
+      "n. 津贴，补助"
+    ]
+  },
+  {
+    "name": "almost",
+    "usphone": "ˈɔːlməʊst",
+    "ukphone": "",
+    "trans": [
+      "ad. 几乎，差不多"
+    ]
+  },
+  {
+    "name": "alone",
+    "usphone": "əˈləʊn",
+    "ukphone": "",
+    "trans": [
+      "a. 单独的，孤独的"
+    ]
+  },
+  {
+    "name": "along",
+    "usphone": "əˈlɔŋ; (US) əˈlɔŋ",
+    "ukphone": "",
+    "trans": [
+      "ad. 向前；和…一起；一同 prep. 沿着；顺着"
+    ]
+  },
+  {
+    "name": "alongside",
+    "usphone": "əlɔŋˈsaɪd; (US) əlɔːŋˈsaɪd",
+    "ukphone": "",
+    "trans": [
+      "ad.在…旁边,与…同时"
+    ]
+  },
+  {
+    "name": "aloud",
+    "usphone": "əˈlaʊd",
+    "ukphone": "",
+    "trans": [
+      "ad. 大声地"
+    ]
+  },
+  {
+    "name": "alphabet",
+    "usphone": "ˈælfəbet",
+    "ukphone": "",
+    "trans": [
+      "n. 字母表，字母"
+    ]
+  },
+  {
+    "name": "already",
+    "usphone": "ɔːlˈredɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 已经"
+    ]
+  },
+  {
+    "name": "also",
+    "usphone": "ˈɔːlsəʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. 也"
+    ]
+  },
+  {
+    "name": "alternative",
+    "usphone": "ɔːlˈtɜːnətɪv",
+    "ukphone": "",
+    "trans": [
+      "a.可供替代,非传统的"
+    ]
+  },
+  {
+    "name": "although",
+    "usphone": "ɔːlˈðəʊ",
+    "ukphone": "",
+    "trans": [
+      "conj. 虽然，尽管"
+    ]
+  },
+  {
+    "name": "altitude",
+    "usphone": "ˈæltɪtjuːd; (US) ælˈtɪtuːd",
+    "ukphone": "",
+    "trans": [
+      "n. 海拔高度"
+    ]
+  },
+  {
+    "name": "altogether",
+    "usphone": "ɔːltəˈɡeðə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 总共"
+    ]
+  },
+  {
+    "name": "aluminium",
+    "usphone": "æljʊˈmɪnɪəm",
+    "ukphone": "",
+    "trans": [
+      "n. （化）铝"
+    ]
+  },
+  {
+    "name": "always",
+    "usphone": "ˈɔːlweɪz",
+    "ukphone": "",
+    "trans": [
+      "ad. 总是；一直；永远"
+    ]
+  },
+  {
+    "name": "am",
+    "usphone": "æm",
+    "ukphone": "",
+    "trans": [
+      "v. be的人称形式之一 "
+    ]
+  },
+  {
+    "name": "ａ.m./A.M.",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 午前，上午"
+    ]
+  },
+  {
+    "name": "amateur",
+    "usphone": "ˈæmətə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 业余爱好的"
+    ]
+  },
+  {
+    "name": "amaze",
+    "usphone": "əˈmeɪz",
+    "ukphone": "",
+    "trans": [
+      "v. 惊奇，惊叹；震惊"
+    ]
+  },
+  {
+    "name": "amazing",
+    "usphone": "əˈmeɪzɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a.惊奇,惊叹的;震惊的"
+    ]
+  },
+  {
+    "name": "ambassador (ambassadress)",
+    "usphone": "æmˈbæsədə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.大使"
+    ]
+  },
+  {
+    "name": "ambiguous",
+    "usphone": "æmˈbɪɡjʊəs",
+    "ukphone": "",
+    "trans": [
+      "a. 模棱两可的"
+    ]
+  },
+  {
+    "name": "ambition",
+    "usphone": "æmˈbɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.目标,野心,雄心,抱负"
+    ]
+  },
+  {
+    "name": "ambulance",
+    "usphone": "ˈæmbjʊləns",
+    "ukphone": "",
+    "trans": [
+      "n. 救护车"
+    ]
+  },
+  {
+    "name": "America",
+    "usphone": "əˈmerɪkə",
+    "ukphone": "",
+    "trans": [
+      "* n. 美国；美洲"
+    ]
+  },
+  {
+    "name": "American",
+    "usphone": "əˈmerɪkən",
+    "ukphone": "",
+    "trans": [
+      "a. 美国的；美国人的n. 美国人"
+    ]
+  },
+  {
+    "name": "among",
+    "usphone": "əˈmʌŋ",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…中间；在（三个以上）之间"
+    ]
+  },
+  {
+    "name": "amount",
+    "usphone": "əˈmaʊnt",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 金额，数量，总计"
+    ]
+  },
+  {
+    "name": "ample",
+    "usphone": "ˈæmp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 足够的，丰裕的"
+    ]
+  },
+  {
+    "name": "amuse",
+    "usphone": "əˈmjuːz",
+    "ukphone": "",
+    "trans": [
+      "vt. （使人）快乐，逗乐"
+    ]
+  },
+  {
+    "name": "amusement",
+    "usphone": "əˈmjuːzmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 娱乐"
+    ]
+  },
+  {
+    "name": "analyze",
+    "usphone": "`ænl,aɪz",
+    "ukphone": "",
+    "trans": [
+      "v. 分析"
+    ]
+  },
+  {
+    "name": "analysis",
+    "usphone": "əˈnæləsɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 分析，分析结果"
+    ]
+  },
+  {
+    "name": "ancestor",
+    "usphone": "ˈænsəstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 祖宗； 祖先"
+    ]
+  },
+  {
+    "name": "anchor",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "v. / n. 锚，抛锚"
+    ]
+  },
+  {
+    "name": "ancient",
+    "usphone": "ˈeɪnʃənt",
+    "ukphone": "",
+    "trans": [
+      "a. 古代的，古老的"
+    ]
+  },
+  {
+    "name": "and",
+    "usphone": "ənd, ænd",
+    "ukphone": "",
+    "trans": [
+      "conj. 和；又；而"
+    ]
+  },
+  {
+    "name": "anecdote",
+    "usphone": "ˈænɪkdəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 逸事，趣闻"
+    ]
+  },
+  {
+    "name": "anger",
+    "usphone": "ˈæŋɡə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 怒，愤怒"
+    ]
+  },
+  {
+    "name": "angle",
+    "usphone": "ˈæŋɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 角度"
+    ]
+  },
+  {
+    "name": "angry",
+    "usphone": "ˈænɡrɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 生气的，愤怒的"
+    ]
+  },
+  {
+    "name": "animal",
+    "usphone": "ˈænɪm(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 动物"
+    ]
+  },
+  {
+    "name": "ankle",
+    "usphone": "ˈæŋk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 踝，踝关节"
+    ]
+  },
+  {
+    "name": "anniversary",
+    "usphone": "ænɪˈvɜːsərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 周年纪念日"
+    ]
+  },
+  {
+    "name": "announce",
+    "usphone": "əˈnaʊns",
+    "ukphone": "",
+    "trans": [
+      "vt. 宣布，宣告"
+    ]
+  },
+  {
+    "name": "announcement",
+    "usphone": "əˈnaʊnsmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 通告，通知"
+    ]
+  },
+  {
+    "name": "annoy",
+    "usphone": "əˈnɔɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. （使）烦恼"
+    ]
+  },
+  {
+    "name": "annual",
+    "usphone": "ˈænjʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 每年的，年度的，一年一次的"
+    ]
+  },
+  {
+    "name": "another",
+    "usphone": "əˈnʌðə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 再一；另一；别的；不同的 pron. 另一个"
+    ]
+  },
+  {
+    "name": "answer",
+    "usphone": "ˈɑːnsə(r); (US) ˈænsər",
+    "ukphone": "",
+    "trans": [
+      "n.回答,答复;回信;答案 v.回答,答复;回信;（作出）答案"
+    ]
+  },
+  {
+    "name": "ant",
+    "usphone": "ænt",
+    "ukphone": "",
+    "trans": [
+      "n. 蚂蚁"
+    ]
+  },
+  {
+    "name": "Antarctic",
+    "usphone": "ænˈtɑːktɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 南极的"
+    ]
+  },
+  {
+    "name": "the Antarctic",
+    "usphone": "ænˈtɑːktɪk",
+    "ukphone": "",
+    "trans": [
+      "南极"
+    ]
+  },
+  {
+    "name": "Antarctica",
+    "usphone": "ænˈtɑ:ktikə",
+    "ukphone": "",
+    "trans": [
+      "* n. 南极洲"
+    ]
+  },
+  {
+    "name": "antique",
+    "usphone": "ænˈtiːk",
+    "ukphone": "",
+    "trans": [
+      "n. 古董"
+    ]
+  },
+  {
+    "name": "anxiety",
+    "usphone": "æŋˈzaɪətɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 担忧，焦虑"
+    ]
+  },
+  {
+    "name": "anxious",
+    "usphone": "ˈæŋkʃəs",
+    "ukphone": "",
+    "trans": [
+      "a. 忧虑的，焦急的"
+    ]
+  },
+  {
+    "name": "any",
+    "usphone": "ˈenɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. （无论）哪一个；哪些 任何的；（用于疑问句、否定句）一些；什么"
+    ]
+  },
+  {
+    "name": "anybody",
+    "usphone": "ˈenɪbɔdɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 任何人，无论谁"
+    ]
+  },
+  {
+    "name": "anyhow",
+    "usphone": "ˈenɪhaʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. 不管怎样"
+    ]
+  },
+  {
+    "name": "anyone",
+    "usphone": "ˈenɪwʌn",
+    "ukphone": "",
+    "trans": [
+      "pron. 任何人，无论谁"
+    ]
+  },
+  {
+    "name": "anything",
+    "usphone": "ˈenɪθɪŋ",
+    "ukphone": "",
+    "trans": [
+      "pron. 什么事（物）；任何事（物）"
+    ]
+  },
+  {
+    "name": "anyway",
+    "usphone": "ˈenɪweɪ",
+    "ukphone": "",
+    "trans": [
+      "y ad. 不管怎样"
+    ]
+  },
+  {
+    "name": "anywhere",
+    "usphone": "ˈenɪweə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 任何地方"
+    ]
+  },
+  {
+    "name": "apart",
+    "usphone": "əˈpɑːt",
+    "ukphone": "",
+    "trans": [
+      "ad, / a. 相隔，相距，除外"
+    ]
+  },
+  {
+    "name": "apartment",
+    "usphone": "əˈpɑːtmənt",
+    "ukphone": "",
+    "trans": [
+      "n. （美）楼中单元房，一套房间；房间"
+    ]
+  },
+  {
+    "name": "apologize",
+    "usphone": "əˈpɔlədʒaɪz",
+    "ukphone": "",
+    "trans": [
+      "vi. 道歉，谢罪"
+    ]
+  },
+  {
+    "name": "apology",
+    "usphone": "əˈpɔlədʒɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 道歉；歉意"
+    ]
+  },
+  {
+    "name": "apparent",
+    "usphone": "əˈpærənt",
+    "ukphone": "",
+    "trans": [
+      "a. 显而易见"
+    ]
+  },
+  {
+    "name": "appeal",
+    "usphone": "əˈpiːl",
+    "ukphone": "",
+    "trans": [
+      "v. 上诉，申诉，吸引力"
+    ]
+  },
+  {
+    "name": "appear",
+    "usphone": "əˈpɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 出现"
+    ]
+  },
+  {
+    "name": "appearance",
+    "usphone": "əˈpɪərəns",
+    "ukphone": "",
+    "trans": [
+      "n. 出现，露面；容貌"
+    ]
+  },
+  {
+    "name": "appendix",
+    "usphone": "əˈpendɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 附录，阑尾"
+    ]
+  },
+  {
+    "name": "appetite",
+    "usphone": "ˈæpɪtaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 食欲，胃口"
+    ]
+  },
+  {
+    "name": "applaud",
+    "usphone": "əˈplɔːd",
+    "ukphone": "",
+    "trans": [
+      "v. / n. 鼓掌,赞许,赞赏"
+    ]
+  },
+  {
+    "name": "apple",
+    "usphone": "ˈæp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 苹果"
+    ]
+  },
+  {
+    "name": "applicant",
+    "usphone": "ˈæplɪkənt",
+    "ukphone": "",
+    "trans": [
+      "n. 申请人"
+    ]
+  },
+  {
+    "name": "application",
+    "usphone": "æplɪˈkeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 申请"
+    ]
+  },
+  {
+    "name": "apply",
+    "usphone": "əˈplaɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 申请"
+    ]
+  },
+  {
+    "name": "appoint",
+    "usphone": "əˈpɔɪnt",
+    "ukphone": "",
+    "trans": [
+      "v. 任命，委任，安排，确定（时间，地点）"
+    ]
+  },
+  {
+    "name": "appointment",
+    "usphone": "əˈpɔɪntmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 约会"
+    ]
+  },
+  {
+    "name": "appreciate",
+    "usphone": "əˈpriːʃɪeɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 欣赏； 感激"
+    ]
+  },
+  {
+    "name": "appreciation",
+    "usphone": "əpriːʃɪˈeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 欣赏,鉴定,评估"
+    ]
+  },
+  {
+    "name": "approach",
+    "usphone": "əˈprəʊtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 靠近，接近，建议，要求"
+    ]
+  },
+  {
+    "name": "appropriate",
+    "usphone": "əˈprəʊprɪət",
+    "ukphone": "",
+    "trans": [
+      "a. 合适的，恰当的"
+    ]
+  },
+  {
+    "name": "approve",
+    "usphone": "əˈpruːv",
+    "ukphone": "",
+    "trans": [
+      "v.赞成,同意,批准,通过"
+    ]
+  },
+  {
+    "name": "approximately",
+    "usphone": "əprɔksɪˈmətlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad.近似，大约"
+    ]
+  },
+  {
+    "name": "apron",
+    "usphone": "ˈeɪprən",
+    "ukphone": "",
+    "trans": [
+      "n. （机场的）停机坪"
+    ]
+  },
+  {
+    "name": "arbitrary",
+    "usphone": "ˈɑːbɪtrərɪ; (US) ˈɑːrbɪtrerɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 随心所欲的，独裁的，专断的"
+    ]
+  },
+  {
+    "name": "arch",
+    "usphone": "ɑːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 拱，拱门"
+    ]
+  },
+  {
+    "name": "architect",
+    "usphone": "ˈɑːkɪtekt",
+    "ukphone": "",
+    "trans": [
+      "n. 建筑师，设计师"
+    ]
+  },
+  {
+    "name": "architecture",
+    "usphone": "ˈɑːkɪtektʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.建筑学，建筑设计，风格"
+    ]
+  },
+  {
+    "name": "April",
+    "usphone": "ˈeɪpr(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 4月"
+    ]
+  },
+  {
+    "name": "Arab",
+    "usphone": "ˈærəb",
+    "ukphone": "",
+    "trans": [
+      "* a. 阿拉伯的 n. 阿拉伯人"
+    ]
+  },
+  {
+    "name": "Arabic",
+    "usphone": "ˈærəbɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 阿拉伯语的 n. 阿拉伯语"
+    ]
+  },
+  {
+    "name": "Arctic",
+    "usphone": "ˈɑːktɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 北极的"
+    ]
+  },
+  {
+    "name": "the Arctic",
+    "usphone": "ˈɑːktɪk",
+    "ukphone": "",
+    "trans": [
+      "北极"
+    ]
+  },
+  {
+    "name": "the Arctic Ocean",
+    "usphone": "ˈɑːktɪk ˈəʊʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "北冰洋"
+    ]
+  },
+  {
+    "name": "are",
+    "usphone": "ɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "v.(be) 是"
+    ]
+  },
+  {
+    "name": "area",
+    "usphone": "ˈeərɪə",
+    "ukphone": "",
+    "trans": [
+      "n. 面积；地域，地方，区域；范围，领域"
+    ]
+  },
+  {
+    "name": "argue",
+    "usphone": "ˈɑːɡjuː",
+    "ukphone": "",
+    "trans": [
+      "vi. 争辩， 争论"
+    ]
+  },
+  {
+    "name": "argument",
+    "usphone": "ˈɑːɡjʊmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 争论，辩论"
+    ]
+  },
+  {
+    "name": "arise (arose, arisen)",
+    "usphone": "əˈraɪz",
+    "ukphone": "",
+    "trans": [
+      "vi. 起来，升起；出现"
+    ]
+  },
+  {
+    "name": "arithmetic",
+    "usphone": "əˈrɪθmətɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 算术"
+    ]
+  },
+  {
+    "name": "arm",
+    "usphone": "ɑːm",
+    "ukphone": "",
+    "trans": [
+      "n. 臂,支架 v. 以…装备,武装起来n. （美）武器,武力"
+    ]
+  },
+  {
+    "name": "armchair",
+    "usphone": "ɑːmˈtʃeə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 扶手椅"
+    ]
+  },
+  {
+    "name": "army",
+    "usphone": "ˈɑːmɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 军队"
+    ]
+  },
+  {
+    "name": "around",
+    "usphone": "əˈraʊnd",
+    "ukphone": "",
+    "trans": [
+      "ad. 在周围；在附近prep. 在……周围；大约"
+    ]
+  },
+  {
+    "name": "arrange",
+    "usphone": "əˈreɪndʒ",
+    "ukphone": "",
+    "trans": [
+      "v. 安排，布置"
+    ]
+  },
+  {
+    "name": "arrangement",
+    "usphone": "əˈreɪndʒmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 安排，布置"
+    ]
+  },
+  {
+    "name": "arrest",
+    "usphone": "əˈrest",
+    "ukphone": "",
+    "trans": [
+      "v. 逮捕，拘留"
+    ]
+  },
+  {
+    "name": "arrival",
+    "usphone": "əˈraɪv(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 到来，到达"
+    ]
+  },
+  {
+    "name": "arrive",
+    "usphone": "əˈraɪv",
+    "ukphone": "",
+    "trans": [
+      "vi. 到达；达到"
+    ]
+  },
+  {
+    "name": "arrow",
+    "usphone": "ˈærəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 箭；箭头"
+    ]
+  },
+  {
+    "name": "art",
+    "usphone": "ɑːt",
+    "ukphone": "",
+    "trans": [
+      "n. 艺术，美术；技艺"
+    ]
+  },
+  {
+    "name": "article",
+    "usphone": "ˈɑːtɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.文章;东西,物品;冠词"
+    ]
+  },
+  {
+    "name": "artificial",
+    "usphone": "ɑːtɪˈfɪʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 人工的，人造的"
+    ]
+  },
+  {
+    "name": "artist",
+    "usphone": "ˈɑːtɪst",
+    "ukphone": "",
+    "trans": [
+      "n.艺术家"
+    ]
+  },
+  {
+    "name": "as",
+    "usphone": "əz, æz",
+    "ukphone": "",
+    "trans": [
+      "ad.& conj.像……一样；如同；因为 prep. 作为，当做"
+    ]
+  },
+  {
+    "name": "ash",
+    "usphone": "æʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 灰； 灰末"
+    ]
+  },
+  {
+    "name": "ashamed",
+    "usphone": "əˈʃeɪmd",
+    "ukphone": "",
+    "trans": [
+      "a. 惭愧； 害臊"
+    ]
+  },
+  {
+    "name": "Asia",
+    "usphone": "ˈeɪʃə",
+    "ukphone": "",
+    "trans": [
+      "* n. 亚洲"
+    ]
+  },
+  {
+    "name": "Asian",
+    "usphone": "ˈeɪʃ(ə)n, ˈeɪʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 亚洲（人）的n. 亚洲人"
+    ]
+  },
+  {
+    "name": "aside",
+    "usphone": "əˈsaɪd",
+    "ukphone": "",
+    "trans": [
+      "ad. 在旁边"
+    ]
+  },
+  {
+    "name": "ask",
+    "usphone": "ɑːsk",
+    "ukphone": "",
+    "trans": [
+      "v. 问；请求，要求；邀请"
+    ]
+  },
+  {
+    "name": "asleep",
+    "usphone": "əˈsliːp",
+    "ukphone": "",
+    "trans": [
+      "a. 睡着的，熟睡"
+    ]
+  },
+  {
+    "name": "aspect",
+    "usphone": "ˈæspekt",
+    "ukphone": "",
+    "trans": [
+      "n. 方面，外观，外表"
+    ]
+  },
+  {
+    "name": "assess",
+    "usphone": "əˈses",
+    "ukphone": "",
+    "trans": [
+      "v.评价,评定（性质,质量）"
+    ]
+  },
+  {
+    "name": "assessment",
+    "usphone": "əˈsesmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 看法，评价"
+    ]
+  },
+  {
+    "name": "assist",
+    "usphone": "əˈsɪst",
+    "ukphone": "",
+    "trans": [
+      "v. 帮助，协助"
+    ]
+  },
+  {
+    "name": "assistance",
+    "usphone": "əˈsɪst(ə)ns",
+    "ukphone": "",
+    "trans": [
+      "n. 帮助，援助，支持"
+    ]
+  },
+  {
+    "name": "assistant",
+    "usphone": "əˈsɪst(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "n. 助手，助理"
+    ]
+  },
+  {
+    "name": "associate",
+    "usphone": "əˈsəʊʃɪeɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 联想，联系"
+    ]
+  },
+  {
+    "name": "association",
+    "usphone": "əsəʊsɪˈeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 协会，社团，联系"
+    ]
+  },
+  {
+    "name": "assume",
+    "usphone": "əˈsjuːm; (US) əˈsuːm",
+    "ukphone": "",
+    "trans": [
+      "v. 假定，假设"
+    ]
+  },
+  {
+    "name": "assumption",
+    "usphone": "əˈsʌmpʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 假定，假设"
+    ]
+  },
+  {
+    "name": "astonish",
+    "usphone": "əˈstɔnɪʃ",
+    "ukphone": "",
+    "trans": [
+      "vt. 使惊讶"
+    ]
+  },
+  {
+    "name": "astronaut",
+    "usphone": "ˈæstrənɔːt",
+    "ukphone": "",
+    "trans": [
+      "n. 宇航员"
+    ]
+  },
+  {
+    "name": "astronomer",
+    "usphone": "əˈstrɔnəmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 天文学家"
+    ]
+  },
+  {
+    "name": "astronomy",
+    "usphone": "əˈstrɔnəmɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 天文学"
+    ]
+  },
+  {
+    "name": "at",
+    "usphone": "æt",
+    "ukphone": "",
+    "trans": [
+      "prep.在（几点钟）;在（某处）"
+    ]
+  },
+  {
+    "name": "athlete",
+    "usphone": "ˈæθliːt",
+    "ukphone": "",
+    "trans": [
+      "n. 运动员"
+    ]
+  },
+  {
+    "name": "athletic",
+    "usphone": "æθˈletɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 健壮的,体育运动的"
+    ]
+  },
+  {
+    "name": "athletics",
+    "usphone": "æθˈletɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 田径"
+    ]
+  },
+  {
+    "name": "Atlantic",
+    "usphone": "ətˈlæntɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 大西洋的"
+    ]
+  },
+  {
+    "name": "the Atlantic Ocean",
+    "usphone": "ətˈlæntɪk ˈəʊʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "大西洋"
+    ]
+  },
+  {
+    "name": "atmosphere",
+    "usphone": "ˈætməsfɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 大气；气氛"
+    ]
+  },
+  {
+    "name": "atom",
+    "usphone": "ˈætəm",
+    "ukphone": "",
+    "trans": [
+      "n. 原子，微粒"
+    ]
+  },
+  {
+    "name": "attach",
+    "usphone": "əˈtætʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 把…固定，重视"
+    ]
+  },
+  {
+    "name": "attack",
+    "usphone": "əˈtæk",
+    "ukphone": "",
+    "trans": [
+      "vt. / n. 攻击，袭击"
+    ]
+  },
+  {
+    "name": "attain",
+    "usphone": "əˈteɪn",
+    "ukphone": "",
+    "trans": [
+      "v.（经过努力）获得,得到"
+    ]
+  },
+  {
+    "name": "attempt",
+    "usphone": "əˈtempt",
+    "ukphone": "",
+    "trans": [
+      "vt. 试图，尝试"
+    ]
+  },
+  {
+    "name": "attend",
+    "usphone": "əˈtend",
+    "ukphone": "",
+    "trans": [
+      "v. 看护，照料，服侍；出席，参加"
+    ]
+  },
+  {
+    "name": "attention",
+    "usphone": "əˈtenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 注意，关心"
+    ]
+  },
+  {
+    "name": "attentively",
+    "usphone": "əˈtentivli",
+    "ukphone": "",
+    "trans": [
+      "ad. 注意地"
+    ]
+  },
+  {
+    "name": "attitude",
+    "usphone": "ˈætɪtjuːd; (US) ˈætɪtud",
+    "ukphone": "",
+    "trans": [
+      "n. 态度，看法"
+    ]
+  },
+  {
+    "name": "attract",
+    "usphone": "əˈtrækt",
+    "ukphone": "",
+    "trans": [
+      "v. 吸引，引起"
+    ]
+  },
+  {
+    "name": "attraction",
+    "usphone": "əˈtrækʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 吸引，爱慕"
+    ]
+  },
+  {
+    "name": "attractive",
+    "usphone": "əˈtræktɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 迷人的，有吸引力的"
+    ]
+  },
+  {
+    "name": "audience",
+    "usphone": "ˈɔːdɪəns",
+    "ukphone": "",
+    "trans": [
+      "n. 观众，听众"
+    ]
+  },
+  {
+    "name": "authentic",
+    "usphone": "ɜːˈθentɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 真正的，真品的"
+    ]
+  },
+  {
+    "name": "author",
+    "usphone": "ˈɔːθə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 作者，作家"
+    ]
+  },
+  {
+    "name": "authority",
+    "usphone": "ɔːˈθɔrɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n.权力,权威,威信,官方"
+    ]
+  },
+  {
+    "name": "automatic",
+    "usphone": "ɔːtəˈmætɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 自动的，机械的"
+    ]
+  },
+  {
+    "name": "autonomous",
+    "usphone": "ɔːˈtɔnəməs",
+    "ukphone": "",
+    "trans": [
+      "a. 自治的，自主的"
+    ]
+  },
+  {
+    "name": "August",
+    "usphone": "ˈɔːɡəst",
+    "ukphone": "",
+    "trans": [
+      "n. 8月"
+    ]
+  },
+  {
+    "name": "aunt",
+    "usphone": "ɑːnt; (US) ænt",
+    "ukphone": "",
+    "trans": [
+      "n. 伯母；舅母；婶；姑；姨"
+    ]
+  },
+  {
+    "name": "Australia",
+    "usphone": "ɔˈstreɪljə",
+    "ukphone": "",
+    "trans": [
+      "* n. 澳洲；澳大利亚"
+    ]
+  },
+  {
+    "name": "Australian",
+    "usphone": "ɔˈstreɪlɪən",
+    "ukphone": "",
+    "trans": [
+      "a. 澳洲的，澳大利亚人的 n. 澳大利亚人"
+    ]
+  },
+  {
+    "name": "autumn",
+    "usphone": "ˈɔːtəm",
+    "ukphone": "",
+    "trans": [
+      "n. 秋天，秋季"
+    ]
+  },
+  {
+    "name": "available",
+    "usphone": "ˈɔːtəm",
+    "ukphone": "",
+    "trans": [
+      "a. 可获得的，有空的"
+    ]
+  },
+  {
+    "name": "avenue",
+    "usphone": "ˈævənjuːˈævənuː",
+    "ukphone": "",
+    "trans": [
+      "n. 大道"
+    ]
+  },
+  {
+    "name": "average",
+    "usphone": "ˈævərɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "a.平均；普通的 n.平均数"
+    ]
+  },
+  {
+    "name": "avoid",
+    "usphone": "əˈvɔɪd",
+    "ukphone": "",
+    "trans": [
+      "v. 避免，躲开，逃避"
+    ]
+  },
+  {
+    "name": "awake (awoke, awoken)",
+    "usphone": "əˈweɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 唤醒 a. 醒着的"
+    ]
+  },
+  {
+    "name": "award",
+    "usphone": "wɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 奖品，奖励"
+    ]
+  },
+  {
+    "name": "aware",
+    "usphone": "əˈweə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 知道，意识到，发觉"
+    ]
+  },
+  {
+    "name": "away",
+    "usphone": "əˈweɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 离开；远离"
+    ]
+  },
+  {
+    "name": "awesome",
+    "usphone": "ˈɔːsəm",
+    "ukphone": "",
+    "trans": [
+      "a.令人惊叹,很困难的"
+    ]
+  },
+  {
+    "name": "awful",
+    "usphone": "ˈɔːfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 很坏的，极讨厌的"
+    ]
+  },
+  {
+    "name": "awkward",
+    "usphone": "ˈɔːkwəd",
+    "ukphone": "",
+    "trans": [
+      "a.令人尴尬,使人难堪的"
+    ]
+  },
+  {
+    "name": "Baby",
+    "usphone": "ˈbeɪbɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 婴儿"
+    ]
+  },
+  {
+    "name": "bachelor",
+    "usphone": "ˈbætʃələ(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 未婚男子，单身汉"
+    ]
+  },
+  {
+    "name": "back",
+    "usphone": "bæk",
+    "ukphone": "",
+    "trans": [
+      "ad. 回（原处）；向后 a. 后面的 n. 背后，后部；背"
+    ]
+  },
+  {
+    "name": "backache",
+    "usphone": "ˈbækeɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 背痛"
+    ]
+  },
+  {
+    "name": "background",
+    "usphone": "ˈbækɡraʊnd",
+    "ukphone": "",
+    "trans": [
+      "n. 背景"
+    ]
+  },
+  {
+    "name": "backward(s)",
+    "usphone": "ˈbækwəd",
+    "ukphone": "",
+    "trans": [
+      "ad. 向后"
+    ]
+  },
+  {
+    "name": "bacon",
+    "usphone": "ˈbeɪkən",
+    "ukphone": "",
+    "trans": [
+      "n. 咸猪肉；熏猪肉 "
+    ]
+  },
+  {
+    "name": "bacterium",
+    "usphone": "bækˈtɪərɪəm",
+    "ukphone": "",
+    "trans": [
+      "(复bacteria) n. 细菌"
+    ]
+  },
+  {
+    "name": "bad (worse, worst)",
+    "usphone": "bæd",
+    "ukphone": "",
+    "trans": [
+      "a. 坏的；有害的，不利的；严重的"
+    ]
+  },
+  {
+    "name": "badly",
+    "usphone": "ˈbædlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 坏，恶劣地"
+    ]
+  },
+  {
+    "name": "badminton",
+    "usphone": "ˈbædmɪntən",
+    "ukphone": "",
+    "trans": [
+      "n. 羽毛球"
+    ]
+  },
+  {
+    "name": "bag",
+    "usphone": "bæɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 书包；提包；袋子"
+    ]
+  },
+  {
+    "name": "baggage",
+    "usphone": "ˈbæɡɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 行李"
+    ]
+  },
+  {
+    "name": "bake",
+    "usphone": "beɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 烤； 烘（面包）"
+    ]
+  },
+  {
+    "name": "bakery",
+    "usphone": "ˈbeɪkərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 面包店"
+    ]
+  },
+  {
+    "name": "balance",
+    "usphone": "ˈbæləns",
+    "ukphone": "",
+    "trans": [
+      "n. 平衡"
+    ]
+  },
+  {
+    "name": "balcony",
+    "usphone": "ˈbælkənɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 阳台；楼座"
+    ]
+  },
+  {
+    "name": "ball",
+    "usphone": "bɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 球 n. 舞会"
+    ]
+  },
+  {
+    "name": "ballet",
+    "usphone": "ˈbæleɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 芭蕾舞"
+    ]
+  },
+  {
+    "name": "balloon",
+    "usphone": "bəˈluːn",
+    "ukphone": "",
+    "trans": [
+      "n. 气球"
+    ]
+  },
+  {
+    "name": "ballpoint = ballpoint pen",
+    "usphone": "`bɔl,pɔɪnt",
+    "ukphone": "",
+    "trans": [
+      "圆珠笔"
+    ]
+  },
+  {
+    "name": "bamboo",
+    "usphone": "bæmˈbuː",
+    "ukphone": "",
+    "trans": [
+      "n. 竹"
+    ]
+  },
+  {
+    "name": "ban",
+    "usphone": "bæn",
+    "ukphone": "",
+    "trans": [
+      "n. 禁令 v. 禁止；取缔"
+    ]
+  },
+  {
+    "name": "banana",
+    "usphone": "bəˈnɑːnə; (US) bəˈnænə",
+    "ukphone": "",
+    "trans": [
+      "n. 香蕉"
+    ]
+  },
+  {
+    "name": "band",
+    "usphone": "bænd",
+    "ukphone": "",
+    "trans": [
+      "n. 乐队"
+    ]
+  },
+  {
+    "name": "bandage",
+    "usphone": "ˈbændɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 绷带"
+    ]
+  },
+  {
+    "name": "bang",
+    "usphone": "bæŋ",
+    "ukphone": "",
+    "trans": [
+      "int. 砰"
+    ]
+  },
+  {
+    "name": "bank",
+    "usphone": "bæŋk",
+    "ukphone": "",
+    "trans": [
+      "n. （河海湖的）岸，堤 n. 银行"
+    ]
+  },
+  {
+    "name": "bank account",
+    "usphone": "bæŋk əˈkaʊnt",
+    "ukphone": "",
+    "trans": [
+      "n. 银行账户"
+    ]
+  },
+  {
+    "name": "bar",
+    "usphone": "bɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 条（长方）块，棒，横木 n.（酒店的）买酒柜台；酒吧；（卖东西的）柜台"
+    ]
+  },
+  {
+    "name": "barbecue",
+    "usphone": "ˈbɑːbɪkjuː",
+    "ukphone": "",
+    "trans": [
+      "n. 烤肉野餐"
+    ]
+  },
+  {
+    "name": "barber",
+    "usphone": "ˈbɑːbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （为男人理发）理发师"
+    ]
+  },
+  {
+    "name": "barbershop",
+    "usphone": "`bɑrbər,ʃɑp",
+    "ukphone": "",
+    "trans": [
+      "n. 理发店"
+    ]
+  },
+  {
+    "name": "bare",
+    "usphone": "beə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 裸露的，光秃秃的"
+    ]
+  },
+  {
+    "name": "bargain",
+    "usphone": "ˈbɑːɡɪn",
+    "ukphone": "",
+    "trans": [
+      "n. （经讨价还价后）成交的商品；廉价货 v. 讨价还价"
+    ]
+  },
+  {
+    "name": "bark",
+    "usphone": "bɑːk",
+    "ukphone": "",
+    "trans": [
+      "v. 狗叫 n. 狗叫声"
+    ]
+  },
+  {
+    "name": "barrier",
+    "usphone": "ˈbærɪə",
+    "ukphone": "",
+    "trans": [
+      "n. 屏障，障碍，关卡"
+    ]
+  },
+  {
+    "name": "base",
+    "usphone": "beɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 根据地，基地（棒球）垒"
+    ]
+  },
+  {
+    "name": "baseball",
+    "usphone": "ˈbeɪsbɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 棒球"
+    ]
+  },
+  {
+    "name": "basement",
+    "usphone": "ˈbeɪsmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 地下室"
+    ]
+  },
+  {
+    "name": "basic",
+    "usphone": "ˈbeɪsɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 基本的"
+    ]
+  },
+  {
+    "name": "basin",
+    "usphone": "ˈbeɪs(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 水盆，脸盆"
+    ]
+  },
+  {
+    "name": "basis",
+    "usphone": "ˈbeɪsɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 原因，缘由，要素"
+    ]
+  },
+  {
+    "name": "basket",
+    "usphone": "ˈbɑːskɪt; (US) ˈbæskɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 篮子"
+    ]
+  },
+  {
+    "name": "basketball",
+    "usphone": "ˈbɑːskɪtbɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 篮球"
+    ]
+  },
+  {
+    "name": "bat",
+    "usphone": "bæt",
+    "ukphone": "",
+    "trans": [
+      "n. （棒球、板球的）球棒 n. 蝙蝠"
+    ]
+  },
+  {
+    "name": "bath",
+    "usphone": "bɑːθ; (US) bæθ",
+    "ukphone": "",
+    "trans": [
+      "n. 洗澡；浴室；澡盆"
+    ]
+  },
+  {
+    "name": "bathe",
+    "usphone": "beɪð",
+    "ukphone": "",
+    "trans": [
+      "vi. 洗澡；游泳"
+    ]
+  },
+  {
+    "name": "bathrobe",
+    "usphone": "ˈbɑːθrəʊb",
+    "ukphone": "",
+    "trans": [
+      "n. 浴衣"
+    ]
+  },
+  {
+    "name": "bathroom",
+    "usphone": "ˈbɑːθruːm",
+    "ukphone": "",
+    "trans": [
+      "n. 浴室，盥洗室"
+    ]
+  },
+  {
+    "name": "bathtub",
+    "usphone": "ˈbɑ:θtʌb",
+    "ukphone": "",
+    "trans": [
+      "n. 澡盆"
+    ]
+  },
+  {
+    "name": "battery",
+    "usphone": "ˈbætərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 电池"
+    ]
+  },
+  {
+    "name": "battle",
+    "usphone": "ˈbæt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 战斗；战役"
+    ]
+  },
+  {
+    "name": "battleground",
+    "usphone": "ˈbæt(ə)lɡraʊnd",
+    "ukphone": "",
+    "trans": [
+      "n. 战场"
+    ]
+  },
+  {
+    "name": "bay",
+    "usphone": "beɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 湾； 海湾"
+    ]
+  },
+  {
+    "name": "BC",
+    "usphone": "ˌbiːˈsiː",
+    "ukphone": "",
+    "trans": [
+      "n. 公元前"
+    ]
+  },
+  {
+    "name": "be",
+    "usphone": "biː",
+    "ukphone": "",
+    "trans": [
+      "v. 是（原形）,其人称和时态形式有(am, is, are, was, were, being, been)；成为"
+    ]
+  },
+  {
+    "name": "beach",
+    "usphone": "biːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 海滨，海滩"
+    ]
+  },
+  {
+    "name": "beam",
+    "usphone": "biːm",
+    "ukphone": "",
+    "trans": [
+      "n. 平衡木"
+    ]
+  },
+  {
+    "name": "bean",
+    "usphone": "biːn",
+    "ukphone": "",
+    "trans": [
+      "n. 豆，豆科植物"
+    ]
+  },
+  {
+    "name": "beancurd",
+    "usphone": "ˈbi:nkə:d",
+    "ukphone": "",
+    "trans": [
+      "n. 豆腐"
+    ]
+  },
+  {
+    "name": "bear",
+    "usphone": "beə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 承受，负担，承担；忍受；容忍 n. 熊"
+    ]
+  },
+  {
+    "name": "beard",
+    "usphone": "bɪəd",
+    "ukphone": "",
+    "trans": [
+      "n. （下巴上的）胡须"
+    ]
+  },
+  {
+    "name": "beast",
+    "usphone": "biːst",
+    "ukphone": "",
+    "trans": [
+      "n. 野兽；牲畜"
+    ]
+  },
+  {
+    "name": "beat (beat, beaten)",
+    "usphone": "biːt",
+    "ukphone": "",
+    "trans": [
+      "v. 敲打；跳动；打赢 n. （音乐）节拍"
+    ]
+  },
+  {
+    "name": "beautiful",
+    "usphone": "ˈbjuːtɪf(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 美，美丽，美观的"
+    ]
+  },
+  {
+    "name": "beauty",
+    "usphone": "ˈbjuːtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 美丽，美人"
+    ]
+  },
+  {
+    "name": "because",
+    "usphone": "bɪˈkɔz; (US) bɪˈkɔːz",
+    "ukphone": "",
+    "trans": [
+      "conj. 因为"
+    ]
+  },
+  {
+    "name": "become (became, be come)",
+    "usphone": "bɪˈkʌm",
+    "ukphone": "",
+    "trans": [
+      "v. 变得；成为"
+    ]
+  },
+  {
+    "name": "bed",
+    "usphone": "bed",
+    "ukphone": "",
+    "trans": [
+      "n. 床"
+    ]
+  },
+  {
+    "name": "bedclothes",
+    "usphone": "ˈbedkləʊðz",
+    "ukphone": "",
+    "trans": [
+      "n. 铺盖（被褥等）"
+    ]
+  },
+  {
+    "name": "beddings",
+    "usphone": "ˈbedɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 卧具，铺盖"
+    ]
+  },
+  {
+    "name": "bedroom",
+    "usphone": "ˈbedruːm",
+    "ukphone": "",
+    "trans": [
+      "n. 寝室，卧室"
+    ]
+  },
+  {
+    "name": "bee",
+    "usphone": "biː",
+    "ukphone": "",
+    "trans": [
+      "n.. 蜜蜂"
+    ]
+  },
+  {
+    "name": "beef",
+    "usphone": "biːf",
+    "ukphone": "",
+    "trans": [
+      "n. 牛肉"
+    ]
+  },
+  {
+    "name": "beehive",
+    "usphone": "ˈbiːhaɪv",
+    "ukphone": "",
+    "trans": [
+      "n. 蜂箱"
+    ]
+  },
+  {
+    "name": "beer",
+    "usphone": "bɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 啤酒"
+    ]
+  },
+  {
+    "name": "before",
+    "usphone": "bɪˈfɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…以前；在…前面 ad. 以前 conj. 在…之前"
+    ]
+  },
+  {
+    "name": "beg",
+    "usphone": "beɡ",
+    "ukphone": "",
+    "trans": [
+      "v. 请求，乞求，乞讨 "
+    ]
+  },
+  {
+    "name": "begin(began,begun)",
+    "usphone": "bɪˈɡɪn",
+    "ukphone": "",
+    "trans": [
+      " v.开始,着手"
+    ]
+  },
+  {
+    "name": "beginning",
+    "usphone": "bɪˈɡɪnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 开始，开端"
+    ]
+  },
+  {
+    "name": "behalf",
+    "usphone": "bɪˈhɑːf",
+    "ukphone": "",
+    "trans": [
+      "n. 代表某人，为了某人"
+    ]
+  },
+  {
+    "name": "behave",
+    "usphone": "bɪˈheɪv",
+    "ukphone": "",
+    "trans": [
+      "v. 守规矩，行为"
+    ]
+  },
+  {
+    "name": "behaviour",
+    "usphone": "bɪ`heɪvjər",
+    "ukphone": "",
+    "trans": [
+      "n. 行为，举止"
+    ]
+  },
+  {
+    "name": "behind",
+    "usphone": "bɪˈhaɪnd",
+    "ukphone": "",
+    "trans": [
+      "prep. (表示位置)在…后面 ad. 在后面；向后"
+    ]
+  },
+  {
+    "name": "being",
+    "usphone": "ˈbiːɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 物；生物；人"
+    ]
+  },
+  {
+    "name": "Belgium",
+    "usphone": "ˈbeldʒəm",
+    "ukphone": "",
+    "trans": [
+      "* n. 比利时"
+    ]
+  },
+  {
+    "name": "belief",
+    "usphone": "bɪˈliːf",
+    "ukphone": "",
+    "trans": [
+      "n. 信条，信念"
+    ]
+  },
+  {
+    "name": "believe",
+    "usphone": "bɪˈliːv",
+    "ukphone": "",
+    "trans": [
+      "v. 相信，认为"
+    ]
+  },
+  {
+    "name": "bell",
+    "usphone": "bel",
+    "ukphone": "",
+    "trans": [
+      "n. 钟,铃;钟(铃)声;钟形物"
+    ]
+  },
+  {
+    "name": "belly",
+    "usphone": "ˈbelɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 肚子"
+    ]
+  },
+  {
+    "name": "belong",
+    "usphone": "bɪˈlɔŋ",
+    "ukphone": "",
+    "trans": [
+      "vi. 属，附属"
+    ]
+  },
+  {
+    "name": "below",
+    "usphone": "bɪˈləʊ",
+    "ukphone": "",
+    "trans": [
+      "prep. 在……下面"
+    ]
+  },
+  {
+    "name": "belt",
+    "usphone": "belt",
+    "ukphone": "",
+    "trans": [
+      "n. （皮）带"
+    ]
+  },
+  {
+    "name": "bench",
+    "usphone": "bentʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 长凳；工作台"
+    ]
+  },
+  {
+    "name": "bend (bent, bent)",
+    "usphone": "bend",
+    "ukphone": "",
+    "trans": [
+      "vt. 使弯曲"
+    ]
+  },
+  {
+    "name": "beneath",
+    "usphone": "bɪˈniːθ",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…下方（面）"
+    ]
+  },
+  {
+    "name": "beneficial",
+    "usphone": "benɪˈfɪʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 有利的，有帮助的，有用的"
+    ]
+  },
+  {
+    "name": "benefit",
+    "usphone": "ˈbenɪfɪt",
+    "ukphone": "",
+    "trans": [
+      "n. / v.优势,益处,使…受益"
+    ]
+  },
+  {
+    "name": "bent",
+    "usphone": "bent",
+    "ukphone": "",
+    "trans": [
+      "a. 弯的"
+    ]
+  },
+  {
+    "name": "beside",
+    "usphone": "bɪˈsaɪd",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…旁边；靠近"
+    ]
+  },
+  {
+    "name": "besides",
+    "usphone": "bɪˈsaɪdz",
+    "ukphone": "",
+    "trans": [
+      "prep. 除…以外（还有） ad. 还有，此外"
+    ]
+  },
+  {
+    "name": "best（good, well 的最 高级）",
+    "usphone": "best",
+    "ukphone": "",
+    "trans": [
+      "a. & ad.最好的；最好地，最 n. 最好的（人或物）"
+    ]
+  },
+  {
+    "name": "best--seller",
+    "usphone": "best- ˈselə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 畅销书"
+    ]
+  },
+  {
+    "name": "better (good, well 的 比较级)",
+    "usphone": "ˈbetə(r)",
+    "ukphone": "",
+    "trans": [
+      "a.& ad. 较好的，更好的；好些； 更好地；更，更多n. 较好的事物；较优者 v. 改善；胜过"
+    ]
+  },
+  {
+    "name": "betray",
+    "usphone": "bɪˈtreɪ",
+    "ukphone": "",
+    "trans": [
+      "v.出卖,泄露（机密）,辜负"
+    ]
+  },
+  {
+    "name": "between",
+    "usphone": "bɪˈtwiːn",
+    "ukphone": "",
+    "trans": [
+      "prep. 在（两者）之间；在…中间"
+    ]
+  },
+  {
+    "name": "beyond",
+    "usphone": "bɪˈjɔnd",
+    "ukphone": "",
+    "trans": [
+      "prep. (表示位置) 在…的那边"
+    ]
+  },
+  {
+    "name": "bicycle",
+    "usphone": "ˈbaɪsɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 自行车"
+    ]
+  },
+  {
+    "name": "bid",
+    "usphone": "bɪd",
+    "ukphone": "",
+    "trans": [
+      "v./ n. 出价，投标，向（某人）道别"
+    ]
+  },
+  {
+    "name": "big",
+    "usphone": "bɪɡ",
+    "ukphone": "",
+    "trans": [
+      "a. 大的"
+    ]
+  },
+  {
+    "name": "bike = bicycle",
+    "usphone": "baɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 自行车"
+    ]
+  },
+  {
+    "name": "bill",
+    "usphone": "bɪl",
+    "ukphone": "",
+    "trans": [
+      "n.账单；法案，议案； （美）钞票，纸币"
+    ]
+  },
+  {
+    "name": "billion",
+    "usphone": "ˈbɪlɪən",
+    "ukphone": "",
+    "trans": [
+      "num. 十亿，百亿"
+    ]
+  },
+  {
+    "name": "bingo",
+    "usphone": "ˈbɪŋɡəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 宾戈游戏"
+    ]
+  },
+  {
+    "name": "biochemistry",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 生物化学"
+    ]
+  },
+  {
+    "name": "biography",
+    "usphone": "baɪˈɔɡrəfɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 传记"
+    ]
+  },
+  {
+    "name": "biology",
+    "usphone": "baɪˈɔlədʒɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 生物（学）"
+    ]
+  },
+  {
+    "name": "bird",
+    "usphone": "bɜːd",
+    "ukphone": "",
+    "trans": [
+      "n. 鸟"
+    ]
+  },
+  {
+    "name": "birdcage",
+    "usphone": "ˈbɜːdkeɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 鸟笼"
+    ]
+  },
+  {
+    "name": "birth",
+    "usphone": "bɜːθ",
+    "ukphone": "",
+    "trans": [
+      "n. 出生； 诞生"
+    ]
+  },
+  {
+    "name": "birthday",
+    "usphone": "ˈbɜːθdeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 生日"
+    ]
+  },
+  {
+    "name": "birthplace",
+    "usphone": "ˈbɜːθpleɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 出生地；故乡"
+    ]
+  },
+  {
+    "name": "biscuit",
+    "usphone": "ˈbɪskɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 饼干"
+    ]
+  },
+  {
+    "name": "bishop",
+    "usphone": "ˈbɪʃəp",
+    "ukphone": "",
+    "trans": [
+      "n. 主教"
+    ]
+  },
+  {
+    "name": "bit",
+    "usphone": "bɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 一点，一些，少量的"
+    ]
+  },
+  {
+    "name": "bite (bit, bitten)",
+    "usphone": "baɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 咬；叮"
+    ]
+  },
+  {
+    "name": "bitter",
+    "usphone": "ˈbɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 有苦味的；痛苦的，难过的；严酷的"
+    ]
+  },
+  {
+    "name": "black",
+    "usphone": "blæk",
+    "ukphone": "",
+    "trans": [
+      "n. 黑色 a. 黑色的"
+    ]
+  },
+  {
+    "name": "blackboard",
+    "usphone": "ˈblækbɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 黑板"
+    ]
+  },
+  {
+    "name": "blame",
+    "usphone": "bleɪm",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 责备；责怪"
+    ]
+  },
+  {
+    "name": "blank",
+    "usphone": "blæŋk",
+    "ukphone": "",
+    "trans": [
+      "n.& a. 空格，空白（处）；空的；茫然无表情的"
+    ]
+  },
+  {
+    "name": "blanket",
+    "usphone": "ˈblæŋkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 毛毯，毯子"
+    ]
+  },
+  {
+    "name": "bleed",
+    "usphone": "bliːd",
+    "ukphone": "",
+    "trans": [
+      "vi. 出血，流血"
+    ]
+  },
+  {
+    "name": "bless",
+    "usphone": "bles",
+    "ukphone": "",
+    "trans": [
+      "vt. 保佑，降福"
+    ]
+  },
+  {
+    "name": "blind",
+    "usphone": "blaɪnd",
+    "ukphone": "",
+    "trans": [
+      "a. 瞎的"
+    ]
+  },
+  {
+    "name": "block",
+    "usphone": "blɔk",
+    "ukphone": "",
+    "trans": [
+      "n. 大块；（木、石等）块；街区；路障 vt. 阻塞；阻挡"
+    ]
+  },
+  {
+    "name": "blood",
+    "usphone": "blʌd",
+    "ukphone": "",
+    "trans": [
+      "n. 血，血液"
+    ]
+  },
+  {
+    "name": "blouse",
+    "usphone": "blaʊz; u.S. blaʊs",
+    "ukphone": "",
+    "trans": [
+      "n. 宽罩衫；（妇女、儿童穿的）短上衣"
+    ]
+  },
+  {
+    "name": "blow",
+    "usphone": "bləʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 击；打击"
+    ]
+  },
+  {
+    "name": "blow (blew, blown)",
+    "usphone": "bləʊ",
+    "ukphone": "",
+    "trans": [
+      "v. 吹；刮风；吹气"
+    ]
+  },
+  {
+    "name": "blue",
+    "usphone": "bluː",
+    "ukphone": "",
+    "trans": [
+      "n. 蓝色 a.蓝色的 a. 悲伤的；沮丧的"
+    ]
+  },
+  {
+    "name": "board",
+    "usphone": "bɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 木板；布告牌；委员会；（政府的）部 v. 上（船、火车、飞机）"
+    ]
+  },
+  {
+    "name": "boat",
+    "usphone": "bəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 小船，小舟"
+    ]
+  },
+  {
+    "name": "boat--race",
+    "usphone": "bəʊt-reɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 划船比赛"
+    ]
+  },
+  {
+    "name": "boating",
+    "usphone": "ˈbəʊtɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 划船（游玩），泛舟 body n. 身体"
+    ]
+  },
+  {
+    "name": "body--building",
+    "usphone": "ˈbɔdɪ-ˈbɪldɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 健美"
+    ]
+  },
+  {
+    "name": "boil",
+    "usphone": "bɔɪl",
+    "ukphone": "",
+    "trans": [
+      "v. 沸腾；烧开；煮……"
+    ]
+  },
+  {
+    "name": "bomb",
+    "usphone": "bɔm",
+    "ukphone": "",
+    "trans": [
+      "n. 炸弹 v. 轰炸"
+    ]
+  },
+  {
+    "name": "bond",
+    "usphone": "bɔnd",
+    "ukphone": "",
+    "trans": [
+      "n. /v. 纽带，联系，使牢固"
+    ]
+  },
+  {
+    "name": "bone",
+    "usphone": "bəʊn",
+    "ukphone": "",
+    "trans": [
+      "n. 骨头，骨质（复数bones骨骼；骨骸）"
+    ]
+  },
+  {
+    "name": "bonus",
+    "usphone": "ˈbəʊnəs",
+    "ukphone": "",
+    "trans": [
+      "n. 津贴，奖金，红利"
+    ]
+  },
+  {
+    "name": "book",
+    "usphone": "bʊk",
+    "ukphone": "",
+    "trans": [
+      "n. 书；本子 v. 预定，定（房间、车票等）"
+    ]
+  },
+  {
+    "name": "bookcase",
+    "usphone": "ˈbʊkkeɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 书橱"
+    ]
+  },
+  {
+    "name": "bookmark",
+    "usphone": "ˈbʊkmɑːk",
+    "ukphone": "",
+    "trans": [
+      "n. 书签"
+    ]
+  },
+  {
+    "name": "bookshelf",
+    "usphone": "`bʊk,ʃelf",
+    "ukphone": "",
+    "trans": [
+      "n. 书架"
+    ]
+  },
+  {
+    "name": "bookshop",
+    "usphone": "ˈbʊkʃɔp",
+    "ukphone": "",
+    "trans": [
+      "n. 书店"
+    ]
+  },
+  {
+    "name": "bookstore",
+    "usphone": "ˈbʊkstɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 书店"
+    ]
+  },
+  {
+    "name": "boom",
+    "usphone": "buːm",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 繁荣，轰鸣，激增"
+    ]
+  },
+  {
+    "name": "boot",
+    "usphone": "buːt",
+    "ukphone": "",
+    "trans": [
+      "n. 长统靴；靴"
+    ]
+  },
+  {
+    "name": "booth",
+    "usphone": "buːð",
+    "ukphone": "",
+    "trans": [
+      "n.岗；（为某种用途而设的）亭或小隔间"
+    ]
+  },
+  {
+    "name": "telephone booth",
+    "usphone": "ˈtelɪfəʊn- buːð",
+    "ukphone": "",
+    "trans": [
+      "电话亭"
+    ]
+  },
+  {
+    "name": "border",
+    "usphone": "ˈbɔːdə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 边缘；边境，国界"
+    ]
+  },
+  {
+    "name": "bored",
+    "usphone": "bɔrd",
+    "ukphone": "",
+    "trans": [
+      "a.（对人，事）厌倦的，烦闷的"
+    ]
+  },
+  {
+    "name": "boring",
+    "usphone": "`bɔrɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 乏味的，无聊的"
+    ]
+  },
+  {
+    "name": "born",
+    "usphone": "bɔːn",
+    "ukphone": "",
+    "trans": [
+      "a. 出生"
+    ]
+  },
+  {
+    "name": "borrow",
+    "usphone": "ˈbɔrəʊ",
+    "ukphone": "",
+    "trans": [
+      "v. （向别人）借用；借"
+    ]
+  },
+  {
+    "name": "boss",
+    "usphone": "bɔs",
+    "ukphone": "",
+    "trans": [
+      "n. 领班；老板"
+    ]
+  },
+  {
+    "name": "botanical",
+    "usphone": "bəˈtænɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 植物学的"
+    ]
+  },
+  {
+    "name": "botany",
+    "usphone": "ˈbɔtənɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 植物； 植物学"
+    ]
+  },
+  {
+    "name": "both",
+    "usphone": "bəʊθ",
+    "ukphone": "",
+    "trans": [
+      "a. 两；双 pron. 两者；双方"
+    ]
+  },
+  {
+    "name": "bottle",
+    "usphone": "ˈbɔt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 瓶子"
+    ]
+  },
+  {
+    "name": "bottom",
+    "usphone": "ˈbɔtəm",
+    "ukphone": "",
+    "trans": [
+      "n. 底部；底"
+    ]
+  },
+  {
+    "name": "bounce",
+    "usphone": "baʊns",
+    "ukphone": "",
+    "trans": [
+      "v. 弹起，蹦，上下晃动"
+    ]
+  },
+  {
+    "name": "bound",
+    "usphone": "baʊnd",
+    "ukphone": "",
+    "trans": [
+      "a. 被束缚的；被绑的；有义务的  v.& n. 跳跃"
+    ]
+  },
+  {
+    "name": "boundary",
+    "usphone": "ˈbaʊndərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 边界，界限"
+    ]
+  },
+  {
+    "name": "bow",
+    "usphone": "bəʊ",
+    "ukphone": "",
+    "trans": [
+      "v.& n. 鞠躬，弯腰行礼"
+    ]
+  },
+  {
+    "name": "bowl",
+    "usphone": "bəʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 碗"
+    ]
+  },
+  {
+    "name": "bowling",
+    "usphone": "ˈbəʊlɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 保龄球"
+    ]
+  },
+  {
+    "name": "box",
+    "usphone": "bɔks",
+    "ukphone": "",
+    "trans": [
+      "n. 盒子，箱子"
+    ]
+  },
+  {
+    "name": "boxing",
+    "usphone": "ˈbɔksɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 拳击（运动）"
+    ]
+  },
+  {
+    "name": "boy",
+    "usphone": "bɔɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 男孩"
+    ]
+  },
+  {
+    "name": "boycott",
+    "usphone": "ˈbɔɪkɔt",
+    "ukphone": "",
+    "trans": [
+      "v. 拒绝购买，抵制"
+    ]
+  },
+  {
+    "name": "brain",
+    "usphone": "breɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 脑（子）"
+    ]
+  },
+  {
+    "name": "brake",
+    "usphone": "breɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 闸 vi. 刹车"
+    ]
+  },
+  {
+    "name": "branch",
+    "usphone": "brɑːntʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 树枝；分枝；分公司，分店；支部"
+    ]
+  },
+  {
+    "name": "brand",
+    "usphone": "brænd",
+    "ukphone": "",
+    "trans": [
+      "n. 品牌"
+    ]
+  },
+  {
+    "name": "brave",
+    "usphone": "breɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 勇敢的"
+    ]
+  },
+  {
+    "name": "bravery",
+    "usphone": "ˈbreɪvərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 勇气"
+    ]
+  },
+  {
+    "name": "bread",
+    "usphone": "bred",
+    "ukphone": "",
+    "trans": [
+      "n. 面包"
+    ]
+  },
+  {
+    "name": "break",
+    "usphone": "breɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 间隙"
+    ]
+  },
+  {
+    "name": "break (broke, bro ken)",
+    "usphone": "breɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 打破（断，碎）；损坏，撕开"
+    ]
+  },
+  {
+    "name": "breakfast",
+    "usphone": "ˈbrekfəst",
+    "ukphone": "",
+    "trans": [
+      "n. 早餐"
+    ]
+  },
+  {
+    "name": "breakthrough",
+    "usphone": "ˈbreɪkθruː",
+    "ukphone": "",
+    "trans": [
+      "n. 重大进展，突破"
+    ]
+  },
+  {
+    "name": "breast",
+    "usphone": "brest",
+    "ukphone": "",
+    "trans": [
+      "n. 乳房，胸脯"
+    ]
+  },
+  {
+    "name": "breath",
+    "usphone": "breθ",
+    "ukphone": "",
+    "trans": [
+      "n. 气息；呼吸"
+    ]
+  },
+  {
+    "name": "breathe",
+    "usphone": "briːð",
+    "ukphone": "",
+    "trans": [
+      "vi. 呼吸"
+    ]
+  },
+  {
+    "name": "breathless",
+    "usphone": "ˈbreθlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 气喘吁吁的，上气不接下气的"
+    ]
+  },
+  {
+    "name": "brewery",
+    "usphone": "ˈbruːərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 啤酒厂（公司）"
+    ]
+  },
+  {
+    "name": "brick",
+    "usphone": "brɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 砖；砖块"
+    ]
+  },
+  {
+    "name": "bride",
+    "usphone": "braɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 新娘"
+    ]
+  },
+  {
+    "name": "bridegroom",
+    "usphone": "ˈbraɪdɡruːm",
+    "ukphone": "",
+    "trans": [
+      "n. 新郎"
+    ]
+  },
+  {
+    "name": "bridge",
+    "usphone": "brɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 桥"
+    ]
+  },
+  {
+    "name": "brief",
+    "usphone": "briːf",
+    "ukphone": "",
+    "trans": [
+      "a. 简洁的"
+    ]
+  },
+  {
+    "name": "bright",
+    "usphone": "braɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 明亮的；聪明的"
+    ]
+  },
+  {
+    "name": "brilliant",
+    "usphone": "ˈbrɪlɪənt",
+    "ukphone": "",
+    "trans": [
+      "a. 巧妙的，使人印象深刻的，技艺高的"
+    ]
+  },
+  {
+    "name": "bring (brought, brought)",
+    "usphone": "brɪŋ",
+    "ukphone": "",
+    "trans": [
+      "vt. 拿来，带来，取来"
+    ]
+  },
+  {
+    "name": "Britain",
+    "usphone": "ˈbrɪtən",
+    "ukphone": "",
+    "trans": [
+      "* n. 英国；不列颠"
+    ]
+  },
+  {
+    "name": "British",
+    "usphone": "ˈbrɪtɪʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 英国的；大不列颠的；英国人的"
+    ]
+  },
+  {
+    "name": "the British",
+    "usphone": "ˈbrɪtɪʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 英国国民；大不列颠人"
+    ]
+  },
+  {
+    "name": "broad",
+    "usphone": "brɔːd",
+    "ukphone": "",
+    "trans": [
+      "a. 宽的，宽大的"
+    ]
+  },
+  {
+    "name": "broadcast",
+    "usphone": "ˈbrɔːdkɑːst",
+    "ukphone": "",
+    "trans": [
+      "n. 广播节目"
+    ]
+  },
+  {
+    "name": "broadcast（broadcast, broadcast或--ed,--ed）",
+    "usphone": "ˈbrɔːdkɑːst",
+    "ukphone": "",
+    "trans": [
+      "vt. 广播"
+    ]
+  },
+  {
+    "name": "brochure",
+    "usphone": "brəʊˈʃə(r); (US) brəʊˈʃʊər",
+    "ukphone": "",
+    "trans": [
+      "n. 资料（或广告）手册"
+    ]
+  },
+  {
+    "name": "broken",
+    "usphone": "ˈbrəʊkən",
+    "ukphone": "",
+    "trans": [
+      "a. 弄坏了的"
+    ]
+  },
+  {
+    "name": "broom",
+    "usphone": "bruːm",
+    "ukphone": "",
+    "trans": [
+      "n. 扫帚"
+    ]
+  },
+  {
+    "name": "brother",
+    "usphone": "ˈbrʌðə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 兄；弟"
+    ]
+  },
+  {
+    "name": "brotherhood",
+    "usphone": "ˈbrʌðəhʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 兄弟般的关系"
+    ]
+  },
+  {
+    "name": "brown",
+    "usphone": "braʊn",
+    "ukphone": "",
+    "trans": [
+      "n. 褐色，棕色 a. 褐色的，棕色的"
+    ]
+  },
+  {
+    "name": "brunch",
+    "usphone": "ˈbrʌntʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 早午饭（晚早饭）"
+    ]
+  },
+  {
+    "name": "brush",
+    "usphone": "brʌʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 刷；擦 n. 刷子"
+    ]
+  },
+  {
+    "name": "bucket",
+    "usphone": "ˈbʌkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 铲斗；桶"
+    ]
+  },
+  {
+    "name": "Buddhism",
+    "usphone": "ˈbʊdɪz(ə)m",
+    "ukphone": "",
+    "trans": [
+      "n. 佛教"
+    ]
+  },
+  {
+    "name": "Buddhist",
+    "usphone": "ˈbudist",
+    "ukphone": "",
+    "trans": [
+      "n. 佛教徒"
+    ]
+  },
+  {
+    "name": "budget",
+    "usphone": "ˈbʌdʒɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 预算"
+    ]
+  },
+  {
+    "name": "buffet",
+    "usphone": "ˈbʊfeɪ; (US) bəˈfeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 自助餐"
+    ]
+  },
+  {
+    "name": "build (built, built)",
+    "usphone": "bɪld",
+    "ukphone": "",
+    "trans": [
+      "v. 建筑；造"
+    ]
+  },
+  {
+    "name": "building",
+    "usphone": "ˈbɪldɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 建筑物；房屋；大楼"
+    ]
+  },
+  {
+    "name": "bun",
+    "usphone": "bʌn",
+    "ukphone": "",
+    "trans": [
+      "n. 馒头；小甜面包"
+    ]
+  },
+  {
+    "name": "bunch",
+    "usphone": "bʌntʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 串,束,扎,大量,大批"
+    ]
+  },
+  {
+    "name": "bungalow",
+    "usphone": "ˈbʌŋɡələʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 平房"
+    ]
+  },
+  {
+    "name": "burden",
+    "usphone": "ˈbɜːd(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. （义务，责任的）重担，负担"
+    ]
+  },
+  {
+    "name": "bureaucratic",
+    "usphone": "bjuəˌrəuˈkrætik",
+    "ukphone": "",
+    "trans": [
+      "a. 官僚的"
+    ]
+  },
+  {
+    "name": "burglar",
+    "usphone": "ˈbɜːɡlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 入室窃贼"
+    ]
+  },
+  {
+    "name": "burial",
+    "usphone": "ˈberɪəl",
+    "ukphone": "",
+    "trans": [
+      "n. 埋葬"
+    ]
+  },
+  {
+    "name": "burn (--ed, --ed 或 burnt, burnt)",
+    "usphone": "bɜːn",
+    "ukphone": "",
+    "trans": [
+      "v. 燃，烧，着火；使烧焦；使晒黑 n. 烧伤；晒伤"
+    ]
+  },
+  {
+    "name": "burst",
+    "usphone": "ˈbɜːst",
+    "ukphone": "",
+    "trans": [
+      "v. 突然发生； 突然发作"
+    ]
+  },
+  {
+    "name": "bury",
+    "usphone": "ˈberɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 埋；葬"
+    ]
+  },
+  {
+    "name": "bus",
+    "usphone": "bʌs",
+    "ukphone": "",
+    "trans": [
+      "n. 公共汽车"
+    ]
+  },
+  {
+    "name": "bus stop",
+    "usphone": "bʌs stɔp",
+    "ukphone": "",
+    "trans": [
+      "n。公共汽车站"
+    ]
+  },
+  {
+    "name": "bush",
+    "usphone": "bʊʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 灌木丛，矮树丛"
+    ]
+  },
+  {
+    "name": "business",
+    "usphone": "ˈbɪznɪs",
+    "ukphone": "",
+    "trans": [
+      "n. （本分）工作，职业；职责；生意，交易；事业"
+    ]
+  },
+  {
+    "name": "businessman (pl. businessmen)",
+    "usphone": "ˈbɪznɪsmæn",
+    "ukphone": "",
+    "trans": [
+      "n. 商人（男）；男企业家"
+    ]
+  },
+  {
+    "name": "businesswoman (businesswomen)",
+    "usphone": "ˈbɪznɪswʊmæn",
+    "ukphone": "",
+    "trans": [
+      "n. 商人（女）；女企业家"
+    ]
+  },
+  {
+    "name": "busy",
+    "usphone": "ˈbɪzɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 忙（碌）的"
+    ]
+  },
+  {
+    "name": "but",
+    "usphone": "bət, bʌt",
+    "ukphone": "",
+    "trans": [
+      "conj. 但是，可是 prep. 除了, 除……外"
+    ]
+  },
+  {
+    "name": "butcher",
+    "usphone": "ˈbʊtʃə",
+    "ukphone": "",
+    "trans": [
+      "n. vt. 肉店；屠夫 屠宰（动物）；残杀（人）"
+    ]
+  },
+  {
+    "name": "butter",
+    "usphone": "ˈbʌtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 黄油，奶油"
+    ]
+  },
+  {
+    "name": "butterfly",
+    "usphone": "ˈbʌtəflaɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 蝴蝶"
+    ]
+  },
+  {
+    "name": "the butterfly",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "蝶泳"
+    ]
+  },
+  {
+    "name": "button",
+    "usphone": "ˈbʌt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 纽扣；（电铃等的）按钮 v. 扣（纽扣） "
+    ]
+  },
+  {
+    "name": "buy (bought,bought)",
+    "usphone": "baɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 买"
+    ]
+  },
+  {
+    "name": "by",
+    "usphone": "baɪ",
+    "ukphone": "",
+    "trans": [
+      "prep. 靠近，在…旁；在…时间；不迟于；被；用；由；乘（车）"
+    ]
+  },
+  {
+    "name": "bye",
+    "usphone": "baɪ",
+    "ukphone": "",
+    "trans": [
+      "int. 再见"
+    ]
+  },
+  {
+    "name": "cab",
+    "usphone": "kæb",
+    "ukphone": "",
+    "trans": [
+      "n. （美）出租车"
+    ]
+  },
+  {
+    "name": "cabbage",
+    "usphone": "ˈkæbɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 卷心菜，洋白菜"
+    ]
+  },
+  {
+    "name": "café",
+    "usphone": "ˈkæfeɪ; (US) kæˈfeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 咖啡馆； 餐馆"
+    ]
+  },
+  {
+    "name": "cafeteria",
+    "usphone": "kæfɪˈtɪərɪə",
+    "ukphone": "",
+    "trans": [
+      "n. 自助餐厅"
+    ]
+  },
+  {
+    "name": "cage",
+    "usphone": "keɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n 笼；鸟笼"
+    ]
+  },
+  {
+    "name": "calculate",
+    "usphone": "ˈkælkjʊleɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 计算，核算，推测"
+    ]
+  },
+  {
+    "name": "cake",
+    "usphone": "keɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 蛋糕，糕点；饼"
+    ]
+  },
+  {
+    "name": "call",
+    "usphone": "kɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 喊，叫；电话，通话 v. 称呼；呼唤；喊，叫"
+    ]
+  },
+  {
+    "name": "calm",
+    "usphone": "kɑːm; (US) kɑːlm",
+    "ukphone": "",
+    "trans": [
+      "a. 镇静,沉着的 v.镇静沉着"
+    ]
+  },
+  {
+    "name": "camel",
+    "usphone": "ˈkæm(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 骆驼"
+    ]
+  },
+  {
+    "name": "camera",
+    "usphone": "ˈkæmərə",
+    "ukphone": "",
+    "trans": [
+      "n. 照相机；摄像机"
+    ]
+  },
+  {
+    "name": "camp",
+    "usphone": "kæmp",
+    "ukphone": "",
+    "trans": [
+      "n.（夏令）营 vi.野营,宿营"
+    ]
+  },
+  {
+    "name": "campaign",
+    "usphone": "kæmˈpeɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 运动，战役"
+    ]
+  },
+  {
+    "name": "can (could) canˈt = can not modal",
+    "usphone": "ken, kæn",
+    "ukphone": "",
+    "trans": [
+      "v. 可能；能够；可以 不能 n.（美）罐头；罐子"
+    ]
+  },
+  {
+    "name": "a garbage can",
+    "usphone": "ˈɡɑːbɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "（美）垃圾桶"
+    ]
+  },
+  {
+    "name": "a can opener",
+    "usphone": "ˈəʊpənə(r)",
+    "ukphone": "",
+    "trans": [
+      "开罐器"
+    ]
+  },
+  {
+    "name": "Canada",
+    "usphone": "ˈkænədə",
+    "ukphone": "",
+    "trans": [
+      "* n. 加拿大"
+    ]
+  },
+  {
+    "name": "Canadian",
+    "usphone": "kəˈneɪdɪən",
+    "ukphone": "",
+    "trans": [
+      "a. 加拿大的；加拿大人的 n. 加拿大人"
+    ]
+  },
+  {
+    "name": "canal",
+    "usphone": "kəˈnæl",
+    "ukphone": "",
+    "trans": [
+      "n. 运河；水道"
+    ]
+  },
+  {
+    "name": "cancel",
+    "usphone": "ˈkæns(ə)l",
+    "ukphone": "",
+    "trans": [
+      "vt. 取消"
+    ]
+  },
+  {
+    "name": "cance",
+    "usphone": "ˈkænsə(r)",
+    "ukphone": "",
+    "trans": [
+      "r n. 癌"
+    ]
+  },
+  {
+    "name": "candidate",
+    "usphone": "ˈkændɪdət; (US) ˈkændɪdeɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 候选人，申请人"
+    ]
+  },
+  {
+    "name": "candle",
+    "usphone": "ˈkænd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 蜡烛"
+    ]
+  },
+  {
+    "name": "candy",
+    "usphone": "ˈkændɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 糖果"
+    ]
+  },
+  {
+    "name": "canteen",
+    "usphone": "kænˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "n. 餐厅；食堂"
+    ]
+  },
+  {
+    "name": "cap",
+    "usphone": "kæp",
+    "ukphone": "",
+    "trans": [
+      "n. （无檐的或仅在前面有檐的）帽子；（瓶子的）盖；（钢笔等的）笔套"
+    ]
+  },
+  {
+    "name": "capital",
+    "usphone": "ˈkæpɪt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.首都.省会.大写；资本"
+    ]
+  },
+  {
+    "name": "capsule",
+    "usphone": "ˈkæpsjuːl; (US) ˈkæpsl",
+    "ukphone": "",
+    "trans": [
+      "n. （药）胶囊"
+    ]
+  },
+  {
+    "name": "captain",
+    "usphone": "ˈkæptɪn",
+    "ukphone": "",
+    "trans": [
+      "n. （海军）上校；船长，舰长；队长"
+    ]
+  },
+  {
+    "name": "caption",
+    "usphone": "ˈkæpʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. （图片，漫画等的）说明文字"
+    ]
+  },
+  {
+    "name": "car",
+    "usphone": "kɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 汽车，小卧车"
+    ]
+  },
+  {
+    "name": "carbon",
+    "usphone": "ˈkɑːbən",
+    "ukphone": "",
+    "trans": [
+      "n. 碳"
+    ]
+  },
+  {
+    "name": "card",
+    "usphone": "kɑːd",
+    "ukphone": "",
+    "trans": [
+      "n.卡片；名片；纸牌"
+    ]
+  },
+  {
+    "name": "card games",
+    "usphone": "kɑːd ɡeɪm",
+    "ukphone": "",
+    "trans": [
+      "纸牌游戏"
+    ]
+  },
+  {
+    "name": "care",
+    "usphone": "keə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 照料，保护；小心v. 介意……，在乎；关心"
+    ]
+  },
+  {
+    "name": "careful",
+    "usphone": "ˈkeəfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 小心，仔细，谨慎的"
+    ]
+  },
+  {
+    "name": "careless",
+    "usphone": "ˈkeəlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 粗心的，漫不经心的"
+    ]
+  },
+  {
+    "name": "carpenter",
+    "usphone": "ˈkɑːpɪntə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 木工，木匠"
+    ]
+  },
+  {
+    "name": "carpet",
+    "usphone": "ˈkɑːpɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 地毯"
+    ]
+  },
+  {
+    "name": "carriage",
+    "usphone": "ˈkærɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 四轮马车;（火车）客车厢"
+    ]
+  },
+  {
+    "name": "carrier",
+    "usphone": "ˈkærɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 搬运者；媒介;（自行车等的）置物架；（车的）货架"
+    ]
+  },
+  {
+    "name": "carrot",
+    "usphone": "ˈkærət",
+    "ukphone": "",
+    "trans": [
+      "n.胡萝卜"
+    ]
+  },
+  {
+    "name": "carry",
+    "usphone": "ˈkærɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 拿，搬，带，提，抬，背，抱，运等"
+    ]
+  },
+  {
+    "name": "cartoon",
+    "usphone": "kɑːˈtuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 动画片，卡通；漫画"
+    ]
+  },
+  {
+    "name": "carve",
+    "usphone": "kɑːv",
+    "ukphone": "",
+    "trans": [
+      "vt.刻；雕刻"
+    ]
+  },
+  {
+    "name": "case",
+    "usphone": "keɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 情况；病例；案件；真相  n. 箱；盒；容器"
+    ]
+  },
+  {
+    "name": "cash",
+    "usphone": "kæʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 现金，现钞 v. 兑现"
+    ]
+  },
+  {
+    "name": "cassettle",
+    "usphone": "kæˈset",
+    "ukphone": "",
+    "trans": [
+      "n. 磁带"
+    ]
+  },
+  {
+    "name": "cast (cast, cast)",
+    "usphone": "kɑːst; (US) kæst",
+    "ukphone": "",
+    "trans": [
+      "v. 扔，抛，撒"
+    ]
+  },
+  {
+    "name": "castle",
+    "usphone": "ˈkɑːs(ə)l; (US) ˈkæsl",
+    "ukphone": "",
+    "trans": [
+      "n. 城堡"
+    ]
+  },
+  {
+    "name": "casual",
+    "usphone": "ˈkæʒʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 漫不经心的，不经意的，非正式的"
+    ]
+  },
+  {
+    "name": "cat",
+    "usphone": "kæt",
+    "ukphone": "",
+    "trans": [
+      "n. 猫 "
+    ]
+  },
+  {
+    "name": "catalogue",
+    "usphone": "ˈkætəlɔg",
+    "ukphone": "",
+    "trans": [
+      "n. 目录"
+    ]
+  },
+  {
+    "name": "catastrophe",
+    "usphone": "kəˈtæstrəfɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 灾难，灾祸，不幸事件"
+    ]
+  },
+  {
+    "name": "catch(caught,caught)",
+    "usphone": "kætʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 接住；捉住；赶上；染上（疾病）"
+    ]
+  },
+  {
+    "name": "category",
+    "usphone": "ˈkætɪɡərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 类别，种类"
+    ]
+  },
+  {
+    "name": "cater",
+    "usphone": "ˈkeɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 提供饮食，承办酒席"
+    ]
+  },
+  {
+    "name": "catholic",
+    "usphone": "ˈkæθəlɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 天主教的"
+    ]
+  },
+  {
+    "name": "cathedral",
+    "usphone": "kəˈθiːdr(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 大教堂（天主教）"
+    ]
+  },
+  {
+    "name": "cattle",
+    "usphone": "ˈkæt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 牛（总称），家畜"
+    ]
+  },
+  {
+    "name": "cause",
+    "usphone": "kɔːz",
+    "ukphone": "",
+    "trans": [
+      "n. 原因，起因 vt. 促使，引起，使发生"
+    ]
+  },
+  {
+    "name": "caution",
+    "usphone": "ˈkɔːʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 谨慎，小心，警告"
+    ]
+  },
+  {
+    "name": "cautious",
+    "usphone": "ˈkɔːʃəs",
+    "ukphone": "",
+    "trans": [
+      "a. 小心的，谨慎的"
+    ]
+  },
+  {
+    "name": "cave",
+    "usphone": "keɪv",
+    "ukphone": "",
+    "trans": [
+      "n. 洞，穴；地窖"
+    ]
+  },
+  {
+    "name": "CD",
+    "usphone": "ˌsi:ˈdi:",
+    "ukphone": "",
+    "trans": [
+      "光盘 (compact disk的缩写)"
+    ]
+  },
+  {
+    "name": "CDROM",
+    "usphone": "ˌsi:ˈdi: -rɔm,rəʊm",
+    "ukphone": "",
+    "trans": [
+      "信息储存光盘(compact disk readonly memory的缩写)"
+    ]
+  },
+  {
+    "name": "ceiling",
+    "usphone": "ˈsiːlɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 天花板，顶棚"
+    ]
+  },
+  {
+    "name": "celebrate",
+    "usphone": "ˈselɪbreɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 庆祝"
+    ]
+  },
+  {
+    "name": "celebration",
+    "usphone": "selɪˈbreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 庆祝；庆祝会"
+    ]
+  },
+  {
+    "name": "cell",
+    "usphone": "sel",
+    "ukphone": "",
+    "trans": [
+      "n.（监狱的）单人牢房；（修道院等的）单人小室；（蜂巢的）小蜂窝，蜂房；［生物］ 细胞"
+    ]
+  },
+  {
+    "name": "cellar",
+    "usphone": "ˈselə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 地窖；地下储藏室"
+    ]
+  },
+  {
+    "name": "cent",
+    "usphone": "sent",
+    "ukphone": "",
+    "trans": [
+      "n. 美分（100 cents = 1 dollar）"
+    ]
+  },
+  {
+    "name": "centigrade",
+    "usphone": "ˈsentɪɡreɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 摄氏的"
+    ]
+  },
+  {
+    "name": "centimetre",
+    "usphone": "ˈsentiˌmi:tə(r)",
+    "ukphone": "",
+    "trans": [
+      "(美 centimeter) n. 公分，厘米"
+    ]
+  },
+  {
+    "name": "central",
+    "usphone": "ˈsentr(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 中心，中央；主要的"
+    ]
+  },
+  {
+    "name": "centre (美 center )",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 中心，中央"
+    ]
+  },
+  {
+    "name": "century",
+    "usphone": "ˈsentʃərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 世纪，百年"
+    ]
+  },
+  {
+    "name": "ceremony",
+    "usphone": "ˈserɪmənɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 典礼，仪式，礼节"
+    ]
+  },
+  {
+    "name": "certain",
+    "usphone": "ˈsɜːt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. （未指明真实名称的）某…；确定的，无疑的；一定会…"
+    ]
+  },
+  {
+    "name": "certainly",
+    "usphone": "ˈsɜːtənlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 当然；一定，无疑"
+    ]
+  },
+  {
+    "name": "certificate",
+    "usphone": "səˈtɪfɪkət",
+    "ukphone": "",
+    "trans": [
+      "n. 证明，证明书"
+    ]
+  },
+  {
+    "name": "chain",
+    "usphone": "tʃeɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 链； 链条"
+    ]
+  },
+  {
+    "name": "chain store(s)",
+    "usphone": "tʃeɪn stɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "连锁店"
+    ]
+  },
+  {
+    "name": "chair",
+    "usphone": "tʃeə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 椅子"
+    ]
+  },
+  {
+    "name": "chairman",
+    "usphone": "ˈtʃeəmən",
+    "ukphone": "",
+    "trans": [
+      "(pl. chairmen) n. 主席，会长；议长"
+    ]
+  },
+  {
+    "name": "chairwoman (pl. chairwomen)",
+    "usphone": "ˈtʃɛəˌwumən",
+    "ukphone": "",
+    "trans": [
+      "n. 女主席, 女会长；女议长"
+    ]
+  },
+  {
+    "name": "chalk",
+    "usphone": "tʃɔːk",
+    "ukphone": "",
+    "trans": [
+      "n. 粉笔"
+    ]
+  },
+  {
+    "name": "challenge",
+    "usphone": "ˈtʃælɪndʒ",
+    "ukphone": "",
+    "trans": [
+      "n.挑战(性)"
+    ]
+  },
+  {
+    "name": "challenging",
+    "usphone": "ˈtʃælɪndʒɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a.具有挑战性的"
+    ]
+  },
+  {
+    "name": "champion",
+    "usphone": "ˈtʃæmpɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 冠军，优胜者"
+    ]
+  },
+  {
+    "name": "chance",
+    "usphone": "tʃɑːns; (US) tʃæns",
+    "ukphone": "",
+    "trans": [
+      "n. 机会，可能性"
+    ]
+  },
+  {
+    "name": "changeable",
+    "usphone": "ˈtʃeɪndʒəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.易变的，变化无常的"
+    ]
+  },
+  {
+    "name": "change",
+    "usphone": "tʃeɪndʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 零钱；找头v. 改变，变化；更换；兑换"
+    ]
+  },
+  {
+    "name": "channel",
+    "usphone": "ˈtʃæn(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.频道；通道；水渠"
+    ]
+  },
+  {
+    "name": "chant",
+    "usphone": "tʃɑːnt",
+    "ukphone": "",
+    "trans": [
+      "v./ n.反复呼喊"
+    ]
+  },
+  {
+    "name": "chaos",
+    "usphone": "ˈkeɪɔs",
+    "ukphone": "",
+    "trans": [
+      "n. 混乱，杂乱，紊乱"
+    ]
+  },
+  {
+    "name": "character",
+    "usphone": "ˈkærɪktə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.（汉）字.字体；品格"
+    ]
+  },
+  {
+    "name": "characteristic",
+    "usphone": "kærɪktəˈrɪstɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 典型的，独特的"
+    ]
+  },
+  {
+    "name": "charge",
+    "usphone": "tʃɑːdʒ",
+    "ukphone": "",
+    "trans": [
+      "v. 要求收费；索价；将(电池)充电 n. 费用；价钱"
+    ]
+  },
+  {
+    "name": "chapter",
+    "usphone": "ˈtʃæptə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 章"
+    ]
+  },
+  {
+    "name": "chart",
+    "usphone": "tʃɑːt",
+    "ukphone": "",
+    "trans": [
+      "n. 图表；航海图"
+    ]
+  },
+  {
+    "name": "chat",
+    "usphone": "tʃæt",
+    "ukphone": "",
+    "trans": [
+      "n. & vi. 聊天，闲谈"
+    ]
+  },
+  {
+    "name": "cheap",
+    "usphone": "tʃiːp",
+    "ukphone": "",
+    "trans": [
+      "a. 便宜的，贱"
+    ]
+  },
+  {
+    "name": "cheat",
+    "usphone": "tʃiːt",
+    "ukphone": "",
+    "trans": [
+      "n. & v. 骗取，哄骗；作弊"
+    ]
+  },
+  {
+    "name": "check",
+    "usphone": "tʃek",
+    "ukphone": "",
+    "trans": [
+      "n. 检查；批改 vt. 校对，核对； 检查；批改"
+    ]
+  },
+  {
+    "name": "cheek",
+    "usphone": "tʃiːk",
+    "ukphone": "",
+    "trans": [
+      "n. 面颊，脸蛋"
+    ]
+  },
+  {
+    "name": "cheer",
+    "usphone": "tʃɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. & vi.欢呼； 喝彩"
+    ]
+  },
+  {
+    "name": "Cheer up",
+    "usphone": "tʃɪə(r)-ʌp",
+    "ukphone": "",
+    "trans": [
+      "振作起来！提起精神！"
+    ]
+  },
+  {
+    "name": "cheerful",
+    "usphone": "ˈtʃɪəfʊl",
+    "ukphone": "",
+    "trans": [
+      "a.兴高采烈的，快活的"
+    ]
+  },
+  {
+    "name": "cheers",
+    "usphone": "tʃɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "int. 干杯，(口)谢谢，再见"
+    ]
+  },
+  {
+    "name": "cheese",
+    "usphone": "tʃiːz",
+    "ukphone": "",
+    "trans": [
+      "n. 奶酪"
+    ]
+  },
+  {
+    "name": "chef",
+    "usphone": "ʃef",
+    "ukphone": "",
+    "trans": [
+      "n. 厨师长，主厨"
+    ]
+  },
+  {
+    "name": "chemical",
+    "usphone": "ˈkemɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 化学的 n. 化学品"
+    ]
+  },
+  {
+    "name": "chemist",
+    "usphone": "ˈkemɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 药剂师；化学家"
+    ]
+  },
+  {
+    "name": "chemistry",
+    "usphone": "ˈkemɪstrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 化学"
+    ]
+  },
+  {
+    "name": "cheque",
+    "usphone": "tʃek",
+    "ukphone": "",
+    "trans": [
+      "(美check) n. 支票"
+    ]
+  },
+  {
+    "name": "chess",
+    "usphone": "tʃes",
+    "ukphone": "",
+    "trans": [
+      "n. 棋"
+    ]
+  },
+  {
+    "name": "chest",
+    "usphone": "tʃest",
+    "ukphone": "",
+    "trans": [
+      "n. 箱子；盒子；胸部"
+    ]
+  },
+  {
+    "name": "chew",
+    "usphone": "tʃuː",
+    "ukphone": "",
+    "trans": [
+      "vt. 咀嚼"
+    ]
+  },
+  {
+    "name": "chick",
+    "usphone": "tʃɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 小鸡"
+    ]
+  },
+  {
+    "name": "chicken",
+    "usphone": "ˈtʃɪkən",
+    "ukphone": "",
+    "trans": [
+      "n. 鸡；鸡肉"
+    ]
+  },
+  {
+    "name": "chief",
+    "usphone": "tʃiːf",
+    "ukphone": "",
+    "trans": [
+      "a. 主要,首要的 n.领导，头"
+    ]
+  },
+  {
+    "name": "child (复children)",
+    "usphone": "tʃaɪld",
+    "ukphone": "",
+    "trans": [
+      "n. 孩子，儿童"
+    ]
+  },
+  {
+    "name": "childhood",
+    "usphone": "ˈtʃaɪldhʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 幼年时代，童年"
+    ]
+  },
+  {
+    "name": "chimney",
+    "usphone": "ˈtʃɪmnɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 烟囱，烟筒"
+    ]
+  },
+  {
+    "name": "China",
+    "usphone": "ˈtʃaɪnə",
+    "ukphone": "",
+    "trans": [
+      "* n. 中国"
+    ]
+  },
+  {
+    "name": "Chinese",
+    "usphone": "tʃaɪˈniːz",
+    "ukphone": "",
+    "trans": [
+      "a.中国的；中国人的；中国话的，汉语的 n.中国人；中国话，汉语，中文"
+    ]
+  },
+  {
+    "name": "chips",
+    "usphone": "tʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. (pl.)炸土豆条（片）"
+    ]
+  },
+  {
+    "name": "chocolate",
+    "usphone": "ˈtʃɔklət",
+    "ukphone": "",
+    "trans": [
+      "n. 巧克力"
+    ]
+  },
+  {
+    "name": "choice",
+    "usphone": "tʃɔɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 选择；抉择"
+    ]
+  },
+  {
+    "name": "choir",
+    "usphone": "ˈkwaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 合唱团，教堂的唱诗班"
+    ]
+  },
+  {
+    "name": "choke",
+    "usphone": "tʃəʊk",
+    "ukphone": "",
+    "trans": [
+      "n. & v. 窒息"
+    ]
+  },
+  {
+    "name": "choose (chose, chosen)",
+    "usphone": "tʃuːz",
+    "ukphone": "",
+    "trans": [
+      "vt. 选择"
+    ]
+  },
+  {
+    "name": "chopsticks",
+    "usphone": "ˈtʃɔpstɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 筷子"
+    ]
+  },
+  {
+    "name": "chorus",
+    "usphone": "ˈkɔːrəs",
+    "ukphone": "",
+    "trans": [
+      "n. 合唱曲，歌咏队"
+    ]
+  },
+  {
+    "name": "Christian",
+    "usphone": "ˈkrɪstɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 基督教徒和天主教徒的总称"
+    ]
+  },
+  {
+    "name": "Christmas",
+    "usphone": "ˈkrɪsməs",
+    "ukphone": "",
+    "trans": [
+      "n. 圣诞节（12月25日）"
+    ]
+  },
+  {
+    "name": "Christmas card",
+    "usphone": "ˈkrɪsməs kɑːd",
+    "ukphone": "",
+    "trans": [
+      "圣诞卡"
+    ]
+  },
+  {
+    "name": "Christmas tree",
+    "usphone": "ˈkrɪsməs triː",
+    "ukphone": "",
+    "trans": [
+      "圣诞树"
+    ]
+  },
+  {
+    "name": "Christmas Eve",
+    "usphone": "ˈkrɪsməs iːv ",
+    "ukphone": "",
+    "trans": [
+      "圣诞（前）夜"
+    ]
+  },
+  {
+    "name": "church",
+    "usphone": "tʃɜːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 教堂；教会"
+    ]
+  },
+  {
+    "name": "cigar",
+    "usphone": "sɪˈɡɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 雪茄烟"
+    ]
+  },
+  {
+    "name": "cigarette",
+    "usphone": "sɪɡəˈret",
+    "ukphone": "",
+    "trans": [
+      "n. 纸烟，香烟"
+    ]
+  },
+  {
+    "name": "cinema",
+    "usphone": "ˈsɪnəmə",
+    "ukphone": "",
+    "trans": [
+      "n. 电影院；电影"
+    ]
+  },
+  {
+    "name": "circle",
+    "usphone": "ˈsɜːk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. /vt. 圆圈 将…圈起来"
+    ]
+  },
+  {
+    "name": "circuit",
+    "usphone": "ˈsɜːkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 环形路线，巡回赛"
+    ]
+  },
+  {
+    "name": "circulate",
+    "usphone": "ˈsɜːkjʊleɪt",
+    "ukphone": "",
+    "trans": [
+      "v. （液体或气体）环流，循环"
+    ]
+  },
+  {
+    "name": "circumstance",
+    "usphone": "ˈsɜːkəmstəns",
+    "ukphone": "",
+    "trans": [
+      "n.条件,环境,状况"
+    ]
+  },
+  {
+    "name": "circus",
+    "usphone": "ˈsɜːkəs",
+    "ukphone": "",
+    "trans": [
+      "n. 马戏团"
+    ]
+  },
+  {
+    "name": "citizen",
+    "usphone": "ˈsɪtɪz(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 公民；居民"
+    ]
+  },
+  {
+    "name": "city",
+    "usphone": "ˈsɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 市，城市，都市"
+    ]
+  },
+  {
+    "name": "civil",
+    "usphone": "ˈsɪv(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 国内的；平民（非军人）的；民用的"
+    ]
+  },
+  {
+    "name": "civilian",
+    "usphone": "sɪˈvɪlɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 平民，老百姓"
+    ]
+  },
+  {
+    "name": "civilization",
+    "usphone": "sɪvɪlaɪˈzeɪʃ(ə)n; (US) sɪvəlɪˈzeɪʃən",
+    "ukphone": "",
+    "trans": [
+      "n. 文明"
+    ]
+  },
+  {
+    "name": "clap",
+    "usphone": "klæp",
+    "ukphone": "",
+    "trans": [
+      "vi. 拍手；鼓掌"
+    ]
+  },
+  {
+    "name": "clarify",
+    "usphone": "ˈklærɪfaɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 澄清，阐明"
+    ]
+  },
+  {
+    "name": "class",
+    "usphone": "klɑːs; (US) klæs",
+    "ukphone": "",
+    "trans": [
+      "n. （学校的）班；年级；课"
+    ]
+  },
+  {
+    "name": "classic",
+    "usphone": "ˈklæsɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 一流的，典型的，有代表性的"
+    ]
+  },
+  {
+    "name": "classical",
+    "usphone": "ˈklæsɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 传统的；古典的"
+    ]
+  },
+  {
+    "name": "classify",
+    "usphone": "ˈklæsɪfaɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 分类，归类"
+    ]
+  },
+  {
+    "name": "classmate",
+    "usphone": "ˈklɑːsmeɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 同班同学"
+    ]
+  },
+  {
+    "name": "classroom",
+    "usphone": "ˈklɑːsruːm",
+    "ukphone": "",
+    "trans": [
+      "n. 教室"
+    ]
+  },
+  {
+    "name": "claw",
+    "usphone": "klɔː",
+    "ukphone": "",
+    "trans": [
+      "n. 爪"
+    ]
+  },
+  {
+    "name": "clay",
+    "usphone": "kleɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 黏土，陶土"
+    ]
+  },
+  {
+    "name": "clean",
+    "usphone": "kliːn",
+    "ukphone": "",
+    "trans": [
+      "vt. 弄干净，擦干净 a. 清洁的，干净的"
+    ]
+  },
+  {
+    "name": "cleaner",
+    "usphone": "kliːnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.清洁工.,清洁器.,清洁剂"
+    ]
+  },
+  {
+    "name": "clear",
+    "usphone": "klɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 清晰；明亮的；清楚的"
+    ]
+  },
+  {
+    "name": "clearly",
+    "usphone": "ˈklɪəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 清楚地，无疑地"
+    ]
+  },
+  {
+    "name": "clerk",
+    "usphone": "klɑːk; (US) klərk",
+    "ukphone": "",
+    "trans": [
+      "n. 书记员；办事员；职员"
+    ]
+  },
+  {
+    "name": "clever",
+    "usphone": "ˈklevə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 聪明的，伶俐的"
+    ]
+  },
+  {
+    "name": "click",
+    "usphone": "klɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 点击（计算机用语）"
+    ]
+  },
+  {
+    "name": "climate",
+    "usphone": "ˈklaɪmɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 气候"
+    ]
+  },
+  {
+    "name": "climb",
+    "usphone": "klaɪm",
+    "ukphone": "",
+    "trans": [
+      "v. 爬，攀登"
+    ]
+  },
+  {
+    "name": "clinic",
+    "usphone": "ˈklɪnɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 诊所"
+    ]
+  },
+  {
+    "name": "clock",
+    "usphone": "klɔk",
+    "ukphone": "",
+    "trans": [
+      "n. 钟"
+    ]
+  },
+  {
+    "name": "clone",
+    "usphone": "kləʊn",
+    "ukphone": "",
+    "trans": [
+      "n.克隆（无性繁殖出来的有机体群）"
+    ]
+  },
+  {
+    "name": "close",
+    "usphone": "kləʊz",
+    "ukphone": "",
+    "trans": [
+      "a. 亲密的；近，靠近 ad. 近，靠近 vt. 关，关闭"
+    ]
+  },
+  {
+    "name": "cloth",
+    "usphone": "klɔθ; (US) klɔθ",
+    "ukphone": "",
+    "trans": [
+      "n. 布"
+    ]
+  },
+  {
+    "name": "clothes",
+    "usphone": "klɔðz; (US) kləʊz",
+    "ukphone": "",
+    "trans": [
+      "n. 衣服；各种衣物"
+    ]
+  },
+  {
+    "name": "clothing",
+    "usphone": "ˈkləʊðɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. (总称) 衣服"
+    ]
+  },
+  {
+    "name": "cloud",
+    "usphone": "ˈkləʊðɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 云；云状物；阴影"
+    ]
+  },
+  {
+    "name": "cloudy",
+    "usphone": "ˈklaʊdɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 多云的，阴天的"
+    ]
+  },
+  {
+    "name": "club",
+    "usphone": "klʌb",
+    "ukphone": "",
+    "trans": [
+      "n. 俱乐部；纸牌中的梅花"
+    ]
+  },
+  {
+    "name": "clumsy",
+    "usphone": "ˈklʌmzɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 笨拙的，不灵巧的"
+    ]
+  },
+  {
+    "name": "coach",
+    "usphone": "kəʊtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 教练；马车；长途车"
+    ]
+  },
+  {
+    "name": "coal",
+    "usphone": "kəʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 煤；煤块"
+    ]
+  },
+  {
+    "name": "coast",
+    "usphone": "kəʊst",
+    "ukphone": "",
+    "trans": [
+      "n. 海岸；海滨"
+    ]
+  },
+  {
+    "name": "coat",
+    "usphone": "kəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 外套；涂层；表皮；皮毛 vt. 给……穿外套；涂上"
+    ]
+  },
+  {
+    "name": "cock",
+    "usphone": "kɔk",
+    "ukphone": "",
+    "trans": [
+      "n. 公鸡"
+    ]
+  },
+  {
+    "name": "cocoa",
+    "usphone": "ˈkəʊkəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 可可粉"
+    ]
+  },
+  {
+    "name": "coffee",
+    "usphone": "ˈkɔfɪ; (US) ˈkɔːfɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 咖啡"
+    ]
+  },
+  {
+    "name": "coin",
+    "usphone": "kɔɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 硬币"
+    ]
+  },
+  {
+    "name": "coincidence",
+    "usphone": "kəʊɪnˈsɪdəns",
+    "ukphone": "",
+    "trans": [
+      "n. 巧合，巧事"
+    ]
+  },
+  {
+    "name": "coke",
+    "usphone": "kəʊk",
+    "ukphone": "",
+    "trans": [
+      "n. 可口可乐"
+    ]
+  },
+  {
+    "name": "cold",
+    "usphone": "kəʊld",
+    "ukphone": "",
+    "trans": [
+      "a. 冷的，寒的 n. 寒冷；感冒，伤风"
+    ]
+  },
+  {
+    "name": "cold--blooded",
+    "usphone": "kəʊld blʌdɪd",
+    "ukphone": "",
+    "trans": [
+      "a. (动物) 冷血的"
+    ]
+  },
+  {
+    "name": "collar",
+    "usphone": "ˈkɔlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 衣领； 硬领"
+    ]
+  },
+  {
+    "name": "colleague",
+    "usphone": "ˈkɔliːɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 同事"
+    ]
+  },
+  {
+    "name": "collect",
+    "usphone": "kəˈlekt",
+    "ukphone": "",
+    "trans": [
+      "vt. 收集，搜集"
+    ]
+  },
+  {
+    "name": "collection",
+    "usphone": "kəˈlekʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 收藏品，收集物"
+    ]
+  },
+  {
+    "name": "college",
+    "usphone": "ˈkɔlɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 学院；专科学校"
+    ]
+  },
+  {
+    "name": "collision",
+    "usphone": "kəˈlɪʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 碰撞事故"
+    ]
+  },
+  {
+    "name": "colour (美color)",
+    "usphone": "ˈkʌlə",
+    "ukphone": "",
+    "trans": [
+      "n. 颜色 vt.给…着色，涂色"
+    ]
+  },
+  {
+    "name": "comb",
+    "usphone": "kəʊm",
+    "ukphone": "",
+    "trans": [
+      "n. 梳子 v. 梳"
+    ]
+  },
+  {
+    "name": "combine",
+    "usphone": "kəmˈbaɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. 使联合；使结合"
+    ]
+  },
+  {
+    "name": "come (came, come)",
+    "usphone": "kʌm",
+    "ukphone": "",
+    "trans": [
+      "vi. 来，来到"
+    ]
+  },
+  {
+    "name": "comedy",
+    "usphone": "ˈkɔmədɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 喜剧"
+    ]
+  },
+  {
+    "name": "comfort",
+    "usphone": "ˈkʌmfət",
+    "ukphone": "",
+    "trans": [
+      "n. 安慰； 慰问"
+    ]
+  },
+  {
+    "name": "comfortable",
+    "usphone": "ˈkʌmfətəb(ə)l; (US) ˈkʌmfərtəbl",
+    "ukphone": "",
+    "trans": [
+      "a. 舒服的；安逸的；舒服自在的"
+    ]
+  },
+  {
+    "name": "comma",
+    "usphone": "ˈkɔmə",
+    "ukphone": "",
+    "trans": [
+      "n. 逗号"
+    ]
+  },
+  {
+    "name": "command",
+    "usphone": "kəˈmɑːnd; (US) kəˈmænd",
+    "ukphone": "",
+    "trans": [
+      "n. & v. 命令"
+    ]
+  },
+  {
+    "name": "comment",
+    "usphone": "ˈkɔment",
+    "ukphone": "",
+    "trans": [
+      "n. 评论"
+    ]
+  },
+  {
+    "name": "commericia",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a.贸易的，商业的"
+    ]
+  },
+  {
+    "name": "commit",
+    "usphone": "kəˈmɪt",
+    "ukphone": "",
+    "trans": [
+      "v.犯（罪，错），自杀"
+    ]
+  },
+  {
+    "name": "commitment",
+    "usphone": "kəˈmɪtmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 承诺,允诺,承担"
+    ]
+  },
+  {
+    "name": "committee",
+    "usphone": "kəˈmɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 委员会"
+    ]
+  },
+  {
+    "name": "common",
+    "usphone": "ˈkɔmən",
+    "ukphone": "",
+    "trans": [
+      "a. 普通，一般；共有的"
+    ]
+  },
+  {
+    "name": "communicate",
+    "usphone": "kəˈmjuːnɪkeɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 交际；传达（感情，信息等）"
+    ]
+  },
+  {
+    "name": "communication",
+    "usphone": "kəmjuːnɪˈkeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.交际,交往;通讯"
+    ]
+  },
+  {
+    "name": "communism",
+    "usphone": "ˈkɔmjʊnɪz(ə)m",
+    "ukphone": "",
+    "trans": [
+      "n. 共产主义"
+    ]
+  },
+  {
+    "name": "communist",
+    "usphone": "ˈkɔmjuːnɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 共产主义者 a. 共产党的；共产主义的"
+    ]
+  },
+  {
+    "name": "companion",
+    "usphone": "kəmˈpænɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 同伴；同事"
+    ]
+  },
+  {
+    "name": "company",
+    "usphone": "ˈkʌmpənɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 公司"
+    ]
+  },
+  {
+    "name": "compare",
+    "usphone": "kəmˈpeə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 比较，对照"
+    ]
+  },
+  {
+    "name": "compass",
+    "usphone": "ˈkʌmpəs",
+    "ukphone": "",
+    "trans": [
+      "n. 罗盘，指南针"
+    ]
+  },
+  {
+    "name": "compensate",
+    "usphone": "ˈkɔmpenseɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 补偿，弥补"
+    ]
+  },
+  {
+    "name": "compete",
+    "usphone": "kəmˈpiːt",
+    "ukphone": "",
+    "trans": [
+      "vi. 比赛，竞赛"
+    ]
+  },
+  {
+    "name": "competence",
+    "usphone": "ˈkɔmpətəns",
+    "ukphone": "",
+    "trans": [
+      "n.能力,胜任,管辖权"
+    ]
+  },
+  {
+    "name": "competition",
+    "usphone": "kɔmpəˈtɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 比赛，竞赛"
+    ]
+  },
+  {
+    "name": "competitor",
+    "usphone": "kəmˈpetɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 竞赛者，比赛者"
+    ]
+  },
+  {
+    "name": "complete",
+    "usphone": "kəmˈpliːt",
+    "ukphone": "",
+    "trans": [
+      "a. 完成vt. 完成，结束"
+    ]
+  },
+  {
+    "name": "complex",
+    "usphone": "ˈkɔmpleks",
+    "ukphone": "",
+    "trans": [
+      "a. / n. 复杂的，建筑群"
+    ]
+  },
+  {
+    "name": "component",
+    "usphone": "kəmˈpəʊnənt",
+    "ukphone": "",
+    "trans": [
+      "n. 组成部分，部件"
+    ]
+  },
+  {
+    "name": "composition",
+    "usphone": "kɔmpəˈzɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 作文；作曲"
+    ]
+  },
+  {
+    "name": "comprehension",
+    "usphone": "kɔmprɪˈhenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 理解"
+    ]
+  },
+  {
+    "name": "compromise",
+    "usphone": "ˈkɔmprəmaɪz",
+    "ukphone": "",
+    "trans": [
+      "v. 妥协,折中,让步"
+    ]
+  },
+  {
+    "name": "compulsory",
+    "usphone": "kəmˈpʌlsərɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 强制的,必须做的"
+    ]
+  },
+  {
+    "name": "computer",
+    "usphone": "kəmˈpjuːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 电子计算机"
+    ]
+  },
+  {
+    "name": "computer game",
+    "usphone": "kəmˈpjuːtə(r) ɡeɪm",
+    "ukphone": "",
+    "trans": [
+      "电子游戏"
+    ]
+  },
+  {
+    "name": "comrade",
+    "usphone": "ˈkɔmrɪd; (US) ˈkɑmræd",
+    "ukphone": "",
+    "trans": [
+      "n. 同志"
+    ]
+  },
+  {
+    "name": "concentrate",
+    "usphone": "ˈkɔnsəntreɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 聚精会神"
+    ]
+  },
+  {
+    "name": "concept",
+    "usphone": "ˈkɔnsept",
+    "ukphone": "",
+    "trans": [
+      "n. 概念"
+    ]
+  },
+  {
+    "name": "concern",
+    "usphone": "kənˈsɜːn",
+    "ukphone": "",
+    "trans": [
+      "v. / n. 涉及，关心"
+    ]
+  },
+  {
+    "name": "concert",
+    "usphone": "ˈkɔnsət",
+    "ukphone": "",
+    "trans": [
+      "n. 音乐会；演奏会"
+    ]
+  },
+  {
+    "name": "conclude",
+    "usphone": "kənˈkluːd",
+    "ukphone": "",
+    "trans": [
+      "v. 完成，结束"
+    ]
+  },
+  {
+    "name": "conclusion",
+    "usphone": "kənˈkluːʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 结论；结束"
+    ]
+  },
+  {
+    "name": "concrete",
+    "usphone": "ˈkɔŋkriːt",
+    "ukphone": "",
+    "trans": [
+      "a. 混凝土制的"
+    ]
+  },
+  {
+    "name": "condition",
+    "usphone": "kənˈdɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 条件，状况"
+    ]
+  },
+  {
+    "name": "condemn",
+    "usphone": "kənˈdem",
+    "ukphone": "",
+    "trans": [
+      "v. 谴责，指责，宣判"
+    ]
+  },
+  {
+    "name": "conduct",
+    "usphone": "ˈkɔndʌkt",
+    "ukphone": "",
+    "trans": [
+      "vt. 引导，带领"
+    ]
+  },
+  {
+    "name": "conductor",
+    "usphone": "kənˈdʌktə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 管理人；指导者；（车上的）售票员，列车员；乐队指挥"
+    ]
+  },
+  {
+    "name": "confident",
+    "usphone": "ˈkɔnfɪdənt",
+    "ukphone": "",
+    "trans": [
+      "a. 自信的"
+    ]
+  },
+  {
+    "name": "confidential",
+    "usphone": "kɔnfɪˈdenʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 机密的，保密的"
+    ]
+  },
+  {
+    "name": "conference",
+    "usphone": "ˈkɔnfərəns",
+    "ukphone": "",
+    "trans": [
+      "n. (正式的)会议；讨论"
+    ]
+  },
+  {
+    "name": "confirm",
+    "usphone": "kənˈfɜːm",
+    "ukphone": "",
+    "trans": [
+      "v. 证实，证明，确认"
+    ]
+  },
+  {
+    "name": "conflict",
+    "usphone": "ˈkɔnflɪkt",
+    "ukphone": "",
+    "trans": [
+      "n. 冲突，争执，争论"
+    ]
+  },
+  {
+    "name": "confuse",
+    "usphone": "kənˈfjuːz",
+    "ukphone": "",
+    "trans": [
+      "v. 使迷惑，混淆"
+    ]
+  },
+  {
+    "name": "congratulate",
+    "usphone": "kənˈɡrætjʊleɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 祝贺"
+    ]
+  },
+  {
+    "name": "congratulation",
+    "usphone": "kənɡrætjʊˈleɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 祝贺，庆贺"
+    ]
+  },
+  {
+    "name": "connect",
+    "usphone": "kəˈnekt",
+    "ukphone": "",
+    "trans": [
+      "v. 连接，把…联系起来"
+    ]
+  },
+  {
+    "name": "connection",
+    "usphone": "kəˈnekʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.连接物;接触,联系"
+    ]
+  },
+  {
+    "name": "conscience",
+    "usphone": "ˈkɔnʃəns",
+    "ukphone": "",
+    "trans": [
+      "n. 良心，良知，内疚"
+    ]
+  },
+  {
+    "name": "consensus",
+    "usphone": "kənˈsensəs",
+    "ukphone": "",
+    "trans": [
+      "n. 一致的意见，共识"
+    ]
+  },
+  {
+    "name": "consequence",
+    "usphone": "ˈkɔnsɪkwəns; (US) ˈkɔnsɪkwens",
+    "ukphone": "",
+    "trans": [
+      "n. 结果，后果"
+    ]
+  },
+  {
+    "name": "conservation",
+    "usphone": "kɔnsəˈveɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n 保存；（自然资源的）保护，管理"
+    ]
+  },
+  {
+    "name": "conservative",
+    "usphone": "kənˈsɜːvətɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 保守的，守旧的；保守主义的；谨慎的 n.保守的人，保守主义"
+    ]
+  },
+  {
+    "name": "consider",
+    "usphone": "kənˈsɪdə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 考虑"
+    ]
+  },
+  {
+    "name": "considerate",
+    "usphone": "kənˈsɪdərət",
+    "ukphone": "",
+    "trans": [
+      "a. 体贴的"
+    ]
+  },
+  {
+    "name": "consideration",
+    "usphone": "kənsɪdəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 考虑；关心"
+    ]
+  },
+  {
+    "name": "consist",
+    "usphone": "kənˈsɪst",
+    "ukphone": "",
+    "trans": [
+      "v. 包含，组成，构成"
+    ]
+  },
+  {
+    "name": "consistent",
+    "usphone": "kənˈsɪst(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "a. 一致的，始终如一的，连续的"
+    ]
+  },
+  {
+    "name": "constant",
+    "usphone": "ˈkɔnstənt",
+    "ukphone": "",
+    "trans": [
+      "a. 经常的，不断的"
+    ]
+  },
+  {
+    "name": "constitution",
+    "usphone": "kɔnstɪˈtjuːʃ(ə)n; (US) kɔnstəˈtuːʃən",
+    "ukphone": "",
+    "trans": [
+      "n. 宪法，章程，身体素质"
+    ]
+  },
+  {
+    "name": "construct",
+    "usphone": "kənˈstrʌkt",
+    "ukphone": "",
+    "trans": [
+      "v. 构筑；建造，建设"
+    ]
+  },
+  {
+    "name": "construction",
+    "usphone": "kənˈstrʌkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.建造,建设,建筑物"
+    ]
+  },
+  {
+    "name": "consult",
+    "usphone": "kənˈsʌlt",
+    "ukphone": "",
+    "trans": [
+      "v. 咨询，商量"
+    ]
+  },
+  {
+    "name": "consultant",
+    "usphone": "kənˈsʌltənt",
+    "ukphone": "",
+    "trans": [
+      "n. 顾问"
+    ]
+  },
+  {
+    "name": "consume",
+    "usphone": "kənˈsʌltənt",
+    "ukphone": "",
+    "trans": [
+      "v. 消耗，耗费（燃料，能量，时间等）"
+    ]
+  },
+  {
+    "name": "contain",
+    "usphone": "kənˈteɪn",
+    "ukphone": "",
+    "trans": [
+      "v. 包含；包括；能容纳"
+    ]
+  },
+  {
+    "name": "container",
+    "usphone": "kənˈteɪnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 容器"
+    ]
+  },
+  {
+    "name": "contemporary",
+    "usphone": "kənˈtempərərɪ; (US) kənˈtempərerɪ",
+    "ukphone": "",
+    "trans": [
+      "a.属同时期的，同一时代的"
+    ]
+  },
+  {
+    "name": "content",
+    "usphone": "kənˈtent",
+    "ukphone": "",
+    "trans": [
+      "a.甘愿的,满意的 n.内容"
+    ]
+  },
+  {
+    "name": "continent",
+    "usphone": "ˈkɔntɪnənt",
+    "ukphone": "",
+    "trans": [
+      "n. 大陆，大洲；陆地"
+    ]
+  },
+  {
+    "name": "continue",
+    "usphone": "kənˈtɪnjuː",
+    "ukphone": "",
+    "trans": [
+      "vi. 继续"
+    ]
+  },
+  {
+    "name": "contradict",
+    "usphone": "kɔntrəˈdɪkt",
+    "ukphone": "",
+    "trans": [
+      "v. 反驳，驳斥，批驳"
+    ]
+  },
+  {
+    "name": "contradictory",
+    "usphone": "ˌkɔntrəˈdiktəri",
+    "ukphone": "",
+    "trans": [
+      "a.相互矛盾,对立的"
+    ]
+  },
+  {
+    "name": "contrary",
+    "usphone": "ˈkɔntrərɪ; (US) ˈkɔntrerɪ",
+    "ukphone": "",
+    "trans": [
+      "n. / a. 相反 相反的"
+    ]
+  },
+  {
+    "name": "contribute",
+    "usphone": "kənˈtrɪbjuːt",
+    "ukphone": "",
+    "trans": [
+      "v. 贡献"
+    ]
+  },
+  {
+    "name": "contribution",
+    "usphone": "kɔnˈtrɪbjuːt",
+    "ukphone": "",
+    "trans": [
+      "n. 贡献"
+    ]
+  },
+  {
+    "name": "control",
+    "usphone": "kənˈtrol",
+    "ukphone": "",
+    "trans": [
+      "vt.& n. 控制"
+    ]
+  },
+  {
+    "name": "controversial",
+    "usphone": "kɔntrəˈvɜːʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.引起争论的,有争议的"
+    ]
+  },
+  {
+    "name": "convenience",
+    "usphone": "kənˈviːnɪəns",
+    "ukphone": "",
+    "trans": [
+      "n. 便利"
+    ]
+  },
+  {
+    "name": "convenient",
+    "usphone": "kənˈviːnɪənt",
+    "ukphone": "",
+    "trans": [
+      "a. 便利的，方便的"
+    ]
+  },
+  {
+    "name": "conventional",
+    "usphone": "kənˈvenʃən(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 依照惯例的，习惯的"
+    ]
+  },
+  {
+    "name": "conversation",
+    "usphone": "kɔnvəˈseɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 谈话，交谈"
+    ]
+  },
+  {
+    "name": "convey",
+    "usphone": "kənˈveɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 表达，传递（思想，感情等）"
+    ]
+  },
+  {
+    "name": "convince",
+    "usphone": "kənˈvɪns",
+    "ukphone": "",
+    "trans": [
+      "v. 使确信，使信服"
+    ]
+  },
+  {
+    "name": "cook",
+    "usphone": "kʊk",
+    "ukphone": "",
+    "trans": [
+      "n.炊事员,厨师 v.烹调,做饭"
+    ]
+  },
+  {
+    "name": "cooker",
+    "usphone": "ˈkʊkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 炊具(锅、炉灶、烤炉等)"
+    ]
+  },
+  {
+    "name": "cookie",
+    "usphone": "ˈkʊkɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 小甜饼"
+    ]
+  },
+  {
+    "name": "cool",
+    "usphone": "kuːl",
+    "ukphone": "",
+    "trans": [
+      "a. 凉的，凉爽的；酷"
+    ]
+  },
+  {
+    "name": "copy",
+    "usphone": "ˈkɔpɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 抄本，副本；一本（份，册……） v. 抄写；复印；（计算机用语）拷（备 份盘）"
+    ]
+  },
+  {
+    "name": "coral",
+    "usphone": "ˈkɔr(ə)l; (US) ˈkɔːrəl",
+    "ukphone": "",
+    "trans": [
+      "n. 珊瑚；珊瑚虫"
+    ]
+  },
+  {
+    "name": "cordless",
+    "usphone": "ˈkɔːdlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 无线的"
+    ]
+  },
+  {
+    "name": "corn",
+    "usphone": "kɔːn",
+    "ukphone": "",
+    "trans": [
+      "n. 玉米，谷物"
+    ]
+  },
+  {
+    "name": "corner",
+    "usphone": "ˈkɔːnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 角；角落；拐角"
+    ]
+  },
+  {
+    "name": "corporation",
+    "usphone": "kɔːpəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. （大）公司"
+    ]
+  },
+  {
+    "name": "correct",
+    "usphone": "kəˈrekt",
+    "ukphone": "",
+    "trans": [
+      "v. 改正；纠正 a. 正确的，对的；恰当的"
+    ]
+  },
+  {
+    "name": "correction",
+    "usphone": "kəˈrekʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 改正"
+    ]
+  },
+  {
+    "name": "correspond",
+    "usphone": "kɔrɪˈspɔnd; (US) kɔːrəˈspɔnd",
+    "ukphone": "",
+    "trans": [
+      "vi. 一致；与……相当；(与人)通信，有书信往来"
+    ]
+  },
+  {
+    "name": "corrupt",
+    "usphone": "kəˈrʌpt",
+    "ukphone": "",
+    "trans": [
+      "a. / v. 贪污的，腐败的，使腐化，堕落"
+    ]
+  },
+  {
+    "name": "cost (cost, cost)",
+    "usphone": "kɔst; (US) kɔːst",
+    "ukphone": "",
+    "trans": [
+      "v.值（钱），花费 n. 价格"
+    ]
+  },
+  {
+    "name": "cosy",
+    "usphone": "ˈkəuzi",
+    "ukphone": "",
+    "trans": [
+      "a.暖和舒适的,亲密无间的"
+    ]
+  },
+  {
+    "name": "cottage",
+    "usphone": "ˈkɔtɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. (郊外)小屋,村舍,别墅"
+    ]
+  },
+  {
+    "name": "cotton",
+    "usphone": "ˈkɔt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 棉花 a. 棉花的"
+    ]
+  },
+  {
+    "name": "cough",
+    "usphone": "kɔf; (US) kɔːf",
+    "ukphone": "",
+    "trans": [
+      "n.& vi. 咳嗽"
+    ]
+  },
+  {
+    "name": "could modal",
+    "usphone": "kʊdˈməʊd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "v.（can的过去式）可以…；（表示许可或请求）可以…，行"
+    ]
+  },
+  {
+    "name": "count",
+    "usphone": "kaʊnt",
+    "ukphone": "",
+    "trans": [
+      "vt. 数，点数"
+    ]
+  },
+  {
+    "name": "counter",
+    "usphone": "ˈkaʊntə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 柜台，结账处"
+    ]
+  },
+  {
+    "name": "country",
+    "usphone": "ˈkʌntrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 国家；农村，乡下"
+    ]
+  },
+  {
+    "name": "countryside",
+    "usphone": "ˈkʌntrɪsaɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 乡下，农村"
+    ]
+  },
+  {
+    "name": "couple",
+    "usphone": "ˈkʌp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 夫妇，一对"
+    ]
+  },
+  {
+    "name": "courage",
+    "usphone": "ˈkʌrɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 勇气； 胆略"
+    ]
+  },
+  {
+    "name": "course",
+    "usphone": "kɔːs",
+    "ukphone": "",
+    "trans": [
+      "n. 过程；经过；课程"
+    ]
+  },
+  {
+    "name": "court",
+    "usphone": "kɔːt",
+    "ukphone": "",
+    "trans": [
+      "n. 法庭；法院"
+    ]
+  },
+  {
+    "name": "courtyard",
+    "usphone": "ˈkɔːtjɑːd",
+    "ukphone": "",
+    "trans": [
+      "n. 庭院，院子"
+    ]
+  },
+  {
+    "name": "cousin",
+    "usphone": "ˈkʌz(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 堂（表）兄弟，堂（表）姐妹"
+    ]
+  },
+  {
+    "name": "cover",
+    "usphone": "ˈkʌvə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 盖子；罩 v. 覆盖，遮盖；掩盖"
+    ]
+  },
+  {
+    "name": "cow",
+    "usphone": "kaʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 母牛，奶牛"
+    ]
+  },
+  {
+    "name": "cowboy",
+    "usphone": "ˈkaʊbɔɪ",
+    "ukphone": "",
+    "trans": [
+      "n.（美国）牛仔;牧场骑士"
+    ]
+  },
+  {
+    "name": "co-worker",
+    "usphone": "ˈkəʊ ˈwɜːkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 合作者；同事"
+    ]
+  },
+  {
+    "name": "crash",
+    "usphone": "kræʃ",
+    "ukphone": "",
+    "trans": [
+      "v. / n. 碰撞，撞击"
+    ]
+  },
+  {
+    "name": "crayon",
+    "usphone": "ˈkreɪən",
+    "ukphone": "",
+    "trans": [
+      "n 蜡笔；蜡笔画"
+    ]
+  },
+  {
+    "name": "crazy",
+    "usphone": "ˈkreɪzɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 疯狂的"
+    ]
+  },
+  {
+    "name": "cream",
+    "usphone": "kriːm",
+    "ukphone": "",
+    "trans": [
+      "n. 奶油，乳脂"
+    ]
+  },
+  {
+    "name": "create",
+    "usphone": "kriːˈeɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 创造； 造成"
+    ]
+  },
+  {
+    "name": "creature",
+    "usphone": "ˈkriːtʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 生物，动物"
+    ]
+  },
+  {
+    "name": "credit",
+    "usphone": "ˈkredɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 信用；信赖；信誉"
+    ]
+  },
+  {
+    "name": "crime",
+    "usphone": "kraɪm",
+    "ukphone": "",
+    "trans": [
+      "n. （法律上的）罪，犯罪"
+    ]
+  },
+  {
+    "name": "criminal",
+    "usphone": "ˈkrɪmɪn(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 罪犯"
+    ]
+  },
+  {
+    "name": "crew",
+    "usphone": "kruː",
+    "ukphone": "",
+    "trans": [
+      "n. 全体船员"
+    ]
+  },
+  {
+    "name": "criterion (pl. criteria)",
+    "usphone": "kraɪˈtɪərɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 标准，准则，原则"
+    ]
+  },
+  {
+    "name": "crop",
+    "usphone": "krɔp",
+    "ukphone": "",
+    "trans": [
+      "n. 庄稼；收成"
+    ]
+  },
+  {
+    "name": "cross",
+    "usphone": "krɔs",
+    "ukphone": "",
+    "trans": [
+      "a. 脾气不好的，易怒的 n. 十字形的东西 vt. 越过；穿过"
+    ]
+  },
+  {
+    "name": "crossing",
+    "usphone": "ˈkrɔsɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 十字路口，人行横道"
+    ]
+  },
+  {
+    "name": "crossroads",
+    "usphone": "ˈkrɔsrəʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 交叉路口"
+    ]
+  },
+  {
+    "name": "crowd",
+    "usphone": "kraʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 人群 vt. 拥挤，群聚"
+    ]
+  },
+  {
+    "name": "crowded",
+    "usphone": "ˈkraʊdɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 拥挤的"
+    ]
+  },
+  {
+    "name": "cruel",
+    "usphone": "ˈkruːəl",
+    "ukphone": "",
+    "trans": [
+      "a. 残忍的，残酷的；无情的"
+    ]
+  },
+  {
+    "name": "cry",
+    "usphone": "kraɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 叫喊；哭声 v. 喊叫；哭"
+    ]
+  },
+  {
+    "name": "cube",
+    "usphone": "kjuːb",
+    "ukphone": "",
+    "trans": [
+      "n. 立方体"
+    ]
+  },
+  {
+    "name": "cubic",
+    "usphone": "ˈkjuːbɪk",
+    "ukphone": "",
+    "trans": [
+      "a.立方体的，立方形的"
+    ]
+  },
+  {
+    "name": "cuisine",
+    "usphone": "kwɪˈziːn",
+    "ukphone": "",
+    "trans": [
+      "n. 饭菜，佳肴"
+    ]
+  },
+  {
+    "name": "culture",
+    "usphone": "ˈkʌltʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 文化"
+    ]
+  },
+  {
+    "name": "cup",
+    "usphone": "kʌp",
+    "ukphone": "",
+    "trans": [
+      "n. 茶杯"
+    ]
+  },
+  {
+    "name": "cupboard",
+    "usphone": "ˈkʌbəd",
+    "ukphone": "",
+    "trans": [
+      "n. 碗柜；橱柜"
+    ]
+  },
+  {
+    "name": "cure",
+    "usphone": "kjʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. & vt. 治疗；医好"
+    ]
+  },
+  {
+    "name": "curious",
+    "usphone": "ˈkjʊərɪəs",
+    "ukphone": "",
+    "trans": [
+      "a. 好奇的；奇异的"
+    ]
+  },
+  {
+    "name": "currency",
+    "usphone": "ˈkʌrənsɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 货币；现金"
+    ]
+  },
+  {
+    "name": "curriculum",
+    "usphone": "kəˈrɪkjʊləm",
+    "ukphone": "",
+    "trans": [
+      "n.（学校的）全部课程"
+    ]
+  },
+  {
+    "name": "curtain",
+    "usphone": "ˈkɜːt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 窗帘"
+    ]
+  },
+  {
+    "name": "cushion",
+    "usphone": "ˈkʊʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 垫子"
+    ]
+  },
+  {
+    "name": "custom",
+    "usphone": "ˈkʌstəm",
+    "ukphone": "",
+    "trans": [
+      "n. 习惯，习俗，风俗习惯"
+    ]
+  },
+  {
+    "name": "customer",
+    "usphone": "ˈkʌstəmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （商店）顾客，主顾"
+    ]
+  },
+  {
+    "name": "customs",
+    "usphone": "ˈkʌstəm",
+    "ukphone": "",
+    "trans": [
+      "n. 海关，关税"
+    ]
+  },
+  {
+    "name": "cut (cut, cut)",
+    "usphone": "kʌt",
+    "ukphone": "",
+    "trans": [
+      "v. / n. 切，剪，削，割, 伤口"
+    ]
+  },
+  {
+    "name": "cycle",
+    "usphone": "ˈsaɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "vi. 骑自行车"
+    ]
+  },
+  {
+    "name": "cyclist",
+    "usphone": "ˈsaɪklɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 骑自行车的人"
+    ]
+  },
+  {
+    "name": "dad = daddy",
+    "usphone": "dæd",
+    "ukphone": "",
+    "trans": [
+      "n.（口）爸爸，爹爹"
+    ]
+  },
+  {
+    "name": "daily",
+    "usphone": "ˈdeɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 每日的；日常的 ad. 每天 n. 日报"
+    ]
+  },
+  {
+    "name": "dam",
+    "usphone": "dæm",
+    "ukphone": "",
+    "trans": [
+      "n. 水坝，堰堤"
+    ]
+  },
+  {
+    "name": "damage",
+    "usphone": "ˈdæmɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 毁坏，损害"
+    ]
+  },
+  {
+    "name": "damp",
+    "usphone": "dæmp",
+    "ukphone": "",
+    "trans": [
+      "a. & n. 潮湿（的）"
+    ]
+  },
+  {
+    "name": "dance",
+    "usphone": "dɑːns; (US) dæns",
+    "ukphone": "",
+    "trans": [
+      "n.& vi. 跳舞"
+    ]
+  },
+  {
+    "name": "danger",
+    "usphone": "ˈdeɪndʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 危险"
+    ]
+  },
+  {
+    "name": "dangerous",
+    "usphone": "ˈdeɪndʒərəs",
+    "ukphone": "",
+    "trans": [
+      "a. 危险的"
+    ]
+  },
+  {
+    "name": "dare",
+    "usphone": "deə(r)",
+    "ukphone": "",
+    "trans": [
+      "v.& aux..（后接不带to的不定式；主要用于疑问，否定或条件句）敢，敢于"
+    ]
+  },
+  {
+    "name": "dark",
+    "usphone": "dɑːk",
+    "ukphone": "",
+    "trans": [
+      "n. 黑暗；暗处；日暮 a. 黑暗的；暗淡的；深色的"
+    ]
+  },
+  {
+    "name": "darkness",
+    "usphone": "ˈdɑːknɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 黑暗，阴暗"
+    ]
+  },
+  {
+    "name": "dash",
+    "usphone": "dæʃ",
+    "ukphone": "",
+    "trans": [
+      "v. & n. 快跑，冲刺，短跑"
+    ]
+  },
+  {
+    "name": "data",
+    "usphone": "ˈdeɪtə, ˈdɑːtə; (US) ˈdætə",
+    "ukphone": "",
+    "trans": [
+      "n. 资料，数据"
+    ]
+  },
+  {
+    "name": "database",
+    "usphone": "ˈdeɪtbeɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 资料库，数据库"
+    ]
+  },
+  {
+    "name": "date",
+    "usphone": "deɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 日期；约会 n.枣"
+    ]
+  },
+  {
+    "name": "daughter",
+    "usphone": "ˈdɔːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 女儿"
+    ]
+  },
+  {
+    "name": "dawn",
+    "usphone": "dɔːn",
+    "ukphone": "",
+    "trans": [
+      "n. 黎明，拂晓"
+    ]
+  },
+  {
+    "name": "day",
+    "usphone": "deɪ",
+    "ukphone": "",
+    "trans": [
+      "n.（一）天，（一）日；白天"
+    ]
+  },
+  {
+    "name": "daylight",
+    "usphone": "ˈdeɪlaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 日光，白昼； 黎明"
+    ]
+  },
+  {
+    "name": "dead",
+    "usphone": "ded",
+    "ukphone": "",
+    "trans": [
+      "a. 死的；无生命的"
+    ]
+  },
+  {
+    "name": "deadline",
+    "usphone": "ˈdedlaɪn",
+    "ukphone": "",
+    "trans": [
+      "n.最后期限，截止日期"
+    ]
+  },
+  {
+    "name": "deaf",
+    "usphone": "def",
+    "ukphone": "",
+    "trans": [
+      "a. 聋的"
+    ]
+  },
+  {
+    "name": "deal",
+    "usphone": "diːl",
+    "ukphone": "",
+    "trans": [
+      "n. 量，数额；交易"
+    ]
+  },
+  {
+    "name": "dear",
+    "usphone": "dɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "int.（表示惊愕）哎呀！唷！ a. 亲爱的；贵的"
+    ]
+  },
+  {
+    "name": "death",
+    "usphone": "deθ",
+    "ukphone": "",
+    "trans": [
+      "n. 死"
+    ]
+  },
+  {
+    "name": "debate",
+    "usphone": "dɪˈbeɪt",
+    "ukphone": "",
+    "trans": [
+      "n. & v.讨论，辩论"
+    ]
+  },
+  {
+    "name": "debt",
+    "usphone": "det",
+    "ukphone": "",
+    "trans": [
+      "n. 债务；欠款"
+    ]
+  },
+  {
+    "name": "decade",
+    "usphone": "ˈdekeɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 十年期"
+    ]
+  },
+  {
+    "name": "December",
+    "usphone": "dɪˈsembə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 12月"
+    ]
+  },
+  {
+    "name": "decide",
+    "usphone": "dɪˈsaɪd",
+    "ukphone": "",
+    "trans": [
+      "v. 决定；下决心"
+    ]
+  },
+  {
+    "name": "decision",
+    "usphone": "dɪˈsɪʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 决定；决心"
+    ]
+  },
+  {
+    "name": "declare",
+    "usphone": "dɪˈkleə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 声明；断言"
+    ]
+  },
+  {
+    "name": "decline",
+    "usphone": "dɪˈklaɪn",
+    "ukphone": "",
+    "trans": [
+      "v. 减少,下降,衰退,谢绝"
+    ]
+  },
+  {
+    "name": "decorate",
+    "usphone": "ˈdekəreɪt",
+    "ukphone": "",
+    "trans": [
+      "vt.装饰…，修饰…"
+    ]
+  },
+  {
+    "name": "decoration",
+    "usphone": "dekəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.装饰，修饰"
+    ]
+  },
+  {
+    "name": "decrease",
+    "usphone": "dɪˈkriːs",
+    "ukphone": "",
+    "trans": [
+      "v.减少，减小，降低"
+    ]
+  },
+  {
+    "name": "deed",
+    "usphone": "diːd",
+    "ukphone": "",
+    "trans": [
+      "n. 行为；事迹"
+    ]
+  },
+  {
+    "name": "deep",
+    "usphone": "diːp",
+    "ukphone": "",
+    "trans": [
+      "a. 深 ad. 深；深厚"
+    ]
+  },
+  {
+    "name": "deeply",
+    "usphone": "ˈdiːplɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 深深地"
+    ]
+  },
+  {
+    "name": "deer",
+    "usphone": "dɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 鹿"
+    ]
+  },
+  {
+    "name": "defeat",
+    "usphone": "dɪˈfiːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 击败；战胜"
+    ]
+  },
+  {
+    "name": "defence (美defense)",
+    "usphone": "diˈfens",
+    "ukphone": "",
+    "trans": [
+      "n. & v. 防御；防务"
+    ]
+  },
+  {
+    "name": "defend",
+    "usphone": "dɪˈfend",
+    "ukphone": "",
+    "trans": [
+      "vt. 防守；保卫"
+    ]
+  },
+  {
+    "name": "degree",
+    "usphone": "dɪˈɡriː",
+    "ukphone": "",
+    "trans": [
+      "n. 程度；度数；学位"
+    ]
+  },
+  {
+    "name": "delay",
+    "usphone": "dɪˈleɪ",
+    "ukphone": "",
+    "trans": [
+      "v.& n. 拖延，延误，延迟，延期；耽搁"
+    ]
+  },
+  {
+    "name": "delete",
+    "usphone": "dɪˈliːt",
+    "ukphone": "",
+    "trans": [
+      "v. 删去"
+    ]
+  },
+  {
+    "name": "deliberately",
+    "usphone": "dɪˈlɪbərətlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad.故意,蓄意,存心"
+    ]
+  },
+  {
+    "name": "delicate",
+    "usphone": "ˈdelɪkət",
+    "ukphone": "",
+    "trans": [
+      "a.易损的，易碎的"
+    ]
+  },
+  {
+    "name": "delicious",
+    "usphone": "dɪˈlɪʃəs",
+    "ukphone": "",
+    "trans": [
+      "a. 美味的，可口的"
+    ]
+  },
+  {
+    "name": "delight",
+    "usphone": "dɪˈlaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 快乐；乐事"
+    ]
+  },
+  {
+    "name": "delighted",
+    "usphone": "diˈlaitid",
+    "ukphone": "",
+    "trans": [
+      "a. 高兴的，快乐的"
+    ]
+  },
+  {
+    "name": "deliver",
+    "usphone": "dɪˈlɪvə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 投递（信件，邮包等）"
+    ]
+  },
+  {
+    "name": "demand",
+    "usphone": "dɪˈmɑːnd; (US) dɪˈmænd",
+    "ukphone": "",
+    "trans": [
+      "vt. 要求"
+    ]
+  },
+  {
+    "name": "dentist",
+    "usphone": "ˈdentɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 牙科医生 "
+    ]
+  },
+  {
+    "name": "department(缩Dept.)",
+    "usphone": "dɪˈpɑːtmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 部门；（机关的）司，处；（大学的）系"
+    ]
+  },
+  {
+    "name": "department -store",
+    "usphone": "dɪˈpɑːtmənt-stɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 百货商场"
+    ]
+  },
+  {
+    "name": "departure",
+    "usphone": "dɪˈpɑːtʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 离开，启程"
+    ]
+  },
+  {
+    "name": "depend",
+    "usphone": "dɪˈpend",
+    "ukphone": "",
+    "trans": [
+      "vi. 依靠，依赖，指望；取决于"
+    ]
+  },
+  {
+    "name": "deposit",
+    "usphone": "dɪˈpɔzɪt",
+    "ukphone": "",
+    "trans": [
+      "v. / n. 订金，押金，放下，放置，储存"
+    ]
+  },
+  {
+    "name": "depth",
+    "usphone": "depθ",
+    "ukphone": "",
+    "trans": [
+      "n. 深，深度"
+    ]
+  },
+  {
+    "name": "describe",
+    "usphone": "dɪˈskraɪb",
+    "ukphone": "",
+    "trans": [
+      "vt. 描写，叙述"
+    ]
+  },
+  {
+    "name": "description",
+    "usphone": "dɪˈskrɪpʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 描述，描写"
+    ]
+  },
+  {
+    "name": "desert",
+    "usphone": "dɪˈzɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. 沙漠 vt. 舍弃； 遗弃"
+    ]
+  },
+  {
+    "name": "deserve",
+    "usphone": "dɪˈzɜːv",
+    "ukphone": "",
+    "trans": [
+      "v.（不用于进行时态）应得，应受"
+    ]
+  },
+  {
+    "name": "design",
+    "usphone": "dɪˈzaɪn",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. n. 设计，策划 图案，图样，样式"
+    ]
+  },
+  {
+    "name": "desire",
+    "usphone": "dɪˈzaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. & n. 要求；期望"
+    ]
+  },
+  {
+    "name": "desk",
+    "usphone": "desk",
+    "ukphone": "",
+    "trans": [
+      "n. 书桌，写字台"
+    ]
+  },
+  {
+    "name": "desperate",
+    "usphone": "ˈdespərət",
+    "ukphone": "",
+    "trans": [
+      "a.（因绝望而）不惜冒险的，不顾一切的，拼命的"
+    ]
+  },
+  {
+    "name": "dessert",
+    "usphone": "dɪˈzɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. 甜点"
+    ]
+  },
+  {
+    "name": "destination",
+    "usphone": "destɪˈneɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.目的地，终点"
+    ]
+  },
+  {
+    "name": "destroy",
+    "usphone": "dɪˈstrɔɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 破坏，毁坏"
+    ]
+  },
+  {
+    "name": "detective",
+    "usphone": "dɪˈtektɪv",
+    "ukphone": "",
+    "trans": [
+      "n. 侦探"
+    ]
+  },
+  {
+    "name": "determination",
+    "usphone": "dɪtɜːmɪˈneɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 决心"
+    ]
+  },
+  {
+    "name": "determine",
+    "usphone": "dɪˈtɜːmɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. 决定；决心"
+    ]
+  },
+  {
+    "name": "develop",
+    "usphone": "dɪˈveləp",
+    "ukphone": "",
+    "trans": [
+      "v. （使）发展；（使）发达；（使）发育；开发 vt. 冲洗（照片）"
+    ]
+  },
+  {
+    "name": "development",
+    "usphone": "dɪˈveləpmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 发展，发达，发育，开发"
+    ]
+  },
+  {
+    "name": "devote",
+    "usphone": "dɪˈvəʊt",
+    "ukphone": "",
+    "trans": [
+      "vt. 把…奉献, 把…专用（于）"
+    ]
+  },
+  {
+    "name": "devotion",
+    "usphone": "dɪˈvəʊʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 奉献，奉献精神"
+    ]
+  },
+  {
+    "name": "diagram",
+    "usphone": "ˈdaɪəɡræm",
+    "ukphone": "",
+    "trans": [
+      "n. 图表，图样"
+    ]
+  },
+  {
+    "name": "dial",
+    "usphone": "ˈdaɪ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "vt. 拨（电话号码）"
+    ]
+  },
+  {
+    "name": "dialogue (美 dialog)",
+    "usphone": "ˈdaɪəlɔɡ; (US) ˈdaɪəlɔːɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 对话"
+    ]
+  },
+  {
+    "name": "diamond",
+    "usphone": "ˈdaɪəmənd",
+    "ukphone": "",
+    "trans": [
+      "n. 钻石，金刚石；纸牌中的方块"
+    ]
+  },
+  {
+    "name": "diary",
+    "usphone": "ˈdaɪərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 日记；日记簿"
+    ]
+  },
+  {
+    "name": "dictation",
+    "usphone": "dɪkˈteɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 听写"
+    ]
+  },
+  {
+    "name": "dictionary",
+    "usphone": "ˈdɪkʃənərɪ; (US) ˈdɪkʃənerɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 词典，字典"
+    ]
+  },
+  {
+    "name": "die",
+    "usphone": "daɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 死"
+    ]
+  },
+  {
+    "name": "diet",
+    "usphone": "daɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 饮食"
+    ]
+  },
+  {
+    "name": "differ",
+    "usphone": "ˈdɪfə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 相异，有区别"
+    ]
+  },
+  {
+    "name": "difference",
+    "usphone": "ˈdɪfrəns",
+    "ukphone": "",
+    "trans": [
+      "n. 不同"
+    ]
+  },
+  {
+    "name": "different",
+    "usphone": "ˈdɪfrənt",
+    "ukphone": "",
+    "trans": [
+      "a. 不同的，有差异的"
+    ]
+  },
+  {
+    "name": "difficult",
+    "usphone": "ˈdɪfɪkəlt",
+    "ukphone": "",
+    "trans": [
+      "a.难；艰难；不易相处"
+    ]
+  },
+  {
+    "name": "difficulty",
+    "usphone": "ˈdɪfɪkəltɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 困难，费力"
+    ]
+  },
+  {
+    "name": "dig (dug, dug)",
+    "usphone": "dɪɡ",
+    "ukphone": "",
+    "trans": [
+      "v. 挖（洞沟）,掘"
+    ]
+  },
+  {
+    "name": "digest",
+    "usphone": "dɪˈdʒest, daɪˈdʒest",
+    "ukphone": "",
+    "trans": [
+      "v.消化, 领会"
+    ]
+  },
+  {
+    "name": "digital",
+    "usphone": "ˈdɪdʒɪt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. .数字的，数码的"
+    ]
+  },
+  {
+    "name": "dignity",
+    "usphone": "ˈdɪɡnɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 庄重，庄严，尊严。尊贵，高尚"
+    ]
+  },
+  {
+    "name": "dilemma",
+    "usphone": "daɪˈlemə",
+    "ukphone": "",
+    "trans": [
+      "n. （进退两难的）窘境，困境"
+    ]
+  },
+  {
+    "name": "dimension",
+    "usphone": "dɪˈmenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.量度，尺寸，面积，程度，范围"
+    ]
+  },
+  {
+    "name": "dine",
+    "usphone": "daɪn",
+    "ukphone": "",
+    "trans": [
+      "v. 吃饭；（指正式）进餐"
+    ]
+  },
+  {
+    "name": "dining-room",
+    "usphone": "ˈdainiŋ-rʊm",
+    "ukphone": "",
+    "trans": [
+      "食堂，饭厅"
+    ]
+  },
+  {
+    "name": "dinner",
+    "usphone": "ˈdɪnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 正餐，宴会"
+    ]
+  },
+  {
+    "name": "dinosaur",
+    "usphone": "ˈdaɪnəsɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 恐龙"
+    ]
+  },
+  {
+    "name": "dioxide",
+    "usphone": "daɪˈɔksaɪd",
+    "ukphone": "",
+    "trans": [
+      "n.二氧化物"
+    ]
+  },
+  {
+    "name": "dip",
+    "usphone": "dɪp",
+    "ukphone": "",
+    "trans": [
+      "vt. 浸，蘸；把…放入又取出"
+    ]
+  },
+  {
+    "name": "diploma",
+    "usphone": "dɪˈpləʊmə",
+    "ukphone": "",
+    "trans": [
+      "n.毕业文凭；学位证书"
+    ]
+  },
+  {
+    "name": "direct",
+    "usphone": "dɪˈrekt, daɪˈrekt",
+    "ukphone": "",
+    "trans": [
+      "a. / vt. 直接的；直达的；直截了当的 指挥；指导；监督；管理；指挥（演奏）；导演（电影）"
+    ]
+  },
+  {
+    "name": "direction",
+    "usphone": "dɪˈrekʃ(ə)n, daɪˈrekʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 方向；方位"
+    ]
+  },
+  {
+    "name": "director",
+    "usphone": "dɪˈrektə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 所长，处长，主任；董事；导演"
+    ]
+  },
+  {
+    "name": "directory",
+    "usphone": "dɪˈrektərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 姓名地址录"
+    ]
+  },
+  {
+    "name": "dirt",
+    "usphone": "dɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. 污物；脏物"
+    ]
+  },
+  {
+    "name": "dirty",
+    "usphone": "ˈdɜːtɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 脏的"
+    ]
+  },
+  {
+    "name": "disability",
+    "usphone": "dɪsəˈbɪlɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n.. 残疾；无能"
+    ]
+  },
+  {
+    "name": "disabled",
+    "usphone": "dɪsˈeɪb(ə)ld",
+    "ukphone": "",
+    "trans": [
+      "a. 残废的，残疾的"
+    ]
+  },
+  {
+    "name": "disadvantage",
+    "usphone": "dɪsədˈvɑːntɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 不利条件；弱点"
+    ]
+  },
+  {
+    "name": "disagree",
+    "usphone": "dɪsəˈɡriː",
+    "ukphone": "",
+    "trans": [
+      "vi. 意见不一致，持不同意见"
+    ]
+  },
+  {
+    "name": "disagreement",
+    "usphone": "dɪsəˈɡriːmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 意见不一致；相违；争论"
+    ]
+  },
+  {
+    "name": "disappear",
+    "usphone": "dɪsəˈpɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 消失"
+    ]
+  },
+  {
+    "name": "disappoint",
+    "usphone": "dɪsəˈpɔɪnt",
+    "ukphone": "",
+    "trans": [
+      "vt. 使失望"
+    ]
+  },
+  {
+    "name": "disappointment",
+    "usphone": "dɪsəˈpɔɪntmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 失望；沮丧"
+    ]
+  },
+  {
+    "name": "disaster",
+    "usphone": "dɪˈzɑːstə(r); (US) dɪzˈæstər",
+    "ukphone": "",
+    "trans": [
+      "n. 灾难；祸患"
+    ]
+  },
+  {
+    "name": "discount",
+    "usphone": "ˈdɪskaʊnt",
+    "ukphone": "",
+    "trans": [
+      "n. 折扣"
+    ]
+  },
+  {
+    "name": "discourage",
+    "usphone": "dɪˈskʌrɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "vt. （使）气馁；打消（做…的念头）"
+    ]
+  },
+  {
+    "name": "discover",
+    "usphone": "dɪˈskʌvə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 发现"
+    ]
+  },
+  {
+    "name": "discovery",
+    "usphone": "dɪˈskʌvərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 发现"
+    ]
+  },
+  {
+    "name": "discrimination",
+    "usphone": "dɪskrɪmɪˈneɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 歧视"
+    ]
+  },
+  {
+    "name": "discuss",
+    "usphone": "dɪsˈkʌs",
+    "ukphone": "",
+    "trans": [
+      "vt. 讨论，议论"
+    ]
+  },
+  {
+    "name": "discussion",
+    "usphone": "dɪsˈkʌʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 讨论，辩论"
+    ]
+  },
+  {
+    "name": "disease",
+    "usphone": "dɪˈziːz",
+    "ukphone": "",
+    "trans": [
+      "n. 病，疾病"
+    ]
+  },
+  {
+    "name": "disgusting",
+    "usphone": "dɪsˈɡʌstɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a.极糟的，令人不快的，令人厌恶的"
+    ]
+  },
+  {
+    "name": "dish",
+    "usphone": "dɪʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 盘，碟；盘装菜；盘形物"
+    ]
+  },
+  {
+    "name": "disk =disc",
+    "usphone": "dɪsk",
+    "ukphone": "",
+    "trans": [
+      "n. 磁盘"
+    ]
+  },
+  {
+    "name": "dislike",
+    "usphone": "dɪsˈlaɪk",
+    "ukphone": "",
+    "trans": [
+      "vt. 不喜爱；厌恶"
+    ]
+  },
+  {
+    "name": "dismiss",
+    "usphone": "dɪsˈmɪs",
+    "ukphone": "",
+    "trans": [
+      "vt. 让……离开；遣散；解散；解雇"
+    ]
+  },
+  {
+    "name": "disobey",
+    "usphone": "dɪsəˈbeɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 不服从"
+    ]
+  },
+  {
+    "name": "distance",
+    "usphone": "ˈdɪstəns",
+    "ukphone": "",
+    "trans": [
+      "n. 距离"
+    ]
+  },
+  {
+    "name": "distant",
+    "usphone": "ˈdɪst(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "a. 远的，遥远的"
+    ]
+  },
+  {
+    "name": "distinction",
+    "usphone": "dɪˈstɪŋkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.差别,区别,优秀,卓越"
+    ]
+  },
+  {
+    "name": "distinguish",
+    "usphone": "dɪˈstɪŋɡwɪʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 区分，辨别，分清"
+    ]
+  },
+  {
+    "name": "distribute",
+    "usphone": "dɪˈstrɪbjuːt",
+    "ukphone": "",
+    "trans": [
+      "v. 分发，分配"
+    ]
+  },
+  {
+    "name": "district",
+    "usphone": "ˈdɪstrɪkt",
+    "ukphone": "",
+    "trans": [
+      "n. 区；地区；区域"
+    ]
+  },
+  {
+    "name": "disturb",
+    "usphone": "dɪˈstɜːb",
+    "ukphone": "",
+    "trans": [
+      "vt. 扰乱；打扰"
+    ]
+  },
+  {
+    "name": "disturbing",
+    "usphone": "dɪˈstɜːbɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 令人不安的，引起恐慌的"
+    ]
+  },
+  {
+    "name": "dive",
+    "usphone": "daɪv",
+    "ukphone": "",
+    "trans": [
+      "vi. 跳水"
+    ]
+  },
+  {
+    "name": "diverse",
+    "usphone": "daɪˈvɜːs",
+    "ukphone": "",
+    "trans": [
+      "v. 不同的，多种多样，形形色色的"
+    ]
+  },
+  {
+    "name": "divide",
+    "usphone": "dɪˈvaɪd",
+    "ukphone": "",
+    "trans": [
+      "vt. 分，划分"
+    ]
+  },
+  {
+    "name": "division",
+    "usphone": "dɪˈvɪʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. （算术用语）除"
+    ]
+  },
+  {
+    "name": "divorce",
+    "usphone": "dɪˈvɔːs",
+    "ukphone": "",
+    "trans": [
+      "v. 离婚"
+    ]
+  },
+  {
+    "name": "dizzy",
+    "usphone": "ˈdɪzɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 头眩目晕的"
+    ]
+  },
+  {
+    "name": "do (did, done) donˈt=do not",
+    "usphone": "dʊ, duː",
+    "ukphone": "",
+    "trans": [
+      "v. & aux. 做，干（用以构成疑问句及否定句。第三人称单数现在时用does） 不做，不干"
+    ]
+  },
+  {
+    "name": "doctor",
+    "usphone": "ˈdɔktə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 医生，大夫；博士"
+    ]
+  },
+  {
+    "name": "document",
+    "usphone": "ˈdɔkjʊmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 文件；文献"
+    ]
+  },
+  {
+    "name": "does doesnˈt = does not",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "v. 动词do的第三人称单数现在式"
+    ]
+  },
+  {
+    "name": "dog",
+    "usphone": "dɔɡ; (US) dɔːɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 狗"
+    ]
+  },
+  {
+    "name": "doll",
+    "usphone": "dɔl; (US) dɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 玩偶，玩具娃娃"
+    ]
+  },
+  {
+    "name": "dollar",
+    "usphone": "dɔl; (US) dɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 元（美国、加拿大、澳大利亚等国货币单位）"
+    ]
+  },
+  {
+    "name": "door",
+    "usphone": "dɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 门"
+    ]
+  },
+  {
+    "name": "dormitory",
+    "usphone": "ˈdɔːmɪtərɪ; (US) ˈdɔːrmɪtɔːrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 学生宿舍（缩写式dorm）"
+    ]
+  },
+  {
+    "name": "dot",
+    "usphone": "dɔt",
+    "ukphone": "",
+    "trans": [
+      "n. 点，小点，圆点"
+    ]
+  },
+  {
+    "name": "double",
+    "usphone": "ˈdʌb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 两倍.双的 n. 两个.双"
+    ]
+  },
+  {
+    "name": "doubt",
+    "usphone": "daʊt",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 怀疑，疑惑"
+    ]
+  },
+  {
+    "name": "down",
+    "usphone": "daʊn",
+    "ukphone": "",
+    "trans": [
+      "prep. 沿着，沿…而下 ad. 向下"
+    ]
+  },
+  {
+    "name": "download",
+    "usphone": "ˈdaunləud",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 下载"
+    ]
+  },
+  {
+    "name": "downstairs",
+    "usphone": "ˈdaʊnsteəz",
+    "ukphone": "",
+    "trans": [
+      "ad. 在楼下；到楼下"
+    ]
+  },
+  {
+    "name": "downtown",
+    "usphone": "ˈdaʊntaʊn",
+    "ukphone": "",
+    "trans": [
+      "ad. 往或在城市的商业区（或中心区、闹市区） n. 城市的商业区，中心区，闹市区 a.城市的商业区的，中心区的，闹市区的"
+    ]
+  },
+  {
+    "name": "downward",
+    "usphone": "ˈdaʊnwəd",
+    "ukphone": "",
+    "trans": [
+      "ad. 向下"
+    ]
+  },
+  {
+    "name": "dozen",
+    "usphone": "ˈdaʊnwəd",
+    "ukphone": "",
+    "trans": [
+      "n. 十二个；几十，许多"
+    ]
+  },
+  {
+    "name": "Dr(缩) = Doctor",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 医生，大夫；博士"
+    ]
+  },
+  {
+    "name": "draft",
+    "usphone": "drɑːft; (US) dræft",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 草稿，草案，起草，草拟"
+    ]
+  },
+  {
+    "name": "drag",
+    "usphone": "dræɡ",
+    "ukphone": "",
+    "trans": [
+      "v. 拖；拽"
+    ]
+  },
+  {
+    "name": "draw (drew, drawn)",
+    "usphone": "drɔː",
+    "ukphone": "",
+    "trans": [
+      "v. 绘画；绘制；拉，拖；提取（金钱）"
+    ]
+  },
+  {
+    "name": "drawback",
+    "usphone": "ˈdrɔːbæk",
+    "ukphone": "",
+    "trans": [
+      "n.缺点，不利条件"
+    ]
+  },
+  {
+    "name": "drawer",
+    "usphone": "ˈdrɔːə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 抽屉"
+    ]
+  },
+  {
+    "name": "drawing",
+    "usphone": "ˈdrɔːɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 图画，素描,绘画"
+    ]
+  },
+  {
+    "name": "dream (dreamt, dreamt 或--ed, --ed)",
+    "usphone": "driːm",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 梦，梦想"
+    ]
+  },
+  {
+    "name": "dress",
+    "usphone": "dres",
+    "ukphone": "",
+    "trans": [
+      "n. 女服，连衣裙；(统指)服装；童装 v. 穿衣；穿着"
+    ]
+  },
+  {
+    "name": "drier =dryer",
+    "usphone": "ˈdraɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 烘干机；吹风机"
+    ]
+  },
+  {
+    "name": "drill",
+    "usphone": "drɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 钻头；（反复的）训练 vt. 钻(孔)， 在…上钻孔；重复训练"
+    ]
+  },
+  {
+    "name": "drink",
+    "usphone": "drɪŋk",
+    "ukphone": "",
+    "trans": [
+      "n. 饮料；喝酒 "
+    ]
+  },
+  {
+    "name": "drink(drank,drunk)",
+    "usphone": "drɪŋk",
+    "ukphone": "",
+    "trans": [
+      "v. 喝，饮"
+    ]
+  },
+  {
+    "name": "drive(drove,driven)",
+    "usphone": "draɪv",
+    "ukphone": "",
+    "trans": [
+      "v. 驾驶，开（车）；驱赶"
+    ]
+  },
+  {
+    "name": "driver",
+    "usphone": "ˈdraɪvə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 司机，驾驶员"
+    ]
+  },
+  {
+    "name": "drop",
+    "usphone": "drɔp",
+    "ukphone": "",
+    "trans": [
+      "n.滴 v.掉下.落下.投递.放弃"
+    ]
+  },
+  {
+    "name": "drown",
+    "usphone": "draʊn",
+    "ukphone": "",
+    "trans": [
+      "vi. 溺死；淹没"
+    ]
+  },
+  {
+    "name": "drug",
+    "usphone": "drʌɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 药，药物；毒品"
+    ]
+  },
+  {
+    "name": "drum",
+    "usphone": "drʌm",
+    "ukphone": "",
+    "trans": [
+      "n. 鼓"
+    ]
+  },
+  {
+    "name": "drunk",
+    "usphone": "drʌŋk",
+    "ukphone": "",
+    "trans": [
+      "a. 醉的"
+    ]
+  },
+  {
+    "name": "dry",
+    "usphone": "draɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 使…干；弄干；擦干 a. 干的；干燥的"
+    ]
+  },
+  {
+    "name": "duck",
+    "usphone": "dʌk",
+    "ukphone": "",
+    "trans": [
+      "n. 鸭子"
+    ]
+  },
+  {
+    "name": "due",
+    "usphone": "djuː; (US) duː",
+    "ukphone": "",
+    "trans": [
+      "a. 预期的；约定的"
+    ]
+  },
+  {
+    "name": "dull",
+    "usphone": "dʌl",
+    "ukphone": "",
+    "trans": [
+      "a. 阴暗的；单调无味"
+    ]
+  },
+  {
+    "name": "dumpling",
+    "usphone": "ˈdʌmplɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 饺子"
+    ]
+  },
+  {
+    "name": "during",
+    "usphone": "ˈdjʊərɪŋ; (US) ˈdʊərɪŋ",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…期间；在…过程中"
+    ]
+  },
+  {
+    "name": "dusk",
+    "usphone": "dʌsk",
+    "ukphone": "",
+    "trans": [
+      "n. 黄昏"
+    ]
+  },
+  {
+    "name": "dust",
+    "usphone": "dʌst",
+    "ukphone": "",
+    "trans": [
+      "n. 灰尘，尘土"
+    ]
+  },
+  {
+    "name": "dustbin",
+    "usphone": "ˈdʌstbɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 垃圾箱"
+    ]
+  },
+  {
+    "name": "dusty",
+    "usphone": "ˈdʌstɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 尘土般的，尘土多的"
+    ]
+  },
+  {
+    "name": "duty",
+    "usphone": "ˈdjuːtɪ; (US) ˈduːtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 责任，义务"
+    ]
+  },
+  {
+    "name": "DVD",
+    "usphone": "ˈdi:ˈvi:ˈdi:",
+    "ukphone": "",
+    "trans": [
+      "数码影碟(digital versatile disk)"
+    ]
+  },
+  {
+    "name": "Dynamic",
+    "usphone": "daɪˈnæmɪk",
+    "ukphone": "",
+    "trans": [
+      "a.充满活力,精力充沛的"
+    ]
+  },
+  {
+    "name": "Dynasty",
+    "usphone": "ˈdɪnəstɪ; (US) ˈdaɪnəstɪ",
+    "ukphone": "",
+    "trans": [
+      "n.王朝，朝代"
+    ]
+  },
+  {
+    "name": "each",
+    "usphone": "iːtʃ",
+    "ukphone": "",
+    "trans": [
+      "a.& pron.每人.每个.每件"
+    ]
+  },
+  {
+    "name": "eager",
+    "usphone": "ˈiːɡə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 渴望的，热切的"
+    ]
+  },
+  {
+    "name": "eagle",
+    "usphone": "ˈiːɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 鹰"
+    ]
+  },
+  {
+    "name": "ear",
+    "usphone": "ɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.耳朵.耳状物；听力，听觉"
+    ]
+  },
+  {
+    "name": "early",
+    "usphone": "ɜːlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 早的 ad. 早地"
+    ]
+  },
+  {
+    "name": "earn",
+    "usphone": "ɜːn",
+    "ukphone": "",
+    "trans": [
+      "vt. 挣得，赚得"
+    ]
+  },
+  {
+    "name": "earth",
+    "usphone": "ɜːθ",
+    "ukphone": "",
+    "trans": [
+      "n. 地球；土，泥；大地"
+    ]
+  },
+  {
+    "name": "earthquake",
+    "usphone": "ˈɜːθkweɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 地震"
+    ]
+  },
+  {
+    "name": "ease",
+    "usphone": "iːz",
+    "ukphone": "",
+    "trans": [
+      "v. 减轻；缓解（难度或严重程度）"
+    ]
+  },
+  {
+    "name": "easily",
+    "usphone": "ˈiːzɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 容易地"
+    ]
+  },
+  {
+    "name": "east",
+    "usphone": "iːst",
+    "ukphone": "",
+    "trans": [
+      "a. 东方；东部的；朝东的；从东方来 ad. 在东方；向东方；从东方 n. 东，东方；东部"
+    ]
+  },
+  {
+    "name": "Easter",
+    "usphone": "ˈiːstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 复活节"
+    ]
+  },
+  {
+    "name": "eastern",
+    "usphone": "ˈiːst(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 东方的；东部的"
+    ]
+  },
+  {
+    "name": "eastwards",
+    "usphone": "ˈiːstwədz",
+    "ukphone": "",
+    "trans": [
+      "ad. 向东"
+    ]
+  },
+  {
+    "name": "easy",
+    "usphone": "ˈiːzɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 容易的，不费力的"
+    ]
+  },
+  {
+    "name": "easy--going",
+    "usphone": "ˈiːzɪ-ˈɡəʊɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 随和的"
+    ]
+  },
+  {
+    "name": "eat (ate, eaten)",
+    "usphone": "iːt",
+    "ukphone": "",
+    "trans": [
+      "v. 吃"
+    ]
+  },
+  {
+    "name": "ecology",
+    "usphone": "ɪˈkɔlədʒɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 生态，生态学"
+    ]
+  },
+  {
+    "name": "edge",
+    "usphone": "edʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 边缘"
+    ]
+  },
+  {
+    "name": "edition",
+    "usphone": "ɪˈdɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.（发行物的）版，版（本）"
+    ]
+  },
+  {
+    "name": "editor",
+    "usphone": "ˈedɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 编辑"
+    ]
+  },
+  {
+    "name": "educate",
+    "usphone": "ˈedjʊkeɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 教育，培养"
+    ]
+  },
+  {
+    "name": "educator",
+    "usphone": "ˈedju:keitə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 教育家"
+    ]
+  },
+  {
+    "name": "education",
+    "usphone": "edjʊˈkeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 教育，培养"
+    ]
+  },
+  {
+    "name": "effect",
+    "usphone": "ɪˈfekt",
+    "ukphone": "",
+    "trans": [
+      "n. 效果；作用"
+    ]
+  },
+  {
+    "name": "effort",
+    "usphone": "ˈefət",
+    "ukphone": "",
+    "trans": [
+      "n. 努力，艰难的尝试"
+    ]
+  },
+  {
+    "name": "egg",
+    "usphone": "eɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 蛋；卵"
+    ]
+  },
+  {
+    "name": "eggplant",
+    "usphone": "ˈeɡplɑːnt",
+    "ukphone": "",
+    "trans": [
+      "n. 茄子"
+    ]
+  },
+  {
+    "name": "Egypt*",
+    "usphone": "ˈiːdʒɪpt",
+    "ukphone": "",
+    "trans": [
+      "n. 埃及"
+    ]
+  },
+  {
+    "name": "Egyptian",
+    "usphone": "ɪˈdʒɪpʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 埃及的；埃及人的；埃及语的 n. 埃及人"
+    ]
+  },
+  {
+    "name": "eight",
+    "usphone": "eɪt",
+    "ukphone": "",
+    "trans": [
+      "num. 八"
+    ]
+  },
+  {
+    "name": "eighteen",
+    "usphone": "ˈeɪˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "num. 十八"
+    ]
+  },
+  {
+    "name": "eighth",
+    "usphone": "eɪtθ",
+    "ukphone": "",
+    "trans": [
+      "num. 第八"
+    ]
+  },
+  {
+    "name": "eighty",
+    "usphone": "ˈeɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 八十"
+    ]
+  },
+  {
+    "name": "either",
+    "usphone": "ˈaɪðə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 两方任一方的；二者之一 conj. 二者之一；要么……"
+    ]
+  },
+  {
+    "name": "ad.",
+    "usphone": "æd",
+    "ukphone": "",
+    "trans": [
+      "(用于否定句或短语后)也"
+    ]
+  },
+  {
+    "name": "elder",
+    "usphone": "ˈeldə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 长者；前辈"
+    ]
+  },
+  {
+    "name": "elect",
+    "usphone": "ɪˈlekt",
+    "ukphone": "",
+    "trans": [
+      "vt. （投票）选举"
+    ]
+  },
+  {
+    "name": "electric",
+    "usphone": "ɪˈlektrɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 电的"
+    ]
+  },
+  {
+    "name": "electrical",
+    "usphone": "ɪˈlektrɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 电的；电器的"
+    ]
+  },
+  {
+    "name": "electricity",
+    "usphone": "ɪlekˈtrɪsɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 电；电流"
+    ]
+  },
+  {
+    "name": "electronic",
+    "usphone": "ɪlekˈtrɔnɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 电子的"
+    ]
+  },
+  {
+    "name": "elegant",
+    "usphone": "ˈelɪɡənt",
+    "ukphone": "",
+    "trans": [
+      "a.文雅的,漂亮的,精美的"
+    ]
+  },
+  {
+    "name": "elephant",
+    "usphone": "ˈelɪfənt",
+    "ukphone": "",
+    "trans": [
+      "n. 象"
+    ]
+  },
+  {
+    "name": "eleven",
+    "usphone": "ɪˈlev(ə)n",
+    "ukphone": "",
+    "trans": [
+      "num. 十一"
+    ]
+  },
+  {
+    "name": "else",
+    "usphone": "els",
+    "ukphone": "",
+    "trans": [
+      "ad. 别的，其他的"
+    ]
+  },
+  {
+    "name": "e-mail/email",
+    "usphone": "iː- meɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 电子邮件"
+    ]
+  },
+  {
+    "name": "embarrass",
+    "usphone": "ɪmˈbærəs",
+    "ukphone": "",
+    "trans": [
+      "v.使窘迫，尴尬"
+    ]
+  },
+  {
+    "name": "embassy",
+    "usphone": "ˈembəsɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 大使馆"
+    ]
+  },
+  {
+    "name": "emergency",
+    "usphone": "ɪˈmɜːdʒənsɪ",
+    "ukphone": "",
+    "trans": [
+      "n.紧急情况或状态"
+    ]
+  },
+  {
+    "name": "emperor",
+    "usphone": "ˈempərə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 皇帝"
+    ]
+  },
+  {
+    "name": "empire",
+    "usphone": "ˈempaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 帝国"
+    ]
+  },
+  {
+    "name": "employ",
+    "usphone": "ɪmˈplɔɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 雇佣"
+    ]
+  },
+  {
+    "name": "empty",
+    "usphone": "ˈemptɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 空的"
+    ]
+  },
+  {
+    "name": "encourage",
+    "usphone": "ɪnˈkʌrɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "vt. 鼓励"
+    ]
+  },
+  {
+    "name": "encouragement",
+    "usphone": "ɪnˈkʌrɪdʒmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 鼓励"
+    ]
+  },
+  {
+    "name": "end",
+    "usphone": "end",
+    "ukphone": "",
+    "trans": [
+      "n. 末尾；终点；结束 v. 结束，终止"
+    ]
+  },
+  {
+    "name": "ending",
+    "usphone": "ˈendɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 结局；结尾，最后"
+    ]
+  },
+  {
+    "name": "endless",
+    "usphone": "ˈendlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 无止境的； 没完的"
+    ]
+  },
+  {
+    "name": "enemy",
+    "usphone": "ˈenɪmɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 敌人；敌军"
+    ]
+  },
+  {
+    "name": "energetic",
+    "usphone": "enəˈdʒetɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 精力旺盛的"
+    ]
+  },
+  {
+    "name": "energ",
+    "usphone": "ˈenədʒɪ",
+    "ukphone": "",
+    "trans": [
+      "y n. 精力，能量"
+    ]
+  },
+  {
+    "name": "engine",
+    "usphone": "ˈendʒɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 发动机，引擎"
+    ]
+  },
+  {
+    "name": "engineer",
+    "usphone": "endʒɪˈnɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 工程师；技师"
+    ]
+  },
+  {
+    "name": "England*",
+    "usphone": "ˈɪŋɡlənd",
+    "ukphone": "",
+    "trans": [
+      "n. 英格兰"
+    ]
+  },
+  {
+    "name": "English",
+    "usphone": "ˈɪŋɡlɪʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 英国的，英国人的，英语的 n. 英语"
+    ]
+  },
+  {
+    "name": "English -speaking",
+    "usphone": "ˈɪŋɡlɪʃ-spiːk",
+    "ukphone": "",
+    "trans": [
+      "a.说英语的"
+    ]
+  },
+  {
+    "name": "enjoy",
+    "usphone": "ɪnˈdʒɔɪ",
+    "ukphone": "",
+    "trans": [
+      "vt.欣赏；享受乐趣；喜欢"
+    ]
+  },
+  {
+    "name": "enjoyable",
+    "usphone": "ɪnˈdʒɔɪəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 愉快的；有趣的"
+    ]
+  },
+  {
+    "name": "enlarge",
+    "usphone": "ɪnˈlɑːdʒ",
+    "ukphone": "",
+    "trans": [
+      "vt. 扩大"
+    ]
+  },
+  {
+    "name": "enough",
+    "usphone": "ɪˈnʌf",
+    "ukphone": "",
+    "trans": [
+      "n. 足够；充足 a. 足够；充分的 ad. 足够地；充分地"
+    ]
+  },
+  {
+    "name": "enquiry",
+    "usphone": "ɪnˈkwaɪərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 询问"
+    ]
+  },
+  {
+    "name": "enter",
+    "usphone": "ˈentə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 进入"
+    ]
+  },
+  {
+    "name": "enterprise",
+    "usphone": "ˈentəpraɪz",
+    "ukphone": "",
+    "trans": [
+      "n.公司，企，事业单位"
+    ]
+  },
+  {
+    "name": "entertainment",
+    "usphone": "entəˈteɪnmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 娱乐"
+    ]
+  },
+  {
+    "name": "enthusiastic",
+    "usphone": "ɪnθjuːzɪˈæstɪk",
+    "ukphone": "",
+    "trans": [
+      "a.热情的，热心的"
+    ]
+  },
+  {
+    "name": "entire",
+    "usphone": "ɪnˈtaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 整个的，全部的"
+    ]
+  },
+  {
+    "name": "entrance",
+    "usphone": "ˈentrəns",
+    "ukphone": "",
+    "trans": [
+      "n. 入口；入场；进入的权利;入学许可"
+    ]
+  },
+  {
+    "name": "entry",
+    "usphone": "ˈentrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 进入"
+    ]
+  },
+  {
+    "name": "envelope",
+    "usphone": "ˈenvələʊp",
+    "ukphone": "",
+    "trans": [
+      "n. 信封"
+    ]
+  },
+  {
+    "name": "environment",
+    "usphone": "ɪnˈvaɪərənmənt",
+    "ukphone": "",
+    "trans": [
+      "n.环境"
+    ]
+  },
+  {
+    "name": "envy",
+    "usphone": "ˈenvɪ",
+    "ukphone": "",
+    "trans": [
+      "vt.& n. 忌妒； 羡慕"
+    ]
+  },
+  {
+    "name": "equal",
+    "usphone": "ˈiːkw(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.平等的 vt.等于，使等于"
+    ]
+  },
+  {
+    "name": "equality",
+    "usphone": "iːˈkwɔlətɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 平等"
+    ]
+  },
+  {
+    "name": "equip",
+    "usphone": "ɪˈkwɪp",
+    "ukphone": "",
+    "trans": [
+      "vt. 提供设备；装备；配备"
+    ]
+  },
+  {
+    "name": "equipment",
+    "usphone": "ɪˈkwɪpmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 装备，设备"
+    ]
+  },
+  {
+    "name": "eraser",
+    "usphone": "ɪˈreɪzə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 橡皮擦；黑板擦"
+    ]
+  },
+  {
+    "name": "error",
+    "usphone": "ˈerə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 错误；差错"
+    ]
+  },
+  {
+    "name": "erupt",
+    "usphone": "ɪˈrʌpt",
+    "ukphone": "",
+    "trans": [
+      "v.（火山）爆发，喷发"
+    ]
+  },
+  {
+    "name": "escape",
+    "usphone": "ɪˈskeɪp",
+    "ukphone": "",
+    "trans": [
+      "n.& vi. 逃跑；逃脱"
+    ]
+  },
+  {
+    "name": "especially",
+    "usphone": "ɪˈspeʃəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 特别，尤其"
+    ]
+  },
+  {
+    "name": "essay",
+    "usphone": "ˈeseɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 散文；文章；随笔"
+    ]
+  },
+  {
+    "name": "Europe*",
+    "usphone": "ˈjʊərəp",
+    "ukphone": "",
+    "trans": [
+      "n. 欧洲"
+    ]
+  },
+  {
+    "name": "European",
+    "usphone": "jʊərəˈpiːən",
+    "ukphone": "",
+    "trans": [
+      "a. 欧洲的，欧洲人的 n. 欧洲人"
+    ]
+  },
+  {
+    "name": "evaluate",
+    "usphone": "ɪˈvæljʊeɪt",
+    "ukphone": "",
+    "trans": [
+      "v.估值，评价，评估"
+    ]
+  },
+  {
+    "name": "even",
+    "usphone": "ˈiːv(ə)n",
+    "ukphone": "",
+    "trans": [
+      "ad. 甚至，连（…都）；更"
+    ]
+  },
+  {
+    "name": "evening",
+    "usphone": "ˈiːvnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 傍晚，晚上"
+    ]
+  },
+  {
+    "name": "event",
+    "usphone": " ɪˈvent",
+    "ukphone": "",
+    "trans": [
+      "n. 事件，大事"
+    ]
+  },
+  {
+    "name": "eventually",
+    "usphone": "ɪˈventjʊəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad.最终地"
+    ]
+  },
+  {
+    "name": "ever",
+    "usphone": "ˈevə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 曾经；无论何时"
+    ]
+  },
+  {
+    "name": "every",
+    "usphone": "ˈevrɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 每一，每个的"
+    ]
+  },
+  {
+    "name": "everybody",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "pron.每人，人人"
+    ]
+  },
+  {
+    "name": "everyday",
+    "usphone": "ˈevrɪbɔdɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 每日的；日常的"
+    ]
+  },
+  {
+    "name": "everyone",
+    "usphone": "ˈevrɪwʌn",
+    "ukphone": "",
+    "trans": [
+      "pron. 每人，人人"
+    ]
+  },
+  {
+    "name": "everything",
+    "usphone": "ˈevrɪθɪŋ",
+    "ukphone": "",
+    "trans": [
+      "pron. 每件事，事事"
+    ]
+  },
+  {
+    "name": "everywhere",
+    "usphone": "ˈevrɪweə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 到处"
+    ]
+  },
+  {
+    "name": "evidence",
+    "usphone": "ˈevɪdəns",
+    "ukphone": "",
+    "trans": [
+      "n. 证据，证明"
+    ]
+  },
+  {
+    "name": "evident",
+    "usphone": "ˈevɪdənt",
+    "ukphone": "",
+    "trans": [
+      "a.清楚的，显而易见的"
+    ]
+  },
+  {
+    "name": "evolution",
+    "usphone": "iːvəˈluːʃ(ə)n; (US) ev-",
+    "ukphone": "",
+    "trans": [
+      "n. 进化，演变"
+    ]
+  },
+  {
+    "name": "exact",
+    "usphone": "ɪɡˈzækt",
+    "ukphone": "",
+    "trans": [
+      "a. 精确的；确切的"
+    ]
+  },
+  {
+    "name": "exactly",
+    "usphone": "exˈact·ly",
+    "ukphone": "",
+    "trans": [
+      "ad. 精确地；确切地"
+    ]
+  },
+  {
+    "name": "exam = examination",
+    "usphone": "ɪɡzæmɪˈneɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 考试，测试；检查；审查"
+    ]
+  },
+  {
+    "name": "examine",
+    "usphone": "ɪɡˈzæmɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. 检查；诊察"
+    ]
+  },
+  {
+    "name": "example",
+    "usphone": "ɪɡˈzɑːmp(ə)l; (US) ɪɡˈzæmpl",
+    "ukphone": "",
+    "trans": [
+      "n. 例子；榜样"
+    ]
+  },
+  {
+    "name": "excellent",
+    "usphone": "ˈeksələnt",
+    "ukphone": "",
+    "trans": [
+      "a. 极好的，优秀的"
+    ]
+  },
+  {
+    "name": "except",
+    "usphone": "ɪkˈsept",
+    "ukphone": "",
+    "trans": [
+      "prep. 除……之外"
+    ]
+  },
+  {
+    "name": "exchange",
+    "usphone": "ɪksˈtʃeɪndʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 交换，掉换；交流"
+    ]
+  },
+  {
+    "name": "excite",
+    "usphone": "ɪkˈsaɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 使兴奋，使激动"
+    ]
+  },
+  {
+    "name": "excuse",
+    "usphone": "ɪkˈskjuːz",
+    "ukphone": "",
+    "trans": [
+      "n.借口.辩解 vt.原谅.宽恕"
+    ]
+  },
+  {
+    "name": "exercise",
+    "usphone": "ˈeksəsaɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 锻炼，做操；练习，习题 vi. 锻炼"
+    ]
+  },
+  {
+    "name": "exhibition",
+    "usphone": "eksɪˈbɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 展览；展览会"
+    ]
+  },
+  {
+    "name": "exist",
+    "usphone": "ɪgˈzɪst",
+    "ukphone": "",
+    "trans": [
+      "vi. 存在"
+    ]
+  },
+  {
+    "name": "existence",
+    "usphone": "ɪɡˈzɪst(ə)ns",
+    "ukphone": "",
+    "trans": [
+      "n.存在；生存；存在物"
+    ]
+  },
+  {
+    "name": "exit",
+    "usphone": "ˈeksɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 出口，太平门"
+    ]
+  },
+  {
+    "name": "expand",
+    "usphone": "ɪkˈspænd",
+    "ukphone": "",
+    "trans": [
+      "v.扩大，增加，扩展"
+    ]
+  },
+  {
+    "name": "expect",
+    "usphone": "ɪkˈspekt",
+    "ukphone": "",
+    "trans": [
+      "vt. 预料；盼望；认为"
+    ]
+  },
+  {
+    "name": "expectation",
+    "usphone": "ekspekˈteɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 预料；期望"
+    ]
+  },
+  {
+    "name": "expense",
+    "usphone": "ɪkˈspens",
+    "ukphone": "",
+    "trans": [
+      "n. 消费； 支出"
+    ]
+  },
+  {
+    "name": "expensive",
+    "usphone": "ɪkˈspensɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 昂贵的"
+    ]
+  },
+  {
+    "name": "experience",
+    "usphone": "ɪkˈspɪərɪəns",
+    "ukphone": "",
+    "trans": [
+      "n. 经验；经历"
+    ]
+  },
+  {
+    "name": "experiment",
+    "usphone": "ɪkˈsperɪmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 实验"
+    ]
+  },
+  {
+    "name": "expert",
+    "usphone": "ˈekspɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. 专家，能手"
+    ]
+  },
+  {
+    "name": "explain",
+    "usphone": "ɪksˈpleɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. 解释，说明"
+    ]
+  },
+  {
+    "name": "explanation",
+    "usphone": "ekspləˈneɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 解释，说明"
+    ]
+  },
+  {
+    "name": "explicit",
+    "usphone": "ɪkˈsplɪsɪt",
+    "ukphone": "",
+    "trans": [
+      "a.清楚明白,易于理解的"
+    ]
+  },
+  {
+    "name": "explode",
+    "usphone": "ɪkˈspləʊd",
+    "ukphone": "",
+    "trans": [
+      "v. （使）爆炸"
+    ]
+  },
+  {
+    "name": "exploit",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "vt.开采.开发.利用.剥削"
+    ]
+  },
+  {
+    "name": "explore",
+    "usphone": "ɪkˈsplɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 探险"
+    ]
+  },
+  {
+    "name": "explorer",
+    "usphone": "ɪkˈsplɔːrə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 探险者"
+    ]
+  },
+  {
+    "name": "export",
+    "usphone": "ɪkˈspɔːt",
+    "ukphone": "",
+    "trans": [
+      "n. / v.出口，输出"
+    ]
+  },
+  {
+    "name": "expose",
+    "usphone": "ɪkˈspəʊz; (US) ekspəˈzeɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 揭露"
+    ]
+  },
+  {
+    "name": "express",
+    "usphone": "ɪkˈspres",
+    "ukphone": "",
+    "trans": [
+      "vt. 表达；表示；表情 n. 快车，特快专递"
+    ]
+  },
+  {
+    "name": "expression",
+    "usphone": "ɪkˈspreʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 表达；词句；表示，说法；表情"
+    ]
+  },
+  {
+    "name": "extension",
+    "usphone": "ɪkˈstenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.扩大，延伸"
+    ]
+  },
+  {
+    "name": "extra",
+    "usphone": "ˈekstrə",
+    "ukphone": "",
+    "trans": [
+      "a. 额外的，外加的"
+    ]
+  },
+  {
+    "name": "extraordinary",
+    "usphone": "ɪkˈstrɔːdɪnərɪ; (US) -dənerɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 离奇的；使人惊奇的"
+    ]
+  },
+  {
+    "name": "extreme",
+    "usphone": "ɪkˈstriːm",
+    "ukphone": "",
+    "trans": [
+      "a. 极其的，非常的"
+    ]
+  },
+  {
+    "name": "extremely",
+    "usphone": "ɪkˈstriːmlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 极其，非常"
+    ]
+  },
+  {
+    "name": "eye",
+    "usphone": "aɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 眼睛"
+    ]
+  },
+  {
+    "name": "eyesight",
+    "usphone": "ˈaɪsaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 视力；视觉"
+    ]
+  },
+  {
+    "name": "eyewitness",
+    "usphone": "ˈaɪwɪtnɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 目击证人"
+    ]
+  },
+  {
+    "name": "f (缩) =female (或 =foot,feet)",
+    "usphone": "ef",
+    "ukphone": "",
+    "trans": [
+      "n. 女(的)；雌(的)； 英尺"
+    ]
+  },
+  {
+    "name": "face",
+    "usphone": "feɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 脸 vt. 面向；面对"
+    ]
+  },
+  {
+    "name": "facial",
+    "usphone": "ˈfeɪʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 面部用的"
+    ]
+  },
+  {
+    "name": "fact",
+    "usphone": "fækt",
+    "ukphone": "",
+    "trans": [
+      "n. 事实，现实"
+    ]
+  },
+  {
+    "name": "factory",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 工厂"
+    ]
+  },
+  {
+    "name": "fade",
+    "usphone": "feɪd",
+    "ukphone": "",
+    "trans": [
+      "vi. 褪色，（颜色）消退"
+    ]
+  },
+  {
+    "name": "fail",
+    "usphone": "feɪl",
+    "ukphone": "",
+    "trans": [
+      "v. 失败；不及格；衰退"
+    ]
+  },
+  {
+    "name": "failure",
+    "usphone": "ˈfeɪljə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 失败"
+    ]
+  },
+  {
+    "name": "fair",
+    "usphone": "feə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 公平的，合理的 a. (肤色)白皙的； （人）白肤金发的 n. 集市；庙会；展览会"
+    ]
+  },
+  {
+    "name": "fairly",
+    "usphone": "ˈfeəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 公正地，正当地；相当（程度）地"
+    ]
+  },
+  {
+    "name": "fairness",
+    "usphone": "ˈfɛənis",
+    "ukphone": "",
+    "trans": [
+      "n. 公平；公正"
+    ]
+  },
+  {
+    "name": "faith",
+    "usphone": "feɪθ",
+    "ukphone": "",
+    "trans": [
+      "n. 信仰；信念"
+    ]
+  },
+  {
+    "name": "fall",
+    "usphone": "fɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. （美）秋季"
+    ]
+  },
+  {
+    "name": "fall",
+    "usphone": "fɔːl",
+    "ukphone": "",
+    "trans": [
+      "(fell, fallen) vi. 落（下），降落；倒"
+    ]
+  },
+  {
+    "name": "false",
+    "usphone": "fɔːls",
+    "ukphone": "",
+    "trans": [
+      "a. 不正确的；假的"
+    ]
+  },
+  {
+    "name": "familiar",
+    "usphone": "fəˈmɪlɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 熟悉的"
+    ]
+  },
+  {
+    "name": "family",
+    "usphone": "ˈfæmɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 家庭；家族；子女"
+    ]
+  },
+  {
+    "name": "family name",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "姓氏"
+    ]
+  },
+  {
+    "name": "famous",
+    "usphone": "ˈfeɪməs",
+    "ukphone": "",
+    "trans": [
+      "a. 著名的"
+    ]
+  },
+  {
+    "name": "fan",
+    "usphone": "fæn",
+    "ukphone": "",
+    "trans": [
+      "n. （电影、运动等的）迷；热心的爱好者（支持者） n. 风扇"
+    ]
+  },
+  {
+    "name": "fancy",
+    "usphone": "ˈfænsɪ",
+    "ukphone": "",
+    "trans": [
+      "a.花式；装饰的；奇特的"
+    ]
+  },
+  {
+    "name": "fantastic",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a. (口语)极好的，美妙的，很棒的"
+    ]
+  },
+  {
+    "name": "fantasy",
+    "usphone": "ˈfæntəsɪ",
+    "ukphone": "",
+    "trans": [
+      "n 幻想，梦想"
+    ]
+  },
+  {
+    "name": "far",
+    "usphone": "fɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "(farther, farthest 或further , furthest) a.& ad. 远的；远地"
+    ]
+  },
+  {
+    "name": "fare",
+    "usphone": "feə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.（车或船的）费用，票（价）"
+    ]
+  },
+  {
+    "name": "farm",
+    "usphone": "fɑːm",
+    "ukphone": "",
+    "trans": [
+      "n. 农场；农庄"
+    ]
+  },
+  {
+    "name": "farmer",
+    "usphone": "ˈfɑːmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 农民"
+    ]
+  },
+  {
+    "name": "fast",
+    "usphone": "fɑːst; (US) fæst",
+    "ukphone": "",
+    "trans": [
+      "a. 快的，迅速的；紧密的 ad. 快地，迅速地；紧密地"
+    ]
+  },
+  {
+    "name": "fasten",
+    "usphone": "ˈfɑːs(ə)n; (US) fæsn",
+    "ukphone": "",
+    "trans": [
+      "vt. 扎牢；扣住"
+    ]
+  },
+  {
+    "name": "fat",
+    "usphone": "fæt",
+    "ukphone": "",
+    "trans": [
+      "n. 脂肪 a. 胖的；肥的"
+    ]
+  },
+  {
+    "name": "father",
+    "usphone": "ˈfɑːðə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 父亲"
+    ]
+  },
+  {
+    "name": "fault",
+    "usphone": "fɔːlt",
+    "ukphone": "",
+    "trans": [
+      "n. 缺点，毛病"
+    ]
+  },
+  {
+    "name": "favour",
+    "usphone": "ˈfeivə",
+    "ukphone": "",
+    "trans": [
+      "(美favor) n. 恩惠；好意；帮助"
+    ]
+  },
+  {
+    "name": "favourite",
+    "usphone": "ˈfeivərit",
+    "ukphone": "",
+    "trans": [
+      "(美 favorite) a. 喜爱的 n. 特别喜爱的人（或物）"
+    ]
+  },
+  {
+    "name": "fax",
+    "usphone": "fæks",
+    "ukphone": "",
+    "trans": [
+      "n. 传真"
+    ]
+  },
+  {
+    "name": "fear",
+    "usphone": "fɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 害怕；恐惧； 担忧"
+    ]
+  },
+  {
+    "name": "feast",
+    "usphone": "fiːst",
+    "ukphone": "",
+    "trans": [
+      "n.盛宴，宴会，（宗教的）节日"
+    ]
+  },
+  {
+    "name": "feather",
+    "usphone": "ˈfeðə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 羽毛"
+    ]
+  },
+  {
+    "name": "February",
+    "usphone": "ˈfebruəri",
+    "ukphone": "",
+    "trans": [
+      "n. 2月"
+    ]
+  },
+  {
+    "name": "federa",
+    "usphone": "ˈfedər(ə)l",
+    "ukphone": "",
+    "trans": [
+      "l a.中央的（政府）联邦的"
+    ]
+  },
+  {
+    "name": "fee",
+    "usphone": "fiː",
+    "ukphone": "",
+    "trans": [
+      "n. 费，费用"
+    ]
+  },
+  {
+    "name": "feed (fed, fed)",
+    "usphone": "fiːd",
+    "ukphone": "",
+    "trans": [
+      "vt. 喂（养）；饲（养）"
+    ]
+  },
+  {
+    "name": "feel (felt, felt)",
+    "usphone": "fiːl",
+    "ukphone": "",
+    "trans": [
+      "v.& link 感觉，觉得；摸，触"
+    ]
+  },
+  {
+    "name": "feeling",
+    "usphone": "ˈfiːlɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 感情；感觉"
+    ]
+  },
+  {
+    "name": "fellow",
+    "usphone": "ˈfeləʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 同伴；伙伴"
+    ]
+  },
+  {
+    "name": "female",
+    "usphone": "ˈfiːmeɪl",
+    "ukphone": "",
+    "trans": [
+      "a. 女的；女性的；雌性的"
+    ]
+  },
+  {
+    "name": "fence",
+    "usphone": "fens",
+    "ukphone": "",
+    "trans": [
+      "n. 栅栏；围栏；篱笆"
+    ]
+  },
+  {
+    "name": "ferry",
+    "usphone": "ˈferɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 渡船"
+    ]
+  },
+  {
+    "name": "festival",
+    "usphone": "ˈfestɪvəl",
+    "ukphone": "",
+    "trans": [
+      "a. 节日的，喜庆的"
+    ]
+  },
+  {
+    "name": "fetch",
+    "usphone": "fetʃ",
+    "ukphone": "",
+    "trans": [
+      "vt. （去）取（物）来，（去）带（人）来"
+    ]
+  },
+  {
+    "name": "fever",
+    "usphone": "ˈfiːvə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 发烧；发热"
+    ]
+  },
+  {
+    "name": "few",
+    "usphone": "fjuː",
+    "ukphone": "",
+    "trans": [
+      "pron. 不多；少数 不多的；少数的"
+    ]
+  },
+  {
+    "name": "fibre",
+    "usphone": "ˈfaibə",
+    "ukphone": "",
+    "trans": [
+      "(美fiber) n. 纤维质"
+    ]
+  },
+  {
+    "name": "fiction",
+    "usphone": "ˈfɪkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.小说，虚构的事"
+    ]
+  },
+  {
+    "name": "field",
+    "usphone": "fiːld",
+    "ukphone": "",
+    "trans": [
+      "n. 田地；牧场；场地"
+    ]
+  },
+  {
+    "name": "fierce",
+    "usphone": "ˈfɪəs",
+    "ukphone": "",
+    "trans": [
+      "a. 猛烈的"
+    ]
+  },
+  {
+    "name": "fifteen",
+    "usphone": "fɪfˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "num. 十五"
+    ]
+  },
+  {
+    "name": "fifth",
+    "usphone": "fɪfθ",
+    "ukphone": "",
+    "trans": [
+      "num. 第五"
+    ]
+  },
+  {
+    "name": "fifty",
+    "usphone": "ˈfɪftɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 五十"
+    ]
+  },
+  {
+    "name": "fight",
+    "usphone": "faɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 打仗（架），争论"
+    ]
+  },
+  {
+    "name": "fight",
+    "usphone": "faɪt",
+    "ukphone": "",
+    "trans": [
+      "(fought, fought) n. 打仗（架），与……打仗（架）"
+    ]
+  },
+  {
+    "name": "fighter",
+    "usphone": "ˈfaɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 战士；斗士"
+    ]
+  },
+  {
+    "name": "figure",
+    "usphone": "ˈfɪɡə(r); (US) ˈfɪgjər",
+    "ukphone": "",
+    "trans": [
+      "n.数字；数目；图；图形；（人的）身型；人物；（绘画、雕刻）人物像 vt.（美口语）认为，判断.（在心里）想像，描绘"
+    ]
+  },
+  {
+    "name": "file",
+    "usphone": "faɪl",
+    "ukphone": "",
+    "trans": [
+      "n.公文柜；档案(计算机)文档"
+    ]
+  },
+  {
+    "name": "fill",
+    "usphone": "fɪl",
+    "ukphone": "",
+    "trans": [
+      "vt. 填空，装满"
+    ]
+  },
+  {
+    "name": "film",
+    "usphone": "fɪlm",
+    "ukphone": "",
+    "trans": [
+      "n. 电影；影片；胶卷vt. 拍摄，把……拍成电影"
+    ]
+  },
+  {
+    "name": "final",
+    "usphone": "ˈfaɪn(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 最后的；终极的"
+    ]
+  },
+  {
+    "name": "finance",
+    "usphone": "ˈfaɪnæns",
+    "ukphone": "",
+    "trans": [
+      "n.资金，财政，财务"
+    ]
+  },
+  {
+    "name": "find",
+    "usphone": "faɪnd",
+    "ukphone": "",
+    "trans": [
+      "(found, found) vt. 找到，发现，感到"
+    ]
+  },
+  {
+    "name": "fine",
+    "usphone": "faɪn",
+    "ukphone": "",
+    "trans": [
+      "a. 细的；晴朗的；美好的；（身体）健康的 n.& v. 罚款"
+    ]
+  },
+  {
+    "name": "finger",
+    "usphone": "ˈfɪŋɡə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 手指"
+    ]
+  },
+  {
+    "name": "fingernail",
+    "usphone": "ˈfɪŋɡəneɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 指甲"
+    ]
+  },
+  {
+    "name": "finish",
+    "usphone": "ˈfɪnɪʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 结束；做完"
+    ]
+  },
+  {
+    "name": "fire",
+    "usphone": "ˈfaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 火；火炉；火灾 vi. 开火，开（枪，炮等），射击"
+    ]
+  },
+  {
+    "name": "firefighter",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 消防人员"
+    ]
+  },
+  {
+    "name": "fireplace",
+    "usphone": "ˈfaɪəpleɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 壁炉"
+    ]
+  },
+  {
+    "name": "firewood",
+    "usphone": "ˈfairwud",
+    "ukphone": "",
+    "trans": [
+      "n. 木柴"
+    ]
+  },
+  {
+    "name": "firework",
+    "usphone": "ˈfaɪəwɜːk",
+    "ukphone": "",
+    "trans": [
+      "n. 焰火"
+    ]
+  },
+  {
+    "name": "firm",
+    "usphone": "fɜːm",
+    "ukphone": "",
+    "trans": [
+      "n.公司;企业 a.坚固的,坚定的"
+    ]
+  },
+  {
+    "name": "firmly",
+    "usphone": "ˈfɜːmlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 牢牢地"
+    ]
+  },
+  {
+    "name": "first",
+    "usphone": "fɜːst",
+    "ukphone": "",
+    "trans": [
+      "num. 第一 a.& ad. 第一；首次；最初 n. 开始；开端"
+    ]
+  },
+  {
+    "name": "fish",
+    "usphone": "fɪʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 鱼；鱼肉 vi. 钓鱼；捕鱼"
+    ]
+  },
+  {
+    "name": "fisherman",
+    "usphone": "ˈfɪʃəmən",
+    "ukphone": "",
+    "trans": [
+      "n. 渔民；钓鱼健身者"
+    ]
+  },
+  {
+    "name": "fist",
+    "usphone": "fɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 拳(头)"
+    ]
+  },
+  {
+    "name": "fit",
+    "usphone": "fɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 健康的, 适合的 v. （使）适合，安装"
+    ]
+  },
+  {
+    "name": "fitting room",
+    "usphone": "ˈfɪtɪŋ-rʊm",
+    "ukphone": "",
+    "trans": [
+      "试衣间"
+    ]
+  },
+  {
+    "name": "five",
+    "usphone": "faɪv",
+    "ukphone": "",
+    "trans": [
+      "num. 五"
+    ]
+  },
+  {
+    "name": "fix",
+    "usphone": "fɪks",
+    "ukphone": "",
+    "trans": [
+      "vt. 修理；安装；确定，决定"
+    ]
+  },
+  {
+    "name": "flag",
+    "usphone": "flæɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 旗；标志；旗舰"
+    ]
+  },
+  {
+    "name": "flame",
+    "usphone": "fleɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 火焰，光辉"
+    ]
+  },
+  {
+    "name": "flaming",
+    "usphone": "ˈfleɪmɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 火红的；火焰般的"
+    ]
+  },
+  {
+    "name": "flash",
+    "usphone": "flæʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 闪；闪光； 转瞬间"
+    ]
+  },
+  {
+    "name": "flashlight",
+    "usphone": "flæʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 手电"
+    ]
+  },
+  {
+    "name": "flat",
+    "usphone": "flæt",
+    "ukphone": "",
+    "trans": [
+      "a. 平的 n. 楼中一套房间； 公寓(常用复数)"
+    ]
+  },
+  {
+    "name": "flee",
+    "usphone": "fliː",
+    "ukphone": "",
+    "trans": [
+      "(fled, fled) v. 逃走；逃跑"
+    ]
+  },
+  {
+    "name": "flexible",
+    "usphone": "ˈfleksəbl",
+    "ukphone": "",
+    "trans": [
+      "a.灵活的，可变动的"
+    ]
+  },
+  {
+    "name": "flesh",
+    "usphone": "fleʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 肉"
+    ]
+  },
+  {
+    "name": "flight",
+    "usphone": "flaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 航班 n. 楼梯的一段"
+    ]
+  },
+  {
+    "name": "float",
+    "usphone": "fləʊt",
+    "ukphone": "",
+    "trans": [
+      "vi. 漂浮，浮动"
+    ]
+  },
+  {
+    "name": "flood",
+    "usphone": "flʌd",
+    "ukphone": "",
+    "trans": [
+      "n. 洪水 vt. 淹没，使泛滥"
+    ]
+  },
+  {
+    "name": "floor",
+    "usphone": "flɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n.地面，地板.（楼房的）层"
+    ]
+  },
+  {
+    "name": "flour",
+    "usphone": "ˈflaʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 面粉，粉"
+    ]
+  },
+  {
+    "name": "flow",
+    "usphone": "fləʊ",
+    "ukphone": "",
+    "trans": [
+      "vi. 流动"
+    ]
+  },
+  {
+    "name": "flower",
+    "usphone": "ˈflaʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 花"
+    ]
+  },
+  {
+    "name": "flu",
+    "usphone": "fluː",
+    "ukphone": "",
+    "trans": [
+      "n. 流行性感冒"
+    ]
+  },
+  {
+    "name": "fluency",
+    "usphone": "ˈfluənsi",
+    "ukphone": "",
+    "trans": [
+      "n.（外语）流利，流畅"
+    ]
+  },
+  {
+    "name": "fluent",
+    "usphone": "ˈfluːənt",
+    "ukphone": "",
+    "trans": [
+      "a. （外语）流利的，流畅"
+    ]
+  },
+  {
+    "name": "fly",
+    "usphone": "ˈfluːənt",
+    "ukphone": "",
+    "trans": [
+      "n. 飞行；苍蝇"
+    ]
+  },
+  {
+    "name": "fly (flew, flown)",
+    "usphone": "flaɪ",
+    "ukphone": "",
+    "trans": [
+      "vi. （鸟、飞机）飞；（人乘飞机）飞行；（旗子等）飘动 vt. 空运（乘客，货物等）；放（风筝、飞机模型等）"
+    ]
+  },
+  {
+    "name": "focus",
+    "usphone": "ˈfəʊkəs",
+    "ukphone": "",
+    "trans": [
+      "v. / n.集中（注意力，精力）于，焦点，中心点"
+    ]
+  },
+  {
+    "name": "fog",
+    "usphone": "fɔɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 雾"
+    ]
+  },
+  {
+    "name": "foggy",
+    "usphone": "ˈfɔɡɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 多雾的"
+    ]
+  },
+  {
+    "name": "fold",
+    "usphone": "fəʊld",
+    "ukphone": "",
+    "trans": [
+      "vt. 折叠；合拢"
+    ]
+  },
+  {
+    "name": "folk",
+    "usphone": "fəʊk",
+    "ukphone": "",
+    "trans": [
+      "a. 民间的"
+    ]
+  },
+  {
+    "name": "follow",
+    "usphone": "ˈfɔləʊ",
+    "ukphone": "",
+    "trans": [
+      "vt. 跟随；仿效；跟得上"
+    ]
+  },
+  {
+    "name": "following",
+    "usphone": "ˈfɔləʊwɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 接着的；以下的"
+    ]
+  },
+  {
+    "name": "fond",
+    "usphone": "fɔnd",
+    "ukphone": "",
+    "trans": [
+      "a. 喜爱的，爱好的"
+    ]
+  },
+  {
+    "name": "food",
+    "usphone": "fɔnd",
+    "ukphone": "",
+    "trans": [
+      "n. 食物，食品"
+    ]
+  },
+  {
+    "name": "fool",
+    "usphone": "fuːl",
+    "ukphone": "",
+    "trans": [
+      "n. 傻子，蠢人"
+    ]
+  },
+  {
+    "name": "foolish",
+    "usphone": "ˈfuːlɪʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 愚蠢的，傻的"
+    ]
+  },
+  {
+    "name": "foot (复 feet)",
+    "usphone": "fʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 足，脚；英尺"
+    ]
+  },
+  {
+    "name": "football",
+    "usphone": "ˈfʊtbɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. （英式）足球；（美式）橄榄球"
+    ]
+  },
+  {
+    "name": "for",
+    "usphone": "fə(r), fɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "prep. 为了…；向…，往…；与…交换；防备…；适合…；因为…；在…期 间；对于…；对…来说 conj. 因为，由于"
+    ]
+  },
+  {
+    "name": "forbid",
+    "usphone": "fəˈbɪd",
+    "ukphone": "",
+    "trans": [
+      "(forbade, forbidden) vt. 禁止，不许"
+    ]
+  },
+  {
+    "name": "force",
+    "usphone": "fɔːs",
+    "ukphone": "",
+    "trans": [
+      "vt. 强迫，迫使"
+    ]
+  },
+  {
+    "name": "forecast",
+    "usphone": "ˈfɔːkɑːst; (US) ˈfɔrkæst",
+    "ukphone": "",
+    "trans": [
+      "n. & vt. 预告"
+    ]
+  },
+  {
+    "name": "forehead",
+    "usphone": "ˈfɔrɪd; (US) ˈfɔːrɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 前额"
+    ]
+  },
+  {
+    "name": "foreign",
+    "usphone": "ˈfɔrən; (US) ˈfɔːrɪn",
+    "ukphone": "",
+    "trans": [
+      "a. 外国的"
+    ]
+  },
+  {
+    "name": "foreigner",
+    "usphone": "ˈfɔrənə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 外国人"
+    ]
+  },
+  {
+    "name": "foresee",
+    "usphone": "fɔːˈsiː",
+    "ukphone": "",
+    "trans": [
+      "(foresaw, foreseen) vt.预见.预知"
+    ]
+  },
+  {
+    "name": "forest",
+    "usphone": "ˈfɔrɪst; (US) ˈfɔːrɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 森林"
+    ]
+  },
+  {
+    "name": "forever",
+    "usphone": "fəˈrevə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 永远；永恒的"
+    ]
+  },
+  {
+    "name": "forget",
+    "usphone": "fəˈrevə(r)",
+    "ukphone": "",
+    "trans": [
+      "(forgot, forgotten) v. 忘记；忘掉"
+    ]
+  },
+  {
+    "name": "forgetful",
+    "usphone": "fəˈɡetfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 健忘的，不留心的"
+    ]
+  },
+  {
+    "name": "forgive",
+    "usphone": "fəˈɡɪv",
+    "ukphone": "",
+    "trans": [
+      "(forgave, forgiven) vt. 原谅，宽恕"
+    ]
+  },
+  {
+    "name": "fork",
+    "usphone": "fɔːk",
+    "ukphone": "",
+    "trans": [
+      "n. 叉，餐叉"
+    ]
+  },
+  {
+    "name": "form",
+    "usphone": "fɔːm",
+    "ukphone": "",
+    "trans": [
+      "n. 表格；形式；结构"
+    ]
+  },
+  {
+    "name": "format",
+    "usphone": "ˈfɔːmæt",
+    "ukphone": "",
+    "trans": [
+      "n.安排，计划，设计"
+    ]
+  },
+  {
+    "name": "former",
+    "usphone": "ˈfɔːmə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 以前的，从前的；（两者之中的）前者"
+    ]
+  },
+  {
+    "name": "fortnight",
+    "usphone": "ˈfɔːtnaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 十四日，两星期"
+    ]
+  },
+  {
+    "name": "fortunate",
+    "usphone": "ˈfɔːtʃənət",
+    "ukphone": "",
+    "trans": [
+      "a. 幸运的； 侥幸的"
+    ]
+  },
+  {
+    "name": "fortune",
+    "usphone": "ˈfɔːtjuːn, ˈfɔːtʃuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 财产；运气"
+    ]
+  },
+  {
+    "name": "forty",
+    "usphone": "ˈfɔːtɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 四十"
+    ]
+  },
+  {
+    "name": "forward",
+    "usphone": "ˈfɔːwəd",
+    "ukphone": "",
+    "trans": [
+      "ad.将来.今后.向前，前进"
+    ]
+  },
+  {
+    "name": "found",
+    "usphone": "faʊnd",
+    "ukphone": "",
+    "trans": [
+      "vt. 成立，建立"
+    ]
+  },
+  {
+    "name": "founding",
+    "usphone": "ˈfaundiŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 成立，建立"
+    ]
+  },
+  {
+    "name": "fountain",
+    "usphone": "ˈfaʊntɪn; (US) ˈfaʊntn",
+    "ukphone": "",
+    "trans": [
+      "n. 喷泉"
+    ]
+  },
+  {
+    "name": "four",
+    "usphone": "fɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "num. 四"
+    ]
+  },
+  {
+    "name": "fourteen",
+    "usphone": "ˈfɔːˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "num. 十四"
+    ]
+  },
+  {
+    "name": "fourth",
+    "usphone": "ˈfɔːˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "num. 第四"
+    ]
+  },
+  {
+    "name": "fox",
+    "usphone": "fɔks",
+    "ukphone": "",
+    "trans": [
+      "n. 狐狸"
+    ]
+  },
+  {
+    "name": "franc",
+    "usphone": "fræŋk",
+    "ukphone": "",
+    "trans": [
+      "n. 法郎"
+    ]
+  },
+  {
+    "name": "France*",
+    "usphone": "fræns",
+    "ukphone": "",
+    "trans": [
+      "n. 法国"
+    ]
+  },
+  {
+    "name": "fragile",
+    "usphone": "ˈfrædʒaɪl; (US) ˈfrædʒl",
+    "ukphone": "",
+    "trans": [
+      "a.易碎的，易损的"
+    ]
+  },
+  {
+    "name": "fragrant",
+    "usphone": "ˈfreɪɡrənt",
+    "ukphone": "",
+    "trans": [
+      "a. 香的，芳香的"
+    ]
+  },
+  {
+    "name": "framework",
+    "usphone": "ˈfreɪmwɜːk",
+    "ukphone": "",
+    "trans": [
+      "n.（建筑物）框架，结构"
+    ]
+  },
+  {
+    "name": "free",
+    "usphone": "friː",
+    "ukphone": "",
+    "trans": [
+      "a. 自由，空闲的；免费的"
+    ]
+  },
+  {
+    "name": "freedom",
+    "usphone": "ˈfriːdəm",
+    "ukphone": "",
+    "trans": [
+      "n. 自由"
+    ]
+  },
+  {
+    "name": "freeway",
+    "usphone": "ˈfriːweɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 高速公路"
+    ]
+  },
+  {
+    "name": "freeze",
+    "usphone": "friːz",
+    "ukphone": "",
+    "trans": [
+      "(froze, frozen) vi. 结冰"
+    ]
+  },
+  {
+    "name": "freezing",
+    "usphone": "ˈfri:ziŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 冻结的；极冷的"
+    ]
+  },
+  {
+    "name": "French",
+    "usphone": "frentʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 法语 a法国的；法国人的；法语的"
+    ]
+  },
+  {
+    "name": "Frenchman",
+    "usphone": "ˈfrentʃmən",
+    "ukphone": "",
+    "trans": [
+      "(复 Frenchmen) n. 法国人（男）"
+    ]
+  },
+  {
+    "name": "frequent",
+    "usphone": "ˈfriːkwənt",
+    "ukphone": "",
+    "trans": [
+      "a. 经常的；频繁的"
+    ]
+  },
+  {
+    "name": "fresh",
+    "usphone": "freʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 新鲜的"
+    ]
+  },
+  {
+    "name": "Friday",
+    "usphone": "ˈfraɪdɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 星期五"
+    ]
+  },
+  {
+    "name": "friction",
+    "usphone": "ˈfrɪkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 摩擦"
+    ]
+  },
+  {
+    "name": "fridge =refrigerator",
+    "usphone": "rɪˈfrɪdʒəreɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 冰箱"
+    ]
+  },
+  {
+    "name": "fried",
+    "usphone": "fraid",
+    "ukphone": "",
+    "trans": [
+      "a. 油煎的"
+    ]
+  },
+  {
+    "name": "friend",
+    "usphone": "frend",
+    "ukphone": "",
+    "trans": [
+      "n. 朋友"
+    ]
+  },
+  {
+    "name": "friendly",
+    "usphone": "ˈfrendlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 友好的"
+    ]
+  },
+  {
+    "name": "friendship",
+    "usphone": "ˈfrendʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 友谊，友情"
+    ]
+  },
+  {
+    "name": "fright",
+    "usphone": "fraɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 惊恐；恐吓"
+    ]
+  },
+  {
+    "name": "frighten",
+    "usphone": "ˈfraɪt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "vt. 使惊恐，吓唬"
+    ]
+  },
+  {
+    "name": "frog",
+    "usphone": "frɔɡ; (US) frɔːɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 青蛙"
+    ]
+  },
+  {
+    "name": "from",
+    "usphone": "frəm, frɔm",
+    "ukphone": "",
+    "trans": [
+      "prep.从；从…起.距.来自"
+    ]
+  },
+  {
+    "name": "front",
+    "usphone": "frʌnt",
+    "ukphone": "",
+    "trans": [
+      "a. 前面的；前部的 n. 前面；前部；前线"
+    ]
+  },
+  {
+    "name": "frontier",
+    "usphone": "ˈfrʌntɪə(r); (US) frʌnˈtɪər",
+    "ukphone": "",
+    "trans": [
+      "n. 前沿 ，边界；前线"
+    ]
+  },
+  {
+    "name": "frost",
+    "usphone": "frɔst; (US) frɔːst",
+    "ukphone": "",
+    "trans": [
+      "n. 霜"
+    ]
+  },
+  {
+    "name": "fruit",
+    "usphone": "fruːt",
+    "ukphone": "",
+    "trans": [
+      "n. 水果；果实"
+    ]
+  },
+  {
+    "name": "fruit juice",
+    "usphone": "fruːt dʒuːs",
+    "ukphone": "",
+    "trans": [
+      "n. 果汁"
+    ]
+  },
+  {
+    "name": "fry",
+    "usphone": "fraɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 用油煎；用油炸"
+    ]
+  },
+  {
+    "name": "fuel",
+    "usphone": "fjuːəl",
+    "ukphone": "",
+    "trans": [
+      "n. 燃料"
+    ]
+  },
+  {
+    "name": "full",
+    "usphone": "fʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 满的，充满的；完全的"
+    ]
+  },
+  {
+    "name": "fun",
+    "usphone": "fʌn",
+    "ukphone": "",
+    "trans": [
+      "n. 有趣的事，娱乐，玩笑"
+    ]
+  },
+  {
+    "name": "function",
+    "usphone": "ˈfʌŋkʃən",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 作用,功能,运转"
+    ]
+  },
+  {
+    "name": "fundamental",
+    "usphone": "fʌndəˈment(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 十分重大的，根本的"
+    ]
+  },
+  {
+    "name": "funeral",
+    "usphone": "ˈfjuːˈnər(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 葬礼"
+    ]
+  },
+  {
+    "name": "funny",
+    "usphone": "ˈfʌnɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 有趣的，滑稽可笑的"
+    ]
+  },
+  {
+    "name": "fur",
+    "usphone": "fɜː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 毛皮；皮子"
+    ]
+  },
+  {
+    "name": "furnished",
+    "usphone": "ˈfə:niʃt",
+    "ukphone": "",
+    "trans": [
+      "a. 配备了家具的"
+    ]
+  },
+  {
+    "name": "furniture",
+    "usphone": "ˈfɜːnɪtʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （总称）家具"
+    ]
+  },
+  {
+    "name": "future",
+    "usphone": "ˈfjuːtʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 将来"
+    ]
+  },
+  {
+    "name": "gain",
+    "usphone": "ɡeɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. 赢得；挣得"
+    ]
+  },
+  {
+    "name": "gale",
+    "usphone": "ɡeɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 强风（约每小时60英里）"
+    ]
+  },
+  {
+    "name": "gallery",
+    "usphone": "ˈɡælərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 画廊；美术品陈列室"
+    ]
+  },
+  {
+    "name": "gallon",
+    "usphone": "ˈɡælən",
+    "ukphone": "",
+    "trans": [
+      "n. 加仑"
+    ]
+  },
+  {
+    "name": "game",
+    "usphone": "ɡeɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 游戏；运动；比赛"
+    ]
+  },
+  {
+    "name": "garage",
+    "usphone": "ˈɡærɑːʒ, -rɪdʒ; (US) ɡəˈrɑːʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 汽车间（库）"
+    ]
+  },
+  {
+    "name": "garbage",
+    "usphone": "ˈɡɑːbɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 垃圾"
+    ]
+  },
+  {
+    "name": "garden",
+    "usphone": "ˈɡɑːd(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 花园，果园，菜园"
+    ]
+  },
+  {
+    "name": "gardening",
+    "usphone": "ˈɡɑːdnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 园艺学"
+    ]
+  },
+  {
+    "name": "garlic",
+    "usphone": "ˈɡɑːlɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 大蒜"
+    ]
+  },
+  {
+    "name": "garment",
+    "usphone": "ˈɡɑːmənt",
+    "ukphone": "",
+    "trans": [
+      "n. （一件）衣服"
+    ]
+  },
+  {
+    "name": "gas",
+    "usphone": "ɡæs",
+    "ukphone": "",
+    "trans": [
+      "n. 煤气"
+    ]
+  },
+  {
+    "name": "gate",
+    "usphone": "ɡeɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 大门"
+    ]
+  },
+  {
+    "name": "gather",
+    "usphone": "ˈɡæðə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 聚集；采集"
+    ]
+  },
+  {
+    "name": "gay",
+    "usphone": "ɡeɪ",
+    "ukphone": "",
+    "trans": [
+      "a. （男）同性恋的；快活的，愉快的"
+    ]
+  },
+  {
+    "name": "general",
+    "usphone": "ˈdʒenər(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 大体，笼统的，总的"
+    ]
+  },
+  {
+    "name": "generation",
+    "usphone": "dʒenəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 代，一代"
+    ]
+  },
+  {
+    "name": "generous",
+    "usphone": "ˈdʒenərəs",
+    "ukphone": "",
+    "trans": [
+      "a. 慷慨大方的"
+    ]
+  },
+  {
+    "name": "gentle",
+    "usphone": "ˈdʒent(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 温柔的，轻轻的"
+    ]
+  },
+  {
+    "name": "gentleman",
+    "usphone": "ˈdʒent(ə)lmən",
+    "ukphone": "",
+    "trans": [
+      "n. 绅士，先生；有身份、有教养的人"
+    ]
+  },
+  {
+    "name": "geography",
+    "usphone": "dʒɪˈɔɡrəfɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 地理学"
+    ]
+  },
+  {
+    "name": "geometry",
+    "usphone": "dʒɪˈɑmɪtrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 几何学"
+    ]
+  },
+  {
+    "name": "German",
+    "usphone": "ˈdʒɜːmən",
+    "ukphone": "",
+    "trans": [
+      "a. 德国的，德国人的，德语的 n. 德国人，德语"
+    ]
+  },
+  {
+    "name": "Germany",
+    "usphone": "ˈdʒɜːmənɪ",
+    "ukphone": "",
+    "trans": [
+      "* n. 德国"
+    ]
+  },
+  {
+    "name": "gesture",
+    "usphone": "ˈdʒestʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 姿势，手势"
+    ]
+  },
+  {
+    "name": "get (got , got)",
+    "usphone": "ɡet",
+    "ukphone": "",
+    "trans": [
+      "vt. 成为；得到；具有；到达"
+    ]
+  },
+  {
+    "name": "get--together",
+    "usphone": "ɡet-təˈɡeðə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 聚会"
+    ]
+  },
+  {
+    "name": "gift",
+    "usphone": "ɡɪft",
+    "ukphone": "",
+    "trans": [
+      "n. 赠品；礼物"
+    ]
+  },
+  {
+    "name": "gifted",
+    "usphone": "ˈɡɪftɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 有天赋的；有才华的"
+    ]
+  },
+  {
+    "name": "giraffe",
+    "usphone": "dʒɪˈrɑːf; (US) dʒəˈræf",
+    "ukphone": "",
+    "trans": [
+      "n. 长颈鹿"
+    ]
+  },
+  {
+    "name": "girl",
+    "usphone": "ɡɜːl",
+    "ukphone": "",
+    "trans": [
+      "n. 女孩"
+    ]
+  },
+  {
+    "name": "give (gave, given)",
+    "usphone": "ɡɪv",
+    "ukphone": "",
+    "trans": [
+      "vt. 给,递给,付出,给予"
+    ]
+  },
+  {
+    "name": "glad",
+    "usphone": "ɡlæd",
+    "ukphone": "",
+    "trans": [
+      "a. 高兴的；乐意的"
+    ]
+  },
+  {
+    "name": "glance",
+    "usphone": "glæns /glɑːns",
+    "ukphone": "",
+    "trans": [
+      "vi. 匆匆一看；一瞥"
+    ]
+  },
+  {
+    "name": "glare",
+    "usphone": "ɡleə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 瞪眼,怒目而视,闪耀"
+    ]
+  },
+  {
+    "name": "glass",
+    "usphone": "ɡlɑːs; (US) ɡlæs",
+    "ukphone": "",
+    "trans": [
+      "n.玻璃杯,玻璃；(复)眼镜"
+    ]
+  },
+  {
+    "name": "glasshouse",
+    "usphone": "ˈɡlɑːshaʊs",
+    "ukphone": "",
+    "trans": [
+      "n. 温室，暖房"
+    ]
+  },
+  {
+    "name": "globe",
+    "usphone": "ɡləʊb",
+    "ukphone": "",
+    "trans": [
+      "n. 地球仪,地球"
+    ]
+  },
+  {
+    "name": "glory",
+    "usphone": "ˈɡlɔːrɪ",
+    "ukphone": "",
+    "trans": [
+      "n.巨大的光荣; 荣誉;赞美"
+    ]
+  },
+  {
+    "name": "glove",
+    "usphone": "ɡlʌv",
+    "ukphone": "",
+    "trans": [
+      "n. 手套"
+    ]
+  },
+  {
+    "name": "glue",
+    "usphone": "ɡluː",
+    "ukphone": "",
+    "trans": [
+      "n. 胶水"
+    ]
+  },
+  {
+    "name": "go (went, gone)",
+    "usphone": "ɡəʊ",
+    "ukphone": "",
+    "trans": [
+      "vi. 去；走；驶；通到；到达 n. 尝试（做某事）"
+    ]
+  },
+  {
+    "name": "goal",
+    "usphone": "ɡəʊl",
+    "ukphone": "",
+    "trans": [
+      "n. （足球）球门，目标"
+    ]
+  },
+  {
+    "name": "goat",
+    "usphone": "ɡəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 山羊"
+    ]
+  },
+  {
+    "name": "god",
+    "usphone": "ɡɔd",
+    "ukphone": "",
+    "trans": [
+      "n. 神，（大写）上帝"
+    ]
+  },
+  {
+    "name": "gold",
+    "usphone": "ɡəʊld",
+    "ukphone": "",
+    "trans": [
+      "n. 黄金 a 金的，黄金的"
+    ]
+  },
+  {
+    "name": "golden",
+    "usphone": "ˈɡəʊld(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 金(黄)色的"
+    ]
+  },
+  {
+    "name": "goldfish",
+    "usphone": "ˈɡəʊldfɪʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 金鱼"
+    ]
+  },
+  {
+    "name": "golf",
+    "usphone": "ɡɔlf",
+    "ukphone": "",
+    "trans": [
+      "n. 高尔夫球"
+    ]
+  },
+  {
+    "name": "good (better ,best)",
+    "usphone": "ɡʊd",
+    "ukphone": "",
+    "trans": [
+      "a. 好；良好"
+    ]
+  },
+  {
+    "name": "good-bye",
+    "usphone": "ɡʊd- baɪ",
+    "ukphone": "",
+    "trans": [
+      "int. 再见；再会"
+    ]
+  },
+  {
+    "name": "goodness",
+    "usphone": "ˈɡʊdnɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 善良，美德"
+    ]
+  },
+  {
+    "name": "goods",
+    "usphone": "ɡʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 商品，货物"
+    ]
+  },
+  {
+    "name": "goose (复 geese)",
+    "usphone": "ɡuːs",
+    "ukphone": "",
+    "trans": [
+      "n. 鹅"
+    ]
+  },
+  {
+    "name": "govern",
+    "usphone": "ˈɡʌv(ə)n",
+    "ukphone": "",
+    "trans": [
+      "v. 统治；管理"
+    ]
+  },
+  {
+    "name": "government",
+    "usphone": "ˈɡʌvənmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 政府"
+    ]
+  },
+  {
+    "name": "gown",
+    "usphone": "ɡaʊn",
+    "ukphone": "",
+    "trans": [
+      "n. 礼服，长外衣，睡衣"
+    ]
+  },
+  {
+    "name": "grade",
+    "usphone": "ɡreɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 等级；（中小学的）学年；成绩，分数"
+    ]
+  },
+  {
+    "name": "gradually",
+    "usphone": "ˈɡrædjʊəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 逐渐地"
+    ]
+  },
+  {
+    "name": "graduate",
+    "usphone": "ˈɡrædjʊət",
+    "ukphone": "",
+    "trans": [
+      "v. 毕业"
+    ]
+  },
+  {
+    "name": "graduation",
+    "usphone": "ɡrædjʊˈeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 毕业，毕业典礼"
+    ]
+  },
+  {
+    "name": "grain",
+    "usphone": "ɡreɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 谷物，谷类"
+    ]
+  },
+  {
+    "name": "gram",
+    "usphone": "ɡræm",
+    "ukphone": "",
+    "trans": [
+      "n. 克(重量单位)"
+    ]
+  },
+  {
+    "name": "grammar",
+    "usphone": "ˈɡræmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 语法"
+    ]
+  },
+  {
+    "name": "grand",
+    "usphone": "ɡrænd",
+    "ukphone": "",
+    "trans": [
+      "a. 宏伟的"
+    ]
+  },
+  {
+    "name": "grandchild",
+    "usphone": "ˈgræntʃaɪld",
+    "ukphone": "",
+    "trans": [
+      "n.(外)孙或孙女.孙辈"
+    ]
+  },
+  {
+    "name": "granddaughter",
+    "usphone": "ˈɡrændɔːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （外）孙女"
+    ]
+  },
+  {
+    "name": "grandma = grandmother",
+    "usphone": "ˈɡrænmɑː, ˈɡrændmɑː",
+    "ukphone": "",
+    "trans": [
+      "n. 奶奶；外婆"
+    ]
+  },
+  {
+    "name": "grandpa = grandfather",
+    "usphone": "ˈɡrænpɑː, ˈɡrændpɑː",
+    "ukphone": "",
+    "trans": [
+      "n.爷爷,外公"
+    ]
+  },
+  {
+    "name": "grandparents",
+    "usphone": "ˈɡrændpeərənt",
+    "ukphone": "",
+    "trans": [
+      "n.祖父母.外祖父母"
+    ]
+  },
+  {
+    "name": "grandson",
+    "usphone": "ˈɡrændsʌn",
+    "ukphone": "",
+    "trans": [
+      "n. （外）孙子"
+    ]
+  },
+  {
+    "name": "granny",
+    "usphone": "ˈɡrænɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 老奶奶；祖母；外婆"
+    ]
+  },
+  {
+    "name": "grape",
+    "usphone": "ɡreɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 葡萄"
+    ]
+  },
+  {
+    "name": "graph",
+    "usphone": "ɡrɑːf; (US) ɡræf",
+    "ukphone": "",
+    "trans": [
+      "n. 图表，曲线图"
+    ]
+  },
+  {
+    "name": "grasp",
+    "usphone": "ɡrɑːsp; (US) ɡræsp",
+    "ukphone": "",
+    "trans": [
+      "v. 抓住；紧握"
+    ]
+  },
+  {
+    "name": "grass",
+    "usphone": "ɡrɑːs; (US) ɡræs",
+    "ukphone": "",
+    "trans": [
+      "n. 草；草场；牧草"
+    ]
+  },
+  {
+    "name": "grateful",
+    "usphone": "ˈɡreɪtfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 感激的，感谢的"
+    ]
+  },
+  {
+    "name": "gravity",
+    "usphone": "ˈɡrævɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 重力，地球引力"
+    ]
+  },
+  {
+    "name": "great",
+    "usphone": "ɡreɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 伟大的,重要的,好极了 ad. （口语）好极了，很好"
+    ]
+  },
+  {
+    "name": "Greece",
+    "usphone": "ɡriːs",
+    "ukphone": "",
+    "trans": [
+      "* n. 希腊"
+    ]
+  },
+  {
+    "name": "greedy",
+    "usphone": "ˈɡriːdɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 贪婪的"
+    ]
+  },
+  {
+    "name": "Greek",
+    "usphone": "ɡriːk",
+    "ukphone": "",
+    "trans": [
+      "a. / n. 希腊的，希腊人的，希腊语的 ; 希腊人，希腊语"
+    ]
+  },
+  {
+    "name": "green",
+    "usphone": "ɡriːn",
+    "ukphone": "",
+    "trans": [
+      "a. 绿色的；青的 n. 绿色"
+    ]
+  },
+  {
+    "name": "greengrocer",
+    "usphone": "ˈɡriːnɡrəʊsə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.（英）蔬菜水果商"
+    ]
+  },
+  {
+    "name": "greet",
+    "usphone": "ɡriːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 问候；向……致敬"
+    ]
+  },
+  {
+    "name": "greeting",
+    "usphone": "ˈɡriːtɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 祝贺"
+    ]
+  },
+  {
+    "name": "grey / gray",
+    "usphone": "ɡreɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 灰色的； 灰白的"
+    ]
+  },
+  {
+    "name": "grill",
+    "usphone": "ɡrɪl",
+    "ukphone": "",
+    "trans": [
+      "n. （烧食物的）烤架"
+    ]
+  },
+  {
+    "name": "grocer",
+    "usphone": "ˈɡrəʊsə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 零售商人；食品店"
+    ]
+  },
+  {
+    "name": "ground",
+    "usphone": "ɡraʊnd",
+    "ukphone": "",
+    "trans": [
+      "n. 地面"
+    ]
+  },
+  {
+    "name": "group",
+    "usphone": "ɡruːp",
+    "ukphone": "",
+    "trans": [
+      "n. 组，群"
+    ]
+  },
+  {
+    "name": "grow (grew, grown)",
+    "usphone": "ɡrəʊ",
+    "ukphone": "",
+    "trans": [
+      "v. 生长；发育；种植；变成"
+    ]
+  },
+  {
+    "name": "growth",
+    "usphone": "ɡrəʊθ",
+    "ukphone": "",
+    "trans": [
+      "n. 生长，增长"
+    ]
+  },
+  {
+    "name": "gruel",
+    "usphone": "ɡrʊəl",
+    "ukphone": "",
+    "trans": [
+      "n. 粥"
+    ]
+  },
+  {
+    "name": "guarantee",
+    "usphone": "ɡærənˈtiː",
+    "ukphone": "",
+    "trans": [
+      "v. 保证，担保"
+    ]
+  },
+  {
+    "name": "guard",
+    "usphone": "ɡɑːd",
+    "ukphone": "",
+    "trans": [
+      "n. 防护装置，警戒"
+    ]
+  },
+  {
+    "name": "guess",
+    "usphone": "ɡes",
+    "ukphone": "",
+    "trans": [
+      "vi. 猜"
+    ]
+  },
+  {
+    "name": "guest",
+    "usphone": "ɡest",
+    "ukphone": "",
+    "trans": [
+      "n. 客人，宾客"
+    ]
+  },
+  {
+    "name": "guidance",
+    "usphone": "ˈɡaɪdəns",
+    "ukphone": "",
+    "trans": [
+      "n. 引导，指导"
+    ]
+  },
+  {
+    "name": "guide",
+    "usphone": "ɡaɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 向导，导游者"
+    ]
+  },
+  {
+    "name": "guilty",
+    "usphone": "ˈɡɪltɪ",
+    "ukphone": "",
+    "trans": [
+      "a.有罪,犯法的,做错事的"
+    ]
+  },
+  {
+    "name": "guitar",
+    "usphone": "ɡɪˈtɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 吉他，六弦琴"
+    ]
+  },
+  {
+    "name": "gun",
+    "usphone": "ɡʌn",
+    "ukphone": "",
+    "trans": [
+      "n. 枪，炮"
+    ]
+  },
+  {
+    "name": "gym =gymnasium",
+    "usphone": "dʒɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 体操；体育馆；健身房"
+    ]
+  },
+  {
+    "name": "gymnastics",
+    "usphone": "dʒɪmˈnæstɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 体操"
+    ]
+  },
+  {
+    "name": "ha",
+    "usphone": "hɑː",
+    "ukphone": "",
+    "trans": [
+      "int. 哈(笑声)"
+    ]
+  },
+  {
+    "name": "habit",
+    "usphone": "ˈhæbɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 习惯，习性"
+    ]
+  },
+  {
+    "name": "hair",
+    "usphone": "heə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 头发"
+    ]
+  },
+  {
+    "name": "haircut",
+    "usphone": "ˈheəkʌt",
+    "ukphone": "",
+    "trans": [
+      "n. （男子）理发"
+    ]
+  },
+  {
+    "name": "half",
+    "usphone": "hɑːf; (US) hæf",
+    "ukphone": "",
+    "trans": [
+      "a.& n. 半，一半，半个"
+    ]
+  },
+  {
+    "name": "hall",
+    "usphone": "hɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 大厅,会堂,礼堂;过道"
+    ]
+  },
+  {
+    "name": "ham",
+    "usphone": "hæm",
+    "ukphone": "",
+    "trans": [
+      "n. 火腿"
+    ]
+  },
+  {
+    "name": "hamburger",
+    "usphone": "ˈhæmbɜːɡə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 汉堡包"
+    ]
+  },
+  {
+    "name": "hammer",
+    "usphone": "ˈhæmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 锤子，锣锤"
+    ]
+  },
+  {
+    "name": "hand",
+    "usphone": "hænd",
+    "ukphone": "",
+    "trans": [
+      "n. 手；指针 v. 递；给；交付 交上；交进"
+    ]
+  },
+  {
+    "name": "handbag",
+    "usphone": "ˈhændbæɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 女用皮包，手提包"
+    ]
+  },
+  {
+    "name": "handful",
+    "usphone": "ˈhændfʊl",
+    "ukphone": "",
+    "trans": [
+      "n.(一)把；少数，少量"
+    ]
+  },
+  {
+    "name": "handkerchief",
+    "usphone": "ˈhæŋkətʃɪf",
+    "ukphone": "",
+    "trans": [
+      "n. 手帕"
+    ]
+  },
+  {
+    "name": "handle",
+    "usphone": "ˈhænd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 柄，把柄 v. 处理"
+    ]
+  },
+  {
+    "name": "handsome",
+    "usphone": "ˈhænsəm",
+    "ukphone": "",
+    "trans": [
+      "a. 英俊的"
+    ]
+  },
+  {
+    "name": "handtruck",
+    "usphone": "ˈhændtrʌk",
+    "ukphone": "",
+    "trans": [
+      "n.手推运货车"
+    ]
+  },
+  {
+    "name": "handwriting",
+    "usphone": "ˈhændraɪtɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 书法"
+    ]
+  },
+  {
+    "name": "handy",
+    "usphone": "ˈhændɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 便利的，顺手的 hang(hanged,hanged) v. 处（人）绞刑；上吊"
+    ]
+  },
+  {
+    "name": "hang (hung, hung)",
+    "usphone": "hæŋ",
+    "ukphone": "",
+    "trans": [
+      "v.悬挂，吊着；把……吊起"
+    ]
+  },
+  {
+    "name": "happen",
+    "usphone": "ˈhæpən",
+    "ukphone": "",
+    "trans": [
+      "vi.（偶然）发生"
+    ]
+  },
+  {
+    "name": "happily",
+    "usphone": "ˈhæpɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 幸福地，快乐地"
+    ]
+  },
+  {
+    "name": "happiness",
+    "usphone": "ˈhæpɪnɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 幸福，愉快"
+    ]
+  },
+  {
+    "name": "happy",
+    "usphone": "ˈhæpɪ",
+    "ukphone": "",
+    "trans": [
+      "a.幸福；快乐的，高兴的"
+    ]
+  },
+  {
+    "name": "harbour (美harbor)",
+    "usphone": "ˈhɑ:bə",
+    "ukphone": "",
+    "trans": [
+      "n. 港口"
+    ]
+  },
+  {
+    "name": "hard",
+    "usphone": "hɑːd",
+    "ukphone": "",
+    "trans": [
+      "ad. 努力地；使劲；猛烈地 a.硬的；困难的；艰难的"
+    ]
+  },
+  {
+    "name": "hardly",
+    "usphone": "ˈhɑːdlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 几乎不"
+    ]
+  },
+  {
+    "name": "hardship",
+    "usphone": "ˈhɑːdʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 困难"
+    ]
+  },
+  {
+    "name": "hardworking",
+    "usphone": "ˈha:dˈwə:kiŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 努力工作的"
+    ]
+  },
+  {
+    "name": "harm",
+    "usphone": "hɑːm",
+    "ukphone": "",
+    "trans": [
+      "n.&v. 伤害；损伤"
+    ]
+  },
+  {
+    "name": "harmful",
+    "usphone": "ˈhɑːmfʊl",
+    "ukphone": "",
+    "trans": [
+      "a.有害的；致伤的"
+    ]
+  },
+  {
+    "name": "harmless",
+    "usphone": "ˈhɑːmlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 无害的;不致伤的"
+    ]
+  },
+  {
+    "name": "harmony",
+    "usphone": "ˈhɑːmənɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 融洽，和睦"
+    ]
+  },
+  {
+    "name": "harvest",
+    "usphone": "ˈhɑːvɪst",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 收割，收获（物）"
+    ]
+  },
+  {
+    "name": "hat",
+    "usphone": "hæt",
+    "ukphone": "",
+    "trans": [
+      "n.帽子(一般指有边的)；礼帽"
+    ]
+  },
+  {
+    "name": "hatch",
+    "usphone": "hætʃ",
+    "ukphone": "",
+    "trans": [
+      "v. （鸟、鸡）孵蛋"
+    ]
+  },
+  {
+    "name": "hate",
+    "usphone": "heɪt",
+    "ukphone": "",
+    "trans": [
+      "vt.& n. 恨，讨厌"
+    ]
+  },
+  {
+    "name": "have (has, had, had)",
+    "usphone": "hæv",
+    "ukphone": "",
+    "trans": [
+      "vt.有；吃；喝；进行；经受"
+    ]
+  },
+  {
+    "name": "hawk",
+    "usphone": "hɔːk",
+    "ukphone": "",
+    "trans": [
+      "n. 鹰"
+    ]
+  },
+  {
+    "name": "hay",
+    "usphone": "heɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 作饲料用的干草"
+    ]
+  },
+  {
+    "name": "he",
+    "usphone": "heɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 他"
+    ]
+  },
+  {
+    "name": "head",
+    "usphone": "hed",
+    "ukphone": "",
+    "trans": [
+      "n. 头；头脑(像)；才智；首脑；源头；标题 a. 头部的；主要的；首席的 v. 率领；加标题；用头顶；出发；(船等)驶向"
+    ]
+  },
+  {
+    "name": "headache",
+    "usphone": "ˈhedeɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 头疼"
+    ]
+  },
+  {
+    "name": "headline",
+    "usphone": "ˈhedlaɪn",
+    "ukphone": "",
+    "trans": [
+      "n. （报刊的）大字标题"
+    ]
+  },
+  {
+    "name": "headmaster",
+    "usphone": "hedˈmɑːstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （英）中小学校长"
+    ]
+  },
+  {
+    "name": "headmistress",
+    "usphone": "ˈhedˈmistrɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 女校长"
+    ]
+  },
+  {
+    "name": "headteacher",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 中小学班主任"
+    ]
+  },
+  {
+    "name": "health",
+    "usphone": "helθ",
+    "ukphone": "",
+    "trans": [
+      "n. 健康，卫生"
+    ]
+  },
+  {
+    "name": "healthy",
+    "usphone": "ˈhelθɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 健康的，健壮的"
+    ]
+  },
+  {
+    "name": "heap",
+    "usphone": "hiːp",
+    "ukphone": "",
+    "trans": [
+      "n. 堆 v. 堆起来"
+    ]
+  },
+  {
+    "name": "hear (heard, heard)",
+    "usphone": "hɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 听见；听说,得知"
+    ]
+  },
+  {
+    "name": "hearing",
+    "usphone": "ˈhɪərɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 听力"
+    ]
+  },
+  {
+    "name": "heart",
+    "usphone": "hɑːt",
+    "ukphone": "",
+    "trans": [
+      "n.心.心脏, 纸牌中的红桃"
+    ]
+  },
+  {
+    "name": "heat",
+    "usphone": "hiːt",
+    "ukphone": "",
+    "trans": [
+      "n. 热 vt. 把……加热"
+    ]
+  },
+  {
+    "name": "heaven",
+    "usphone": "ˈhev(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 天，天空"
+    ]
+  },
+  {
+    "name": "heavy",
+    "usphone": "ˈhevɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 重的"
+    ]
+  },
+  {
+    "name": "heavily",
+    "usphone": "ˈhevɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 重地，大量地"
+    ]
+  },
+  {
+    "name": "heel",
+    "usphone": "hiːl",
+    "ukphone": "",
+    "trans": [
+      "n. 脚后跟"
+    ]
+  },
+  {
+    "name": "height",
+    "usphone": "haɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 高，高度"
+    ]
+  },
+  {
+    "name": "helicopter",
+    "usphone": "ˈhelɪkɔptə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 直升飞机"
+    ]
+  },
+  {
+    "name": "hello",
+    "usphone": "həˈləʊ",
+    "ukphone": "",
+    "trans": [
+      "int. 喂；你好（表示打招呼，问候或唤起注意）"
+    ]
+  },
+  {
+    "name": "helmet",
+    "usphone": "ˈhelmɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 头盔"
+    ]
+  },
+  {
+    "name": "help",
+    "usphone": "help",
+    "ukphone": "",
+    "trans": [
+      "n. & vt. 帮助，帮忙"
+    ]
+  },
+  {
+    "name": "helpful",
+    "usphone": "ˈhelpfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 有帮助的，有益的"
+    ]
+  },
+  {
+    "name": "hen",
+    "usphone": "hen",
+    "ukphone": "",
+    "trans": [
+      "n. 母鸡"
+    ]
+  },
+  {
+    "name": "her",
+    "usphone": "hɜː(r)",
+    "ukphone": "",
+    "trans": [
+      "pron. 她(宾格),她的"
+    ]
+  },
+  {
+    "name": "herb",
+    "usphone": "hɜːb; (US) ɜːrb",
+    "ukphone": "",
+    "trans": [
+      "n. 草药"
+    ]
+  },
+  {
+    "name": "here",
+    "usphone": "hɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 这里，在这里；向这里"
+    ]
+  },
+  {
+    "name": "hero",
+    "usphone": "ˈhɪərəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 英雄，勇士，男主角"
+    ]
+  },
+  {
+    "name": "heroine",
+    "usphone": "ˈherəʊɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 女英雄，女主角"
+    ]
+  },
+  {
+    "name": "hers",
+    "usphone": "hɜːz",
+    "ukphone": "",
+    "trans": [
+      "pron. 她的"
+    ]
+  },
+  {
+    "name": "herself",
+    "usphone": "hɜːˈself",
+    "ukphone": "",
+    "trans": [
+      "pron. 她自己"
+    ]
+  },
+  {
+    "name": "hey",
+    "usphone": "heɪ",
+    "ukphone": "",
+    "trans": [
+      "int. 嘿！"
+    ]
+  },
+  {
+    "name": "hi",
+    "usphone": "haɪ",
+    "ukphone": "",
+    "trans": [
+      "int. 你好（表示打招呼、问候或唤起注 意）"
+    ]
+  },
+  {
+    "name": "hibernate",
+    "usphone": "ˈhaɪbəneɪt",
+    "ukphone": "",
+    "trans": [
+      "vi. 冬眠"
+    ]
+  },
+  {
+    "name": "hibernation",
+    "usphone": "haɪbə(r)ˈneɪʃn",
+    "ukphone": "",
+    "trans": [
+      "n. 冬眠"
+    ]
+  },
+  {
+    "name": "hide (hid, hidden)",
+    "usphone": "haɪd",
+    "ukphone": "",
+    "trans": [
+      "v. 把…藏起来，隐藏"
+    ]
+  },
+  {
+    "name": "hide and seek",
+    "usphone": "haɪd-ənd-siːk",
+    "ukphone": "",
+    "trans": [
+      "捉迷藏"
+    ]
+  },
+  {
+    "name": "high",
+    "usphone": "haɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 高的;高度的 ad. 高地"
+    ]
+  },
+  {
+    "name": "highway",
+    "usphone": "ˈhaɪweɪ",
+    "ukphone": "",
+    "trans": [
+      "n.公路,主要交通道路"
+    ]
+  },
+  {
+    "name": "hill",
+    "usphone": "hɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 小山;丘陵;土堆;斜坡"
+    ]
+  },
+  {
+    "name": "hillside",
+    "usphone": "ˈhɪlsaɪd",
+    "ukphone": "",
+    "trans": [
+      "n. （小山）山腰，山坡"
+    ]
+  },
+  {
+    "name": "hilly",
+    "usphone": "ˈhɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 丘陵的； 多小山的"
+    ]
+  },
+  {
+    "name": "him",
+    "usphone": "hɪm",
+    "ukphone": "",
+    "trans": [
+      "pron. 他（宾格）"
+    ]
+  },
+  {
+    "name": "himself",
+    "usphone": "hɪmˈself",
+    "ukphone": "",
+    "trans": [
+      "pron. 他自己"
+    ]
+  },
+  {
+    "name": "hire",
+    "usphone": "ˈhaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 租用"
+    ]
+  },
+  {
+    "name": "his",
+    "usphone": "hɪz",
+    "ukphone": "",
+    "trans": [
+      "pron. 他的"
+    ]
+  },
+  {
+    "name": "history",
+    "usphone": "ˈhɪstərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 历史，历史学"
+    ]
+  },
+  {
+    "name": "hit (hit, hit)",
+    "usphone": "hɪt",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 打,撞,击中"
+    ]
+  },
+  {
+    "name": "hive",
+    "usphone": "haɪv",
+    "ukphone": "",
+    "trans": [
+      "n. 蜂房；蜂箱"
+    ]
+  },
+  {
+    "name": "hobby",
+    "usphone": "ˈhɔbɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 业余爱好，嗜好"
+    ]
+  },
+  {
+    "name": "hold (held, held)",
+    "usphone": "həʊld",
+    "ukphone": "",
+    "trans": [
+      "vt.拿；抱；握住；举行；进行"
+    ]
+  },
+  {
+    "name": "hole",
+    "usphone": "həʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 洞，坑"
+    ]
+  },
+  {
+    "name": "holiday",
+    "usphone": "ˈhɔlɪdɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 假日；假期"
+    ]
+  },
+  {
+    "name": "holy",
+    "usphone": "ˈhəʊlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 神圣的"
+    ]
+  },
+  {
+    "name": "home",
+    "usphone": "həʊm",
+    "ukphone": "",
+    "trans": [
+      "n. 家 ad. 到家；回家"
+    ]
+  },
+  {
+    "name": "homeland",
+    "usphone": "ˈhəʊmlænd",
+    "ukphone": "",
+    "trans": [
+      "n. 祖国"
+    ]
+  },
+  {
+    "name": "hometown",
+    "usphone": "ˈhəʊmtaʊn",
+    "ukphone": "",
+    "trans": [
+      "n. 故乡"
+    ]
+  },
+  {
+    "name": "homework",
+    "usphone": "ˈhəʊmwɜːk",
+    "ukphone": "",
+    "trans": [
+      "n. 家庭作业"
+    ]
+  },
+  {
+    "name": "honest",
+    "usphone": "ˈɔnɪst",
+    "ukphone": "",
+    "trans": [
+      "a. 诚实的，正直的"
+    ]
+  },
+  {
+    "name": "honey",
+    "usphone": "ˈɔnɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 蜂蜜"
+    ]
+  },
+  {
+    "name": "Hong Kong",
+    "usphone": "hɔŋ kɔŋ",
+    "ukphone": "",
+    "trans": [
+      "* n. 香港"
+    ]
+  },
+  {
+    "name": "honour (美honor)",
+    "usphone": "ˈɔnə",
+    "ukphone": "",
+    "trans": [
+      "n. 荣誉，光荣 vt. 尊敬，给予荣誉"
+    ]
+  },
+  {
+    "name": "hook",
+    "usphone": "hʊk",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 钩子；衔接，连接"
+    ]
+  },
+  {
+    "name": "hooray",
+    "usphone": "hʊˈreɪ",
+    "ukphone": "",
+    "trans": [
+      "int. 好哇！（欢呼声）"
+    ]
+  },
+  {
+    "name": "hope",
+    "usphone": "həʊp",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 希望"
+    ]
+  },
+  {
+    "name": "hopeful",
+    "usphone": "ˈhəʊpfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 有希望的；有前途的"
+    ]
+  },
+  {
+    "name": "hopeless",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a.没有希望,不可救药的"
+    ]
+  },
+  {
+    "name": "horrible",
+    "usphone": "ˈhɔrɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 令人恐惧；恐怖的"
+    ]
+  },
+  {
+    "name": "horse",
+    "usphone": "hɔːs",
+    "ukphone": "",
+    "trans": [
+      "n. 马"
+    ]
+  },
+  {
+    "name": "hospital",
+    "usphone": "ˈhɔspɪt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 医院"
+    ]
+  },
+  {
+    "name": "host",
+    "usphone": "həʊst",
+    "ukphone": "",
+    "trans": [
+      "n. 主人；节目主持人 v. 做主人招待"
+    ]
+  },
+  {
+    "name": "hostess",
+    "usphone": "ˈhəʊstɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 女主人"
+    ]
+  },
+  {
+    "name": "hot",
+    "usphone": "hɔt,hɑt",
+    "ukphone": "",
+    "trans": [
+      "a. 热的"
+    ]
+  },
+  {
+    "name": "hot dog",
+    "usphone": "hɔt- dɔɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 热狗(红肠面包)"
+    ]
+  },
+  {
+    "name": "hotel",
+    "usphone": "həʊˈtel",
+    "ukphone": "",
+    "trans": [
+      "n. 旅馆，饭店，宾馆"
+    ]
+  },
+  {
+    "name": "hour",
+    "usphone": "ˈaʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 小时"
+    ]
+  },
+  {
+    "name": "house",
+    "usphone": "haʊs",
+    "ukphone": "",
+    "trans": [
+      "n. 房子；住宅"
+    ]
+  },
+  {
+    "name": "housewife",
+    "usphone": "ˈhaʊswaɪf",
+    "ukphone": "",
+    "trans": [
+      "n. 家庭主妇"
+    ]
+  },
+  {
+    "name": "housework",
+    "usphone": "ˈhaʊswɜːk",
+    "ukphone": "",
+    "trans": [
+      "n. 家务劳动"
+    ]
+  },
+  {
+    "name": "how",
+    "usphone": "haʊ",
+    "ukphone": "",
+    "trans": [
+      "ad.怎样,如何；多少；多么"
+    ]
+  },
+  {
+    "name": "however",
+    "usphone": "haʊˈevə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 可是 conj. 然而，可是，尽管如此"
+    ]
+  },
+  {
+    "name": "howl",
+    "usphone": "haʊl",
+    "ukphone": "",
+    "trans": [
+      "vi. 嚎叫，嚎哭"
+    ]
+  },
+  {
+    "name": "hug",
+    "usphone": "hʌɡ",
+    "ukphone": "",
+    "trans": [
+      "v. 拥抱"
+    ]
+  },
+  {
+    "name": "huge",
+    "usphone": "hjuːdʒ",
+    "ukphone": "",
+    "trans": [
+      "a. 巨大的，庞大的"
+    ]
+  },
+  {
+    "name": "human",
+    "usphone": "ˈhjuːmən",
+    "ukphone": "",
+    "trans": [
+      "a. 人的，人类的"
+    ]
+  },
+  {
+    "name": "human being",
+    "usphone": "ˈhjuːmən ˈbiːɪŋ",
+    "ukphone": "",
+    "trans": [
+      "人"
+    ]
+  },
+  {
+    "name": "humorous",
+    "usphone": "ˈhjuːmərəs",
+    "ukphone": "",
+    "trans": [
+      "a. 富于幽默的"
+    ]
+  },
+  {
+    "name": "humour (美humor)",
+    "usphone": "ˈhju:mə",
+    "ukphone": "",
+    "trans": [
+      "n.幽默,幽默感"
+    ]
+  },
+  {
+    "name": "hundred",
+    "usphone": "ˈhʌndrəd",
+    "ukphone": "",
+    "trans": [
+      "num. 百"
+    ]
+  },
+  {
+    "name": "hunger",
+    "usphone": "ˈhʌŋɡə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 饥饿"
+    ]
+  },
+  {
+    "name": "hungry",
+    "usphone": "ˈhʌŋɡrɪ",
+    "ukphone": "",
+    "trans": [
+      "a. （饥）饿的"
+    ]
+  },
+  {
+    "name": "hunt",
+    "usphone": "hʌnt",
+    "ukphone": "",
+    "trans": [
+      "vt. 寻找；狩猎，猎取"
+    ]
+  },
+  {
+    "name": "hunter",
+    "usphone": "ˈhʌntə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 猎人"
+    ]
+  },
+  {
+    "name": "hurricane",
+    "usphone": "ˈhʌrɪkən",
+    "ukphone": "",
+    "trans": [
+      "n. 飓风，十二级风"
+    ]
+  },
+  {
+    "name": "hurry",
+    "usphone": "ˈhʌrɪ",
+    "ukphone": "",
+    "trans": [
+      "vi. 赶快；急忙"
+    ]
+  },
+  {
+    "name": "hurt (hurt, hurt)",
+    "usphone": "hɜːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 伤害，受伤；伤人感情"
+    ]
+  },
+  {
+    "name": "husband",
+    "usphone": "ˈhʌzbənd",
+    "ukphone": "",
+    "trans": [
+      "n. 丈夫"
+    ]
+  },
+  {
+    "name": "hydrogen",
+    "usphone": "ˈhaɪdrədʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 氢"
+    ]
+  },
+  {
+    "name": "I",
+    "usphone": "aɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 我"
+    ]
+  },
+  {
+    "name": "ice",
+    "usphone": "aɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 冰"
+    ]
+  },
+  {
+    "name": "ice--cream",
+    "usphone": "aɪs- kriːm",
+    "ukphone": "",
+    "trans": [
+      "n. 冰淇淋"
+    ]
+  },
+  {
+    "name": "Iceland",
+    "usphone": "ˈaɪslənd",
+    "ukphone": "",
+    "trans": [
+      "* n. 冰岛"
+    ]
+  },
+  {
+    "name": "idea",
+    "usphone": "aɪˈdɪə",
+    "ukphone": "",
+    "trans": [
+      "n. 主意,意见,打算,想法"
+    ]
+  },
+  {
+    "name": "identity",
+    "usphone": "aɪˈdentɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 身份，特征"
+    ]
+  },
+  {
+    "name": "identification",
+    "usphone": "aɪdentɪfɪˈkeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 鉴定，辨别"
+    ]
+  },
+  {
+    "name": "idiom",
+    "usphone": "ˈɪdɪəm",
+    "ukphone": "",
+    "trans": [
+      "n. 习语，成语"
+    ]
+  },
+  {
+    "name": "if",
+    "usphone": "ɪf",
+    "ukphone": "",
+    "trans": [
+      "conj.如果,假使,是否,是不是"
+    ]
+  },
+  {
+    "name": "ignore",
+    "usphone": "ɪɡˈnɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 忽视，对…不理会"
+    ]
+  },
+  {
+    "name": "ill",
+    "usphone": "ɪl",
+    "ukphone": "",
+    "trans": [
+      "a. 有病的；不健康的"
+    ]
+  },
+  {
+    "name": "illegal",
+    "usphone": "ɪˈliːɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 非法的"
+    ]
+  },
+  {
+    "name": "illness",
+    "usphone": "ˈɪlnɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 疾病"
+    ]
+  },
+  {
+    "name": "imagine",
+    "usphone": "ɪˈmædʒɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. 想像，设想"
+    ]
+  },
+  {
+    "name": "immediate",
+    "usphone": "ɪˈmiːdɪət",
+    "ukphone": "",
+    "trans": [
+      "a. 立即的，马上"
+    ]
+  },
+  {
+    "name": "immediately",
+    "usphone": "ɪˈmiːdɪətlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 立即"
+    ]
+  },
+  {
+    "name": "immigration",
+    "usphone": "ɪmɪˈgreɪʃn",
+    "ukphone": "",
+    "trans": [
+      "n. 移民"
+    ]
+  },
+  {
+    "name": "import",
+    "usphone": "ɪmˈpɔːt",
+    "ukphone": "",
+    "trans": [
+      "v.& n. 进口，输入"
+    ]
+  },
+  {
+    "name": "importance",
+    "usphone": "ɪmˈpɔːt(ə)ns",
+    "ukphone": "",
+    "trans": [
+      "n. 重要性"
+    ]
+  },
+  {
+    "name": "important",
+    "usphone": "ɪmˈpɔːtənt",
+    "ukphone": "",
+    "trans": [
+      "a. 重要的"
+    ]
+  },
+  {
+    "name": "impossible",
+    "usphone": "ɪmˈpɔsɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 不可能的"
+    ]
+  },
+  {
+    "name": "impress",
+    "usphone": "ɪmˈpres",
+    "ukphone": "",
+    "trans": [
+      "vt. 留下极深的印象"
+    ]
+  },
+  {
+    "name": "impression",
+    "usphone": "ɪmˈpreʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 印象，感觉"
+    ]
+  },
+  {
+    "name": "improve",
+    "usphone": "ɪmˈpruːv",
+    "ukphone": "",
+    "trans": [
+      "vt. 改进，更新"
+    ]
+  },
+  {
+    "name": "in",
+    "usphone": "ɪn",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…里(内)；在…；以… ad. 在家，在内，向内"
+    ]
+  },
+  {
+    "name": "inch",
+    "usphone": "ɪntʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 英寸"
+    ]
+  },
+  {
+    "name": "incident",
+    "usphone": "ˈɪnsɪd(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "n. 事件"
+    ]
+  },
+  {
+    "name": "include",
+    "usphone": "ɪnˈkluːd",
+    "ukphone": "",
+    "trans": [
+      "vt. 包含，包括"
+    ]
+  },
+  {
+    "name": "income",
+    "usphone": "ˈɪnkʌm",
+    "ukphone": "",
+    "trans": [
+      "n. 收入，所得"
+    ]
+  },
+  {
+    "name": "incorrect",
+    "usphone": "ɪnkəˈrekt",
+    "ukphone": "",
+    "trans": [
+      "a. 不正确的，错误的"
+    ]
+  },
+  {
+    "name": "increase",
+    "usphone": "ɪnˈkriːs",
+    "ukphone": "",
+    "trans": [
+      "v. & n. 增加，繁殖"
+    ]
+  },
+  {
+    "name": "indeed",
+    "usphone": "ɪnˈdiːd",
+    "ukphone": "",
+    "trans": [
+      "a. 确实；实在"
+    ]
+  },
+  {
+    "name": "independence",
+    "usphone": "ɪndɪˈpendəns",
+    "ukphone": "",
+    "trans": [
+      "n. 独立"
+    ]
+  },
+  {
+    "name": "independent",
+    "usphone": "ɪndɪˈpendənt",
+    "ukphone": "",
+    "trans": [
+      "a.独立的,有主见的"
+    ]
+  },
+  {
+    "name": "India",
+    "usphone": "ˈɪndɪə",
+    "ukphone": "",
+    "trans": [
+      "* n. 印度"
+    ]
+  },
+  {
+    "name": "Indian",
+    "usphone": "ˈɪndɪən",
+    "ukphone": "",
+    "trans": [
+      "a. （美洲）印地安人的； 印度人的 n. 印地安人；印度人"
+    ]
+  },
+  {
+    "name": "Indicate",
+    "usphone": "ˈɪndɪkeɪt",
+    "ukphone": "",
+    "trans": [
+      "v.表明，象征，暗示"
+    ]
+  },
+  {
+    "name": "industry",
+    "usphone": "ˈɪndəstrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 工业，产业"
+    ]
+  },
+  {
+    "name": "influence",
+    "usphone": "ˈɪnflʊəns",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 影响"
+    ]
+  },
+  {
+    "name": "inform",
+    "usphone": "ɪnˈfɔːm",
+    "ukphone": "",
+    "trans": [
+      "vt. 告诉； 通知"
+    ]
+  },
+  {
+    "name": "information",
+    "usphone": "ɪnfəˈmeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 信息"
+    ]
+  },
+  {
+    "name": "information desk",
+    "usphone": "ɪnfəˈmeɪʃ(ə)n desk",
+    "ukphone": "",
+    "trans": [
+      "问讯处"
+    ]
+  },
+  {
+    "name": "initial",
+    "usphone": "ɪˈnɪʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 开始的，最初的"
+    ]
+  },
+  {
+    "name": "injure",
+    "usphone": "ˈɪndʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 损害，伤害"
+    ]
+  },
+  {
+    "name": "injury",
+    "usphone": "ˈɪndʒərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 受伤处"
+    ]
+  },
+  {
+    "name": "ink",
+    "usphone": "ɪŋk",
+    "ukphone": "",
+    "trans": [
+      "n. 墨水，油墨"
+    ]
+  },
+  {
+    "name": "inland",
+    "usphone": "ˈɪnlənd, ˈɪnlænd",
+    "ukphone": "",
+    "trans": [
+      "a. 内陆的；内地的"
+    ]
+  },
+  {
+    "name": "inn",
+    "usphone": "ɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 小旅店；小饭店"
+    ]
+  },
+  {
+    "name": "innocent",
+    "usphone": "ˈɪnəsənt",
+    "ukphone": "",
+    "trans": [
+      "a.无辜的，清白的"
+    ]
+  },
+  {
+    "name": "insect",
+    "usphone": "ˈɪnsekt",
+    "ukphone": "",
+    "trans": [
+      "n. 昆虫"
+    ]
+  },
+  {
+    "name": "insert",
+    "usphone": "ɪnˈsɜːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 插入"
+    ]
+  },
+  {
+    "name": "inside",
+    "usphone": "ɪnˈsaɪd",
+    "ukphone": "",
+    "trans": [
+      "prep.在…里面 ad.在里面"
+    ]
+  },
+  {
+    "name": "insist",
+    "usphone": "ɪnˈsɪst",
+    "ukphone": "",
+    "trans": [
+      "vi. 坚持；坚决认为"
+    ]
+  },
+  {
+    "name": "inspect",
+    "usphone": "ɪnˈspekt",
+    "ukphone": "",
+    "trans": [
+      "vt. 检查；检验；审视"
+    ]
+  },
+  {
+    "name": "inspire",
+    "usphone": "ɪnˈspaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 鼓舞； 激励"
+    ]
+  },
+  {
+    "name": "instant",
+    "usphone": "ˈɪnst(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "a. 瞬间；刹那"
+    ]
+  },
+  {
+    "name": "instead",
+    "usphone": "ɪnˈsted",
+    "ukphone": "",
+    "trans": [
+      "ad. 代替，顶替"
+    ]
+  },
+  {
+    "name": "institute",
+    "usphone": "ˈɪnstɪtjuːt; (US) ˈɪnstətuːt",
+    "ukphone": "",
+    "trans": [
+      "n. (研究)所, 院，学院"
+    ]
+  },
+  {
+    "name": "institution",
+    "usphone": "ɪnstɪˈtjuːʃ(ə)n; (US) ɪnstəˈtuːʃn",
+    "ukphone": "",
+    "trans": [
+      "n. (慈善、宗教等性质的)公共机构； 学校"
+    ]
+  },
+  {
+    "name": "instruct",
+    "usphone": "ɪnˈstrʌkt",
+    "ukphone": "",
+    "trans": [
+      "vt. 通知；指示；教"
+    ]
+  },
+  {
+    "name": "instruction",
+    "usphone": "ɪnˈstrʌkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 说明,须知;教导"
+    ]
+  },
+  {
+    "name": "instrument",
+    "usphone": "ˈɪnstrʊmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 乐器;工具,器械"
+    ]
+  },
+  {
+    "name": "insurance",
+    "usphone": "ɪnˈʃʊərəns",
+    "ukphone": "",
+    "trans": [
+      "n. 保险"
+    ]
+  },
+  {
+    "name": "insure",
+    "usphone": "ɪnˈʃʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 给……保险"
+    ]
+  },
+  {
+    "name": "intelligence",
+    "usphone": "ɪnˈtelɪdʒəns",
+    "ukphone": "",
+    "trans": [
+      "n.智力,才智,智慧"
+    ]
+  },
+  {
+    "name": "intend",
+    "usphone": "ɪnˈtend",
+    "ukphone": "",
+    "trans": [
+      "vt. 想要，打算"
+    ]
+  },
+  {
+    "name": "intention",
+    "usphone": "ɪnˈtenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 打算,计划,意图"
+    ]
+  },
+  {
+    "name": "interest",
+    "usphone": "ˈɪntrəst",
+    "ukphone": "",
+    "trans": [
+      "n. 兴趣，趣味;利息"
+    ]
+  },
+  {
+    "name": "interesting",
+    "usphone": "ˈɪntrətɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 有趣的"
+    ]
+  },
+  {
+    "name": "international",
+    "usphone": "ɪntəˈnæʃən(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 国际的"
+    ]
+  },
+  {
+    "name": "internet",
+    "usphone": "ˈɪntənet",
+    "ukphone": "",
+    "trans": [
+      "n. 互联网，英特网"
+    ]
+  },
+  {
+    "name": "interpreter",
+    "usphone": "ɪnˈtɜːprɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.翻译"
+    ]
+  },
+  {
+    "name": "interrupt",
+    "usphone": "ɪntəˈrʌpt",
+    "ukphone": "",
+    "trans": [
+      "v. 打扰，打断"
+    ]
+  },
+  {
+    "name": "interval",
+    "usphone": "ˈɪntəv(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 间歇；间隔"
+    ]
+  },
+  {
+    "name": "interview",
+    "usphone": "ˈɪntəvjuː",
+    "ukphone": "",
+    "trans": [
+      "n.& vt.采访,会见,面试"
+    ]
+  },
+  {
+    "name": "into",
+    "usphone": "ˈɪntʊ, ˈɪntə",
+    "ukphone": "",
+    "trans": [
+      "prep. 到…里;向内；变成"
+    ]
+  },
+  {
+    "name": "introduce",
+    "usphone": "ɪntrəˈdjuːs; (US) -duːs",
+    "ukphone": "",
+    "trans": [
+      "vt. 介绍"
+    ]
+  },
+  {
+    "name": "introduction",
+    "usphone": "ɪntrəˈdʌkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 引进，介绍"
+    ]
+  },
+  {
+    "name": "invent",
+    "usphone": "ɪnˈvent",
+    "ukphone": "",
+    "trans": [
+      "vt. 发明，创造"
+    ]
+  },
+  {
+    "name": "invention",
+    "usphone": "ɪnˈvenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 发明，创造"
+    ]
+  },
+  {
+    "name": "inventor",
+    "usphone": "ɪnˈventə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 发明者，创造者"
+    ]
+  },
+  {
+    "name": "invitation",
+    "usphone": "ɪnvɪˈteɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 邀请，请帖"
+    ]
+  },
+  {
+    "name": "invite",
+    "usphone": "ɪnˈvaɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 邀请，招待"
+    ]
+  },
+  {
+    "name": "Ireland",
+    "usphone": "ˈaɪələnd",
+    "ukphone": "",
+    "trans": [
+      "* n. 爱尔兰"
+    ]
+  },
+  {
+    "name": "Irish",
+    "usphone": "ˈaɪərɪʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 爱尔兰的，爱尔兰人的"
+    ]
+  },
+  {
+    "name": "iron",
+    "usphone": "ˈaɪən; (US) ˈaɪərn",
+    "ukphone": "",
+    "trans": [
+      "n. 铁，熨斗 vt. 熨烫"
+    ]
+  },
+  {
+    "name": "irrigate",
+    "usphone": "ˈɪrɪɡeɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 灌溉"
+    ]
+  },
+  {
+    "name": "irrigation",
+    "usphone": "ɪrɪˈɡeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 灌溉"
+    ]
+  },
+  {
+    "name": "island",
+    "usphone": "ˈaɪlənd",
+    "ukphone": "",
+    "trans": [
+      "n. 岛"
+    ]
+  },
+  {
+    "name": "it",
+    "usphone": "ɪt",
+    "ukphone": "",
+    "trans": [
+      "pron. 它"
+    ]
+  },
+  {
+    "name": "Italian",
+    "usphone": "ɪˈtæljən",
+    "ukphone": "",
+    "trans": [
+      "a. 意大利(人)的；意大利语的 n. 意大利人；意大利语"
+    ]
+  },
+  {
+    "name": "Italy",
+    "usphone": "ˈɪtəlɪ",
+    "ukphone": "",
+    "trans": [
+      "* n. 意大利"
+    ]
+  },
+  {
+    "name": "its",
+    "usphone": "ɪts",
+    "ukphone": "",
+    "trans": [
+      "pron. 它的"
+    ]
+  },
+  {
+    "name": "itself",
+    "usphone": "ɪtˈself",
+    "ukphone": "",
+    "trans": [
+      "pron. 它自己"
+    ]
+  },
+  {
+    "name": "jacket",
+    "usphone": "ˈdʒækɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 短上衣，夹克衫"
+    ]
+  },
+  {
+    "name": "jam",
+    "usphone": "dʒæm",
+    "ukphone": "",
+    "trans": [
+      "n. 果酱；阻塞"
+    ]
+  },
+  {
+    "name": "January",
+    "usphone": "ˈdʒænjʊərɪ; (US) ˈdʒænjʊerɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 1月"
+    ]
+  },
+  {
+    "name": "Japan",
+    "usphone": "dʒæˈpæn",
+    "ukphone": "",
+    "trans": [
+      "* n. 日本"
+    ]
+  },
+  {
+    "name": "Japanese",
+    "usphone": "dʒæpəˈniːz",
+    "ukphone": "",
+    "trans": [
+      "a. 日本的，日本人的，日语的 n. 日本人，日语"
+    ]
+  },
+  {
+    "name": "jar",
+    "usphone": "dʒɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 罐子；坛子"
+    ]
+  },
+  {
+    "name": "jaw",
+    "usphone": "dʒɔː",
+    "ukphone": "",
+    "trans": [
+      "n. 下巴"
+    ]
+  },
+  {
+    "name": "jazz",
+    "usphone": "dʒæz",
+    "ukphone": "",
+    "trans": [
+      "n. 爵士音乐，爵士舞曲"
+    ]
+  },
+  {
+    "name": "jeans",
+    "usphone": "dʒiːns",
+    "ukphone": "",
+    "trans": [
+      "n. 牛仔裤"
+    ]
+  },
+  {
+    "name": "jeep",
+    "usphone": "dʒiːp",
+    "ukphone": "",
+    "trans": [
+      "n. 吉普车"
+    ]
+  },
+  {
+    "name": "jet",
+    "usphone": "dʒet",
+    "ukphone": "",
+    "trans": [
+      "n. 喷气式飞机；喷射（器）"
+    ]
+  },
+  {
+    "name": "jewel",
+    "usphone": "ˈdʒuːəl",
+    "ukphone": "",
+    "trans": [
+      "n. 宝石"
+    ]
+  },
+  {
+    "name": "jewelry",
+    "usphone": "ˈdʒuːəlrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. （总称）珠宝"
+    ]
+  },
+  {
+    "name": "job",
+    "usphone": "dʒɔb",
+    "ukphone": "",
+    "trans": [
+      "n. （一份）工作"
+    ]
+  },
+  {
+    "name": "jog",
+    "usphone": "dʒɔɡ",
+    "ukphone": "",
+    "trans": [
+      "v. 慢跑"
+    ]
+  },
+  {
+    "name": "join",
+    "usphone": "dʒɔɪn",
+    "ukphone": "",
+    "trans": [
+      "v.参加,加入;连接;会合"
+    ]
+  },
+  {
+    "name": "joke",
+    "usphone": "dʒəʊk",
+    "ukphone": "",
+    "trans": [
+      "n. 笑话"
+    ]
+  },
+  {
+    "name": "journalist",
+    "usphone": "ˈdʒɜːnəlɪzt",
+    "ukphone": "",
+    "trans": [
+      "n. 记者，新闻工作者"
+    ]
+  },
+  {
+    "name": "journey",
+    "usphone": "ˈdʒɜːnɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 旅行，路程"
+    ]
+  },
+  {
+    "name": "joy",
+    "usphone": "dʒɔɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 欢乐，高兴，乐趣"
+    ]
+  },
+  {
+    "name": "judge",
+    "usphone": "dʒʌdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 裁判；审判员；法官vt. 判断，断定"
+    ]
+  },
+  {
+    "name": "judgement",
+    "usphone": "ˈdʒʌdʒmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 裁判"
+    ]
+  },
+  {
+    "name": "juice",
+    "usphone": "dʒuːs",
+    "ukphone": "",
+    "trans": [
+      "n. 汁、液"
+    ]
+  },
+  {
+    "name": "juicy",
+    "usphone": "dʒuːsɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 多汁的；水分多的"
+    ]
+  },
+  {
+    "name": "July",
+    "usphone": "dʒʊˈlaɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 7月"
+    ]
+  },
+  {
+    "name": "jump",
+    "usphone": "dʒʌmp",
+    "ukphone": "",
+    "trans": [
+      "n. 跳跃；跳变 v. 跳跃；惊起；猛扑"
+    ]
+  },
+  {
+    "name": "June",
+    "usphone": "dʒuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 6月"
+    ]
+  },
+  {
+    "name": "jungle",
+    "usphone": "ˈdʒʌŋɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 丛林，密林"
+    ]
+  },
+  {
+    "name": "junior",
+    "usphone": "ˈdʒuːnɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 初级的；年少的"
+    ]
+  },
+  {
+    "name": "junk",
+    "usphone": "dʒʌŋk",
+    "ukphone": "",
+    "trans": [
+      "n. （口语）废品，破烂货"
+    ]
+  },
+  {
+    "name": "junk mail",
+    "usphone": "dʒʌŋk meɪl",
+    "ukphone": "",
+    "trans": [
+      "塞到邮箱的广告宣传品"
+    ]
+  },
+  {
+    "name": "junk food",
+    "usphone": "dʒʌŋk fuːd",
+    "ukphone": "",
+    "trans": [
+      "没有营养的垃圾食品"
+    ]
+  },
+  {
+    "name": "just",
+    "usphone": "dʒʌst",
+    "ukphone": "",
+    "trans": [
+      "ad. 刚才；恰好；不过；仅 a. 公正的"
+    ]
+  },
+  {
+    "name": "justice",
+    "usphone": "ˈdʒʌstɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 正义；公正；司法"
+    ]
+  },
+  {
+    "name": "kangaroo",
+    "usphone": "kæŋɡəˈruː",
+    "ukphone": "",
+    "trans": [
+      "n. 大袋鼠"
+    ]
+  },
+  {
+    "name": "keep (kept, kept)",
+    "usphone": "kiːp",
+    "ukphone": "",
+    "trans": [
+      "v. 保持；保存；继续不断 vt. 培育，饲养"
+    ]
+  },
+  {
+    "name": "keeper",
+    "usphone": "ˈkiːpə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （动物园中的）饲养员，看守人"
+    ]
+  },
+  {
+    "name": "kettle",
+    "usphone": "ˈket(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. (烧水用的)水壶"
+    ]
+  },
+  {
+    "name": "key",
+    "usphone": "kiː",
+    "ukphone": "",
+    "trans": [
+      "n. 钥匙;答案;键;关键"
+    ]
+  },
+  {
+    "name": "keyboard",
+    "usphone": "kiːbɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 键盘"
+    ]
+  },
+  {
+    "name": "kick",
+    "usphone": "kɪk",
+    "ukphone": "",
+    "trans": [
+      "v.& n. 踢"
+    ]
+  },
+  {
+    "name": "kid",
+    "usphone": "kɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 小孩"
+    ]
+  },
+  {
+    "name": "kill",
+    "usphone": "kɪl",
+    "ukphone": "",
+    "trans": [
+      "v. 杀死，弄死"
+    ]
+  },
+  {
+    "name": "kilo",
+    "usphone": "ˈkiːləʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 千克；千米"
+    ]
+  },
+  {
+    "name": "kilogram",
+    "usphone": "ˈkɪləɡræm",
+    "ukphone": "",
+    "trans": [
+      "n. 千克"
+    ]
+  },
+  {
+    "name": "kilometr",
+    "usphone": "ˈkiləʊmi:tə(r)",
+    "ukphone": "",
+    "trans": [
+      "e n. 千米（公里）"
+    ]
+  },
+  {
+    "name": "kind",
+    "usphone": "kaɪnd",
+    "ukphone": "",
+    "trans": [
+      "n. 种;类 a. 善良,友好的"
+    ]
+  },
+  {
+    "name": "kindergarten",
+    "usphone": "kɪndəˈɡɑːt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 幼儿园"
+    ]
+  },
+  {
+    "name": "kind-hearted",
+    "usphone": "kaɪnd- ˈhɑ:tid",
+    "ukphone": "",
+    "trans": [
+      "a. 好心的"
+    ]
+  },
+  {
+    "name": "kindness",
+    "usphone": "ˈkaɪndnɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 仁慈；善良"
+    ]
+  },
+  {
+    "name": "king",
+    "usphone": "kɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 国王"
+    ]
+  },
+  {
+    "name": "kingdom",
+    "usphone": "ˈkɪŋdəm",
+    "ukphone": "",
+    "trans": [
+      "n. 王国"
+    ]
+  },
+  {
+    "name": "kiss",
+    "usphone": "kɪs",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 吻，亲吻"
+    ]
+  },
+  {
+    "name": "kitchen",
+    "usphone": "ˈkɪtʃɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 厨房"
+    ]
+  },
+  {
+    "name": "kite",
+    "usphone": "kaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 风筝"
+    ]
+  },
+  {
+    "name": "knee",
+    "usphone": "niː",
+    "ukphone": "",
+    "trans": [
+      "n. 膝盖"
+    ]
+  },
+  {
+    "name": "knife",
+    "usphone": "naɪf",
+    "ukphone": "",
+    "trans": [
+      "(复 knives) n.小刀;匕首;刀片"
+    ]
+  },
+  {
+    "name": "knock",
+    "usphone": "nɔk",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 敲；打；击 "
+    ]
+  },
+  {
+    "name": "know(knew,known)",
+    "usphone": "nəʊ",
+    "ukphone": "",
+    "trans": [
+      "v. 知道，了解；认识；懂得"
+    ]
+  },
+  {
+    "name": "knowledge",
+    "usphone": "ˈnɔlɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 知识，学问"
+    ]
+  },
+  {
+    "name": "lab",
+    "usphone": "ˈnɔlɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "= laboratory n. 实验室"
+    ]
+  },
+  {
+    "name": "labour (美labor)",
+    "usphone": "ˈleɪbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 劳动"
+    ]
+  },
+  {
+    "name": "labourer (laborer)",
+    "usphone": "ˈleibərə",
+    "ukphone": "",
+    "trans": [
+      "n.体力劳动者"
+    ]
+  },
+  {
+    "name": "lack",
+    "usphone": "læk",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 缺乏，缺少"
+    ]
+  },
+  {
+    "name": "ladder",
+    "usphone": "ˈlædə(r)",
+    "ukphone": "",
+    "trans": [
+      "r n. 梯子"
+    ]
+  },
+  {
+    "name": "lady",
+    "usphone": "ˈleɪdɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 女士，夫人"
+    ]
+  },
+  {
+    "name": "lake",
+    "usphone": "leɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 湖"
+    ]
+  },
+  {
+    "name": "lamb",
+    "usphone": "læm",
+    "ukphone": "",
+    "trans": [
+      "n. 羔羊"
+    ]
+  },
+  {
+    "name": "lame",
+    "usphone": "leɪm",
+    "ukphone": "",
+    "trans": [
+      "a. 跛的，瘸的，残废的"
+    ]
+  },
+  {
+    "name": "lamp",
+    "usphone": "læmp",
+    "ukphone": "",
+    "trans": [
+      "n. 灯，油灯；光源"
+    ]
+  },
+  {
+    "name": "land",
+    "usphone": "lænd",
+    "ukphone": "",
+    "trans": [
+      "n.陆地,土地v.登岸(陆)降落"
+    ]
+  },
+  {
+    "name": "language",
+    "usphone": "ˈlæŋɡwɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 语言"
+    ]
+  },
+  {
+    "name": "lantern",
+    "usphone": "ˈlæntən",
+    "ukphone": "",
+    "trans": [
+      "n. 灯笼；提灯"
+    ]
+  },
+  {
+    "name": "lap",
+    "usphone": "læp",
+    "ukphone": "",
+    "trans": [
+      "n. (人坐时)膝部.(跑道的)一圈"
+    ]
+  },
+  {
+    "name": "large",
+    "usphone": "lɑːdʒ",
+    "ukphone": "",
+    "trans": [
+      "a. 大的；巨大的"
+    ]
+  },
+  {
+    "name": "laser",
+    "usphone": "ˈleɪzə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 激光"
+    ]
+  },
+  {
+    "name": "last",
+    "usphone": "lɑːst; (US) læst",
+    "ukphone": "",
+    "trans": [
+      "a.最近刚过去;最后的ad.最近刚过去;最后地 n.最后v.持续"
+    ]
+  },
+  {
+    "name": "late",
+    "usphone": "leɪt",
+    "ukphone": "",
+    "trans": [
+      "a.晚的,迟的ad.晚地,迟地"
+    ]
+  },
+  {
+    "name": "lately",
+    "usphone": "ˈleɪtlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 最近，不久前"
+    ]
+  },
+  {
+    "name": "later",
+    "usphone": "ˈleɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 晚些的，迟些的"
+    ]
+  },
+  {
+    "name": "latest",
+    "usphone": "ˈleɪtɪst",
+    "ukphone": "",
+    "trans": [
+      "a.最近，最新的；最晚的"
+    ]
+  },
+  {
+    "name": "latter",
+    "usphone": "ˈlætə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.（两者之中的）后者"
+    ]
+  },
+  {
+    "name": "laugh",
+    "usphone": "lɑːf",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 笑，大笑；嘲笑"
+    ]
+  },
+  {
+    "name": "laughter",
+    "usphone": "ˈlɑːftə(r); (US) ˈlæftər",
+    "ukphone": "",
+    "trans": [
+      "n. 笑； 笑声"
+    ]
+  },
+  {
+    "name": "laundry",
+    "usphone": "ˈlɔːndrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 洗衣店;要洗的衣服"
+    ]
+  },
+  {
+    "name": "lavatory",
+    "usphone": "ˈlævətrɪ; (US) ˈlævətɔːrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 便所，厕所"
+    ]
+  },
+  {
+    "name": "law",
+    "usphone": "lɔː",
+    "ukphone": "",
+    "trans": [
+      "n. 法律，法令；定律"
+    ]
+  },
+  {
+    "name": "lawyer",
+    "usphone": "ˈlɔːjə(r), ˈlɔɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 律师"
+    ]
+  },
+  {
+    "name": "lay (laid, laid)",
+    "usphone": "leɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 放，搁"
+    ]
+  },
+  {
+    "name": "lazy",
+    "usphone": "ˈleɪzɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 懒惰的"
+    ]
+  },
+  {
+    "name": "lead (led, led)",
+    "usphone": "liːd",
+    "ukphone": "",
+    "trans": [
+      "v. 领导，带领 n. 铅"
+    ]
+  },
+  {
+    "name": "leader",
+    "usphone": "ˈliːdə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 领袖，领导人"
+    ]
+  },
+  {
+    "name": "leading",
+    "usphone": "ˈliːdɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 最主要的，第一位的"
+    ]
+  },
+  {
+    "name": "leaf (复 leaves)",
+    "usphone": "liːf",
+    "ukphone": "",
+    "trans": [
+      "n. （树，菜）叶"
+    ]
+  },
+  {
+    "name": "league",
+    "usphone": "liːɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 联盟，社团"
+    ]
+  },
+  {
+    "name": "leak",
+    "usphone": "liːk",
+    "ukphone": "",
+    "trans": [
+      "vi. 漏； 渗"
+    ]
+  },
+  {
+    "name": "learn (learnt, learnt；--ed --ed)",
+    "usphone": "lɜːn",
+    "ukphone": "",
+    "trans": [
+      "vt. 学，学习，学会"
+    ]
+  },
+  {
+    "name": "learned",
+    "usphone": "ˈlɜːnɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 有才华的；博学的"
+    ]
+  },
+  {
+    "name": "least",
+    "usphone": "liːst",
+    "ukphone": "",
+    "trans": [
+      "n.最少，最少量"
+    ]
+  },
+  {
+    "name": "leather",
+    "usphone": "ˈleðə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 皮革"
+    ]
+  },
+  {
+    "name": "leave (left, left)",
+    "usphone": "liːv",
+    "ukphone": "",
+    "trans": [
+      "v. 离开;把…留下，剩下"
+    ]
+  },
+  {
+    "name": "lecture",
+    "usphone": "ˈlektʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 讲课，演讲"
+    ]
+  },
+  {
+    "name": "left",
+    "usphone": "left",
+    "ukphone": "",
+    "trans": [
+      "a.左边的 ad.向左 n.左,左边"
+    ]
+  },
+  {
+    "name": "left-handed",
+    "usphone": "left- ˈ hændid",
+    "ukphone": "",
+    "trans": [
+      "a. 惯用左手的"
+    ]
+  },
+  {
+    "name": "leftover",
+    "usphone": "ˈleftˌəuvə",
+    "ukphone": "",
+    "trans": [
+      "a.剩余,剩下的n.剩饭菜"
+    ]
+  },
+  {
+    "name": "left-wing",
+    "usphone": "left-wɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 左翼的"
+    ]
+  },
+  {
+    "name": "leg",
+    "usphone": "leɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 腿；腿脚；支柱"
+    ]
+  },
+  {
+    "name": "legal",
+    "usphone": "ˈliːɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.与法律有关的，法律的"
+    ]
+  },
+  {
+    "name": "lemon",
+    "usphone": "ˈlemən",
+    "ukphone": "",
+    "trans": [
+      "n. 柠檬 a. 柠檬色(味)的"
+    ]
+  },
+  {
+    "name": "lemonade",
+    "usphone": "leməˈneɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 柠檬水"
+    ]
+  },
+  {
+    "name": "lend (lent, lent)",
+    "usphone": "lend",
+    "ukphone": "",
+    "trans": [
+      "vt.借(出),把…借给"
+    ]
+  },
+  {
+    "name": "length",
+    "usphone": "leŋθ",
+    "ukphone": "",
+    "trans": [
+      "n. 长，长度，段，节"
+    ]
+  },
+  {
+    "name": "less（little的比较级）",
+    "usphone": "les",
+    "ukphone": "",
+    "trans": [
+      "a.& ad. 少于,小于"
+    ]
+  },
+  {
+    "name": "lesson",
+    "usphone": "ˈles(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 课；功课；教训"
+    ]
+  },
+  {
+    "name": "let (let, let)",
+    "usphone": "let",
+    "ukphone": "",
+    "trans": [
+      "vt. 让"
+    ]
+  },
+  {
+    "name": "letter",
+    "usphone": "ˈletə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 信；字母"
+    ]
+  },
+  {
+    "name": "letter-box",
+    "usphone": "ˈletə(r)- bɔks",
+    "ukphone": "",
+    "trans": [
+      "n. 信箱"
+    ]
+  },
+  {
+    "name": "level",
+    "usphone": "ˈlev(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 水平线，水平"
+    ]
+  },
+  {
+    "name": "liberty",
+    "usphone": "ˈlɪbətɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 自由"
+    ]
+  },
+  {
+    "name": "liberate",
+    "usphone": "ˈlɪbəreɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 解放，使获自由"
+    ]
+  },
+  {
+    "name": "liberation",
+    "usphone": "lɪbəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 解放"
+    ]
+  },
+  {
+    "name": "librarian",
+    "usphone": "laɪˈbreərɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 图书管理员；（西方的）图书馆馆长"
+    ]
+  },
+  {
+    "name": "library",
+    "usphone": "ˈlaɪbrərɪ; (US) ˈlaɪbrerɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 图书馆，图书室"
+    ]
+  },
+  {
+    "name": "license",
+    "usphone": "ˈlaɪsəns",
+    "ukphone": "",
+    "trans": [
+      "n. 执照，许可证"
+    ]
+  },
+  {
+    "name": "lid",
+    "usphone": "lɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 盖子"
+    ]
+  },
+  {
+    "name": "lie (lay, lain)",
+    "usphone": "laɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 躺;卧;平放;位于n.& vi. 谎言; 说谎"
+    ]
+  },
+  {
+    "name": "life (复lives)",
+    "usphone": "laɪf",
+    "ukphone": "",
+    "trans": [
+      "n. 生命；生涯；生活；人生；生物"
+    ]
+  },
+  {
+    "name": "lifetime",
+    "usphone": "ˈlaɪftaɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 一生，终生"
+    ]
+  },
+  {
+    "name": "lift",
+    "usphone": "lɪft",
+    "ukphone": "",
+    "trans": [
+      "v. 举起，抬起；（云、烟等）消散 n. （英）电梯"
+    ]
+  },
+  {
+    "name": "light",
+    "usphone": "laɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 光，光亮；灯，灯光 vt. 点（火），点燃 a. 明亮的；轻的；浅色的"
+    ]
+  },
+  {
+    "name": "lightning",
+    "usphone": "ˈlaɪtnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n.闪电"
+    ]
+  },
+  {
+    "name": "like",
+    "usphone": "laɪk",
+    "ukphone": "",
+    "trans": [
+      "prep. 像，跟…一样 vt. 喜欢，喜爱"
+    ]
+  },
+  {
+    "name": "likely",
+    "usphone": "ˈlaɪklɪ",
+    "ukphone": "",
+    "trans": [
+      "a.很可能的"
+    ]
+  },
+  {
+    "name": "limit",
+    "usphone": "ˈlɪmɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 限制；减少"
+    ]
+  },
+  {
+    "name": "line",
+    "usphone": "laɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 绳索，线，排，行，线路 v. 画线于，（使）成行"
+    ]
+  },
+  {
+    "name": "link",
+    "usphone": "lɪŋk",
+    "ukphone": "",
+    "trans": [
+      "v. 连接； 联系"
+    ]
+  },
+  {
+    "name": "lion",
+    "usphone": "ˈlaɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 狮子"
+    ]
+  },
+  {
+    "name": "lip",
+    "usphone": "lɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 嘴唇"
+    ]
+  },
+  {
+    "name": "liquid",
+    "usphone": "ˈlɪkwɪd",
+    "ukphone": "",
+    "trans": [
+      "n. & a. 液体；液体的"
+    ]
+  },
+  {
+    "name": "list",
+    "usphone": "lɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 一览表，清单"
+    ]
+  },
+  {
+    "name": "listen",
+    "usphone": "ˈlɪs(ə)n",
+    "ukphone": "",
+    "trans": [
+      "vi. 听,仔细听"
+    ]
+  },
+  {
+    "name": "literature",
+    "usphone": "ˈlɪtərətʃə(r); (US) ˈlɪtrətʃʊər",
+    "ukphone": "",
+    "trans": [
+      "n. 文学"
+    ]
+  },
+  {
+    "name": "literary",
+    "usphone": "ˈlɪtərərɪ; (US) ˈlɪtərerɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 文学的"
+    ]
+  },
+  {
+    "name": "litre (美liter)",
+    "usphone": "liːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 升； 公升"
+    ]
+  },
+  {
+    "name": "litter",
+    "usphone": "ˈlɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 乱丢杂物"
+    ]
+  },
+  {
+    "name": "little (less, least)",
+    "usphone": "ˈlɪt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.小的,少的 ad. 很少地, 稍许 n.没有多少,一点"
+    ]
+  },
+  {
+    "name": "live",
+    "usphone": "lɪv",
+    "ukphone": "",
+    "trans": [
+      "vi. 生活;居住;活着 a. 活的,活着的;实况,现场（直播）的"
+    ]
+  },
+  {
+    "name": "lively",
+    "usphone": "ˈlaɪvlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 活泼的;充满生气的"
+    ]
+  },
+  {
+    "name": "living",
+    "usphone": "ˈlɪvɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 活着的 n. 生计"
+    ]
+  },
+  {
+    "name": "load",
+    "usphone": "ləʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 担子，货物"
+    ]
+  },
+  {
+    "name": "loaf",
+    "usphone": "ləʊf",
+    "ukphone": "",
+    "trans": [
+      "n. 一个面包"
+    ]
+  },
+  {
+    "name": "local",
+    "usphone": "ˈləʊk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 当地的；地方的"
+    ]
+  },
+  {
+    "name": "lock",
+    "usphone": "lɔk",
+    "ukphone": "",
+    "trans": [
+      "n. 锁 vt. 锁，锁上"
+    ]
+  },
+  {
+    "name": "locust",
+    "usphone": "ˈləʊkəst",
+    "ukphone": "",
+    "trans": [
+      "n. 蝗虫"
+    ]
+  },
+  {
+    "name": "London",
+    "usphone": "ˈlʌnd(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 伦敦"
+    ]
+  },
+  {
+    "name": "lonely",
+    "usphone": "ˈləʊnlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 孤独的，寂寞的"
+    ]
+  },
+  {
+    "name": "long",
+    "usphone": "lɔŋ; (US) lɔːŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 长的，远 ad. 长久"
+    ]
+  },
+  {
+    "name": "look",
+    "usphone": "lʊk",
+    "ukphone": "",
+    "trans": [
+      "n. 看，瞧 v. 看，观看 v. link 看起来"
+    ]
+  },
+  {
+    "name": "loose",
+    "usphone": "luːs",
+    "ukphone": "",
+    "trans": [
+      "a. 松散的； 宽松的"
+    ]
+  },
+  {
+    "name": "lorry",
+    "usphone": "ˈlɔrɪ; (US) ˈlɔːrɪ",
+    "ukphone": "",
+    "trans": [
+      "n.（英）运货汽车，卡车"
+    ]
+  },
+  {
+    "name": "loss",
+    "usphone": "lɔs; (US) lɔːs",
+    "ukphone": "",
+    "trans": [
+      "n. 丧失；损耗"
+    ]
+  },
+  {
+    "name": "lose (lost, lost)",
+    "usphone": "luːz",
+    "ukphone": "",
+    "trans": [
+      "vt. 失去，丢失"
+    ]
+  },
+  {
+    "name": "Lost & Found",
+    "usphone": "lɔst; (US) lɔːst",
+    "ukphone": "",
+    "trans": [
+      "失物招领处"
+    ]
+  },
+  {
+    "name": "lot",
+    "usphone": "lɔt",
+    "ukphone": "",
+    "trans": [
+      "n. 许多，好些"
+    ]
+  },
+  {
+    "name": "loud",
+    "usphone": "laʊd",
+    "ukphone": "",
+    "trans": [
+      "a. 大声的"
+    ]
+  },
+  {
+    "name": "loudly",
+    "usphone": "laʊdlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 大声地"
+    ]
+  },
+  {
+    "name": "loudspeaker",
+    "usphone": "laʊdˈspiːkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 扬声器，喇叭"
+    ]
+  },
+  {
+    "name": "lounge",
+    "usphone": "laʊndʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 休息厅；休息室"
+    ]
+  },
+  {
+    "name": "love",
+    "usphone": "lʌv",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 爱；热爱;很喜欢"
+    ]
+  },
+  {
+    "name": "lovely",
+    "usphone": "ˈlʌvlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 美好的，可爱的"
+    ]
+  },
+  {
+    "name": "low",
+    "usphone": "ləʊ",
+    "ukphone": "",
+    "trans": [
+      "a.& ad. 低；矮"
+    ]
+  },
+  {
+    "name": "luck",
+    "usphone": "lʌk",
+    "ukphone": "",
+    "trans": [
+      "n. 运气，好运"
+    ]
+  },
+  {
+    "name": "lucky",
+    "usphone": "ˈlʌkɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 运气好，侥幸"
+    ]
+  },
+  {
+    "name": "luggage",
+    "usphone": "ˈlʌɡɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. (总称)行李"
+    ]
+  },
+  {
+    "name": "lunch",
+    "usphone": "lʌntʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 午餐，午饭"
+    ]
+  },
+  {
+    "name": "lung",
+    "usphone": "lʌŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 肺；肺脏"
+    ]
+  },
+  {
+    "name": "machine",
+    "usphone": "məˈʃiːn",
+    "ukphone": "",
+    "trans": [
+      "n. 机器"
+    ]
+  },
+  {
+    "name": "mad",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a. 发疯的；生气的"
+    ]
+  },
+  {
+    "name": "madam/ madame",
+    "usphone": "ˈmædəm",
+    "ukphone": "",
+    "trans": [
+      "n. 夫人,女士"
+    ]
+  },
+  {
+    "name": "magazine",
+    "usphone": "mæɡəˈziːn",
+    "ukphone": "",
+    "trans": [
+      "n. 杂志"
+    ]
+  },
+  {
+    "name": "magic",
+    "usphone": "ˈmædʒɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 有魔力的"
+    ]
+  },
+  {
+    "name": "maid",
+    "usphone": "meɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 女仆；侍女"
+    ]
+  },
+  {
+    "name": "mail",
+    "usphone": "meɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 邮政,邮递 v. (美)邮寄"
+    ]
+  },
+  {
+    "name": "mailbox",
+    "usphone": "ˈmeɪlbɒks",
+    "ukphone": "",
+    "trans": [
+      "n. 邮筒；邮箱"
+    ]
+  },
+  {
+    "name": "main",
+    "usphone": "meɪn",
+    "ukphone": "",
+    "trans": [
+      "a. 主要的"
+    ]
+  },
+  {
+    "name": "mainland",
+    "usphone": "ˈmeɪnlənd",
+    "ukphone": "",
+    "trans": [
+      "n. 大陆"
+    ]
+  },
+  {
+    "name": "major",
+    "usphone": "ˈmeɪdʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 较大的；主要的"
+    ]
+  },
+  {
+    "name": "majority",
+    "usphone": "məˈdʒɔrɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 大多数 "
+    ]
+  },
+  {
+    "name": "make (made,made)",
+    "usphone": "meɪk",
+    "ukphone": "",
+    "trans": [
+      "vt.制造,做;使得 n. 样式；制造"
+    ]
+  },
+  {
+    "name": "male",
+    "usphone": "meɪl",
+    "ukphone": "",
+    "trans": [
+      "a. 男（性）的；雄的"
+    ]
+  },
+  {
+    "name": "man (复men)",
+    "usphone": "mæn",
+    "ukphone": "",
+    "trans": [
+      "n. 成年男人;人类"
+    ]
+  },
+  {
+    "name": "manage",
+    "usphone": "ˈmænɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "v. 管理；设法对付"
+    ]
+  },
+  {
+    "name": "manager",
+    "usphone": "ˈmænɪdʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 经理"
+    ]
+  },
+  {
+    "name": "mankind",
+    "usphone": "mænˈkaɪnd",
+    "ukphone": "",
+    "trans": [
+      "n. 人类;（总称）人"
+    ]
+  },
+  {
+    "name": "man-made",
+    "usphone": "mæn- meɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 人造的，人工的"
+    ]
+  },
+  {
+    "name": "manner",
+    "usphone": "ˈmænə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 方式，态度，举止"
+    ]
+  },
+  {
+    "name": "table manners",
+    "usphone": "ˈteɪb(ə)l ˈmænə(r) z",
+    "ukphone": "",
+    "trans": [
+      "餐桌礼节，用餐的规矩"
+    ]
+  },
+  {
+    "name": "many (more, most)",
+    "usphone": "ˈmenɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 许多人（或物）a. 许多的"
+    ]
+  },
+  {
+    "name": "map",
+    "usphone": "mæp",
+    "ukphone": "",
+    "trans": [
+      "n. 地图"
+    ]
+  },
+  {
+    "name": "maple",
+    "usphone": "ˈmeɪp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 枫树"
+    ]
+  },
+  {
+    "name": "maple leaves",
+    "usphone": "ˈmeɪp(ə)l-li:vz",
+    "ukphone": "",
+    "trans": [
+      "枫叶"
+    ]
+  },
+  {
+    "name": "marathon",
+    "usphone": "ˈmærəθ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 马拉松"
+    ]
+  },
+  {
+    "name": "marble",
+    "usphone": "ˈmɑːb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 大理石；玻璃弹子"
+    ]
+  },
+  {
+    "name": "march",
+    "usphone": "mɑːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 游行，行进"
+    ]
+  },
+  {
+    "name": "March",
+    "usphone": "mɑːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 3月"
+    ]
+  },
+  {
+    "name": "mark",
+    "usphone": "mɑːk",
+    "ukphone": "",
+    "trans": [
+      "n.标记 vt.标明,作记号于"
+    ]
+  },
+  {
+    "name": "market",
+    "usphone": "ˈmɑːkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 市场，集市"
+    ]
+  },
+  {
+    "name": "marriage",
+    "usphone": "ˈmærɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 结婚，婚姻"
+    ]
+  },
+  {
+    "name": "married",
+    "usphone": "ˈmærɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 已婚的"
+    ]
+  },
+  {
+    "name": "marry",
+    "usphone": "ˈmærɪ",
+    "ukphone": "",
+    "trans": [
+      "v.（使）成婚，结婚"
+    ]
+  },
+  {
+    "name": "mask",
+    "usphone": "mɑːsk; (US) mæsk",
+    "ukphone": "",
+    "trans": [
+      "n. 口罩；面罩(具)；遮盖物 v. 戴面具；掩饰；伪装"
+    ]
+  },
+  {
+    "name": "mass",
+    "usphone": "mæs",
+    "ukphone": "",
+    "trans": [
+      "n. 众多;大量;（复）群众"
+    ]
+  },
+  {
+    "name": "master",
+    "usphone": "ˈmɑːstə(r); (US) ˈmæstər",
+    "ukphone": "",
+    "trans": [
+      "vt. 精通，掌握"
+    ]
+  },
+  {
+    "name": "mat",
+    "usphone": "mæt",
+    "ukphone": "",
+    "trans": [
+      "n. 垫子"
+    ]
+  },
+  {
+    "name": "match",
+    "usphone": "mætʃ",
+    "ukphone": "",
+    "trans": [
+      "vt. 使相配，使成对 n. 比赛，竞赛 n. 火柴"
+    ]
+  },
+  {
+    "name": "material",
+    "usphone": "məˈtɪərɪəl",
+    "ukphone": "",
+    "trans": [
+      "n. 材料，原料"
+    ]
+  },
+  {
+    "name": "mathematics =math / maths",
+    "usphone": "mæθəˈmætɪks",
+    "ukphone": "",
+    "trans": [
+      "n.（常作单数用）数学, (英美口语) 数学"
+    ]
+  },
+  {
+    "name": "matter",
+    "usphone": "ˈmætə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 要紧事，要紧, 事情；问题 vi. 要紧，有重大关系"
+    ]
+  },
+  {
+    "name": "mature",
+    "usphone": "məˈtjʊə(r); (US) məˈtʊər",
+    "ukphone": "",
+    "trans": [
+      "a. 成熟的"
+    ]
+  },
+  {
+    "name": "maximum",
+    "usphone": "ˈmæksɪməm",
+    "ukphone": "",
+    "trans": [
+      "a.& n. 最大量(的)； 最大限度(的)"
+    ]
+  },
+  {
+    "name": "may modal",
+    "usphone": "meɪ ˈməʊd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "v. 可以;也许,可能"
+    ]
+  },
+  {
+    "name": "May",
+    "usphone": "meɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 5月"
+    ]
+  },
+  {
+    "name": "maybe",
+    "usphone": "ˈmeɪbiː",
+    "ukphone": "",
+    "trans": [
+      "ad. 可能，大概，也许"
+    ]
+  },
+  {
+    "name": "me",
+    "usphone": "miː, mɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 我（宾格）"
+    ]
+  },
+  {
+    "name": "meal",
+    "usphone": "miːl",
+    "ukphone": "",
+    "trans": [
+      "n. 一餐（饭） "
+    ]
+  },
+  {
+    "name": "mean(meant,meant)",
+    "usphone": "miːn",
+    "ukphone": "",
+    "trans": [
+      "vt.意思,意指"
+    ]
+  },
+  {
+    "name": "meaning",
+    "usphone": "ˈmiːnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 意思，含意"
+    ]
+  },
+  {
+    "name": "means",
+    "usphone": "miːnz",
+    "ukphone": "",
+    "trans": [
+      "n. 方法，手段；财产"
+    ]
+  },
+  {
+    "name": "meanwhile",
+    "usphone": "ˈmiːnwaɪl; (US) ˈmɪnhwaɪl",
+    "ukphone": "",
+    "trans": [
+      "ad. 同时"
+    ]
+  },
+  {
+    "name": "measure",
+    "usphone": "ˈmeʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 量"
+    ]
+  },
+  {
+    "name": "meat",
+    "usphone": "miːt",
+    "ukphone": "",
+    "trans": [
+      "n.（猪、牛、羊等的）肉"
+    ]
+  },
+  {
+    "name": "medal",
+    "usphone": "ˈmed(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 奖牌"
+    ]
+  },
+  {
+    "name": "gold medal",
+    "usphone": "ɡəʊld ˈmed(ə)l",
+    "ukphone": "",
+    "trans": [
+      "金牌"
+    ]
+  },
+  {
+    "name": "media",
+    "usphone": "ˈmiːdɪə",
+    "ukphone": "",
+    "trans": [
+      "n. 大众传播媒介"
+    ]
+  },
+  {
+    "name": "medical",
+    "usphone": "ˈmedɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 医学的，医疗的"
+    ]
+  },
+  {
+    "name": "medicine",
+    "usphone": "ˈmeds(ə)n; (US) ˈmedɪsn",
+    "ukphone": "",
+    "trans": [
+      "n. 药"
+    ]
+  },
+  {
+    "name": "medium",
+    "usphone": "ˈmiːdɪəm",
+    "ukphone": "",
+    "trans": [
+      "n.媒体,中间的,中等的"
+    ]
+  },
+  {
+    "name": "meet (met, met)",
+    "usphone": "miːt",
+    "ukphone": "",
+    "trans": [
+      "vt./ n. 遇见，见到 会；集会"
+    ]
+  },
+  {
+    "name": "meeting",
+    "usphone": "ˈmiːtɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n.会,集会,会见,汇合点"
+    ]
+  },
+  {
+    "name": "melon",
+    "usphone": "ˈmelən",
+    "ukphone": "",
+    "trans": [
+      "n. （甜）瓜；瓜状物"
+    ]
+  },
+  {
+    "name": "member",
+    "usphone": "ˈmembə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 成员，会员"
+    ]
+  },
+  {
+    "name": "memorial",
+    "usphone": "mɪˈmɔːrɪəl",
+    "ukphone": "",
+    "trans": [
+      "n. 纪念馆"
+    ]
+  },
+  {
+    "name": "memory",
+    "usphone": "ˈmemərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 回忆，记忆"
+    ]
+  },
+  {
+    "name": "memorize",
+    "usphone": "ˈmeməraɪz",
+    "ukphone": "",
+    "trans": [
+      "v. 记忆"
+    ]
+  },
+  {
+    "name": "mend",
+    "usphone": "mend",
+    "ukphone": "",
+    "trans": [
+      "v. 修理，修补"
+    ]
+  },
+  {
+    "name": "mental",
+    "usphone": "ˈment(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 精神的；脑力的"
+    ]
+  },
+  {
+    "name": "mentally",
+    "usphone": "ˈmentəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 精神上；智力上"
+    ]
+  },
+  {
+    "name": "mention",
+    "usphone": "ˈmenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 提及；记载 vt. 提到，说起；提名表扬"
+    ]
+  },
+  {
+    "name": "menu",
+    "usphone": "ˈmenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 菜单"
+    ]
+  },
+  {
+    "name": "merchant",
+    "usphone": "ˈmɜːtʃənt",
+    "ukphone": "",
+    "trans": [
+      "a. 商业的；商人的 n. 商人；生意人"
+    ]
+  },
+  {
+    "name": "merciful",
+    "usphone": "ˈmɜːsɪfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 仁慈的；宽大的"
+    ]
+  },
+  {
+    "name": "mercy",
+    "usphone": "ˈmɜːsɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 怜悯"
+    ]
+  },
+  {
+    "name": "merely",
+    "usphone": "ˈmɪəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 仅仅，只不过"
+    ]
+  },
+  {
+    "name": "merry",
+    "usphone": "ˈmerɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 高兴的，愉快的"
+    ]
+  },
+  {
+    "name": "mess",
+    "usphone": "mes",
+    "ukphone": "",
+    "trans": [
+      "n. 凌乱"
+    ]
+  },
+  {
+    "name": "message",
+    "usphone": "ˈmesɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 消息，音信"
+    ]
+  },
+  {
+    "name": "messy",
+    "usphone": "ˈmesɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 乱七八糟的"
+    ]
+  },
+  {
+    "name": "metal",
+    "usphone": "ˈmet(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 金属 a. 金属制成的"
+    ]
+  },
+  {
+    "name": "method",
+    "usphone": "ˈmeθəd",
+    "ukphone": "",
+    "trans": [
+      "n. 方法，办法"
+    ]
+  },
+  {
+    "name": "metre (美meter)",
+    "usphone": "ˈmi:tə",
+    "ukphone": "",
+    "trans": [
+      "n. 米，公尺"
+    ]
+  },
+  {
+    "name": "Mexican",
+    "usphone": "ˈmeksɪkən",
+    "ukphone": "",
+    "trans": [
+      "a. 墨西哥的"
+    ]
+  },
+  {
+    "name": "Mexico",
+    "usphone": "ˈmeksɪkəʊ",
+    "ukphone": "",
+    "trans": [
+      "* n. 墨西哥"
+    ]
+  },
+  {
+    "name": "microcomputer",
+    "usphone": "ˈmaɪkrəʊkəmpjuːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 微机"
+    ]
+  },
+  {
+    "name": "microscope",
+    "usphone": "ˈmaɪkrəskəʊp",
+    "ukphone": "",
+    "trans": [
+      "n. 显微镜"
+    ]
+  },
+  {
+    "name": "microwave",
+    "usphone": "ˈmaɪkrəʊweɪv",
+    "ukphone": "",
+    "trans": [
+      "n. 微波"
+    ]
+  },
+  {
+    "name": "mid-autumn",
+    "usphone": "mɪd- ˈɔːtəm",
+    "ukphone": "",
+    "trans": [
+      "n. 中秋"
+    ]
+  },
+  {
+    "name": "midday",
+    "usphone": "ˈmɪddeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 中午, 正午"
+    ]
+  },
+  {
+    "name": "middle",
+    "usphone": "ˈmɪd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 中间;当中;中级的"
+    ]
+  },
+  {
+    "name": "Middle East",
+    "usphone": "ˈmɪd(ə)l iːst",
+    "ukphone": "",
+    "trans": [
+      "n. 中东"
+    ]
+  },
+  {
+    "name": "midnight",
+    "usphone": "ˈmɪdnaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 午夜"
+    ]
+  },
+  {
+    "name": "might",
+    "usphone": "maɪt",
+    "ukphone": "",
+    "trans": [
+      "v. aux. (may的过去式，助动词) 可能，也许，或许"
+    ]
+  },
+  {
+    "name": "mild",
+    "usphone": "maɪld",
+    "ukphone": "",
+    "trans": [
+      "a. 温和,暖和的,凉爽的"
+    ]
+  },
+  {
+    "name": "mile",
+    "usphone": "maɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 英里"
+    ]
+  },
+  {
+    "name": "milk",
+    "usphone": "mɪlk",
+    "ukphone": "",
+    "trans": [
+      "n. 牛奶 vt. 挤奶"
+    ]
+  },
+  {
+    "name": "million",
+    "usphone": "ˈmɪlɪən",
+    "ukphone": "",
+    "trans": [
+      "num. 百万 n. 百万个（人或物）"
+    ]
+  },
+  {
+    "name": "millionaire",
+    "usphone": "mɪljəˈneə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 百万富翁"
+    ]
+  },
+  {
+    "name": "mind",
+    "usphone": "maɪnd",
+    "ukphone": "",
+    "trans": [
+      "n. 思想,想法 v.介意,关心"
+    ]
+  },
+  {
+    "name": "mine",
+    "usphone": "maɪn",
+    "ukphone": "",
+    "trans": [
+      "n.矿藏,矿山vt.开采(矿物) pron. 我的"
+    ]
+  },
+  {
+    "name": "mineral",
+    "usphone": "ˈmɪnər(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 矿物质，矿物"
+    ]
+  },
+  {
+    "name": "minibus",
+    "usphone": "ˈmɪnɪbʌs",
+    "ukphone": "",
+    "trans": [
+      "n. 小型公共汽车"
+    ]
+  },
+  {
+    "name": "minimum",
+    "usphone": "ˈmɪnɪməm",
+    "ukphone": "",
+    "trans": [
+      "a.最小的"
+    ]
+  },
+  {
+    "name": "miniskirt",
+    "usphone": "ˈmɪnɪskɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. 超短裙"
+    ]
+  },
+  {
+    "name": "minister",
+    "usphone": "ˈmɪnɪstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 部长；牧师"
+    ]
+  },
+  {
+    "name": "ministry",
+    "usphone": "ˈmɪnɪstrɪ",
+    "ukphone": "",
+    "trans": [
+      "n.（政府的）部"
+    ]
+  },
+  {
+    "name": "minority",
+    "usphone": "maɪˈnɔrɪtɪ; (US) -ˈnɔːr-",
+    "ukphone": "",
+    "trans": [
+      "n. 少数；少数民族"
+    ]
+  },
+  {
+    "name": "minus",
+    "usphone": "ˈmaɪnəs",
+    "ukphone": "",
+    "trans": [
+      "prep. & a.负的，减去的"
+    ]
+  },
+  {
+    "name": "minute",
+    "usphone": "ˈmɪnɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 分钟;一会儿，瞬间"
+    ]
+  },
+  {
+    "name": "mirror",
+    "usphone": "ˈmɪrə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 镜子"
+    ]
+  },
+  {
+    "name": "miss",
+    "usphone": "mɪs",
+    "ukphone": "",
+    "trans": [
+      "vt. 失去，错过，缺"
+    ]
+  },
+  {
+    "name": "Miss.",
+    "usphone": "mɪs",
+    "ukphone": "",
+    "trans": [
+      "n.小姐,女士(称呼未婚妇女)"
+    ]
+  },
+  {
+    "name": "missile",
+    "usphone": "ˈmɪsaɪl",
+    "ukphone": "",
+    "trans": [
+      "n 导弹"
+    ]
+  },
+  {
+    "name": "mist",
+    "usphone": "mɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 雾"
+    ]
+  },
+  {
+    "name": "mistake (mistook, mistaken)",
+    "usphone": "mɪsˈteɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 错误 vt. 弄错"
+    ]
+  },
+  {
+    "name": "mistaken",
+    "usphone": "mɪsˈteɪkən",
+    "ukphone": "",
+    "trans": [
+      "a. 错误的"
+    ]
+  },
+  {
+    "name": "misunderstand (-stood, -stood)",
+    "usphone": "mɪsʌndəˈstænd",
+    "ukphone": "",
+    "trans": [
+      "v. 误会；不理解"
+    ]
+  },
+  {
+    "name": "mix",
+    "usphone": "mɪks",
+    "ukphone": "",
+    "trans": [
+      "v. 混合，搅拌"
+    ]
+  },
+  {
+    "name": "mixture",
+    "usphone": "ˈmɪkstʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 混合物"
+    ]
+  },
+  {
+    "name": "mm (缩) = millimetre",
+    "usphone": "ˈmiliˌmi:tə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 毫米"
+    ]
+  },
+  {
+    "name": "mobile",
+    "usphone": "ˈməʊbaɪl; (US) məʊbl",
+    "ukphone": "",
+    "trans": [
+      "a. 活动的，可移动的"
+    ]
+  },
+  {
+    "name": "mobile phone",
+    "usphone": "ˈməʊbaɪl fəʊn",
+    "ukphone": "",
+    "trans": [
+      "手提电话，手机"
+    ]
+  },
+  {
+    "name": "model",
+    "usphone": "ˈmɔd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.模型,原形,范例,模范"
+    ]
+  },
+  {
+    "name": "modem",
+    "usphone": "ˈməʊdem",
+    "ukphone": "",
+    "trans": [
+      "n. 调制解调器"
+    ]
+  },
+  {
+    "name": "modern",
+    "usphone": "ˈmɔd(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 现代的"
+    ]
+  },
+  {
+    "name": "modest",
+    "usphone": "ˈmɔdɪst",
+    "ukphone": "",
+    "trans": [
+      "a. 谦虚的；谦逊的"
+    ]
+  },
+  {
+    "name": "Mom =Mum",
+    "usphone": "mɒm",
+    "ukphone": "",
+    "trans": [
+      "n. 妈妈"
+    ]
+  },
+  {
+    "name": "moment",
+    "usphone": "ˈməʊmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 片刻，瞬间"
+    ]
+  },
+  {
+    "name": "mommy = mummy",
+    "usphone": "ˈmɔmɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 妈妈（美）"
+    ]
+  },
+  {
+    "name": "Monday",
+    "usphone": "ˈmʌndeɪ, ˈmʌndɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 星期一"
+    ]
+  },
+  {
+    "name": "money",
+    "usphone": "ˈmʌnɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 钱；货币"
+    ]
+  },
+  {
+    "name": "monitor",
+    "usphone": "ˈmɔnɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （班级内的）班长；纠察生；监视器"
+    ]
+  },
+  {
+    "name": "monkey",
+    "usphone": "ˈmʌŋkɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 猴子"
+    ]
+  },
+  {
+    "name": "month",
+    "usphone": "mʌnθ",
+    "ukphone": "",
+    "trans": [
+      "n. 月，月份"
+    ]
+  },
+  {
+    "name": "monument",
+    "usphone": "ˈmɔnjʊmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 纪念碑，纪念物"
+    ]
+  },
+  {
+    "name": "moon",
+    "usphone": "muːn",
+    "ukphone": "",
+    "trans": [
+      "n. 月球；月光；月状物"
+    ]
+  },
+  {
+    "name": "moon cake",
+    "usphone": "muːn keɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 月饼"
+    ]
+  },
+  {
+    "name": "mop",
+    "usphone": "mɔp",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 拖把 拖地"
+    ]
+  },
+  {
+    "name": "moral",
+    "usphone": "ˈmɔr(ə)l; (US) ˈmɔːrəl",
+    "ukphone": "",
+    "trans": [
+      "a.道德的 n.寓意,道德启示"
+    ]
+  },
+  {
+    "name": "more（much或many 的比较级）",
+    "usphone": "mɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "a./ ad.另外的；附加的；较多的再；另外；而且；更 n. 更多的量；另外的一些"
+    ]
+  },
+  {
+    "name": "morning",
+    "usphone": "ˈmɔːnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 早晨，上午"
+    ]
+  },
+  {
+    "name": "Moscow",
+    "usphone": "ˈmɔskəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 莫斯科"
+    ]
+  },
+  {
+    "name": "Moslem",
+    "usphone": "ˈmɔzləm",
+    "ukphone": "",
+    "trans": [
+      "n. 伊斯兰教徒,回教徒"
+    ]
+  },
+  {
+    "name": "Mosquito",
+    "usphone": "məˈskiːtəʊ",
+    "ukphone": "",
+    "trans": [
+      "n.蚊子"
+    ]
+  },
+  {
+    "name": "most (much或many 的最高级)",
+    "usphone": "məʊst; (US) mɔːst",
+    "ukphone": "",
+    "trans": [
+      "a. & ad.最多 n.大部分,大多数"
+    ]
+  },
+  {
+    "name": "mother",
+    "usphone": "ˈmʌðə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 母亲"
+    ]
+  },
+  {
+    "name": "motherland",
+    "usphone": "ˈmʌðəlænd",
+    "ukphone": "",
+    "trans": [
+      "n. 祖国"
+    ]
+  },
+  {
+    "name": "motivation",
+    "usphone": "məʊtɪˈveɪʃn",
+    "ukphone": "",
+    "trans": [
+      "n. （做事的）动机"
+    ]
+  },
+  {
+    "name": "motor",
+    "usphone": "ˈməʊtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 发动机，马达"
+    ]
+  },
+  {
+    "name": "motorbike",
+    "usphone": "ˈməʊtəbaɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 摩托车"
+    ]
+  },
+  {
+    "name": "motorcycle",
+    "usphone": "ˈməʊtəsaikl",
+    "ukphone": "",
+    "trans": [
+      "n. 摩托车"
+    ]
+  },
+  {
+    "name": "motto",
+    "usphone": "ˈmɔtəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 箴言，格言"
+    ]
+  },
+  {
+    "name": "mountain(s)",
+    "usphone": "ˈmaʊntɪn(z)",
+    "ukphone": "",
+    "trans": [
+      "n. 山，山脉"
+    ]
+  },
+  {
+    "name": "mountainous",
+    "usphone": "ˈmaʊntɪnəs",
+    "ukphone": "",
+    "trans": [
+      "a. 多山的"
+    ]
+  },
+  {
+    "name": "mourn",
+    "usphone": "mɔːn",
+    "ukphone": "",
+    "trans": [
+      "vt. 哀痛； 哀悼"
+    ]
+  },
+  {
+    "name": "mouse (复mice)",
+    "usphone": "maʊs",
+    "ukphone": "",
+    "trans": [
+      "n. 鼠，耗子；（计算机）鼠标"
+    ]
+  },
+  {
+    "name": "moustache",
+    "usphone": "məsˈtɑ:ʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 小胡子"
+    ]
+  },
+  {
+    "name": "mouth",
+    "usphone": "maʊθ",
+    "ukphone": "",
+    "trans": [
+      "n. 嘴，口"
+    ]
+  },
+  {
+    "name": "mouthful",
+    "usphone": "ˈmaʊθfʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 满口，一口"
+    ]
+  },
+  {
+    "name": "from mouth to mouth",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "ad. 口口相传；人传人地"
+    ]
+  },
+  {
+    "name": "move",
+    "usphone": "muːv",
+    "ukphone": "",
+    "trans": [
+      "v. 移动，搬动，搬家"
+    ]
+  },
+  {
+    "name": "movement",
+    "usphone": "ˈmuːvmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 运动，活动"
+    ]
+  },
+  {
+    "name": "movie",
+    "usphone": "ˈmuːvɪ",
+    "ukphone": "",
+    "trans": [
+      "n.（口语）电影"
+    ]
+  },
+  {
+    "name": "Mr. (mister)",
+    "usphone": "ˈmɪstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 先生（用于姓名前）"
+    ]
+  },
+  {
+    "name": "Mrs. (mistress)",
+    "usphone": "ˈmɪsɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 夫人, 太太（称呼已婚妇女）"
+    ]
+  },
+  {
+    "name": "Ms.",
+    "usphone": "mɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 女士(用在婚姻状况不明的女子姓名前)"
+    ]
+  },
+  {
+    "name": "much (more，most)",
+    "usphone": "mʌtʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 许多的，大量的 ad. 非常；更加 n. 许多，大量，非常"
+    ]
+  },
+  {
+    "name": "mud",
+    "usphone": "mʌd",
+    "ukphone": "",
+    "trans": [
+      "n. 泥, 泥浆"
+    ]
+  },
+  {
+    "name": "muddy",
+    "usphone": "ˈmʌdɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 泥泞的"
+    ]
+  },
+  {
+    "name": "multiply",
+    "usphone": "ˈmʌltɪplaɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 乘；使相乘"
+    ]
+  },
+  {
+    "name": "murder",
+    "usphone": "ˈmɜːdə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 谋杀"
+    ]
+  },
+  {
+    "name": "museum",
+    "usphone": "mjuːˈzɪəm",
+    "ukphone": "",
+    "trans": [
+      "n. 博物馆，博物院"
+    ]
+  },
+  {
+    "name": "mushroom",
+    "usphone": "ˈmʌʃrʊm",
+    "ukphone": "",
+    "trans": [
+      "n. 蘑菇"
+    ]
+  },
+  {
+    "name": "music",
+    "usphone": "ˈmjuːzɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 音乐，乐曲"
+    ]
+  },
+  {
+    "name": "musical",
+    "usphone": "ˈmjuːzɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 音乐的，爱好音乐的 n. 音乐片"
+    ]
+  },
+  {
+    "name": "musician",
+    "usphone": "mjuːˈzɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 音乐家，乐师"
+    ]
+  },
+  {
+    "name": "must modal",
+    "usphone": "mʌst ˈməʊd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "v.必须,应当;必定是"
+    ]
+  },
+  {
+    "name": "mustard",
+    "usphone": "ˈmʌstəd",
+    "ukphone": "",
+    "trans": [
+      "n. 芥末，芥子粉"
+    ]
+  },
+  {
+    "name": "mutton",
+    "usphone": "ˈmʌt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 羊肉"
+    ]
+  },
+  {
+    "name": "my",
+    "usphone": "maɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 我的"
+    ]
+  },
+  {
+    "name": "myself",
+    "usphone": "maɪˈself",
+    "ukphone": "",
+    "trans": [
+      "pron. 我自己"
+    ]
+  },
+  {
+    "name": "nail",
+    "usphone": "neɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 钉，钉子"
+    ]
+  },
+  {
+    "name": "name",
+    "usphone": "neɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 名字,姓名,名称 vt. 命名,名叫"
+    ]
+  },
+  {
+    "name": "narrow",
+    "usphone": "ˈnærəʊ",
+    "ukphone": "",
+    "trans": [
+      "a. 狭窄的"
+    ]
+  },
+  {
+    "name": "nation",
+    "usphone": "ˈneɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 民族，国家"
+    ]
+  },
+  {
+    "name": "national",
+    "usphone": "ˈnæʃən(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 国家的,全国性的，民族的"
+    ]
+  },
+  {
+    "name": "nationality",
+    "usphone": "næʃəˈnælətɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 国籍"
+    ]
+  },
+  {
+    "name": "nationwide",
+    "usphone": "ˈneɪʃ(ə)nwaɪd",
+    "ukphone": "",
+    "trans": [
+      "ad.全国范围内的,全国性的"
+    ]
+  },
+  {
+    "name": "native",
+    "usphone": "ˈneɪtɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 本土的，本国的"
+    ]
+  },
+  {
+    "name": "natural",
+    "usphone": "ˈnætʃər(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 自然的"
+    ]
+  },
+  {
+    "name": "nature",
+    "usphone": "ˈneɪtʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 自然, 性质，种类"
+    ]
+  },
+  {
+    "name": "navy",
+    "usphone": "ˈneɪvɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 海军"
+    ]
+  },
+  {
+    "name": "near",
+    "usphone": "nɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 近的 ad. 附近，邻近 prep. 在……附近，靠近"
+    ]
+  },
+  {
+    "name": "nearby",
+    "usphone": "ˈnɪəbaɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 附近的"
+    ]
+  },
+  {
+    "name": "nearly",
+    "usphone": "ˈnɪəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 将近，几乎"
+    ]
+  },
+  {
+    "name": "neat",
+    "usphone": "niːt",
+    "ukphone": "",
+    "trans": [
+      "a. 整洁的；灵巧的"
+    ]
+  },
+  {
+    "name": "necessary",
+    "usphone": "ˈnesəsərɪ; (US) ˈnesəserɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 必需的，必要的"
+    ]
+  },
+  {
+    "name": "neck",
+    "usphone": "nek",
+    "ukphone": "",
+    "trans": [
+      "n. 颈，脖子"
+    ]
+  },
+  {
+    "name": "necklace",
+    "usphone": "ˈneklɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 项链"
+    ]
+  },
+  {
+    "name": "necktie",
+    "usphone": "ˈnektaɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 领带，领花"
+    ]
+  },
+  {
+    "name": "need",
+    "usphone": "niːd",
+    "ukphone": "",
+    "trans": [
+      "n. 需要,需求aux.& v.需要,必须"
+    ]
+  },
+  {
+    "name": "needle",
+    "usphone": "niːd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 针"
+    ]
+  },
+  {
+    "name": "negotiate",
+    "usphone": "nɪˈɡəʊʃɪeɪt",
+    "ukphone": "",
+    "trans": [
+      "v.谈判，协商"
+    ]
+  },
+  {
+    "name": "neighbour (美neighbor)",
+    "usphone": "ˈneɪbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 邻居，邻人"
+    ]
+  },
+  {
+    "name": "neighbourhood (美neighborhood)",
+    "usphone": "ˈneibəhud",
+    "ukphone": "",
+    "trans": [
+      "n. 四邻；邻近地区"
+    ]
+  },
+  {
+    "name": "neither",
+    "usphone": "ˈnaɪðə(r), ˈniːðə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. （两者）都不;也不"
+    ]
+  },
+  {
+    "name": "nephew",
+    "usphone": "ˈnefjuː, ˈnevjuː",
+    "ukphone": "",
+    "trans": [
+      "n. 侄子，外甥"
+    ]
+  },
+  {
+    "name": "nervous",
+    "usphone": "ˈnɜːvəs",
+    "ukphone": "",
+    "trans": [
+      "a. 紧张不安的"
+    ]
+  },
+  {
+    "name": "nest",
+    "usphone": "nest",
+    "ukphone": "",
+    "trans": [
+      "n. 巢；窝"
+    ]
+  },
+  {
+    "name": "net",
+    "usphone": "net",
+    "ukphone": "",
+    "trans": [
+      "n. 网"
+    ]
+  },
+  {
+    "name": "network",
+    "usphone": "ˈnetwɜːk",
+    "ukphone": "",
+    "trans": [
+      "n. 网络，网状系统"
+    ]
+  },
+  {
+    "name": "never",
+    "usphone": "ˈnevə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 决不，从来没有"
+    ]
+  },
+  {
+    "name": "new",
+    "usphone": "njuː; (US) nuː",
+    "ukphone": "",
+    "trans": [
+      "a. 新的；新鲜的"
+    ]
+  },
+  {
+    "name": "New York",
+    "usphone": "njuː jɔːk",
+    "ukphone": "",
+    "trans": [
+      "n. 纽约"
+    ]
+  },
+  {
+    "name": "New Zealand",
+    "usphone": "njuː ˈzi:lənd",
+    "ukphone": "",
+    "trans": [
+      "* n. 新西兰"
+    ]
+  },
+  {
+    "name": "New Zealander",
+    "usphone": "njuː ˈzi:ləndə",
+    "ukphone": "",
+    "trans": [
+      "n. 新西兰人"
+    ]
+  },
+  {
+    "name": "news",
+    "usphone": "njuːz; (US) nuːz",
+    "ukphone": "",
+    "trans": [
+      "n. 新闻，消息"
+    ]
+  },
+  {
+    "name": "newspaper",
+    "usphone": "njuːz; (US) nuːz",
+    "ukphone": "",
+    "trans": [
+      "n. 报纸"
+    ]
+  },
+  {
+    "name": "next",
+    "usphone": "nekst",
+    "ukphone": "",
+    "trans": [
+      "a. 最近的，紧挨着的，隔壁的；下一次 ad. 随后，然后，下一步 n. 下一个人（东西）"
+    ]
+  },
+  {
+    "name": "nice",
+    "usphone": "naɪs",
+    "ukphone": "",
+    "trans": [
+      "a.令人愉快;好的漂亮的"
+    ]
+  },
+  {
+    "name": "niece",
+    "usphone": "niːs",
+    "ukphone": "",
+    "trans": [
+      "n. 侄女，甥女"
+    ]
+  },
+  {
+    "name": "night",
+    "usphone": "naɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 夜；夜间"
+    ]
+  },
+  {
+    "name": "night-club",
+    "usphone": "naɪt-klʌb",
+    "ukphone": "",
+    "trans": [
+      "n. 夜总会"
+    ]
+  },
+  {
+    "name": "nine",
+    "usphone": "naɪn",
+    "ukphone": "",
+    "trans": [
+      "num. 九"
+    ]
+  },
+  {
+    "name": "nineteen",
+    "usphone": "naɪnˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "num. 十九"
+    ]
+  },
+  {
+    "name": "ninety",
+    "usphone": "ˈnaɪntɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 九十"
+    ]
+  },
+  {
+    "name": "ninth",
+    "usphone": "naɪnθ",
+    "ukphone": "",
+    "trans": [
+      "num. 第九"
+    ]
+  },
+  {
+    "name": "no",
+    "usphone": "nəʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. 不,不是 a.没有,无,不"
+    ]
+  },
+  {
+    "name": "No.(缩) = number",
+    "usphone": "ˈnʌmbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.数字;号码"
+    ]
+  },
+  {
+    "name": "noble",
+    "usphone": "ˈnəʊb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 高贵的，贵族的"
+    ]
+  },
+  {
+    "name": "nobody",
+    "usphone": "ˈnəʊbədɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 渺小人物 pron. 没有人，谁也不"
+    ]
+  },
+  {
+    "name": "nod",
+    "usphone": "nɔd",
+    "ukphone": "",
+    "trans": [
+      "vi. 点头"
+    ]
+  },
+  {
+    "name": "noise",
+    "usphone": "nɔɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 声音，噪声，喧闹声"
+    ]
+  },
+  {
+    "name": "noisily",
+    "usphone": "ˈnɔɪzɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 喧闹地"
+    ]
+  },
+  {
+    "name": "noisy",
+    "usphone": "ˈnɔɪzɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 喧闹的，嘈杂的"
+    ]
+  },
+  {
+    "name": "none",
+    "usphone": "nʌn",
+    "ukphone": "",
+    "trans": [
+      "pron.无任何东西, 无一人"
+    ]
+  },
+  {
+    "name": "non-stop",
+    "usphone": "nʌn-stɔp",
+    "ukphone": "",
+    "trans": [
+      "a.& ad.不停的,不断地"
+    ]
+  },
+  {
+    "name": "non-violent",
+    "usphone": "nɔn-ˈvaɪələnt",
+    "ukphone": "",
+    "trans": [
+      "a. 非暴力的"
+    ]
+  },
+  {
+    "name": "noodle",
+    "usphone": "ˈnuːd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 面条"
+    ]
+  },
+  {
+    "name": "noon",
+    "usphone": "nuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 中午，正午"
+    ]
+  },
+  {
+    "name": "nor",
+    "usphone": "nɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "conj. 也不"
+    ]
+  },
+  {
+    "name": "normal",
+    "usphone": "ˈnɔːm(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.& a. 正常的（状态）"
+    ]
+  },
+  {
+    "name": "north",
+    "usphone": "nɔːθ",
+    "ukphone": "",
+    "trans": [
+      "a.北的;朝北的;从北来的 ad.向（在,从）北方 n.北;北方;北部"
+    ]
+  },
+  {
+    "name": "northeast",
+    "usphone": "nɒ:θˈi:st",
+    "ukphone": "",
+    "trans": [
+      "n. 东北（部）"
+    ]
+  },
+  {
+    "name": "northern",
+    "usphone": "ˈnɔːð(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 北方的，北部的"
+    ]
+  },
+  {
+    "name": "northwards",
+    "usphone": "ˈnɔːθwədz",
+    "ukphone": "",
+    "trans": [
+      "ad. 向北"
+    ]
+  },
+  {
+    "name": "northwest",
+    "usphone": "nɒ:θˈwest",
+    "ukphone": "",
+    "trans": [
+      "n. 西北"
+    ]
+  },
+  {
+    "name": "nose",
+    "usphone": "nəʊz",
+    "ukphone": "",
+    "trans": [
+      "n. 鼻"
+    ]
+  },
+  {
+    "name": "not",
+    "usphone": "nɔt",
+    "ukphone": "",
+    "trans": [
+      "ad. 不，没"
+    ]
+  },
+  {
+    "name": "note",
+    "usphone": "nəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 便条，笔记，注释；钞票，纸币；音符，音调 vt. 记下，记录；注意，留意"
+    ]
+  },
+  {
+    "name": "notebook",
+    "usphone": "ˈnəʊtbʊk",
+    "ukphone": "",
+    "trans": [
+      "n. 笔记簿"
+    ]
+  },
+  {
+    "name": "nothing",
+    "usphone": "ˈnʌθɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 没有东西,没有什么 adv.一点也不；并不"
+    ]
+  },
+  {
+    "name": "notice",
+    "usphone": "ˈnəʊtɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 布告，通告；注意 vt. 注意，注意到"
+    ]
+  },
+  {
+    "name": "novel",
+    "usphone": "ˈnɔv(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. （长篇）小说"
+    ]
+  },
+  {
+    "name": "novelist",
+    "usphone": "ˈnɔvəlɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 小说家"
+    ]
+  },
+  {
+    "name": "November",
+    "usphone": "nəʊˈvembə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 11月"
+    ]
+  },
+  {
+    "name": "now",
+    "usphone": "naʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. 现在"
+    ]
+  },
+  {
+    "name": "nowadays",
+    "usphone": "ˈnaʊədeɪz",
+    "ukphone": "",
+    "trans": [
+      "ad. 当今，现在"
+    ]
+  },
+  {
+    "name": "nowhere",
+    "usphone": "ˈnəʊweə(r); (US) ˈnəʊhweər",
+    "ukphone": "",
+    "trans": [
+      "ad.任何地方都不,无处"
+    ]
+  },
+  {
+    "name": "nuclear",
+    "usphone": "ˈnjuːklɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 原子核的，原子能的，核动力的"
+    ]
+  },
+  {
+    "name": "numb",
+    "usphone": "nʌm",
+    "ukphone": "",
+    "trans": [
+      "a. 麻木的，失去知觉的，迟钝的"
+    ]
+  },
+  {
+    "name": "number",
+    "usphone": "ˈnʌmbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 数,数字,号码,数量"
+    ]
+  },
+  {
+    "name": "nurse",
+    "usphone": "nɜːs",
+    "ukphone": "",
+    "trans": [
+      "n. 护士；保育员"
+    ]
+  },
+  {
+    "name": "nursery",
+    "usphone": "ˈnɜːsərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 托儿所"
+    ]
+  },
+  {
+    "name": "nursing",
+    "usphone": "nɜːsɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n.(职业性的）保育,护理"
+    ]
+  },
+  {
+    "name": "nut",
+    "usphone": "nʌt",
+    "ukphone": "",
+    "trans": [
+      "n.坚果,果仁(胡桃,栗子等)"
+    ]
+  },
+  {
+    "name": "nutrition",
+    "usphone": "njuːˈtrɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 营养，滋养"
+    ]
+  },
+  {
+    "name": "nylon",
+    "usphone": "ˈnaɪlɔn",
+    "ukphone": "",
+    "trans": [
+      "n. 尼龙"
+    ]
+  },
+  {
+    "name": "obey",
+    "usphone": "əʊˈbeɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 服从，顺从，听从"
+    ]
+  },
+  {
+    "name": "object",
+    "usphone": "ˈɔbdʒɪkt",
+    "ukphone": "",
+    "trans": [
+      "n. 物，物体；宾语"
+    ]
+  },
+  {
+    "name": "observe",
+    "usphone": "əbˈzɜːv",
+    "ukphone": "",
+    "trans": [
+      "v. 观察，监视，观测"
+    ]
+  },
+  {
+    "name": "obtain",
+    "usphone": "əbˈteɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. 获得；得到"
+    ]
+  },
+  {
+    "name": "obvious",
+    "usphone": "ˈɔbvɪəs",
+    "ukphone": "",
+    "trans": [
+      "a. 显然"
+    ]
+  },
+  {
+    "name": "occupation",
+    "usphone": "ɔkjʊˈpeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 职业，工作"
+    ]
+  },
+  {
+    "name": "occur",
+    "usphone": "əˈkɜː(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 发生"
+    ]
+  },
+  {
+    "name": "ocean",
+    "usphone": "ˈəʊʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 海洋"
+    ]
+  },
+  {
+    "name": "Oceania*",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 大洋洲"
+    ]
+  },
+  {
+    "name": "oˈclock",
+    "usphone": "əˈklɔk",
+    "ukphone": "",
+    "trans": [
+      "n. 点钟"
+    ]
+  },
+  {
+    "name": "October",
+    "usphone": "ɔkˈtəʊbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 10月"
+    ]
+  },
+  {
+    "name": "of",
+    "usphone": "ɔv, əv; (US) ɔːf",
+    "ukphone": "",
+    "trans": [
+      "prep.(表所属,数量,) ….的"
+    ]
+  },
+  {
+    "name": "off",
+    "usphone": "ˈɔf; (US) ɔːf",
+    "ukphone": "",
+    "trans": [
+      "prep. 离开,脱离,（走）开"
+    ]
+  },
+  {
+    "name": "ad",
+    "usphone": "æd",
+    "ukphone": "",
+    "trans": [
+      ".离开；（电自来水）停了,中断"
+    ]
+  },
+  {
+    "name": "offence",
+    "usphone": "of·fence || əˈfens",
+    "ukphone": "",
+    "trans": [
+      "n. 违法行为，犯罪"
+    ]
+  },
+  {
+    "name": "offer",
+    "usphone": "ˈɔfə(r); (US) ɔːfər",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 提供；建议"
+    ]
+  },
+  {
+    "name": "office",
+    "usphone": "ˈɔfɪs; (US) ˈɔːfɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 办公室"
+    ]
+  },
+  {
+    "name": "officer",
+    "usphone": "ˈɔfɪsə(r); (US) ˈɔːfɪsər",
+    "ukphone": "",
+    "trans": [
+      "n. 军官;公务员,官员；警察，警官"
+    ]
+  },
+  {
+    "name": "official",
+    "usphone": "əˈfɪʃ(ə)l; (US) ˈɔːf-",
+    "ukphone": "",
+    "trans": [
+      "n.（公司、团体或政府）官员 ,高级职员 a.官方,政府的"
+    ]
+  },
+  {
+    "name": "offshore",
+    "usphone": "ˈɔfʃɔː(r); (US) ˈɔːf-",
+    "ukphone": "",
+    "trans": [
+      "a. 近海的"
+    ]
+  },
+  {
+    "name": "often",
+    "usphone": "ˈɔf(ə)n; (US) ˈɔːfn",
+    "ukphone": "",
+    "trans": [
+      "ad. 经常，常常"
+    ]
+  },
+  {
+    "name": "oh",
+    "usphone": "əʊ",
+    "ukphone": "",
+    "trans": [
+      "int. 哦！啊！"
+    ]
+  },
+  {
+    "name": "oil",
+    "usphone": "ɔɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 油"
+    ]
+  },
+  {
+    "name": "oilfield",
+    "usphone": "ˈɔɪlfiːld",
+    "ukphone": "",
+    "trans": [
+      "n.油田"
+    ]
+  },
+  {
+    "name": "OK",
+    "usphone": "əʊˈkeɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. （口语）好,对,不错"
+    ]
+  },
+  {
+    "name": "old",
+    "usphone": "əʊld",
+    "ukphone": "",
+    "trans": [
+      "a. 老的，旧的"
+    ]
+  },
+  {
+    "name": "Olympic(s)",
+    "usphone": "əˈlɪmpɪk",
+    "ukphone": "",
+    "trans": [
+      "a. & n. 奥林匹克"
+    ]
+  },
+  {
+    "name": "Olympic Games",
+    "usphone": "əˈlɪmpɪk ɡeɪms",
+    "ukphone": "",
+    "trans": [
+      "n. 奥运会"
+    ]
+  },
+  {
+    "name": "omelette",
+    "usphone": "ˈɔmlɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 煎蛋卷；煎蛋饼"
+    ]
+  },
+  {
+    "name": "on",
+    "usphone": "ɔn",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…上（时），关于 ad. （穿，放…）上；接通；进行下  去；（电灯）开"
+    ]
+  },
+  {
+    "name": "once",
+    "usphone": "wʌns",
+    "ukphone": "",
+    "trans": [
+      "n.& ad. 一次,一度,从前 conj. 一旦"
+    ]
+  },
+  {
+    "name": "one",
+    "usphone": "wʌn",
+    "ukphone": "",
+    "trans": [
+      "pron. 一（个，只…）(pl. ones) num. 一"
+    ]
+  },
+  {
+    "name": "oneself",
+    "usphone": "wʌnˈself",
+    "ukphone": "",
+    "trans": [
+      "pron. 自己；自身"
+    ]
+  },
+  {
+    "name": "onion",
+    "usphone": "ˈʌnjən",
+    "ukphone": "",
+    "trans": [
+      "n. 洋葱；洋葱头"
+    ]
+  },
+  {
+    "name": "only",
+    "usphone": "ˈəʊnlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 惟一的，仅有的 ad. 仅仅，只，才"
+    ]
+  },
+  {
+    "name": "onto",
+    "usphone": "ˈɔntʊ",
+    "ukphone": "",
+    "trans": [
+      "prep. 到…的上面"
+    ]
+  },
+  {
+    "name": "open",
+    "usphone": "ˈəʊpən",
+    "ukphone": "",
+    "trans": [
+      "a.开着的,开的 vt.开,打开"
+    ]
+  },
+  {
+    "name": "opener",
+    "usphone": "ˈəʊpənə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 开具，启子"
+    ]
+  },
+  {
+    "name": "opening",
+    "usphone": "ˈəʊpənɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 开放，口子"
+    ]
+  },
+  {
+    "name": "opera",
+    "usphone": "ˈɔpərə",
+    "ukphone": "",
+    "trans": [
+      "n. 歌剧"
+    ]
+  },
+  {
+    "name": "opera house",
+    "usphone": "ˈɔpərə haʊs",
+    "ukphone": "",
+    "trans": [
+      "n.歌剧院,艺术剧院"
+    ]
+  },
+  {
+    "name": "operate",
+    "usphone": "ˈɔpəreɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 做手术，运转；实施，负责, 经营，管理"
+    ]
+  },
+  {
+    "name": "operation",
+    "usphone": "ɔpəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 手术，操作"
+    ]
+  },
+  {
+    "name": "operator",
+    "usphone": "ˈɔpəreɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 接线员"
+    ]
+  },
+  {
+    "name": "opinion",
+    "usphone": "əˈpɪnjən",
+    "ukphone": "",
+    "trans": [
+      "n. 看法，见解"
+    ]
+  },
+  {
+    "name": "oppose",
+    "usphone": "əˈpəʊz",
+    "ukphone": "",
+    "trans": [
+      "vt. 反对；反抗"
+    ]
+  },
+  {
+    "name": "opposite",
+    "usphone": "ˈɔpəzɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 相反，对面 a. 相反的，对面的"
+    ]
+  },
+  {
+    "name": "optimistic",
+    "usphone": "ɔptɪˈmɪstɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 乐观的"
+    ]
+  },
+  {
+    "name": "optional",
+    "usphone": "ˈɔpʃən(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 可选择的，选修的"
+    ]
+  },
+  {
+    "name": "or",
+    "usphone": "ə(r), ɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "conj. 或；就是；否则"
+    ]
+  },
+  {
+    "name": "oral",
+    "usphone": "ˈɔːrəl",
+    "ukphone": "",
+    "trans": [
+      "a. 口述的，口头上的"
+    ]
+  },
+  {
+    "name": "orange",
+    "usphone": "ˈɔrɪndʒ; (US) ˈɔːr-",
+    "ukphone": "",
+    "trans": [
+      "n. 橘子，橙子，橘汁 a. 橘色的，橙色的"
+    ]
+  },
+  {
+    "name": "orbit",
+    "usphone": "ˈɔːbɪt",
+    "ukphone": "",
+    "trans": [
+      "n.（天体等的）运行轨道"
+    ]
+  },
+  {
+    "name": "order",
+    "usphone": "ˈɔːdə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 顺序"
+    ]
+  },
+  {
+    "name": "order",
+    "usphone": "ˈɔːdə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 定购，定货；点菜"
+    ]
+  },
+  {
+    "name": "ordinary",
+    "usphone": "ˈɔːdɪnərɪ; (US) ˈɔːrdənerɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 普通的，平常的"
+    ]
+  },
+  {
+    "name": "organ",
+    "usphone": "ˈɔːɡən",
+    "ukphone": "",
+    "trans": [
+      "n. （人，动物）器官"
+    ]
+  },
+  {
+    "name": "organise(美organize)",
+    "usphone": "ˈɔ:gənaiz",
+    "ukphone": "",
+    "trans": [
+      "vt. 组织"
+    ]
+  },
+  {
+    "name": "organiser (organizer)",
+    "usphone": "ˈɔ:gənaizə",
+    "ukphone": "",
+    "trans": [
+      "n. 组织者"
+    ]
+  },
+  {
+    "name": "organization",
+    "usphone": "ɔːɡənaɪˈzeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 组织，机构"
+    ]
+  },
+  {
+    "name": "origin",
+    "usphone": "ˈɔrɪdʒɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 起源，由来"
+    ]
+  },
+  {
+    "name": "other",
+    "usphone": "ˈʌðə(r)",
+    "ukphone": "",
+    "trans": [
+      "pron. 别人，别的东西 a. 别的,另外的"
+    ]
+  },
+  {
+    "name": "otherwise",
+    "usphone": "ˈʌðəwaɪz",
+    "ukphone": "",
+    "trans": [
+      "ad.要不然,否则,另样"
+    ]
+  },
+  {
+    "name": "Ottawa",
+    "usphone": "ˈɔtəwə",
+    "ukphone": "",
+    "trans": [
+      "n. 渥太华"
+    ]
+  },
+  {
+    "name": "ouch",
+    "usphone": "aʊtʃ",
+    "ukphone": "",
+    "trans": [
+      "int（突然受痛时叫声）哎哟"
+    ]
+  },
+  {
+    "name": "ought",
+    "usphone": "ɔːt",
+    "ukphone": "",
+    "trans": [
+      "v.& aux.应该，应当"
+    ]
+  },
+  {
+    "name": "our",
+    "usphone": "ˈaʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "pron.我们的"
+    ]
+  },
+  {
+    "name": "ours",
+    "usphone": "ˈaʊəz",
+    "ukphone": "",
+    "trans": [
+      "pron.我们的"
+    ]
+  },
+  {
+    "name": "ourselves",
+    "usphone": "aʊəˈselvz",
+    "ukphone": "",
+    "trans": [
+      "pron. 我们自己"
+    ]
+  },
+  {
+    "name": "out",
+    "usphone": "aʊt",
+    "ukphone": "",
+    "trans": [
+      "ad. 出外;在外,向外;熄"
+    ]
+  },
+  {
+    "name": "outcome",
+    "usphone": "ˈaʊtkʌm",
+    "ukphone": "",
+    "trans": [
+      "n. 结果，效果"
+    ]
+  },
+  {
+    "name": "outdoors",
+    "usphone": "aʊtˈdɔːz",
+    "ukphone": "",
+    "trans": [
+      "ad. 在户外, 在野外"
+    ]
+  },
+  {
+    "name": "outer",
+    "usphone": "ˈaʊtə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 外部的，外面的"
+    ]
+  },
+  {
+    "name": "outgoing",
+    "usphone": "ˈaʊtɡəʊɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 爱交际的,外向的"
+    ]
+  },
+  {
+    "name": "outing",
+    "usphone": "ˈaʊtɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 郊游，远足"
+    ]
+  },
+  {
+    "name": "outline",
+    "usphone": "ˈaʊtlaɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 概述，略述"
+    ]
+  },
+  {
+    "name": "output",
+    "usphone": "ˈaʊtpʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 产量，输出量"
+    ]
+  },
+  {
+    "name": "outside",
+    "usphone": "aʊtˈsaɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 外面 ad. 在外面；向外面 prep. 在…外面"
+    ]
+  },
+  {
+    "name": "outspoken",
+    "usphone": "aʊtˈspəʊkən",
+    "ukphone": "",
+    "trans": [
+      "a. 直率，坦诚"
+    ]
+  },
+  {
+    "name": "outstanding",
+    "usphone": "aʊtˈstændɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 优秀的，杰出的"
+    ]
+  },
+  {
+    "name": "outward(s)",
+    "usphone": "ˈaʊtwəd",
+    "ukphone": "",
+    "trans": [
+      "ad. 向外的，外出的"
+    ]
+  },
+  {
+    "name": "oval",
+    "usphone": "ˈəʊv(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.& adj.椭圆；椭圆形的"
+    ]
+  },
+  {
+    "name": "over",
+    "usphone": "ˈəʊvə(r)",
+    "ukphone": "",
+    "trans": [
+      "prep. 在…上方,越过,遍及 ad. 翻倒,遍布,越过,结束"
+    ]
+  },
+  {
+    "name": "overcoat",
+    "usphone": "ˈəʊvəkəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 大衣"
+    ]
+  },
+  {
+    "name": "overcome",
+    "usphone": "əʊvəˈkʌm",
+    "ukphone": "",
+    "trans": [
+      "v. 克服，解决"
+    ]
+  },
+  {
+    "name": "overhead",
+    "usphone": "əʊvəˈhed",
+    "ukphone": "",
+    "trans": [
+      "a.在头顶上;架空的"
+    ]
+  },
+  {
+    "name": "overlook",
+    "usphone": "əʊvəˈlʊk",
+    "ukphone": "",
+    "trans": [
+      "v. 忽略,不予理会"
+    ]
+  },
+  {
+    "name": "overweight",
+    "usphone": "əʊvəˈweɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 太胖的,超重的"
+    ]
+  },
+  {
+    "name": "owe",
+    "usphone": "əʊ",
+    "ukphone": "",
+    "trans": [
+      "vt. 欠（债等）"
+    ]
+  },
+  {
+    "name": "own",
+    "usphone": "əʊn",
+    "ukphone": "",
+    "trans": [
+      "a. 自己的 v. 拥有,所有"
+    ]
+  },
+  {
+    "name": "owner",
+    "usphone": "ˈəʊnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 物主，所有人"
+    ]
+  },
+  {
+    "name": "ownership",
+    "usphone": "ˈəʊnəʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 所有制"
+    ]
+  },
+  {
+    "name": "ox (复oxen)",
+    "usphone": "ɔks",
+    "ukphone": "",
+    "trans": [
+      "n. 牛；公牛"
+    ]
+  },
+  {
+    "name": "oxygen",
+    "usphone": "ˈɔksɪdʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 氧；氧气"
+    ]
+  },
+  {
+    "name": "pace",
+    "usphone": "peɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 步子；节奏"
+    ]
+  },
+  {
+    "name": "Pacific",
+    "usphone": "pəˈsɪfɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 太平洋的"
+    ]
+  },
+  {
+    "name": "the Pacific Ocean",
+    "usphone": "ðə pəˈsɪfɪkˈəʊʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "太平洋"
+    ]
+  },
+  {
+    "name": "pack",
+    "usphone": "pæk",
+    "ukphone": "",
+    "trans": [
+      "n. 包,捆;（猎犬、野兽的）一群 v.(为运输或储存而)打包"
+    ]
+  },
+  {
+    "name": "package",
+    "usphone": "ˈpækɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. （尤指包装好或密封的容器）一包，一袋，一盒"
+    ]
+  },
+  {
+    "name": "packet",
+    "usphone": "ˈpækɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 小包裹，袋"
+    ]
+  },
+  {
+    "name": "paddle",
+    "usphone": "ˈpæd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 桨状物，蹼"
+    ]
+  },
+  {
+    "name": "page",
+    "usphone": "peɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 页，页码"
+    ]
+  },
+  {
+    "name": "pain",
+    "usphone": "peɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 疼痛，疼"
+    ]
+  },
+  {
+    "name": "painful",
+    "usphone": "ˈpeɪnfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 使痛的，使痛苦的"
+    ]
+  },
+  {
+    "name": "paint",
+    "usphone": "peɪnt",
+    "ukphone": "",
+    "trans": [
+      "n.油漆 vt.油漆,粉刷,绘画"
+    ]
+  },
+  {
+    "name": "painter",
+    "usphone": "ˈpeɪntə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 绘画者,（油）画家"
+    ]
+  },
+  {
+    "name": "painting",
+    "usphone": "ˈpeɪntɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 油画，水彩画"
+    ]
+  },
+  {
+    "name": "pair",
+    "usphone": "peə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 一双，一对"
+    ]
+  },
+  {
+    "name": "palace",
+    "usphone": "ˈpælɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 宫，宫殿"
+    ]
+  },
+  {
+    "name": "pale",
+    "usphone": "peɪl",
+    "ukphone": "",
+    "trans": [
+      "a. 苍白的，灰白的"
+    ]
+  },
+  {
+    "name": "pan",
+    "usphone": "pæn",
+    "ukphone": "",
+    "trans": [
+      "n. 平底锅"
+    ]
+  },
+  {
+    "name": "pancake",
+    "usphone": "ˈpænkeɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 薄煎饼"
+    ]
+  },
+  {
+    "name": "panda",
+    "usphone": "ˈpændə",
+    "ukphone": "",
+    "trans": [
+      "n. 熊猫"
+    ]
+  },
+  {
+    "name": "panic",
+    "usphone": "ˈpænɪk",
+    "ukphone": "",
+    "trans": [
+      "a./ v.惊慌,恐慌,惶恐不安"
+    ]
+  },
+  {
+    "name": "paper",
+    "usphone": "ˈpeɪpə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 纸；报纸"
+    ]
+  },
+  {
+    "name": "paperwork",
+    "usphone": "ˈpeɪpəwɜːk",
+    "ukphone": "",
+    "trans": [
+      "n. 日常文书工作"
+    ]
+  },
+  {
+    "name": "paragraph",
+    "usphone": "ˈpærəɡrɑːf; (US) ˈpærəgræf",
+    "ukphone": "",
+    "trans": [
+      "n. （文章的）段落"
+    ]
+  },
+  {
+    "name": "parallel",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 极其相似的人,纬线"
+    ]
+  },
+  {
+    "name": "parcel",
+    "usphone": "ˈpɑːs(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 包裹"
+    ]
+  },
+  {
+    "name": "pardon",
+    "usphone": "ˈpɑːd(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 原谅,宽恕,对不起"
+    ]
+  },
+  {
+    "name": "parent",
+    "usphone": "ˈpeərənt",
+    "ukphone": "",
+    "trans": [
+      "n. 父(母)，双亲"
+    ]
+  },
+  {
+    "name": "Paris",
+    "usphone": "ˈpærɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 巴黎"
+    ]
+  },
+  {
+    "name": "park",
+    "usphone": "ˈpærɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 公园"
+    ]
+  },
+  {
+    "name": "park",
+    "usphone": "pɑːk",
+    "ukphone": "",
+    "trans": [
+      "vt. 停放（汽车）"
+    ]
+  },
+  {
+    "name": "parking",
+    "usphone": "ˈpɑːkɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 停车"
+    ]
+  },
+  {
+    "name": "parrot",
+    "usphone": "ˈpærət",
+    "ukphone": "",
+    "trans": [
+      "n. 鹦鹉"
+    ]
+  },
+  {
+    "name": "part",
+    "usphone": "pɑːt",
+    "ukphone": "",
+    "trans": [
+      "n. 部分；成分；角色；部件；零件 a. 局部的；部分的 v. 分离；分开；分割"
+    ]
+  },
+  {
+    "name": "participate",
+    "usphone": "pɑːˈtɪsɪpeɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 参加，参与"
+    ]
+  },
+  {
+    "name": "particular",
+    "usphone": "pəˈtɪkjʊlə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 特殊的，个别的"
+    ]
+  },
+  {
+    "name": "partly",
+    "usphone": "ˈpɑːtlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad.部分地,在一定程度上"
+    ]
+  },
+  {
+    "name": "partner",
+    "usphone": "ˈpɑːtnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 搭档，合作者"
+    ]
+  },
+  {
+    "name": "part-time",
+    "usphone": "pɑːt -taɪm",
+    "ukphone": "",
+    "trans": [
+      "a.& ad. 兼职的； 部分时间的（地）"
+    ]
+  },
+  {
+    "name": "party",
+    "usphone": "ˈpɑːtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 聚会，晚会；党派"
+    ]
+  },
+  {
+    "name": "pass",
+    "usphone": "pɑːs; (US) pæs",
+    "ukphone": "",
+    "trans": [
+      "vt. 传，递；经过；通过"
+    ]
+  },
+  {
+    "name": "passage",
+    "usphone": "ˈpæsɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. （文章等的）一节，一段；通道；走廊"
+    ]
+  },
+  {
+    "name": "passenger",
+    "usphone": "ˈpæsɪndʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 乘客，旅客"
+    ]
+  },
+  {
+    "name": "passer-by",
+    "usphone": "ˈpɑ:sə-baɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 过客，过路人"
+    ]
+  },
+  {
+    "name": "passive",
+    "usphone": "ˈpæsɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 被动的"
+    ]
+  },
+  {
+    "name": "passport",
+    "usphone": "ˈpɑːspɔːt; (US) ˈpæ-",
+    "ukphone": "",
+    "trans": [
+      "n. 护照"
+    ]
+  },
+  {
+    "name": "past",
+    "usphone": "pɑːst; (US) pæst",
+    "ukphone": "",
+    "trans": [
+      "ad. 过 n.过去，昔日，往事 prep. 过…，走过某处"
+    ]
+  },
+  {
+    "name": "patent",
+    "usphone": "ˈpeɪt(ə)nt; (US) ˈpætnt",
+    "ukphone": "",
+    "trans": [
+      "n.专利权，专利证书"
+    ]
+  },
+  {
+    "name": "path",
+    "usphone": "pɑːθ; (US) pæθ",
+    "ukphone": "",
+    "trans": [
+      "n. 小道，小径"
+    ]
+  },
+  {
+    "name": "patience",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 容忍；耐心"
+    ]
+  },
+  {
+    "name": "patient",
+    "usphone": "ˈpeɪʃ(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "n. 病人"
+    ]
+  },
+  {
+    "name": "pattern",
+    "usphone": "ˈpæt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 式样"
+    ]
+  },
+  {
+    "name": "pause",
+    "usphone": "pɔːz",
+    "ukphone": "",
+    "trans": [
+      "n.& vi. 中止，暂停；停止"
+    ]
+  },
+  {
+    "name": "pay",
+    "usphone": "peɪ",
+    "ukphone": "",
+    "trans": [
+      "(paid, paid) v. 付钱，给…报酬 n. 工资"
+    ]
+  },
+  {
+    "name": "P.E.(缩) =physical education",
+    "usphone": "piːiː",
+    "ukphone": "",
+    "trans": [
+      "体育"
+    ]
+  },
+  {
+    "name": "P.C.(缩) =personal computer",
+    "usphone": "piːsiː",
+    "ukphone": "",
+    "trans": [
+      "个人电脑"
+    ]
+  },
+  {
+    "name": "pea",
+    "usphone": "piː",
+    "ukphone": "",
+    "trans": [
+      "n. 豌豆"
+    ]
+  },
+  {
+    "name": "peace",
+    "usphone": "piːs",
+    "ukphone": "",
+    "trans": [
+      "n. 和平"
+    ]
+  },
+  {
+    "name": "peaceful",
+    "usphone": "ˈpiːsfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 和平的，安宁的"
+    ]
+  },
+  {
+    "name": "peach",
+    "usphone": "piːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 桃子"
+    ]
+  },
+  {
+    "name": "pear",
+    "usphone": "peə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 梨子，梨树"
+    ]
+  },
+  {
+    "name": "peasant",
+    "usphone": "ˈpezənt",
+    "ukphone": "",
+    "trans": [
+      "n. 农民；佃农"
+    ]
+  },
+  {
+    "name": "pedestrian",
+    "usphone": "pɪˈdestrɪən",
+    "ukphone": "",
+    "trans": [
+      "n. 步行者，行人"
+    ]
+  },
+  {
+    "name": "pen",
+    "usphone": "pen",
+    "ukphone": "",
+    "trans": [
+      "n. 钢笔，笔"
+    ]
+  },
+  {
+    "name": "pencil",
+    "usphone": "ˈpens(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 铅笔"
+    ]
+  },
+  {
+    "name": "pencil-box",
+    "usphone": "ˈpens(ə)l -bɔks",
+    "ukphone": "",
+    "trans": [
+      "n. 铅笔盒"
+    ]
+  },
+  {
+    "name": "pen-friend",
+    "usphone": "pen- friend",
+    "ukphone": "",
+    "trans": [
+      "n. 笔友"
+    ]
+  },
+  {
+    "name": "penny",
+    "usphone": "ˈpenɪ",
+    "ukphone": "",
+    "trans": [
+      "(英复pence) n. （英）便士；美分"
+    ]
+  },
+  {
+    "name": "pension",
+    "usphone": "ˈpenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 养老金"
+    ]
+  },
+  {
+    "name": "people",
+    "usphone": "ˈpiːp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 人，人们；人民"
+    ]
+  },
+  {
+    "name": "pepper",
+    "usphone": "ˈpepə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 胡椒粉"
+    ]
+  },
+  {
+    "name": "per",
+    "usphone": "pə(r)",
+    "ukphone": "",
+    "trans": [
+      "prep. 每，每一"
+    ]
+  },
+  {
+    "name": "percent",
+    "usphone": "pəˈsent",
+    "ukphone": "",
+    "trans": [
+      "n. 百分之……"
+    ]
+  },
+  {
+    "name": "percentage",
+    "usphone": "pəˈsentədʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 百分率"
+    ]
+  },
+  {
+    "name": "perfect",
+    "usphone": "kwestʃəˈneə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 完美的，极好的"
+    ]
+  },
+  {
+    "name": "perform",
+    "usphone": "pəˈfɔːm",
+    "ukphone": "",
+    "trans": [
+      "v. 表演，履行；行动"
+    ]
+  },
+  {
+    "name": "performance",
+    "usphone": "pəˈfɔːm",
+    "ukphone": "",
+    "trans": [
+      "n. 演出，表演"
+    ]
+  },
+  {
+    "name": "performer",
+    "usphone": "pəˈfɔːmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 表演者，执行者"
+    ]
+  },
+  {
+    "name": "perfume",
+    "usphone": "ˈpɜːfjuːm",
+    "ukphone": "",
+    "trans": [
+      "n. 香水"
+    ]
+  },
+  {
+    "name": "perhaps",
+    "usphone": "pəˈhæps",
+    "ukphone": "",
+    "trans": [
+      "ad. 可能，或"
+    ]
+  },
+  {
+    "name": "period",
+    "usphone": "ˈpɪərɪəd",
+    "ukphone": "",
+    "trans": [
+      "n. 时期，时代"
+    ]
+  },
+  {
+    "name": "permanent",
+    "usphone": "ˈpɜːmənənt",
+    "ukphone": "",
+    "trans": [
+      "a. 永久的，永恒的"
+    ]
+  },
+  {
+    "name": "permission",
+    "usphone": "pəˈmɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 允许,许可,同意"
+    ]
+  },
+  {
+    "name": "permit",
+    "usphone": "pəˈmɪt",
+    "ukphone": "",
+    "trans": [
+      "vt.许可,允许;执照 n.许可证"
+    ]
+  },
+  {
+    "name": "person",
+    "usphone": "ˈpɜːs(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 人"
+    ]
+  },
+  {
+    "name": "personal",
+    "usphone": "ˈpɜːsən(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 个人的，私人的"
+    ]
+  },
+  {
+    "name": "personnel",
+    "usphone": "pɜːsəˈnel",
+    "ukphone": "",
+    "trans": [
+      "n. 全体人员，职员"
+    ]
+  },
+  {
+    "name": "personally",
+    "usphone": "ˈpɜːsənəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 就自己而言"
+    ]
+  },
+  {
+    "name": "persuade",
+    "usphone": "ˈpɜːsənəlɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 说服，劝说"
+    ]
+  },
+  {
+    "name": "pest",
+    "usphone": "pest",
+    "ukphone": "",
+    "trans": [
+      "n. 害虫"
+    ]
+  },
+  {
+    "name": "pet",
+    "usphone": "pet",
+    "ukphone": "",
+    "trans": [
+      "n. 宠物，爱畜"
+    ]
+  },
+  {
+    "name": "petrol",
+    "usphone": "ˈpetr(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 石油"
+    ]
+  },
+  {
+    "name": "phenomenon (pl. phenomena)",
+    "usphone": "fɪˈnɔmɪnən; (US) -nɔn-",
+    "ukphone": "",
+    "trans": [
+      "n. 现象"
+    ]
+  },
+  {
+    "name": "phone = telephone",
+    "usphone": "fəʊn",
+    "ukphone": "",
+    "trans": [
+      "v. 打电话 n. 电话，电话机"
+    ]
+  },
+  {
+    "name": "phone-booth",
+    "usphone": "fəʊn-buːð",
+    "ukphone": "",
+    "trans": [
+      "n. 公用电话间"
+    ]
+  },
+  {
+    "name": "photo =photograph",
+    "usphone": "ˈfəʊtəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 照片"
+    ]
+  },
+  {
+    "name": "photograph",
+    "usphone": "ˈfəʊtəɡrɑːf; (US) -ɡræf",
+    "ukphone": "",
+    "trans": [
+      "n. 照片"
+    ]
+  },
+  {
+    "name": "photographer",
+    "usphone": "fəˈtɔɡrəfə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 摄影师"
+    ]
+  },
+  {
+    "name": "phrase",
+    "usphone": "freɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 短语；习惯用语"
+    ]
+  },
+  {
+    "name": "physical",
+    "usphone": "ˈfɪzɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 身体的；物理的"
+    ]
+  },
+  {
+    "name": "physician",
+    "usphone": "fɪˈzɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.(有行医执照的)医生"
+    ]
+  },
+  {
+    "name": "physicist",
+    "usphone": "ˈfɪzɪsɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 物理学家"
+    ]
+  },
+  {
+    "name": "physics",
+    "usphone": "ˈfɪzɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 物理（学）"
+    ]
+  },
+  {
+    "name": "pianist",
+    "usphone": "ˈfɪzɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 钢琴家"
+    ]
+  },
+  {
+    "name": "piano",
+    "usphone": "pɪˈænəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 钢琴"
+    ]
+  },
+  {
+    "name": "pick",
+    "usphone": "pɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 拾起，采集；挑选"
+    ]
+  },
+  {
+    "name": "picnic",
+    "usphone": "ˈpɪknɪk",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 野餐"
+    ]
+  },
+  {
+    "name": "picture",
+    "usphone": "ˈpɪktʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 图片，画片，照片"
+    ]
+  },
+  {
+    "name": "pie",
+    "usphone": "paɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 甜馅饼"
+    ]
+  },
+  {
+    "name": "piece",
+    "usphone": "paɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 一块（片，张，件…）"
+    ]
+  },
+  {
+    "name": "pig",
+    "usphone": "paɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 猪"
+    ]
+  },
+  {
+    "name": "pile",
+    "usphone": "paɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 堆"
+    ]
+  },
+  {
+    "name": "pill",
+    "usphone": "pɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 药丸，药片"
+    ]
+  },
+  {
+    "name": "pillow",
+    "usphone": "pɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 枕头"
+    ]
+  },
+  {
+    "name": "pilot",
+    "usphone": "ˈpaɪlət",
+    "ukphone": "",
+    "trans": [
+      "n. 飞行员"
+    ]
+  },
+  {
+    "name": "pin",
+    "usphone": "pɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 别针 v. 别住, 钉住"
+    ]
+  },
+  {
+    "name": "pine",
+    "usphone": "paɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 松树"
+    ]
+  },
+  {
+    "name": "pineapple",
+    "usphone": "ˈpaɪnæp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 菠萝"
+    ]
+  },
+  {
+    "name": "ping-pong",
+    "usphone": "pɪŋ-pɔɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 乒乓球"
+    ]
+  },
+  {
+    "name": "pink",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a. 粉红色的"
+    ]
+  },
+  {
+    "name": "pint",
+    "usphone": "paɪnt",
+    "ukphone": "",
+    "trans": [
+      "n.（液量单位）品脱"
+    ]
+  },
+  {
+    "name": "pioneer",
+    "usphone": "paɪəˈnɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 先锋，开拓者"
+    ]
+  },
+  {
+    "name": "pipe",
+    "usphone": "paɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 管子，输送管"
+    ]
+  },
+  {
+    "name": "pity",
+    "usphone": "ˈpɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 怜悯，同情"
+    ]
+  },
+  {
+    "name": "place",
+    "usphone": "pleɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 地方，处所 v. 放置，安置，安排"
+    ]
+  },
+  {
+    "name": "plain",
+    "usphone": "pleɪn",
+    "ukphone": "",
+    "trans": [
+      "a. 家常的； 普通的"
+    ]
+  },
+  {
+    "name": "plan",
+    "usphone": "plæn",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 计划，打算"
+    ]
+  },
+  {
+    "name": "plane",
+    "usphone": "pleɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 飞机"
+    ]
+  },
+  {
+    "name": "planet",
+    "usphone": "ˈplænɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 行星"
+    ]
+  },
+  {
+    "name": "plant",
+    "usphone": "plɑːnt; (US) ˈplænt",
+    "ukphone": "",
+    "trans": [
+      "vt. 种植，播种 n. 植物"
+    ]
+  },
+  {
+    "name": "plastic",
+    "usphone": "ˈplæstɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 塑料的"
+    ]
+  },
+  {
+    "name": "plate",
+    "usphone": "pleɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 板；片；牌；盘子；盆子"
+    ]
+  },
+  {
+    "name": "platform",
+    "usphone": "ˈplætfɔːm",
+    "ukphone": "",
+    "trans": [
+      "n. 讲台,(车站的)月台"
+    ]
+  },
+  {
+    "name": "play",
+    "usphone": "pleɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 玩；打（球）；游戏；播放 n. 玩耍，戏剧"
+    ]
+  },
+  {
+    "name": "playroom",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 游戏室"
+    ]
+  },
+  {
+    "name": "player",
+    "usphone": "ˈpleɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 比赛者，选手"
+    ]
+  },
+  {
+    "name": "playground",
+    "usphone": "ˈpleɪgraʊnd",
+    "ukphone": "",
+    "trans": [
+      "n. 操场，运动场"
+    ]
+  },
+  {
+    "name": "playmate",
+    "usphone": "ˈpleɪmeɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 玩伴"
+    ]
+  },
+  {
+    "name": "pleasant",
+    "usphone": "ˈplezənt",
+    "ukphone": "",
+    "trans": [
+      "a. 令人愉快的，舒适的"
+    ]
+  },
+  {
+    "name": "please",
+    "usphone": "pliːz",
+    "ukphone": "",
+    "trans": [
+      "v. 请,使人高兴,使人满意"
+    ]
+  },
+  {
+    "name": "pleased",
+    "usphone": "pliːzd",
+    "ukphone": "",
+    "trans": [
+      "a. 高兴的"
+    ]
+  },
+  {
+    "name": "pleasure",
+    "usphone": "pliːzd",
+    "ukphone": "",
+    "trans": [
+      "n. 高兴，愉快"
+    ]
+  },
+  {
+    "name": "plenty",
+    "usphone": "pliːzd",
+    "ukphone": "",
+    "trans": [
+      "n. 充足，大量"
+    ]
+  },
+  {
+    "name": "plot",
+    "usphone": "plɔt",
+    "ukphone": "",
+    "trans": [
+      "v. / n. 故事情节，密谋"
+    ]
+  },
+  {
+    "name": "plug",
+    "usphone": "plʌɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 塞子 vt.（用塞子）把…塞住"
+    ]
+  },
+  {
+    "name": "plus",
+    "usphone": "plʌs",
+    "ukphone": "",
+    "trans": [
+      "prep.加，加上"
+    ]
+  },
+  {
+    "name": "p.m./pm, P.M. /PM",
+    "usphone": "piːem",
+    "ukphone": "",
+    "trans": [
+      "n. 下午,午后"
+    ]
+  },
+  {
+    "name": "pocket",
+    "usphone": "ˈpɔkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. （衣服的）口袋"
+    ]
+  },
+  {
+    "name": "poem",
+    "usphone": "ˈpəʊɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 诗"
+    ]
+  },
+  {
+    "name": "poet",
+    "usphone": "ˈpəʊɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 诗人"
+    ]
+  },
+  {
+    "name": "point",
+    "usphone": "pɔɪnt",
+    "ukphone": "",
+    "trans": [
+      "v. 指，指向 n. 点；分数"
+    ]
+  },
+  {
+    "name": "poison",
+    "usphone": "ˈpɔɪz(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 毒药"
+    ]
+  },
+  {
+    "name": "poisonous",
+    "usphone": "ˈpɔɪzənəs",
+    "ukphone": "",
+    "trans": [
+      "a. 有毒的，致命的"
+    ]
+  },
+  {
+    "name": "pole",
+    "usphone": "pəʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 杆，电线杆；"
+    ]
+  },
+  {
+    "name": "the North (South) Pole",
+    "usphone": "ðə nɔːθpəʊ",
+    "ukphone": "",
+    "trans": [
+      "（地球的）极，极地 北（南）极"
+    ]
+  },
+  {
+    "name": "police",
+    "usphone": "pəˈliːs",
+    "ukphone": "",
+    "trans": [
+      "n. 警察，警务人员"
+    ]
+  },
+  {
+    "name": "policeman (复-men)",
+    "usphone": "pəˈliːsmən",
+    "ukphone": "",
+    "trans": [
+      "n.警察,巡警policewoman ( -women) n.女警察"
+    ]
+  },
+  {
+    "name": "policy",
+    "usphone": "ˈpɔlɪsɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 政策，方针，原则"
+    ]
+  },
+  {
+    "name": "polish",
+    "usphone": "ˈpɔlɪsɪ",
+    "ukphone": "",
+    "trans": [
+      "v.擦亮 n.擦光剂,亮光剂"
+    ]
+  },
+  {
+    "name": "polite",
+    "usphone": "pəˈlaɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 有礼貌的,有教养的"
+    ]
+  },
+  {
+    "name": "political",
+    "usphone": "pəˈlɪtɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 政治的"
+    ]
+  },
+  {
+    "name": "politician",
+    "usphone": "pɔlɪˈtɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 政治家"
+    ]
+  },
+  {
+    "name": "politics",
+    "usphone": "ˈpɔlɪtɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 政治"
+    ]
+  },
+  {
+    "name": "pollute",
+    "usphone": "pəˈluːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 污染"
+    ]
+  },
+  {
+    "name": "pollution",
+    "usphone": "pəˈluːʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 污染"
+    ]
+  },
+  {
+    "name": "pond",
+    "usphone": "pɔnd",
+    "ukphone": "",
+    "trans": [
+      "n. 池塘"
+    ]
+  },
+  {
+    "name": "pool",
+    "usphone": "puːl",
+    "ukphone": "",
+    "trans": [
+      "n. 水塘，水池"
+    ]
+  },
+  {
+    "name": "poor",
+    "usphone": "pʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "a.贫穷；可怜；不好的,差的"
+    ]
+  },
+  {
+    "name": "pop = popular",
+    "usphone": "pɔp",
+    "ukphone": "",
+    "trans": [
+      "a. (口语) （音乐、艺术等）大众的，通俗的"
+    ]
+  },
+  {
+    "name": "popcorn",
+    "usphone": "ˈpɔpkɔːn",
+    "ukphone": "",
+    "trans": [
+      "n. 爆米花"
+    ]
+  },
+  {
+    "name": "popular",
+    "usphone": "ˈpɔpjʊlə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 流行,大众,受欢迎的"
+    ]
+  },
+  {
+    "name": "population",
+    "usphone": "pɔpjʊˈleɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 人口，人数"
+    ]
+  },
+  {
+    "name": "pork",
+    "usphone": "pɔːk",
+    "ukphone": "",
+    "trans": [
+      "n. 猪肉"
+    ]
+  },
+  {
+    "name": "porridge",
+    "usphone": "ˈpɔrɪdʒ; (US) ˈpɔːrɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 稀饭，粥"
+    ]
+  },
+  {
+    "name": "port",
+    "usphone": "pɔːt",
+    "ukphone": "",
+    "trans": [
+      "n. 港口，码头"
+    ]
+  },
+  {
+    "name": "portable",
+    "usphone": "ˈpɔːtəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.手提的，便携式的"
+    ]
+  },
+  {
+    "name": "porter",
+    "usphone": "ˈpɔːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （火车站或旅馆处的）搬运工"
+    ]
+  },
+  {
+    "name": "position",
+    "usphone": "pəˈzɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 位置"
+    ]
+  },
+  {
+    "name": "possess",
+    "usphone": "pəˈzɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "vt. 占有；拥有"
+    ]
+  },
+  {
+    "name": "possession",
+    "usphone": "pəˈzeʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 所有，拥有；财产，所有物"
+    ]
+  },
+  {
+    "name": "possibility",
+    "usphone": "pɔsɪˈbɪlɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "vn. 可能，可能性"
+    ]
+  },
+  {
+    "name": "possible",
+    "usphone": "ˈpɔsɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 可能的"
+    ]
+  },
+  {
+    "name": "possibly",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "adv. 可能地，也许"
+    ]
+  },
+  {
+    "name": "post",
+    "usphone": "pəʊst",
+    "ukphone": "",
+    "trans": [
+      "n. 邮政，邮寄，邮件 v. 投寄； 邮寄"
+    ]
+  },
+  {
+    "name": "postage",
+    "usphone": "ˈpəʊstɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 邮费"
+    ]
+  },
+  {
+    "name": "postbox",
+    "usphone": "ˈpəʊstbɔks",
+    "ukphone": "",
+    "trans": [
+      "n. 邮箱"
+    ]
+  },
+  {
+    "name": "postcard",
+    "usphone": "ˈpəʊstkɑːd",
+    "ukphone": "",
+    "trans": [
+      "n. 明信片"
+    ]
+  },
+  {
+    "name": "postcode",
+    "usphone": "ˈpəʊstkəʊd",
+    "ukphone": "",
+    "trans": [
+      "n. （英）邮政编码"
+    ]
+  },
+  {
+    "name": "poster",
+    "usphone": "ˈpəʊstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. (贴在公共场所的大型)招贴；广告(画)"
+    ]
+  },
+  {
+    "name": "postman",
+    "usphone": "ˈpəʊstmən",
+    "ukphone": "",
+    "trans": [
+      "n. 邮递员"
+    ]
+  },
+  {
+    "name": "postpone",
+    "usphone": "pəʊstˈpəʊn",
+    "ukphone": "",
+    "trans": [
+      "vt. 推迟，延期"
+    ]
+  },
+  {
+    "name": "pot",
+    "usphone": "pɔt",
+    "ukphone": "",
+    "trans": [
+      "n. 锅，壶，瓶，罐"
+    ]
+  },
+  {
+    "name": "potato",
+    "usphone": "pəˈteɪtəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 土豆，马铃薯"
+    ]
+  },
+  {
+    "name": "potential",
+    "usphone": "pəˈtenʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 潜在的，可能的"
+    ]
+  },
+  {
+    "name": "pound",
+    "usphone": "pəˈtenʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 磅；英镑"
+    ]
+  },
+  {
+    "name": "pour",
+    "usphone": "pɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 倾泻，不断流出"
+    ]
+  },
+  {
+    "name": "powder",
+    "usphone": "ˈpaʊdə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 粉，粉末"
+    ]
+  },
+  {
+    "name": "power",
+    "usphone": "ˈpaʊdə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 力，动力，电力"
+    ]
+  },
+  {
+    "name": "powerful",
+    "usphone": "ˈpaʊəfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 效力大的，强有力的，强大的"
+    ]
+  },
+  {
+    "name": "practical",
+    "usphone": "ˈpræktɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 实际的，适用的"
+    ]
+  },
+  {
+    "name": "practice(s)e",
+    "usphone": "ˈpræktɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 练习"
+    ]
+  },
+  {
+    "name": "prairie",
+    "usphone": "ˈpreərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 大草原"
+    ]
+  },
+  {
+    "name": "praise",
+    "usphone": "preɪz",
+    "ukphone": "",
+    "trans": [
+      "n.& vt.赞扬，表扬"
+    ]
+  },
+  {
+    "name": "pray",
+    "usphone": "preɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 祈祷；祈求"
+    ]
+  },
+  {
+    "name": "prayer",
+    "usphone": "preə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 祈祷"
+    ]
+  },
+  {
+    "name": "precious",
+    "usphone": "ˈpreʃəs",
+    "ukphone": "",
+    "trans": [
+      "a. 宝贵的, 珍贵的"
+    ]
+  },
+  {
+    "name": "precise",
+    "usphone": "prɪˈsaɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 准确,精确的,确切的"
+    ]
+  },
+  {
+    "name": "predict",
+    "usphone": "prɪˈdɪkt",
+    "ukphone": "",
+    "trans": [
+      "v. 预言，预告，预报"
+    ]
+  },
+  {
+    "name": "prefer",
+    "usphone": "prɪˈfɜː(r)",
+    "ukphone": "",
+    "trans": [
+      "vt.宁愿（选择）,更喜欢"
+    ]
+  },
+  {
+    "name": "preference",
+    "usphone": "ˈprefərəns",
+    "ukphone": "",
+    "trans": [
+      "n. 选择，趋向"
+    ]
+  },
+  {
+    "name": "pregnant",
+    "usphone": "ˈpreɡnənt",
+    "ukphone": "",
+    "trans": [
+      "a. 怀孕的"
+    ]
+  },
+  {
+    "name": "prejudice",
+    "usphone": "ˈpredʒʊdɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 偏见，成见"
+    ]
+  },
+  {
+    "name": "premier",
+    "usphone": "ˈpremɪə(r); (US) priːˈmɪər",
+    "ukphone": "",
+    "trans": [
+      "n. 首相，总理"
+    ]
+  },
+  {
+    "name": "preparation",
+    "usphone": "prepəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 准备"
+    ]
+  },
+  {
+    "name": "prepare",
+    "usphone": "prɪˈpeə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 准备,预备,调制,配制"
+    ]
+  },
+  {
+    "name": "prescription",
+    "usphone": "prɪˈskrɪpʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 处方，药方"
+    ]
+  },
+  {
+    "name": "present",
+    "usphone": "ˈprez(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "a. 出现的，出席的 n. 礼物，赠品 vt. 呈奉，奉送"
+    ]
+  },
+  {
+    "name": "presentation",
+    "usphone": "prezənˈteɪʃ(ə)n; (US) priːzenˈteʃn",
+    "ukphone": "",
+    "trans": [
+      "n. 演示，演出"
+    ]
+  },
+  {
+    "name": "preserve",
+    "usphone": "prezənˈteɪʃ(ə)n; (US) priːzenˈteʃn",
+    "ukphone": "",
+    "trans": [
+      "v.保护，保留，保存"
+    ]
+  },
+  {
+    "name": "president",
+    "usphone": "ˈprezɪdənt",
+    "ukphone": "",
+    "trans": [
+      "n. 总统；主席"
+    ]
+  },
+  {
+    "name": "press",
+    "usphone": "ˈprezɪdənt",
+    "ukphone": "",
+    "trans": [
+      "vt.压,按 n.新闻界,出版社"
+    ]
+  },
+  {
+    "name": "pressure",
+    "usphone": "ˈpreʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 压迫,压力,压强"
+    ]
+  },
+  {
+    "name": "pretend",
+    "usphone": "ˈpreʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 假装，装作"
+    ]
+  },
+  {
+    "name": "pretty",
+    "usphone": "ˈprɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 漂亮的，俊俏的"
+    ]
+  },
+  {
+    "name": "prevent",
+    "usphone": "prɪˈvent",
+    "ukphone": "",
+    "trans": [
+      "vt. 防止, 预防"
+    ]
+  },
+  {
+    "name": "preview",
+    "usphone": "ˈpriːvjuː",
+    "ukphone": "",
+    "trans": [
+      "vt. 预习;试演;预展"
+    ]
+  },
+  {
+    "name": "price",
+    "usphone": "praɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 价格，价钱"
+    ]
+  },
+  {
+    "name": "pride",
+    "usphone": "praɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 自豪，骄傲"
+    ]
+  },
+  {
+    "name": "primary",
+    "usphone": "ˈpraɪmərɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 初等的；初级的"
+    ]
+  },
+  {
+    "name": "primary school",
+    "usphone": "ˈpraɪmərɪ skuːl",
+    "ukphone": "",
+    "trans": [
+      "小学"
+    ]
+  },
+  {
+    "name": "primitive",
+    "usphone": "ˈprɪmɪtɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 原始的，远古的"
+    ]
+  },
+  {
+    "name": "principle",
+    "usphone": "ˈprɪnsɪp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 道德原则，法则"
+    ]
+  },
+  {
+    "name": "print",
+    "usphone": "prɪnt",
+    "ukphone": "",
+    "trans": [
+      "vt. 印刷"
+    ]
+  },
+  {
+    "name": "printer",
+    "usphone": "ˈprɪntə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 打印机"
+    ]
+  },
+  {
+    "name": "printing",
+    "usphone": "ˈprɪntɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 印刷，印刷术"
+    ]
+  },
+  {
+    "name": "prison",
+    "usphone": "ˈprɪz(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 监狱"
+    ]
+  },
+  {
+    "name": "prisoner",
+    "usphone": "ˈprɪznə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 囚犯"
+    ]
+  },
+  {
+    "name": "private",
+    "usphone": "ˈpraɪvɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 私人的"
+    ]
+  },
+  {
+    "name": "privilege",
+    "usphone": "ˈprɪvɪlɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "特权，特殊待遇"
+    ]
+  },
+  {
+    "name": "prize",
+    "usphone": "praɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 奖赏，奖品"
+    ]
+  },
+  {
+    "name": "probable",
+    "usphone": "ˈprɔbəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.很可能,很有希望的"
+    ]
+  },
+  {
+    "name": "probably",
+    "usphone": "ˈprɔbəb(ə)lɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 很可能，大概"
+    ]
+  },
+  {
+    "name": "problem",
+    "usphone": "ˈprɔbləm",
+    "ukphone": "",
+    "trans": [
+      "n. 问题，难题"
+    ]
+  },
+  {
+    "name": "procedure",
+    "usphone": "prəˈsiːdʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 程序,手续,待遇"
+    ]
+  },
+  {
+    "name": "process",
+    "usphone": "ˈprəʊses; (US) ˈprɔses",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 过程,加工,处理"
+    ]
+  },
+  {
+    "name": "produce",
+    "usphone": "prəˈdjuːs; (US) -ˈduːs",
+    "ukphone": "",
+    "trans": [
+      "vt. 生产；制造"
+    ]
+  },
+  {
+    "name": "product",
+    "usphone": "ˈprɔdʌkt",
+    "ukphone": "",
+    "trans": [
+      "n. 产品，制品"
+    ]
+  },
+  {
+    "name": "production",
+    "usphone": "prəˈdʌkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 生产；制造"
+    ]
+  },
+  {
+    "name": "profession",
+    "usphone": "prəˈfeʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.（需要有高等教育学位的）职业（如医生或律师）"
+    ]
+  },
+  {
+    "name": "professor",
+    "usphone": "prəˈfesə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 教授"
+    ]
+  },
+  {
+    "name": "profit",
+    "usphone": "ˈprɔfɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 利润，收益"
+    ]
+  },
+  {
+    "name": "programme (美program)",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 节目；项目"
+    ]
+  },
+  {
+    "name": "progress",
+    "usphone": "ˈprəʊɡres; (US) ˈprɔɡres",
+    "ukphone": "",
+    "trans": [
+      "n.进步,上进vi.进展,进行"
+    ]
+  },
+  {
+    "name": "prohibit",
+    "usphone": "prəˈhɪbɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 禁止"
+    ]
+  },
+  {
+    "name": "project",
+    "usphone": "ˈprɔdʒekt",
+    "ukphone": "",
+    "trans": [
+      "n. 工程"
+    ]
+  },
+  {
+    "name": "promise",
+    "usphone": "ˈprɔmɪs",
+    "ukphone": "",
+    "trans": [
+      "n.& vi. 答应，允诺"
+    ]
+  },
+  {
+    "name": "promote",
+    "usphone": "prəˈməʊt",
+    "ukphone": "",
+    "trans": [
+      "v.促进,推动,促销,晋升"
+    ]
+  },
+  {
+    "name": "pronounce",
+    "usphone": "prəˈnaʊns",
+    "ukphone": "",
+    "trans": [
+      "vt. 发音"
+    ]
+  },
+  {
+    "name": "pronunciation",
+    "usphone": "prənʌnsɪˈeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 发音"
+    ]
+  },
+  {
+    "name": "proper",
+    "usphone": "ˈprɔpə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 恰当的，合适的"
+    ]
+  },
+  {
+    "name": "properly",
+    "usphone": "ˈprɔpəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 适当地"
+    ]
+  },
+  {
+    "name": "protect",
+    "usphone": "prəˈtekt",
+    "ukphone": "",
+    "trans": [
+      "vt. 保护"
+    ]
+  },
+  {
+    "name": "protection",
+    "usphone": "prəˈtekʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 保护"
+    ]
+  },
+  {
+    "name": "proud",
+    "usphone": "praʊd",
+    "ukphone": "",
+    "trans": [
+      "a. 自豪的；骄傲的"
+    ]
+  },
+  {
+    "name": "prove",
+    "usphone": "pruːv",
+    "ukphone": "",
+    "trans": [
+      "vt. 证明"
+    ]
+  },
+  {
+    "name": "provide",
+    "usphone": "prəˈvaɪd",
+    "ukphone": "",
+    "trans": [
+      "vt. 提供"
+    ]
+  },
+  {
+    "name": "province",
+    "usphone": "ˈprɔvɪns",
+    "ukphone": "",
+    "trans": [
+      "n. 省"
+    ]
+  },
+  {
+    "name": "psychology",
+    "usphone": "saɪˈkɔlədʒɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 心理学"
+    ]
+  },
+  {
+    "name": "pub",
+    "usphone": "pʌb",
+    "ukphone": "",
+    "trans": [
+      "n. 酒店，酒吧"
+    ]
+  },
+  {
+    "name": "public",
+    "usphone": "ˈpʌblɪk",
+    "ukphone": "",
+    "trans": [
+      "a.公共,公众的 n. 公众"
+    ]
+  },
+  {
+    "name": "publicly",
+    "usphone": "ˈpʌblɪklɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 当众；公开地"
+    ]
+  },
+  {
+    "name": "publish",
+    "usphone": "ˈpʌblɪʃ",
+    "ukphone": "",
+    "trans": [
+      "t. 出版，发行"
+    ]
+  },
+  {
+    "name": "pull",
+    "usphone": "pʊl",
+    "ukphone": "",
+    "trans": [
+      "拉，拖 n. 拉力，引力"
+    ]
+  },
+  {
+    "name": "pulse",
+    "usphone": "pʌls",
+    "ukphone": "",
+    "trans": [
+      "n. 脉搏，（光、能量、波等的）脉动，搏动"
+    ]
+  },
+  {
+    "name": "pump",
+    "usphone": "ˈpʌmp",
+    "ukphone": "",
+    "trans": [
+      "t. 用泵抽水"
+    ]
+  },
+  {
+    "name": "punctual",
+    "usphone": "ˈpʌŋktjʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 准时的"
+    ]
+  },
+  {
+    "name": "punctuate",
+    "usphone": "ˈpʌŋktjʊeɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 加标点"
+    ]
+  },
+  {
+    "name": "punctuation",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 标点符号"
+    ]
+  },
+  {
+    "name": "punish",
+    "usphone": "ˈpʌnɪʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 惩罚，处罚"
+    ]
+  },
+  {
+    "name": "punishment",
+    "usphone": "ˈpʌnɪʃmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 惩罚"
+    ]
+  },
+  {
+    "name": "pupil",
+    "usphone": "ˈpjuːpɪl",
+    "ukphone": "",
+    "trans": [
+      "n. （小）学生"
+    ]
+  },
+  {
+    "name": "purchase",
+    "usphone": "ˈpɜːtʃəs",
+    "ukphone": "",
+    "trans": [
+      "v. 购买，采购"
+    ]
+  },
+  {
+    "name": "pure",
+    "usphone": "pjʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 纯的, 不掺杂的"
+    ]
+  },
+  {
+    "name": "purple",
+    "usphone": "ˈpɜːp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. / a. 紫色"
+    ]
+  },
+  {
+    "name": "purpose",
+    "usphone": "ˈpɜːpəs",
+    "ukphone": "",
+    "trans": [
+      "n. 目的，意图"
+    ]
+  },
+  {
+    "name": "purse",
+    "usphone": "pɜːs",
+    "ukphone": "",
+    "trans": [
+      "n. 钱包"
+    ]
+  },
+  {
+    "name": "push",
+    "usphone": "pʊʃ",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 推"
+    ]
+  },
+  {
+    "name": "put (put, put)",
+    "usphone": "pʊt",
+    "ukphone": "",
+    "trans": [
+      "vt. 放，摆"
+    ]
+  },
+  {
+    "name": "puzzle",
+    "usphone": "ˈpʌz(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 难题,（字、画）谜"
+    ]
+  },
+  {
+    "name": "puzzled",
+    "usphone": "ˈpʌz(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 迷惑的，困惑的"
+    ]
+  },
+  {
+    "name": "pyramid",
+    "usphone": "ˈpɪrəmɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 角锥形，金字塔"
+    ]
+  },
+  {
+    "name": "quake",
+    "usphone": "kweɪk",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 震动，颤抖"
+    ]
+  },
+  {
+    "name": "qualification",
+    "usphone": "kwɔlɪfɪˈkeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 资格，学历"
+    ]
+  },
+  {
+    "name": "quality",
+    "usphone": "ˈkwɔlɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 质量，性质"
+    ]
+  },
+  {
+    "name": "quantity",
+    "usphone": "ˈkwɔntətɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 量，数"
+    ]
+  },
+  {
+    "name": "quarrel",
+    "usphone": "ˈkwɔrəl; (US) ˈkwɔːrəl",
+    "ukphone": "",
+    "trans": [
+      "vi. 争吵，吵架"
+    ]
+  },
+  {
+    "name": "quarter",
+    "usphone": "ˈkwɔːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 四分之一，一刻钟"
+    ]
+  },
+  {
+    "name": "queen",
+    "usphone": "kwiːn",
+    "ukphone": "",
+    "trans": [
+      "n. 皇后，女王"
+    ]
+  },
+  {
+    "name": "question",
+    "usphone": "ˈkwestʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "vt. 询问 n. 问题"
+    ]
+  },
+  {
+    "name": "questionnaire",
+    "usphone": "kwestʃəˈneə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 调查表，问卷"
+    ]
+  },
+  {
+    "name": "queue",
+    "usphone": "kjuː",
+    "ukphone": "",
+    "trans": [
+      "n. 行列，长队"
+    ]
+  },
+  {
+    "name": "quick",
+    "usphone": "kwɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 快；敏捷的；急剧的 ad. 快地；敏捷地；急剧地"
+    ]
+  },
+  {
+    "name": "quiet",
+    "usphone": "ˈkwaɪət",
+    "ukphone": "",
+    "trans": [
+      "a. 安静的；寂静的"
+    ]
+  },
+  {
+    "name": "quilt",
+    "usphone": "kwɪlt",
+    "ukphone": "",
+    "trans": [
+      "n. 被子；被状物"
+    ]
+  },
+  {
+    "name": "quit",
+    "usphone": "kwɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 离任，离校，戒掉"
+    ]
+  },
+  {
+    "name": "quite",
+    "usphone": "kwaɪt",
+    "ukphone": "",
+    "trans": [
+      "ad. 完全，十分"
+    ]
+  },
+  {
+    "name": "quiz",
+    "usphone": "kwɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 测验，小型考试"
+    ]
+  },
+  {
+    "name": "rabbit",
+    "usphone": "ˈræbɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 兔，家兔"
+    ]
+  },
+  {
+    "name": "race",
+    "usphone": "reɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 种族，民族 v. （速度）竞赛，比赛 n. 赛跑，竞赛"
+    ]
+  },
+  {
+    "name": "racial",
+    "usphone": "ˈreɪʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 种族的"
+    ]
+  },
+  {
+    "name": "radiation",
+    "usphone": "reɪdɪˈeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 放射，放射物"
+    ]
+  },
+  {
+    "name": "radio",
+    "usphone": "reɪdɪəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 无线电，收音机"
+    ]
+  },
+  {
+    "name": "radioactive",
+    "usphone": "reɪdɪəʊˈæktɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 放射性的"
+    ]
+  },
+  {
+    "name": "radium",
+    "usphone": "ˈreɪdɪəm",
+    "ukphone": "",
+    "trans": [
+      "n. 镭"
+    ]
+  },
+  {
+    "name": "rag",
+    "usphone": "ræɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 破布，抹布"
+    ]
+  },
+  {
+    "name": "rail",
+    "usphone": "reɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 铁路"
+    ]
+  },
+  {
+    "name": "railway",
+    "usphone": "ˈreɪlweɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 铁路；铁道"
+    ]
+  },
+  {
+    "name": "rain",
+    "usphone": "reɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 雨，雨水 vi. 下雨"
+    ]
+  },
+  {
+    "name": "rainbow",
+    "usphone": "ˈreɪnbəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 虹，彩虹"
+    ]
+  },
+  {
+    "name": "raincoat",
+    "usphone": "ˈreɪnkəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 雨衣"
+    ]
+  },
+  {
+    "name": "rainfall",
+    "usphone": "ˈreɪnfɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 一场雨； 降雨量"
+    ]
+  },
+  {
+    "name": "rainy",
+    "usphone": "ˈreɪnɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 下雨的；多雨的"
+    ]
+  },
+  {
+    "name": "raise",
+    "usphone": "reɪz",
+    "ukphone": "",
+    "trans": [
+      "vt. 使升高； 饲养"
+    ]
+  },
+  {
+    "name": "random",
+    "usphone": "ˈrændəm",
+    "ukphone": "",
+    "trans": [
+      "a.随意,未经事先考虑的"
+    ]
+  },
+  {
+    "name": "range",
+    "usphone": "reɪndʒ",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 变化，变动，排序"
+    ]
+  },
+  {
+    "name": "rank",
+    "usphone": "ræŋk",
+    "ukphone": "",
+    "trans": [
+      "n. 职衔，军衔"
+    ]
+  },
+  {
+    "name": "rapid",
+    "usphone": "ˈræpɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 快的，迅速的"
+    ]
+  },
+  {
+    "name": "rare",
+    "usphone": "reə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 罕见的，稀有的"
+    ]
+  },
+  {
+    "name": "rat",
+    "usphone": "ræt",
+    "ukphone": "",
+    "trans": [
+      "n. 老鼠"
+    ]
+  },
+  {
+    "name": "rate",
+    "usphone": "reɪt",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 率，评估，评价"
+    ]
+  },
+  {
+    "name": "rather",
+    "usphone": "ˈrɑːðə; (US) ˈræðər",
+    "ukphone": "",
+    "trans": [
+      "ad. 相当，宁可"
+    ]
+  },
+  {
+    "name": "raw",
+    "usphone": "rɔː",
+    "ukphone": "",
+    "trans": [
+      "a.生的,未煮过的,未加工的"
+    ]
+  },
+  {
+    "name": "raw material",
+    "usphone": "rɔː məˈtɪərɪəl",
+    "ukphone": "",
+    "trans": [
+      "原料"
+    ]
+  },
+  {
+    "name": "ray",
+    "usphone": "reɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 光辉，光线"
+    ]
+  },
+  {
+    "name": "razor",
+    "usphone": "ˈreɪzə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 剃须刀"
+    ]
+  },
+  {
+    "name": "reach",
+    "usphone": "riːtʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 到达，伸手(脚)够到"
+    ]
+  },
+  {
+    "name": "react",
+    "usphone": "riːˈækt",
+    "ukphone": "",
+    "trans": [
+      "v. 回应，过敏，起物理，化学反应"
+    ]
+  },
+  {
+    "name": "read (read, read)",
+    "usphone": "riːd",
+    "ukphone": "",
+    "trans": [
+      "v. 读；朗读"
+    ]
+  },
+  {
+    "name": "reading",
+    "usphone": "ʃɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. 阅读；朗读"
+    ]
+  },
+  {
+    "name": "ready",
+    "usphone": "ˈredɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 准备好的"
+    ]
+  },
+  {
+    "name": "real",
+    "usphone": "riːl",
+    "ukphone": "",
+    "trans": [
+      "a. 真实的，确实的"
+    ]
+  },
+  {
+    "name": "reality",
+    "usphone": "rɪˈælɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 现实"
+    ]
+  },
+  {
+    "name": "realise (美realize)",
+    "usphone": "ˈrɪəlaɪz",
+    "ukphone": "",
+    "trans": [
+      "vt.认识到,实现"
+    ]
+  },
+  {
+    "name": "really",
+    "usphone": "ˈrɪəlɪ",
+    "ukphone": "",
+    "trans": [
+      "adv. 真正地；到底；确实"
+    ]
+  },
+  {
+    "name": "reason",
+    "usphone": "ˈriːz(ə)n",
+    "ukphone": "",
+    "trans": [
+      "vi.评理,劝说n.理由,原因"
+    ]
+  },
+  {
+    "name": "reasonable",
+    "usphone": "ˈriːzənəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 合乎情理的"
+    ]
+  },
+  {
+    "name": "rebuild",
+    "usphone": "riːˈbɪld",
+    "ukphone": "",
+    "trans": [
+      "vt. 重建"
+    ]
+  },
+  {
+    "name": "receipt",
+    "usphone": "rɪˈsiːt",
+    "ukphone": "",
+    "trans": [
+      "n. 收据"
+    ]
+  },
+  {
+    "name": "receive",
+    "usphone": "rɪˈsiːv",
+    "ukphone": "",
+    "trans": [
+      "v. 收到，得到"
+    ]
+  },
+  {
+    "name": "receiver",
+    "usphone": "rɪˈsiːvə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 电话听筒"
+    ]
+  },
+  {
+    "name": "recent",
+    "usphone": "ˈriːsənt",
+    "ukphone": "",
+    "trans": [
+      "a. 近来的，最近的"
+    ]
+  },
+  {
+    "name": "reception",
+    "usphone": "rɪˈsepʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 接待"
+    ]
+  },
+  {
+    "name": "receptionist",
+    "usphone": "rɪˈsepʃənɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 接待员"
+    ]
+  },
+  {
+    "name": "recipe",
+    "usphone": "ˈresɪpɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 烹饪法，食谱"
+    ]
+  },
+  {
+    "name": "recite",
+    "usphone": "rɪˈsaɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 背诵"
+    ]
+  },
+  {
+    "name": "recognise (美recognize)",
+    "usphone": "ˈrekəɡnaɪz",
+    "ukphone": "",
+    "trans": [
+      "vt.认出"
+    ]
+  },
+  {
+    "name": "recommend",
+    "usphone": "rekəˈmend",
+    "ukphone": "",
+    "trans": [
+      "v. 推荐"
+    ]
+  },
+  {
+    "name": "record",
+    "usphone": "ˈrekɔːd; (US) ˈrekərd",
+    "ukphone": "",
+    "trans": [
+      "n. 记录；唱片"
+    ]
+  },
+  {
+    "name": "record holder",
+    "usphone": "ˈrekɔːd ˈhəʊldə(r)",
+    "ukphone": "",
+    "trans": [
+      "记录保持者"
+    ]
+  },
+  {
+    "name": "record",
+    "usphone": "ˈrekɔːd; (US) ˈrekərd",
+    "ukphone": "",
+    "trans": [
+      "v. 录制，记录"
+    ]
+  },
+  {
+    "name": "recorder",
+    "usphone": "rɪˈkɔːdə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 录音机"
+    ]
+  },
+  {
+    "name": "recover",
+    "usphone": "rɪˈkʌvə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 痊愈；恢复"
+    ]
+  },
+  {
+    "name": "recreation",
+    "usphone": "rekrɪˈeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 娱乐，消遣"
+    ]
+  },
+  {
+    "name": "recycle",
+    "usphone": "riːˈsaɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "vt. 回收；再循环"
+    ]
+  },
+  {
+    "name": "rectangle",
+    "usphone": "ˈrektæŋɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. & a.长方形,长方形的"
+    ]
+  },
+  {
+    "name": "red",
+    "usphone": "red",
+    "ukphone": "",
+    "trans": [
+      "n. 红色 a.红色的"
+    ]
+  },
+  {
+    "name": "redirect",
+    "usphone": "riːdaɪˈrekt",
+    "ukphone": "",
+    "trans": [
+      "vt. 使改变，使转移"
+    ]
+  },
+  {
+    "name": "reduce",
+    "usphone": "rɪˈdjuːs; (US) -ˈduːs",
+    "ukphone": "",
+    "trans": [
+      "vt. 减少，缩减"
+    ]
+  },
+  {
+    "name": "refer",
+    "usphone": "rɪˈfɜː(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 谈到,提到,涉及,有关"
+    ]
+  },
+  {
+    "name": "referee",
+    "usphone": "refəˈriː",
+    "ukphone": "",
+    "trans": [
+      "n. 裁判，仲裁，调解员"
+    ]
+  },
+  {
+    "name": "reference",
+    "usphone": "ˈref(ə)rəns",
+    "ukphone": "",
+    "trans": [
+      "n.提到,涉及,谈及,查询"
+    ]
+  },
+  {
+    "name": "reflect",
+    "usphone": "rɪˈflekt",
+    "ukphone": "",
+    "trans": [
+      "v. 反映，反射"
+    ]
+  },
+  {
+    "name": "reform",
+    "usphone": "rɪˈfɔːm",
+    "ukphone": "",
+    "trans": [
+      "v./ n. 改革，改进，改良"
+    ]
+  },
+  {
+    "name": "refresh",
+    "usphone": "rɪˈfreʃ",
+    "ukphone": "",
+    "trans": [
+      "v. 使恢复精力，提醒"
+    ]
+  },
+  {
+    "name": "refreshments",
+    "usphone": "rɪˈfreʃmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 点心，便餐；(会议后的)简单茶点招待"
+    ]
+  },
+  {
+    "name": "refrigerator",
+    "usphone": "rɪˈfrɪdʒəreɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 冰箱"
+    ]
+  },
+  {
+    "name": "refusal",
+    "usphone": "rɪˈfjuːz(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 拒绝"
+    ]
+  },
+  {
+    "name": "refuse",
+    "usphone": "rɪˈfjuːz",
+    "ukphone": "",
+    "trans": [
+      "vi. 拒绝，不愿"
+    ]
+  },
+  {
+    "name": "regard",
+    "usphone": "rɪˈɡɑːd",
+    "ukphone": "",
+    "trans": [
+      "v. 把……看作"
+    ]
+  },
+  {
+    "name": "regards",
+    "usphone": "rɪˈɡɑːd",
+    "ukphone": "",
+    "trans": [
+      "n. 问候，致意"
+    ]
+  },
+  {
+    "name": "regardless",
+    "usphone": "rɪˈɡɑːdlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 不顾，不加理会"
+    ]
+  },
+  {
+    "name": "register",
+    "usphone": "ˈredʒɪstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 登记簿，花名册，注册员 v. 登记，注册"
+    ]
+  },
+  {
+    "name": "regret",
+    "usphone": "rɪˈɡret",
+    "ukphone": "",
+    "trans": [
+      "n./ vt.可惜,遗憾;痛惜;哀悼"
+    ]
+  },
+  {
+    "name": "regular",
+    "usphone": "ˈreɡjʊlə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 规则的，经常"
+    ]
+  },
+  {
+    "name": "regulation",
+    "usphone": "reɡjʊˈleɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 规则，规章"
+    ]
+  },
+  {
+    "name": "reject",
+    "usphone": "rɪˈdʒekt",
+    "ukphone": "",
+    "trans": [
+      "v. 拒绝"
+    ]
+  },
+  {
+    "name": "relate",
+    "usphone": "rɪˈleɪt",
+    "ukphone": "",
+    "trans": [
+      "vi. 有关； 涉及"
+    ]
+  },
+  {
+    "name": "relation",
+    "usphone": "rɪˈleɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 关系； 亲属"
+    ]
+  },
+  {
+    "name": "relationship",
+    "usphone": "rɪˈleɪʃənʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 关系"
+    ]
+  },
+  {
+    "name": "relative",
+    "usphone": "ˈrelətɪv",
+    "ukphone": "",
+    "trans": [
+      "n. 亲属，亲戚"
+    ]
+  },
+  {
+    "name": "relax",
+    "usphone": "rɪˈlæks",
+    "ukphone": "",
+    "trans": [
+      "v. （使）放松，轻松"
+    ]
+  },
+  {
+    "name": "relay",
+    "usphone": "ˈriːleɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 接力，接替人，中转 v. 接替，补充；转运"
+    ]
+  },
+  {
+    "name": "relevant",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a. 紧密相关,有意义的"
+    ]
+  },
+  {
+    "name": "reliable",
+    "usphone": "rɪˈlaɪəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 可信赖的，可依靠的"
+    ]
+  },
+  {
+    "name": "relief",
+    "usphone": "rɪˈliːf",
+    "ukphone": "",
+    "trans": [
+      "n. 轻松,解脱,缓和,救济"
+    ]
+  },
+  {
+    "name": "religion",
+    "usphone": "rɪˈlɪdʒən",
+    "ukphone": "",
+    "trans": [
+      "n. 宗教"
+    ]
+  },
+  {
+    "name": "religious",
+    "usphone": "rɪˈlɪdʒəs",
+    "ukphone": "",
+    "trans": [
+      "a. 宗教的"
+    ]
+  },
+  {
+    "name": "rely",
+    "usphone": "rɪˈlaɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 依赖，依靠"
+    ]
+  },
+  {
+    "name": "remain",
+    "usphone": "rɪˈmeɪn",
+    "ukphone": "",
+    "trans": [
+      "vt.余下,留下vi.保持,仍是"
+    ]
+  },
+  {
+    "name": "remark",
+    "usphone": "rɪˈmɑːk",
+    "ukphone": "",
+    "trans": [
+      "n. 陈述；话；议论"
+    ]
+  },
+  {
+    "name": "remember",
+    "usphone": "rɪˈmembə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 记得，想起"
+    ]
+  },
+  {
+    "name": "remind",
+    "usphone": "rɪˈmaɪnd",
+    "ukphone": "",
+    "trans": [
+      "vt. 提醒，使记起"
+    ]
+  },
+  {
+    "name": "remote",
+    "usphone": "rɪˈməʊt",
+    "ukphone": "",
+    "trans": [
+      "a. 偏远的，偏僻的"
+    ]
+  },
+  {
+    "name": "remove",
+    "usphone": "rɪˈmuːv",
+    "ukphone": "",
+    "trans": [
+      "vt. 移动，拿走，脱掉（衣服等）"
+    ]
+  },
+  {
+    "name": "rent",
+    "usphone": "rent",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 租金"
+    ]
+  },
+  {
+    "name": "repair",
+    "usphone": "rɪˈpeə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 修理；修补"
+    ]
+  },
+  {
+    "name": "repairs",
+    "usphone": "rɪˈpeə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 修理工作"
+    ]
+  },
+  {
+    "name": "repeat",
+    "usphone": "rɪˈpiːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 重说，重做"
+    ]
+  },
+  {
+    "name": "replace",
+    "usphone": "rɪˈpleɪs",
+    "ukphone": "",
+    "trans": [
+      "vt. 取代"
+    ]
+  },
+  {
+    "name": "reply",
+    "usphone": "rɪˈplaɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 回答，答复"
+    ]
+  },
+  {
+    "name": "report",
+    "usphone": "rɪˈpɔːt",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 报道，报告"
+    ]
+  },
+  {
+    "name": "reporter",
+    "usphone": "rɪˈpɔːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 记者，新闻通讯员"
+    ]
+  },
+  {
+    "name": "represent",
+    "usphone": "reprɪˈzent",
+    "ukphone": "",
+    "trans": [
+      "vt. 代表"
+    ]
+  },
+  {
+    "name": "representative",
+    "usphone": "reprɪˈzentətɪv",
+    "ukphone": "",
+    "trans": [
+      "n.代表,典型人物"
+    ]
+  },
+  {
+    "name": "republic",
+    "usphone": "rɪˈpʌblɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 共和国"
+    ]
+  },
+  {
+    "name": "reputation",
+    "usphone": "repjʊˈteɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 名声，名誉"
+    ]
+  },
+  {
+    "name": "request",
+    "usphone": "rɪˈkwest",
+    "ukphone": "",
+    "trans": [
+      "n. 请求，要求的事物"
+    ]
+  },
+  {
+    "name": "require",
+    "usphone": "rɪˈkwaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 需求；要求"
+    ]
+  },
+  {
+    "name": "requirement",
+    "usphone": "rɪˈkwaɪəmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 需要； 要求； 必要的条件"
+    ]
+  },
+  {
+    "name": "rescue",
+    "usphone": "ˈreskjuː",
+    "ukphone": "",
+    "trans": [
+      "vt. 营救，援救"
+    ]
+  },
+  {
+    "name": "research",
+    "usphone": "rɪˈsɜːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 研究，调查"
+    ]
+  },
+  {
+    "name": "resemble",
+    "usphone": "rɪˈzemb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "v. （不用进行时）像，看起来像"
+    ]
+  },
+  {
+    "name": "reservation",
+    "usphone": "rezəˈveɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 预定"
+    ]
+  },
+  {
+    "name": "reserve",
+    "usphone": "rɪˈzɜːv",
+    "ukphone": "",
+    "trans": [
+      "n. & v. 储备；预定"
+    ]
+  },
+  {
+    "name": "resign",
+    "usphone": "rɪˈzaɪn",
+    "ukphone": "",
+    "trans": [
+      "v. 辞职"
+    ]
+  },
+  {
+    "name": "resist",
+    "usphone": "rɪˈzɪst",
+    "ukphone": "",
+    "trans": [
+      "v. 抵抗；挡开"
+    ]
+  },
+  {
+    "name": "respect",
+    "usphone": "rɪˈspekt",
+    "ukphone": "",
+    "trans": [
+      "vt.& n. 尊敬，尊重"
+    ]
+  },
+  {
+    "name": "respond",
+    "usphone": "rɪˈspekt",
+    "ukphone": "",
+    "trans": [
+      "v.回答,回应,作出反应"
+    ]
+  },
+  {
+    "name": "responsibility",
+    "usphone": "rɪspɔnsɪˈbɪlɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 责任，负责"
+    ]
+  },
+  {
+    "name": "rest",
+    "usphone": "rest",
+    "ukphone": "",
+    "trans": [
+      "n. 休息；剩余的部分，其余的人（物） vi. 休息，歇息"
+    ]
+  },
+  {
+    "name": "restaurant",
+    "usphone": "ˈrestərɔnt; (US) ˈrestərənt",
+    "ukphone": "",
+    "trans": [
+      "n. 饭馆, 饭店"
+    ]
+  },
+  {
+    "name": "restrict",
+    "usphone": "rɪˈstrɪkt",
+    "ukphone": "",
+    "trans": [
+      "v. 限制"
+    ]
+  },
+  {
+    "name": "restriction",
+    "usphone": "rɪˈstrɪkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 限制，约束"
+    ]
+  },
+  {
+    "name": "result",
+    "usphone": "rɪˈzʌlt",
+    "ukphone": "",
+    "trans": [
+      "n. 结果，效果"
+    ]
+  },
+  {
+    "name": "retell",
+    "usphone": "riːˈtel",
+    "ukphone": "",
+    "trans": [
+      "vt. 重讲，重复，复述"
+    ]
+  },
+  {
+    "name": "retire",
+    "usphone": "rɪˈtaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 退休"
+    ]
+  },
+  {
+    "name": "return",
+    "usphone": "rɪˈtɜːn",
+    "ukphone": "",
+    "trans": [
+      "v. 归还"
+    ]
+  },
+  {
+    "name": "reuse",
+    "usphone": "riːˈjuːz",
+    "ukphone": "",
+    "trans": [
+      "vt. 重新使用；循环使用"
+    ]
+  },
+  {
+    "name": "review",
+    "usphone": "rɪˈvjuː",
+    "ukphone": "",
+    "trans": [
+      "vt. 重新调查； 回顾； 复习 n. 复查；复习；评论"
+    ]
+  },
+  {
+    "name": "reviewer",
+    "usphone": "rɪˈvjuːə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 评论者；书评家"
+    ]
+  },
+  {
+    "name": "revision",
+    "usphone": "rɪˈvɪʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 复习，温习"
+    ]
+  },
+  {
+    "name": "revolution",
+    "usphone": "revəˈluːʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 革命，变革"
+    ]
+  },
+  {
+    "name": "reward",
+    "usphone": "rɪˈwɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 奖赏"
+    ]
+  },
+  {
+    "name": "rewind",
+    "usphone": "riːˈwaɪnd",
+    "ukphone": "",
+    "trans": [
+      "v. 回转（磁带等）"
+    ]
+  },
+  {
+    "name": "rewrite",
+    "usphone": "riːˈraɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 重写"
+    ]
+  },
+  {
+    "name": "rhyme",
+    "usphone": "raɪm",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 押韵"
+    ]
+  },
+  {
+    "name": "rice",
+    "usphone": "raɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 稻米；米饭"
+    ]
+  },
+  {
+    "name": "rich",
+    "usphone": "rɪtʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 富裕的，有钱的"
+    ]
+  },
+  {
+    "name": "rid (rid, rid / ridded, ridded)",
+    "usphone": "rɪd",
+    "ukphone": "",
+    "trans": [
+      "vt. 使摆脱"
+    ]
+  },
+  {
+    "name": "riddle",
+    "usphone": "ˈrɪd(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 谜(语)"
+    ]
+  },
+  {
+    "name": "ridiculous",
+    "usphone": "rɪˈdɪkjʊləs",
+    "ukphone": "",
+    "trans": [
+      "a. 荒谬的，愚蠢的"
+    ]
+  },
+  {
+    "name": "ride (rode, ridden)",
+    "usphone": "raɪd",
+    "ukphone": "",
+    "trans": [
+      "v. 骑（马、自行车）；乘车 n. 乘车旅行"
+    ]
+  },
+  {
+    "name": "right",
+    "usphone": "raɪt",
+    "ukphone": "",
+    "trans": [
+      "n.权利 a.对,正确的 ad. 正确地,恰恰,完全地 a. 右,右边的"
+    ]
+  },
+  {
+    "name": "right-handed",
+    "usphone": "raɪt-hænd",
+    "ukphone": "",
+    "trans": [
+      "a. 惯用右手的"
+    ]
+  },
+  {
+    "name": "right-wing",
+    "usphone": "raɪt-wɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 右翼"
+    ]
+  },
+  {
+    "name": "ring (rang, rung)",
+    "usphone": "rɪŋ",
+    "ukphone": "",
+    "trans": [
+      "v. （钟、铃等）响；打电话 n. 电话，铃声 n. 环形物（如环、圈、戒指等）"
+    ]
+  },
+  {
+    "name": "ring-road",
+    "usphone": "rɪŋ-rəʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 环形公路"
+    ]
+  },
+  {
+    "name": "rigid",
+    "usphone": "ˈrɪdʒɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 死板的,僵硬的,固执的"
+    ]
+  },
+  {
+    "name": "ripe",
+    "usphone": "raɪp",
+    "ukphone": "",
+    "trans": [
+      "a. 成熟的，熟的"
+    ]
+  },
+  {
+    "name": "ripen",
+    "usphone": "ˈraɪpən",
+    "ukphone": "",
+    "trans": [
+      "v. 成熟"
+    ]
+  },
+  {
+    "name": "rise (rose, risen)",
+    "usphone": "raɪz",
+    "ukphone": "",
+    "trans": [
+      "vi. 上升，上涨"
+    ]
+  },
+  {
+    "name": "risk",
+    "usphone": "rɪsk",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 危险，风险，冒险"
+    ]
+  },
+  {
+    "name": "river",
+    "usphone": "ˈrɪvə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 江；河；水道；巨流"
+    ]
+  },
+  {
+    "name": "road",
+    "usphone": "rəʊd",
+    "ukphone": "",
+    "trans": [
+      "n. 路，道路"
+    ]
+  },
+  {
+    "name": "roast",
+    "usphone": "rəʊst",
+    "ukphone": "",
+    "trans": [
+      "v. 烤（肉）"
+    ]
+  },
+  {
+    "name": "rob",
+    "usphone": "rɔb",
+    "ukphone": "",
+    "trans": [
+      "v. 抢夺，抢劫"
+    ]
+  },
+  {
+    "name": "robot",
+    "usphone": "ˈrəʊbɔt",
+    "ukphone": "",
+    "trans": [
+      "n. 机器人"
+    ]
+  },
+  {
+    "name": "rock",
+    "usphone": "rɔk",
+    "ukphone": "",
+    "trans": [
+      "n.岩石,大石头vt. 摇,摇晃"
+    ]
+  },
+  {
+    "name": "rocket",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 火箭"
+    ]
+  },
+  {
+    "name": "role",
+    "usphone": "rəʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 角色"
+    ]
+  },
+  {
+    "name": "roll",
+    "usphone": "rəʊl",
+    "ukphone": "",
+    "trans": [
+      "v. 滚动, 打滚 n. 面包圈，小圆面包；卷状物"
+    ]
+  },
+  {
+    "name": "roller",
+    "usphone": "ˈrəʊlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 滚筒； 辊"
+    ]
+  },
+  {
+    "name": "roller skatingn",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "滑旱冰"
+    ]
+  },
+  {
+    "name": "roof",
+    "usphone": "ruːf",
+    "ukphone": "",
+    "trans": [
+      "n. 屋顶，顶部"
+    ]
+  },
+  {
+    "name": "room",
+    "usphone": "rʊm",
+    "ukphone": "",
+    "trans": [
+      "n. 房间,室;空间;地方"
+    ]
+  },
+  {
+    "name": "rooster",
+    "usphone": "ˈruːstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. (美)公鸡"
+    ]
+  },
+  {
+    "name": "root",
+    "usphone": "ruːt",
+    "ukphone": "",
+    "trans": [
+      "n. 根，根源，起源"
+    ]
+  },
+  {
+    "name": "rope",
+    "usphone": "rəʊp",
+    "ukphone": "",
+    "trans": [
+      "n. 绳，索"
+    ]
+  },
+  {
+    "name": "rose",
+    "usphone": "rəʊz",
+    "ukphone": "",
+    "trans": [
+      "n. 玫瑰花"
+    ]
+  },
+  {
+    "name": "rot",
+    "usphone": "rɔt",
+    "ukphone": "",
+    "trans": [
+      "vi. 烂； 腐败"
+    ]
+  },
+  {
+    "name": "rough",
+    "usphone": "rʌf",
+    "ukphone": "",
+    "trans": [
+      "a. 粗糙的，粗略的"
+    ]
+  },
+  {
+    "name": "round",
+    "usphone": "raʊnd",
+    "ukphone": "",
+    "trans": [
+      "ad. 转过来 prep. 环绕一周，围着 a.圆的；球形的"
+    ]
+  },
+  {
+    "name": "roundabout",
+    "usphone": "ˈraʊndəbaʊt",
+    "ukphone": "",
+    "trans": [
+      "a. & n. 绕道的，不直接的；转盘路"
+    ]
+  },
+  {
+    "name": "routine",
+    "usphone": "ruːˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "n. 常规,正常顺序,无聊"
+    ]
+  },
+  {
+    "name": "row",
+    "usphone": "rəʊ",
+    "ukphone": "",
+    "trans": [
+      "n.（一）排,（一）行 v.划船"
+    ]
+  },
+  {
+    "name": "royal",
+    "usphone": "ˈrɔɪəl",
+    "ukphone": "",
+    "trans": [
+      "a. 皇家的，王室的，国王的，女王的"
+    ]
+  },
+  {
+    "name": "rubber",
+    "usphone": "ˈrʌbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 橡胶； 合成橡胶"
+    ]
+  },
+  {
+    "name": "rubbish",
+    "usphone": "ˈrʌbɪʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 垃圾； 废物"
+    ]
+  },
+  {
+    "name": "rude",
+    "usphone": "ruːd",
+    "ukphone": "",
+    "trans": [
+      "a. 无理的, 粗鲁的"
+    ]
+  },
+  {
+    "name": "rugby",
+    "usphone": "ˈrʌɡbɪ",
+    "ukphone": "",
+    "trans": [
+      "n. （英）橄榄球"
+    ]
+  },
+  {
+    "name": "ruin",
+    "usphone": "ˈruːɪn",
+    "ukphone": "",
+    "trans": [
+      "vt. （使）毁坏；（使） 毁灭 n. (复) 废墟；遗迹"
+    ]
+  },
+  {
+    "name": "rule",
+    "usphone": "ruːl",
+    "ukphone": "",
+    "trans": [
+      "n. 规则,规定 vt.统治,支配"
+    ]
+  },
+  {
+    "name": "ruler",
+    "usphone": "ˈruːlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 统治者；直尺"
+    ]
+  },
+  {
+    "name": "run (ran, run)",
+    "usphone": "rʌn",
+    "ukphone": "",
+    "trans": [
+      "vi. 跑，奔跑；（颜色）褪色"
+    ]
+  },
+  {
+    "name": "runner",
+    "usphone": "ˈrʌnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 赛跑者；操作者；滑行装置"
+    ]
+  },
+  {
+    "name": "running",
+    "usphone": "ˈrʌnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 跑步"
+    ]
+  },
+  {
+    "name": "rush",
+    "usphone": "rʌʃ",
+    "ukphone": "",
+    "trans": [
+      "vi. 冲，奔跑"
+    ]
+  },
+  {
+    "name": "Russia",
+    "usphone": "ˈrʌʃə",
+    "ukphone": "",
+    "trans": [
+      "* n. 俄罗斯，俄国"
+    ]
+  },
+  {
+    "name": "Russian",
+    "usphone": "ˈrʌʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 俄国人的，俄语的 n. 俄国人，俄语"
+    ]
+  },
+  {
+    "name": "sacred",
+    "usphone": "ˈseɪkrɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 害怕，恐惧，担心"
+    ]
+  },
+  {
+    "name": "sacrifice",
+    "usphone": "ˈsækrɪfaɪs",
+    "ukphone": "",
+    "trans": [
+      "vt. 牺牲"
+    ]
+  },
+  {
+    "name": "sad",
+    "usphone": "sæd",
+    "ukphone": "",
+    "trans": [
+      "a. （使人）悲伤的"
+    ]
+  },
+  {
+    "name": "sadness",
+    "usphone": "ˈsædnɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 悲哀，忧伤"
+    ]
+  },
+  {
+    "name": "safe",
+    "usphone": "seɪf",
+    "ukphone": "",
+    "trans": [
+      "a. 安全的 n. 保险柜"
+    ]
+  },
+  {
+    "name": "safety",
+    "usphone": "ˈseɪftɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 安全，保险"
+    ]
+  },
+  {
+    "name": "sail",
+    "usphone": "seɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 航行 v. 航行，开航"
+    ]
+  },
+  {
+    "name": "sailing",
+    "usphone": "ˈseɪlɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 航海"
+    ]
+  },
+  {
+    "name": "sailor",
+    "usphone": "ˈseɪlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 水手，海员"
+    ]
+  },
+  {
+    "name": "salad",
+    "usphone": "ˈsæləd",
+    "ukphone": "",
+    "trans": [
+      "n. 色拉（西餐中的一种菜）"
+    ]
+  },
+  {
+    "name": "salary",
+    "usphone": "ˈsælərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 薪金，薪水"
+    ]
+  },
+  {
+    "name": "sale",
+    "usphone": "seɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 卖，出售"
+    ]
+  },
+  {
+    "name": "salesgirl",
+    "usphone": "ˈseɪlzɡɜːl",
+    "ukphone": "",
+    "trans": [
+      "n. 女售货员"
+    ]
+  },
+  {
+    "name": "salesman",
+    "usphone": "ˈseɪlzmən",
+    "ukphone": "",
+    "trans": [
+      "n. 男售货员"
+    ]
+  },
+  {
+    "name": "saleswoman",
+    "usphone": "seɪlz‚wʊmən",
+    "ukphone": "",
+    "trans": [
+      "n. 女售货员"
+    ]
+  },
+  {
+    "name": "salt",
+    "usphone": "sɔːlt, sɔlt",
+    "ukphone": "",
+    "trans": [
+      "n. 盐"
+    ]
+  },
+  {
+    "name": "salty",
+    "usphone": "ˈsɔːltɪ, ˈsɔltɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 盐的，咸的，含盐的"
+    ]
+  },
+  {
+    "name": "salute",
+    "usphone": "səˈluːt, səˈljuːt",
+    "ukphone": "",
+    "trans": [
+      "v.& n. 敬礼"
+    ]
+  },
+  {
+    "name": "same",
+    "usphone": "seɪm",
+    "ukphone": "",
+    "trans": [
+      "n.同样的事a同样的,同一"
+    ]
+  },
+  {
+    "name": "sand",
+    "usphone": "sænd",
+    "ukphone": "",
+    "trans": [
+      "n. 沙，沙子"
+    ]
+  },
+  {
+    "name": "sandwich",
+    "usphone": "ˈsænwɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n.三明治（夹心面包片）"
+    ]
+  },
+  {
+    "name": "satellite",
+    "usphone": "ˈsætəlaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 卫星"
+    ]
+  },
+  {
+    "name": "satisfaction",
+    "usphone": "sætɪsˈfækʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 满意"
+    ]
+  },
+  {
+    "name": "satisfy",
+    "usphone": "ˈsætɪsfaɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 满足，使满意"
+    ]
+  },
+  {
+    "name": "Saturday",
+    "usphone": "ˈsætədeɪ, ˈsætədɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 星期六"
+    ]
+  },
+  {
+    "name": "sauce",
+    "usphone": "sɔːs",
+    "ukphone": "",
+    "trans": [
+      "n. 酱汁； 调味汁"
+    ]
+  },
+  {
+    "name": "saucer",
+    "usphone": "ˈsɔːsə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 茶碟，茶托，小圆盘"
+    ]
+  },
+  {
+    "name": "sausage",
+    "usphone": "ˈsɔsɪdʒ; (US) ˈsɔːsɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 香肠，腊肠"
+    ]
+  },
+  {
+    "name": "savage",
+    "usphone": "ˈsævɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 野蛮人，未开化的人"
+    ]
+  },
+  {
+    "name": "save",
+    "usphone": "seɪv",
+    "ukphone": "",
+    "trans": [
+      "vt. 救，挽救，节省"
+    ]
+  },
+  {
+    "name": "say (said, said)",
+    "usphone": "seɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 说，讲"
+    ]
+  },
+  {
+    "name": "saying",
+    "usphone": "ˈseɪɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 说，俗话，谚语"
+    ]
+  },
+  {
+    "name": "scan",
+    "usphone": "skæn",
+    "ukphone": "",
+    "trans": [
+      "v. 略读，浏览，扫描"
+    ]
+  },
+  {
+    "name": "scar",
+    "usphone": "skɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 伤疤，伤痕"
+    ]
+  },
+  {
+    "name": "scare",
+    "usphone": "skeə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 使害怕，使恐惧"
+    ]
+  },
+  {
+    "name": "scarf",
+    "usphone": "skɑːf",
+    "ukphone": "",
+    "trans": [
+      "n. 领巾，围巾"
+    ]
+  },
+  {
+    "name": "scene",
+    "usphone": "sɪːn",
+    "ukphone": "",
+    "trans": [
+      "n. （戏剧、电影等的）一场，场景，布景"
+    ]
+  },
+  {
+    "name": "scenery",
+    "usphone": "ˈsiːnərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 风景，景色，风光"
+    ]
+  },
+  {
+    "name": "sceptical (AmE skeptical)",
+    "usphone": "ˈskeptɪkl",
+    "ukphone": "",
+    "trans": [
+      "a.怀疑的"
+    ]
+  },
+  {
+    "name": "schedule",
+    "usphone": "ˈʃedjuːl; (US) ˈskedʒʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 工作计划，日程安排v. 安排时间，预定"
+    ]
+  },
+  {
+    "name": "school",
+    "usphone": "skuːl",
+    "ukphone": "",
+    "trans": [
+      "n. 学校"
+    ]
+  },
+  {
+    "name": "scholar",
+    "usphone": "ˈskɔlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 学者"
+    ]
+  },
+  {
+    "name": "scholarship",
+    "usphone": "ˈskɔləʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 奖学金"
+    ]
+  },
+  {
+    "name": "schoolbag",
+    "usphone": "ˈsku:lbæg",
+    "ukphone": "",
+    "trans": [
+      "n. 书包"
+    ]
+  },
+  {
+    "name": "school-leaver",
+    "usphone": "skuːl-",
+    "ukphone": "",
+    "trans": [
+      "n.(英)学校毕业生"
+    ]
+  },
+  {
+    "name": "schoolmate",
+    "usphone": "ˈskuːlmeɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 同校同学"
+    ]
+  },
+  {
+    "name": "science",
+    "usphone": "ˈsaɪəns",
+    "ukphone": "",
+    "trans": [
+      "n. 科学，自然科学"
+    ]
+  },
+  {
+    "name": "scientific",
+    "usphone": "saɪənˈtɪfɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 科学的"
+    ]
+  },
+  {
+    "name": "scientist",
+    "usphone": "ˈsaɪəntɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 科学家"
+    ]
+  },
+  {
+    "name": "scissors",
+    "usphone": "ˈsɪzəz",
+    "ukphone": "",
+    "trans": [
+      "n. 剪刀，剪子"
+    ]
+  },
+  {
+    "name": "scold",
+    "usphone": "skəʊld",
+    "ukphone": "",
+    "trans": [
+      "vt. 责骂"
+    ]
+  },
+  {
+    "name": "score",
+    "usphone": "skɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 得分，分数"
+    ]
+  },
+  {
+    "name": "scores",
+    "usphone": "skɔː(r) z",
+    "ukphone": "",
+    "trans": [
+      "n. 许多，很多"
+    ]
+  },
+  {
+    "name": "Scotland",
+    "usphone": "ˈskɔtlənd",
+    "ukphone": "",
+    "trans": [
+      "* n. 苏格兰"
+    ]
+  },
+  {
+    "name": "Scottish",
+    "usphone": "ˈskɔtɪʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 苏格兰（人）的 n. 苏格兰人"
+    ]
+  },
+  {
+    "name": "Scratch",
+    "usphone": " krætʃ ",
+    "ukphone": "",
+    "trans": [
+      "v./ n. 划破，划痕，划伤"
+    ]
+  },
+  {
+    "name": "scream",
+    "usphone": "skriːm",
+    "ukphone": "",
+    "trans": [
+      "n. 尖叫"
+    ]
+  },
+  {
+    "name": "screen",
+    "usphone": "skriːn",
+    "ukphone": "",
+    "trans": [
+      "n. 幕，荧光屏"
+    ]
+  },
+  {
+    "name": "sculpture",
+    "usphone": "ˈskʌlptʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 雕塑（术），雕刻（术），雕刻作品，雕像"
+    ]
+  },
+  {
+    "name": "sea",
+    "usphone": "siː",
+    "ukphone": "",
+    "trans": [
+      "n. 海，海洋"
+    ]
+  },
+  {
+    "name": "seagull",
+    "usphone": "ˈsiːɡʌl",
+    "ukphone": "",
+    "trans": [
+      "n. 海鸥"
+    ]
+  },
+  {
+    "name": "seal",
+    "usphone": "siːl",
+    "ukphone": "",
+    "trans": [
+      "n. 海豹"
+    ]
+  },
+  {
+    "name": "seaman",
+    "usphone": "ˈsiːmən",
+    "ukphone": "",
+    "trans": [
+      "n. 水手； 海员"
+    ]
+  },
+  {
+    "name": "search",
+    "usphone": "sɜːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 搜寻，搜查"
+    ]
+  },
+  {
+    "name": "seashell",
+    "usphone": "ˈsiːʃel",
+    "ukphone": "",
+    "trans": [
+      "n. 海贝"
+    ]
+  },
+  {
+    "name": "seaside",
+    "usphone": "ˈsiːsaɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 海滨"
+    ]
+  },
+  {
+    "name": "season",
+    "usphone": "ˈsiːz(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 季；季节"
+    ]
+  },
+  {
+    "name": "seat",
+    "usphone": "siːt",
+    "ukphone": "",
+    "trans": [
+      "n. 座位，座"
+    ]
+  },
+  {
+    "name": "seaweed",
+    "usphone": "ˈsiːwiːd",
+    "ukphone": "",
+    "trans": [
+      "n. 海草,海藻,海带"
+    ]
+  },
+  {
+    "name": "second",
+    "usphone": "ˈsekənd",
+    "ukphone": "",
+    "trans": [
+      "n.秒 num.第二a.第二的"
+    ]
+  },
+  {
+    "name": "secondhand",
+    "usphone": "ˈsekəndˈhænd",
+    "ukphone": "",
+    "trans": [
+      "n. 二手货; 旧货"
+    ]
+  },
+  {
+    "name": "secret",
+    "usphone": "ˈsiːkrɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 秘密，内情"
+    ]
+  },
+  {
+    "name": "secretary",
+    "usphone": "ˈsekrətərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 秘书；书记"
+    ]
+  },
+  {
+    "name": "section",
+    "usphone": "ˈsekʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 段，部分，部门"
+    ]
+  },
+  {
+    "name": "secure",
+    "usphone": "sɪˈkjʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "a.安心的,有把握的,牢靠的"
+    ]
+  },
+  {
+    "name": "security",
+    "usphone": "sɪˈkjʊərɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 安全，平安"
+    ]
+  },
+  {
+    "name": "see (saw, seen)",
+    "usphone": "siː",
+    "ukphone": "",
+    "trans": [
+      "vt. 看见，看到；领会；拜会"
+    ]
+  },
+  {
+    "name": "seed",
+    "usphone": "siːd",
+    "ukphone": "",
+    "trans": [
+      "n. 种子"
+    ]
+  },
+  {
+    "name": "melon seed",
+    "usphone": "ˈmelən siːd",
+    "ukphone": "",
+    "trans": [
+      "瓜子"
+    ]
+  },
+  {
+    "name": "seek (sought, sought)",
+    "usphone": "siːk",
+    "ukphone": "",
+    "trans": [
+      "vt.试图;探寻"
+    ]
+  },
+  {
+    "name": "seem",
+    "usphone": "siːm",
+    "ukphone": "",
+    "trans": [
+      "v. 似乎，好像"
+    ]
+  },
+  {
+    "name": "see-saw",
+    "usphone": "siː-sɔː",
+    "ukphone": "",
+    "trans": [
+      "n. 跷跷板（游戏）"
+    ]
+  },
+  {
+    "name": "seize",
+    "usphone": "siːz",
+    "ukphone": "",
+    "trans": [
+      "vt. 抓住(时机等)"
+    ]
+  },
+  {
+    "name": "seldom",
+    "usphone": "ˈseldəm",
+    "ukphone": "",
+    "trans": [
+      "ad. 很少，不常"
+    ]
+  },
+  {
+    "name": "select",
+    "usphone": "sɪˈlekt",
+    "ukphone": "",
+    "trans": [
+      "vt. 选择，挑选，选拔"
+    ]
+  },
+  {
+    "name": "self",
+    "usphone": "self",
+    "ukphone": "",
+    "trans": [
+      "n. 自己，自我，自身"
+    ]
+  },
+  {
+    "name": "selfish",
+    "usphone": "ˈselfɪʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 自私的"
+    ]
+  },
+  {
+    "name": "self-service",
+    "usphone": "self-ˈsɜːvɪs",
+    "ukphone": "",
+    "trans": [
+      "n.自助,自我服务的"
+    ]
+  },
+  {
+    "name": "sell (sold, sold)",
+    "usphone": "sel",
+    "ukphone": "",
+    "trans": [
+      "v. 卖，售"
+    ]
+  },
+  {
+    "name": "semicircle",
+    "usphone": "ˈsemɪsɜːk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 半圆"
+    ]
+  },
+  {
+    "name": "send (sent, sent)",
+    "usphone": "send",
+    "ukphone": "",
+    "trans": [
+      "v. 打发，派遣；送，邮寄"
+    ]
+  },
+  {
+    "name": "senior",
+    "usphone": "ˈsiːnɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 年长的,资深的,高年级的 n. 上级，长辈，高年级生"
+    ]
+  },
+  {
+    "name": "sense",
+    "usphone": "sens",
+    "ukphone": "",
+    "trans": [
+      "n. 感觉，意识"
+    ]
+  },
+  {
+    "name": "sensitive",
+    "usphone": "ˈsensɪtɪv",
+    "ukphone": "",
+    "trans": [
+      "a.体贴的,善解人意的"
+    ]
+  },
+  {
+    "name": "sentence",
+    "usphone": "ˈsent(ə)ns",
+    "ukphone": "",
+    "trans": [
+      "n. 句子"
+    ]
+  },
+  {
+    "name": "separate",
+    "usphone": "ˈsepərət",
+    "ukphone": "",
+    "trans": [
+      "v. 使分开，使分离a. 单独的，分开的"
+    ]
+  },
+  {
+    "name": "separately",
+    "usphone": "ˈsepərətlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 单独地，各自地"
+    ]
+  },
+  {
+    "name": "separation",
+    "usphone": "sepəˈreɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 分离，隔离"
+    ]
+  },
+  {
+    "name": "September",
+    "usphone": "səpˈtembə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 9月"
+    ]
+  },
+  {
+    "name": "serious",
+    "usphone": "ˈsɪərɪəs",
+    "ukphone": "",
+    "trans": [
+      "a.严肃的,严重的,认真的"
+    ]
+  },
+  {
+    "name": "servant",
+    "usphone": "ˈsɜːvənt",
+    "ukphone": "",
+    "trans": [
+      "n. 仆人，佣人"
+    ]
+  },
+  {
+    "name": "serve",
+    "usphone": "sɜːv",
+    "ukphone": "",
+    "trans": [
+      "vt. 招待（顾客等）,服务"
+    ]
+  },
+  {
+    "name": "service",
+    "usphone": "ˈsɜːvɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 服务"
+    ]
+  },
+  {
+    "name": "service-charge",
+    "usphone": "ˈsɜːvɪs-tʃɑːdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 服务费,小费"
+    ]
+  },
+  {
+    "name": "session",
+    "usphone": "ˈseʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.一场,一节,一段时间"
+    ]
+  },
+  {
+    "name": "set (set, set)",
+    "usphone": "set",
+    "ukphone": "",
+    "trans": [
+      "vt. 释放，安置 n. 装备，设备"
+    ]
+  },
+  {
+    "name": "settle",
+    "usphone": "ˈset(ə)l",
+    "ukphone": "",
+    "trans": [
+      "vi. 安家，定居"
+    ]
+  },
+  {
+    "name": "settlement",
+    "usphone": "ˈsetəlmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 新拓居地；（美）部落，村落"
+    ]
+  },
+  {
+    "name": "settler",
+    "usphone": "ˈsetlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 移居者，开拓者"
+    ]
+  },
+  {
+    "name": "seven",
+    "usphone": "ˈsev(ə)n",
+    "ukphone": "",
+    "trans": [
+      "num. 七"
+    ]
+  },
+  {
+    "name": "seventeen",
+    "usphone": "sevənˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "num. 十七"
+    ]
+  },
+  {
+    "name": "seventh",
+    "usphone": "ˈsevənθ",
+    "ukphone": "",
+    "trans": [
+      "num. 第七"
+    ]
+  },
+  {
+    "name": "seventy",
+    "usphone": "ˈsevəntɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 七十"
+    ]
+  },
+  {
+    "name": "several",
+    "usphone": "ˈsevr(ə)l",
+    "ukphone": "",
+    "trans": [
+      "pron. 几个,数个 a.若干"
+    ]
+  },
+  {
+    "name": "severe",
+    "usphone": "sɪˈvɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a.极为恶劣,十分严重的"
+    ]
+  },
+  {
+    "name": "sew (sewed, sewn 或sewed)",
+    "usphone": "səʊ",
+    "ukphone": "",
+    "trans": [
+      "vi. 缝, 缝制；缝补；缝纫"
+    ]
+  },
+  {
+    "name": "sex",
+    "usphone": "seks",
+    "ukphone": "",
+    "trans": [
+      "n. 性，性别"
+    ]
+  },
+  {
+    "name": "shabby",
+    "usphone": "ˈʃæbɪ",
+    "ukphone": "",
+    "trans": [
+      "a.破旧,破烂,衣衫褴褛的"
+    ]
+  },
+  {
+    "name": "shade",
+    "usphone": "ʃeɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 阴凉处，树荫处"
+    ]
+  },
+  {
+    "name": "shadow",
+    "usphone": "ˈʃædəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 影子, 阴影"
+    ]
+  },
+  {
+    "name": "shake (shook, shak en)",
+    "usphone": "ʃeɪk",
+    "ukphone": "",
+    "trans": [
+      "v. （使）动摇，震动"
+    ]
+  },
+  {
+    "name": "shall (should)",
+    "usphone": "ʃæl, ʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "v. aux. （表示将来）将要，会；……好吗"
+    ]
+  },
+  {
+    "name": "shallow",
+    "usphone": "ˈʃæləʊ",
+    "ukphone": "",
+    "trans": [
+      "a. 浅的,不深的,肤浅的"
+    ]
+  },
+  {
+    "name": "shame",
+    "usphone": "ʃeɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 遗憾的事；羞愧"
+    ]
+  },
+  {
+    "name": "Shanghai",
+    "usphone": "ʃæŋˈhaɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 上海"
+    ]
+  },
+  {
+    "name": "shape",
+    "usphone": "ʃeɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 形状，外形 v. 使成型，制造，塑造"
+    ]
+  },
+  {
+    "name": "share",
+    "usphone": "ʃeə(r)",
+    "ukphone": "",
+    "trans": [
+      "vt. 分享，共同使用"
+    ]
+  },
+  {
+    "name": "shark",
+    "usphone": "ʃɑːk",
+    "ukphone": "",
+    "trans": [
+      "n. 鲨鱼"
+    ]
+  },
+  {
+    "name": "sharp",
+    "usphone": "ʃɑːp",
+    "ukphone": "",
+    "trans": [
+      "a. 锋利的，尖的"
+    ]
+  },
+  {
+    "name": "sharpen",
+    "usphone": "ˈʃɑːpən",
+    "ukphone": "",
+    "trans": [
+      "v. （使）变锐利，削尖"
+    ]
+  },
+  {
+    "name": "sharpener",
+    "usphone": "ˈʃɑːpənə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 削尖用的器具"
+    ]
+  },
+  {
+    "name": "pencil- sharpener",
+    "usphone": "ˈpens(ə)l-ˈʃɑːpənə(r)",
+    "ukphone": "",
+    "trans": [
+      "转笔刀"
+    ]
+  },
+  {
+    "name": "shave (shaved, shaved 或 shaven)",
+    "usphone": "ʃeɪv",
+    "ukphone": "",
+    "trans": [
+      "v. 刮（脸，胡子）"
+    ]
+  },
+  {
+    "name": "shaver",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 电动剃须刀"
+    ]
+  },
+  {
+    "name": "she",
+    "usphone": "ʃiː",
+    "ukphone": "",
+    "trans": [
+      "pron. 她"
+    ]
+  },
+  {
+    "name": "sheep (复sheep)",
+    "usphone": "ʃiːp",
+    "ukphone": "",
+    "trans": [
+      "n. （绵）羊；羊皮；驯服者"
+    ]
+  },
+  {
+    "name": "sheet",
+    "usphone": "ʃiːt",
+    "ukphone": "",
+    "trans": [
+      "n. 成幅的薄片，薄板"
+    ]
+  },
+  {
+    "name": "shelf (复 shelves)",
+    "usphone": "ʃelf",
+    "ukphone": "",
+    "trans": [
+      "n. 架子；搁板；格层；礁；陆架"
+    ]
+  },
+  {
+    "name": "shelter",
+    "usphone": "ˈʃeltə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 掩蔽；隐蔽处"
+    ]
+  },
+  {
+    "name": "shine",
+    "usphone": "ʃaɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 光泽；光彩；阳光；晴天；光(亮)"
+    ]
+  },
+  {
+    "name": "shine (shone, shone 或-d, -d)",
+    "usphone": "ʃaɪn",
+    "ukphone": "",
+    "trans": [
+      "v. 发光；照耀；杰出；擦亮"
+    ]
+  },
+  {
+    "name": "ship",
+    "usphone": "ʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 船，轮船 vi. 用船装运"
+    ]
+  },
+  {
+    "name": "shirt",
+    "usphone": "ʃɜːt",
+    "ukphone": "",
+    "trans": [
+      "vn. 男衬衫"
+    ]
+  },
+  {
+    "name": "shock",
+    "usphone": "ʃɔk",
+    "ukphone": "",
+    "trans": [
+      "vt. 使震惊"
+    ]
+  },
+  {
+    "name": "shoe",
+    "usphone": "ʃuː",
+    "ukphone": "",
+    "trans": [
+      "n. 鞋"
+    ]
+  },
+  {
+    "name": "shoot",
+    "usphone": "ʃuːt",
+    "ukphone": "",
+    "trans": [
+      "(shot, shot) vt. 射击，射中，发射 n. 嫩枝；苗；芽"
+    ]
+  },
+  {
+    "name": "shooting",
+    "usphone": "ˈʃuːtɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 射击"
+    ]
+  },
+  {
+    "name": "shop",
+    "usphone": "ʃɔp",
+    "ukphone": "",
+    "trans": [
+      "vi. 买东西 n. 商店,车间"
+    ]
+  },
+  {
+    "name": "shop assistant",
+    "usphone": "ʃɔp əˈsɪst(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "(英) 售货员"
+    ]
+  },
+  {
+    "name": "shopkeeper",
+    "usphone": "ˈʃɔpkiːpə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 店主，零售商人"
+    ]
+  },
+  {
+    "name": "shopping",
+    "usphone": "ˈʃɔpɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 买东西"
+    ]
+  },
+  {
+    "name": "shore",
+    "usphone": "ʃɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 滨，岸"
+    ]
+  },
+  {
+    "name": "short",
+    "usphone": "ʃɔːt",
+    "ukphone": "",
+    "trans": [
+      "a. 短的；矮的"
+    ]
+  },
+  {
+    "name": "shortcoming",
+    "usphone": "ˈʃɔːtkʌmɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 缺点，短处"
+    ]
+  },
+  {
+    "name": "shortly",
+    "usphone": "ˈʃɔːtlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 不久"
+    ]
+  },
+  {
+    "name": "shorts",
+    "usphone": "ʃɔːts",
+    "ukphone": "",
+    "trans": [
+      "n. 短裤；运动短裤"
+    ]
+  },
+  {
+    "name": "short wave",
+    "usphone": "ʃɔːt",
+    "ukphone": "",
+    "trans": [
+      ""
+    ]
+  },
+  {
+    "name": "[weɪv]",
+    "usphone": "n. 短波",
+    "ukphone": "",
+    "trans": [
+      "shot"
+    ]
+  },
+  {
+    "name": "[ʃɔt]",
+    "usphone": "n. 射击，开枪，开炮，射击声；子弹",
+    "ukphone": "",
+    "trans": [
+      "should"
+    ]
+  },
+  {
+    "name": "[ʃɔt]",
+    "usphone": "v. mod. 应当，应该，会 v. aux.会,应该（shall的过去时态）",
+    "ukphone": "",
+    "trans": [
+      "shoulder"
+    ]
+  },
+  {
+    "name": "[ˈʃəʊldə(r)]",
+    "usphone": "n. 肩膀,(道路的)路肩",
+    "ukphone": "",
+    "trans": [
+      "shout"
+    ]
+  },
+  {
+    "name": "[ˈʃəʊldə(r)]",
+    "usphone": "n.& v. 喊，高声呼喊",
+    "ukphone": "",
+    "trans": [
+      "show"
+    ]
+  },
+  {
+    "name": "[ʃəʊ]",
+    "usphone": "n. 展示,展览（会）;演出",
+    "ukphone": "",
+    "trans": [
+      "show"
+    ]
+  },
+  {
+    "name": "[ʃəʊ]",
+    "usphone": "(showed, shown 或 showed) v. 给…看,出示,显示",
+    "ukphone": "",
+    "trans": [
+      "shower"
+    ]
+  },
+  {
+    "name": "[ˈʃaʊə(r)]",
+    "usphone": "n. 阵雨；淋浴",
+    "ukphone": "",
+    "trans": [
+      "shrink (shrank, shrunk / shrunk, shrunken)"
+    ]
+  },
+  {
+    "name": "[ʃrɪŋk]",
+    "usphone": "v. 缩小，收缩，减少",
+    "ukphone": "",
+    "trans": [
+      "shut (shut, shut)"
+    ]
+  },
+  {
+    "name": "[ʃʌt]",
+    "usphone": "v. / n. 关上，封闭；禁闭；",
+    "ukphone": "",
+    "trans": [
+      "shuttle"
+    ]
+  },
+  {
+    "name": "[ˈʃʌt(ə)l]",
+    "usphone": "vn. 合拢 （往返与两个定点之间的）（火车汽车飞机）班车/机",
+    "ukphone": "",
+    "trans": [
+      "shyv"
+    ]
+  },
+  {
+    "name": "[ʃaɪ]",
+    "usphone": "a. 害羞的",
+    "ukphone": "",
+    "trans": [
+      "sick"
+    ]
+  },
+  {
+    "name": "[sɪk]",
+    "usphone": "a.有病,患病的,（想）呕吐",
+    "ukphone": "",
+    "trans": [
+      "sickness"
+    ]
+  },
+  {
+    "name": "[ˈsɪknɪs]",
+    "usphone": "n. 疾病",
+    "ukphone": "",
+    "trans": [
+      "side"
+    ]
+  },
+  {
+    "name": "[ˈsɪknɪs]",
+    "usphone": "n. 边，旁边，面，侧面",
+    "ukphone": "",
+    "trans": [
+      "sideroad (AmE sidewalk) n.人行道"
+    ]
+  },
+  {
+    "name": "sideway",
+    "usphone": "ˈsaɪdweɪz",
+    "ukphone": "",
+    "trans": [
+      "n. 岔路，旁路"
+    ]
+  },
+  {
+    "name": "sideways",
+    "usphone": "ˈsaɪdweɪz",
+    "ukphone": "",
+    "trans": [
+      "ad. 斜向一边的"
+    ]
+  },
+  {
+    "name": "sigh",
+    "usphone": "saɪ",
+    "ukphone": "",
+    "trans": [
+      "vi. 叹息；叹气"
+    ]
+  },
+  {
+    "name": "sight",
+    "usphone": "saɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 情景，风景；视力"
+    ]
+  },
+  {
+    "name": "sightseeing",
+    "usphone": "ˈsaɪtsiːɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 游览，观光"
+    ]
+  },
+  {
+    "name": "sign",
+    "usphone": "saɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 符号，标记"
+    ]
+  },
+  {
+    "name": "signal",
+    "usphone": "ˈsɪɡn(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 信号，暗号"
+    ]
+  },
+  {
+    "name": "signature",
+    "usphone": "ˈsɪɡnətʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 签名"
+    ]
+  },
+  {
+    "name": "significance",
+    "usphone": "ˈsɪɡnətʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 重要性，意义"
+    ]
+  },
+  {
+    "name": "silence",
+    "usphone": "ˈsaɪləns",
+    "ukphone": "",
+    "trans": [
+      "n. 安静，沉默"
+    ]
+  },
+  {
+    "name": "silent",
+    "usphone": "ˈsaɪlənt",
+    "ukphone": "",
+    "trans": [
+      "a. 无声的，无对话的"
+    ]
+  },
+  {
+    "name": "silk",
+    "usphone": "sɪlk",
+    "ukphone": "",
+    "trans": [
+      "n. （蚕）丝，丝织品"
+    ]
+  },
+  {
+    "name": "silly",
+    "usphone": "ˈsɪlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 傻的，愚蠢的"
+    ]
+  },
+  {
+    "name": "silver",
+    "usphone": "ˈsɪlvə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 银"
+    ]
+  },
+  {
+    "name": "similar",
+    "usphone": "ˈsɪmɪlə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 相似的，像"
+    ]
+  },
+  {
+    "name": "simple",
+    "usphone": "ˈsɪmp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 简单的，简易的"
+    ]
+  },
+  {
+    "name": "simple-minded",
+    "usphone": "ˈsɪmp(ə)l maɪndɪ",
+    "ukphone": "",
+    "trans": [
+      "a.纯朴,头脑简单"
+    ]
+  },
+  {
+    "name": "simplify",
+    "usphone": "ˈsɪmplɪfaɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 使简化，使简易"
+    ]
+  },
+  {
+    "name": "simply",
+    "usphone": "ˈsɪmplɪ",
+    "ukphone": "",
+    "trans": [
+      "ad.简单地,(加强语气)的确"
+    ]
+  },
+  {
+    "name": "since",
+    "usphone": "sɪns",
+    "ukphone": "",
+    "trans": [
+      "ad. 从那时以来 conj. 从…以来，…以后，由于 prep. 从…以来"
+    ]
+  },
+  {
+    "name": "sincerely",
+    "usphone": "sɪnˈsɪrlɪ /-ˈsɪəl-",
+    "ukphone": "",
+    "trans": [
+      "ad. 真诚地"
+    ]
+  },
+  {
+    "name": "sing (sang, sung)",
+    "usphone": "sɪŋ",
+    "ukphone": "",
+    "trans": [
+      "v. 唱，唱歌"
+    ]
+  },
+  {
+    "name": "singer",
+    "usphone": "sɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 歌唱家，歌手"
+    ]
+  },
+  {
+    "name": "single",
+    "usphone": "ˈsɪŋɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 单一的，单个的"
+    ]
+  },
+  {
+    "name": "sink",
+    "usphone": "sɪŋk",
+    "ukphone": "",
+    "trans": [
+      "n. 洗涤槽；污水槽"
+    ]
+  },
+  {
+    "name": "sink (sank, sunk)",
+    "usphone": "sɪŋk",
+    "ukphone": "",
+    "trans": [
+      "vi. 下沉；消沉"
+    ]
+  },
+  {
+    "name": "sir",
+    "usphone": "sɜː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 先生；阁下"
+    ]
+  },
+  {
+    "name": "sister",
+    "usphone": "ˈsɪstə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 姐；妹"
+    ]
+  },
+  {
+    "name": "sister-in-law",
+    "usphone": "ˈsɪstə(r) -ɪn-lɔː",
+    "ukphone": "",
+    "trans": [
+      "n. 嫂，弟媳"
+    ]
+  },
+  {
+    "name": "sit (sat, sat)",
+    "usphone": "sɪt",
+    "ukphone": "",
+    "trans": [
+      "vi. 坐"
+    ]
+  },
+  {
+    "name": "situation",
+    "usphone": "sɪtjʊˈeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 形势，情况"
+    ]
+  },
+  {
+    "name": "six",
+    "usphone": "sɪks",
+    "ukphone": "",
+    "trans": [
+      "num. 六"
+    ]
+  },
+  {
+    "name": "sixth",
+    "usphone": "sɪksθ",
+    "ukphone": "",
+    "trans": [
+      "num. 第六"
+    ]
+  },
+  {
+    "name": "sixty",
+    "usphone": "ˈsɪkstɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 六十"
+    ]
+  },
+  {
+    "name": "sixteen",
+    "usphone": "ˈsɪkstɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 十六"
+    ]
+  },
+  {
+    "name": "sixteenth",
+    "usphone": "sɪksˈtiːnθ",
+    "ukphone": "",
+    "trans": [
+      "num. 第十六"
+    ]
+  },
+  {
+    "name": "size",
+    "usphone": "sɪksˈtiːnθ",
+    "ukphone": "",
+    "trans": [
+      "n. 尺寸，大小"
+    ]
+  },
+  {
+    "name": "skate",
+    "usphone": "sɪksˈtiːnθ",
+    "ukphone": "",
+    "trans": [
+      "vi. 溜冰，滑冰"
+    ]
+  },
+  {
+    "name": "skateboard",
+    "usphone": "ˈskeɪtbɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 冰鞋，滑板"
+    ]
+  },
+  {
+    "name": "ski",
+    "usphone": "skiː",
+    "ukphone": "",
+    "trans": [
+      "n.& vi. 滑雪板；滑雪"
+    ]
+  },
+  {
+    "name": "skill",
+    "usphone": "skiː",
+    "ukphone": "",
+    "trans": [
+      "n. 技能，技巧"
+    ]
+  },
+  {
+    "name": "skilled",
+    "usphone": "skiː",
+    "ukphone": "",
+    "trans": [
+      "a. 熟练的；有技能的"
+    ]
+  },
+  {
+    "name": "skillful",
+    "usphone": "ˈskɪlf(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 熟练,精湛的,灵巧的"
+    ]
+  },
+  {
+    "name": "skillfully",
+    "usphone": "ˈskilfuli",
+    "ukphone": "",
+    "trans": [
+      "ad. 精湛地,巧妙地"
+    ]
+  },
+  {
+    "name": "skin",
+    "usphone": "skɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 皮，皮肤；兽皮"
+    ]
+  },
+  {
+    "name": "skip",
+    "usphone": "skɪp",
+    "ukphone": "",
+    "trans": [
+      "v. 蹦蹦跳跳；跳绳"
+    ]
+  },
+  {
+    "name": "skipping",
+    "usphone": "skɪpɪŋ",
+    "ukphone": "",
+    "trans": [
+      "rope （跳绳用）绳"
+    ]
+  },
+  {
+    "name": "skirt",
+    "usphone": "skɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. 女裙"
+    ]
+  },
+  {
+    "name": "sky",
+    "usphone": "skaɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 天；天空"
+    ]
+  },
+  {
+    "name": "skyscraper",
+    "usphone": "ˈskaɪskreɪpə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 摩天楼"
+    ]
+  },
+  {
+    "name": "slave",
+    "usphone": "sleɪv",
+    "ukphone": "",
+    "trans": [
+      "n. 奴隶"
+    ]
+  },
+  {
+    "name": "slavery",
+    "usphone": "ˈsleɪvərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 奴隶制度"
+    ]
+  },
+  {
+    "name": "sleep",
+    "usphone": "sliːp",
+    "ukphone": "",
+    "trans": [
+      "n. 睡觉"
+    ]
+  },
+  {
+    "name": "sleep (slept, slept)",
+    "usphone": "sliːp",
+    "ukphone": "",
+    "trans": [
+      "vi. 睡觉"
+    ]
+  },
+  {
+    "name": "sleepy",
+    "usphone": "sliːp",
+    "ukphone": "",
+    "trans": [
+      "a. 想睡的,困倦的,瞌睡的"
+    ]
+  },
+  {
+    "name": "sleeve",
+    "usphone": "sliːv",
+    "ukphone": "",
+    "trans": [
+      "n. 袖子，袖套"
+    ]
+  },
+  {
+    "name": "slice",
+    "usphone": "sliːv",
+    "ukphone": "",
+    "trans": [
+      "n. 片，切面（薄）片"
+    ]
+  },
+  {
+    "name": "slide",
+    "usphone": "slaɪd",
+    "ukphone": "",
+    "trans": [
+      "n.幻灯片,滑道 v.滑行,滑动"
+    ]
+  },
+  {
+    "name": "slight",
+    "usphone": "slaɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 轻微的，细小的"
+    ]
+  },
+  {
+    "name": "slim",
+    "usphone": "slɪm",
+    "ukphone": "",
+    "trans": [
+      "a. 苗条的，纤细的"
+    ]
+  },
+  {
+    "name": "slip",
+    "usphone": "slɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 片，条，纸片，纸条"
+    ]
+  },
+  {
+    "name": "slow",
+    "usphone": "slɪp",
+    "ukphone": "",
+    "trans": [
+      "ad. 慢慢地，缓慢地"
+    ]
+  },
+  {
+    "name": "small",
+    "usphone": "smɔːl",
+    "ukphone": "",
+    "trans": [
+      "a. 小的，少的"
+    ]
+  },
+  {
+    "name": "smart",
+    "usphone": "smɑːt",
+    "ukphone": "",
+    "trans": [
+      "a. 灵巧的，伶俐的；（人、服装等）时髦的，帅的"
+    ]
+  },
+  {
+    "name": "smell (smelt, smelt 或-ed,-ed)",
+    "usphone": "smel",
+    "ukphone": "",
+    "trans": [
+      "v. 嗅，闻到；发气味 n. 气味"
+    ]
+  },
+  {
+    "name": "smelly",
+    "usphone": "ˈsmelɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 有臭味的,发出臭味的"
+    ]
+  },
+  {
+    "name": "smile",
+    "usphone": "smaɪl",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 微笑"
+    ]
+  },
+  {
+    "name": "smog",
+    "usphone": "smaɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 烟雾(= smoke + fog)"
+    ]
+  },
+  {
+    "name": "smoke",
+    "usphone": "smaɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 烟 v. 冒烟；吸烟"
+    ]
+  },
+  {
+    "name": "smoke-free",
+    "usphone": "sməʊk-friː",
+    "ukphone": "",
+    "trans": [
+      "a. 非吸烟的,无烟的"
+    ]
+  },
+  {
+    "name": "smoker",
+    "usphone": "ˈsməʊkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 吸烟者"
+    ]
+  },
+  {
+    "name": "smoking",
+    "usphone": "ˈsməʊkɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 吸烟,抽烟;冒烟"
+    ]
+  },
+  {
+    "name": "smooth",
+    "usphone": "ˈsməʊkɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 光滑的;平坦的"
+    ]
+  },
+  {
+    "name": "snack",
+    "usphone": "snæk",
+    "ukphone": "",
+    "trans": [
+      "n. 小吃"
+    ]
+  },
+  {
+    "name": "snack bar",
+    "usphone": "snæk bɑː",
+    "ukphone": "",
+    "trans": [
+      "n. 快餐店"
+    ]
+  },
+  {
+    "name": "snake",
+    "usphone": "sneɪk",
+    "ukphone": "",
+    "trans": [
+      "n.蛇v.蛇般爬行;蜿蜒行进"
+    ]
+  },
+  {
+    "name": "snatch",
+    "usphone": "sneɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 夺，夺得，夺走"
+    ]
+  },
+  {
+    "name": "sneaker",
+    "usphone": "sneɪk",
+    "ukphone": "",
+    "trans": [
+      "n. （复）轻便运动鞋（美）"
+    ]
+  },
+  {
+    "name": "sneeze",
+    "usphone": "sneɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 打喷嚏"
+    ]
+  },
+  {
+    "name": "sniff",
+    "usphone": "snɪf",
+    "ukphone": "",
+    "trans": [
+      "v. 抽鼻子（哭,患感冒时）"
+    ]
+  },
+  {
+    "name": "snow",
+    "usphone": "snəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 雪 vi.下雪"
+    ]
+  },
+  {
+    "name": "snowball",
+    "usphone": "ˈsnəʊbɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 雪球"
+    ]
+  },
+  {
+    "name": "snowman",
+    "usphone": "ˈsnəʊmæn",
+    "ukphone": "",
+    "trans": [
+      "n. 雪人"
+    ]
+  },
+  {
+    "name": "snowy",
+    "usphone": "ˈsnəʊɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 雪(白)的；下雪的；多(积)雪的"
+    ]
+  },
+  {
+    "name": "so",
+    "usphone": "səʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. 如此，这么；非常；同样 conj. 因此，所以"
+    ]
+  },
+  {
+    "name": "soap",
+    "usphone": "səʊp",
+    "ukphone": "",
+    "trans": [
+      "n. 肥皂"
+    ]
+  },
+  {
+    "name": "sob",
+    "usphone": "səʊp",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 抽泣，啜泣"
+    ]
+  },
+  {
+    "name": "soccer",
+    "usphone": "ˈsɔkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.英式足球"
+    ]
+  },
+  {
+    "name": "social",
+    "usphone": "ˈsəʊʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 社会的；社交的"
+    ]
+  },
+  {
+    "name": "socialism",
+    "usphone": "ˈsəʊʃəlɪz(ə)m",
+    "ukphone": "",
+    "trans": [
+      "n. 社会主义"
+    ]
+  },
+  {
+    "name": "socialist",
+    "usphone": "ˈsəʊʃəlɪst",
+    "ukphone": "",
+    "trans": [
+      "a. 社会主义的"
+    ]
+  },
+  {
+    "name": "society",
+    "usphone": "səˈsaɪətɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 社会"
+    ]
+  },
+  {
+    "name": "sock",
+    "usphone": "sɔk",
+    "ukphone": "",
+    "trans": [
+      "n. 短袜"
+    ]
+  },
+  {
+    "name": "socket",
+    "usphone": "ˈsɔkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. （电源）插座"
+    ]
+  },
+  {
+    "name": "sofa",
+    "usphone": "ˈsɔkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. （长）沙发"
+    ]
+  },
+  {
+    "name": "soft sɔft; (US) sɔːft]",
+    "usphone": "a. 软的，柔和的",
+    "ukphone": "",
+    "trans": [
+      "software"
+    ]
+  },
+  {
+    "name": "[sɔft; (US) sɔːft]",
+    "usphone": "n. 软件",
+    "ukphone": "",
+    "trans": [
+      "soft drink"
+    ]
+  },
+  {
+    "name": "[sɔft drɪŋk]",
+    "usphone": "n. (不含酒精)清凉饮料",
+    "ukphone": "",
+    "trans": [
+      "softball"
+    ]
+  },
+  {
+    "name": "[ˈsɔftbɔːl]",
+    "usphone": "n. 垒球",
+    "ukphone": "",
+    "trans": [
+      "soil"
+    ]
+  },
+  {
+    "name": "[sɔɪl]",
+    "usphone": "n. 土壤，土地",
+    "ukphone": "",
+    "trans": [
+      "solar"
+    ]
+  },
+  {
+    "name": "[ˈsəʊlə(r)]",
+    "usphone": "a. 太阳的",
+    "ukphone": "",
+    "trans": [
+      "soldier"
+    ]
+  },
+  {
+    "name": "[ˈsəʊldʒə(r)]",
+    "usphone": "n. 士兵，战士",
+    "ukphone": "",
+    "trans": [
+      "solid"
+    ]
+  },
+  {
+    "name": "[ˈsɔlɪd]",
+    "usphone": "a. 结实的,固体的 n.固体",
+    "ukphone": "",
+    "trans": [
+      "some"
+    ]
+  },
+  {
+    "name": "[sʌm]",
+    "usphone": "a. 一些，若干；有些；某一 pron. 若干，一些",
+    "ukphone": "",
+    "trans": [
+      "somebody"
+    ]
+  },
+  {
+    "name": "[ˈsʌmbʌdɪ; ˈsʌmbədɪ]",
+    "usphone": "pron. 某人；有人；有名气的人",
+    "ukphone": "",
+    "trans": [
+      "someone"
+    ]
+  },
+  {
+    "name": "[ˈsʌmwʌn]",
+    "usphone": "pron. 某一个人",
+    "ukphone": "",
+    "trans": [
+      "something"
+    ]
+  },
+  {
+    "name": "[ˈsʌmθɪŋ]",
+    "usphone": "pron. 某事；某物",
+    "ukphone": "",
+    "trans": [
+      "sometimes"
+    ]
+  },
+  {
+    "name": "[ˈsʌmtaɪmz]",
+    "usphone": "ad. 有时",
+    "ukphone": "",
+    "trans": [
+      "somewhere"
+    ]
+  },
+  {
+    "name": "[ˈsʌmtaɪmz]",
+    "usphone": "ad. 在某处",
+    "ukphone": "",
+    "trans": [
+      "son"
+    ]
+  },
+  {
+    "name": "[sʌn]",
+    "usphone": "n. 儿子",
+    "ukphone": "",
+    "trans": [
+      "song"
+    ]
+  },
+  {
+    "name": "[sʌn]",
+    "usphone": "n. 歌唱；歌曲",
+    "ukphone": "",
+    "trans": [
+      "soon"
+    ]
+  },
+  {
+    "name": "[sʌn]",
+    "usphone": "ad. 不久,很快,一会儿",
+    "ukphone": "",
+    "trans": [
+      "sorrow"
+    ]
+  },
+  {
+    "name": "[ˈsɔrəʊ]",
+    "usphone": "n. 悲伤，悲痛",
+    "ukphone": "",
+    "trans": [
+      "sorry"
+    ]
+  },
+  {
+    "name": "[ˈsɔrɪ]",
+    "usphone": "a. 对不起,抱歉;难过的",
+    "ukphone": "",
+    "trans": [
+      "sort"
+    ]
+  },
+  {
+    "name": "[sɔːt]",
+    "usphone": "v",
+    "ukphone": "",
+    "trans": [
+      "t. 把…分类，拣选 n. 种类，类别"
+    ]
+  },
+  {
+    "name": "so-so",
+    "usphone": "səʊ-səʊ",
+    "ukphone": "",
+    "trans": [
+      "a. 一般；不怎么样；凑合"
+    ]
+  },
+  {
+    "name": "soul",
+    "usphone": "səʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 灵魂；心灵；气魄"
+    ]
+  },
+  {
+    "name": "sound",
+    "usphone": "saʊnd",
+    "ukphone": "",
+    "trans": [
+      "vi.听起来,发出声音n.声音"
+    ]
+  },
+  {
+    "name": "soup",
+    "usphone": "suːp",
+    "ukphone": "",
+    "trans": [
+      "n. 汤"
+    ]
+  },
+  {
+    "name": "sour",
+    "usphone": "ˈsaʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 酸的，馊的"
+    ]
+  },
+  {
+    "name": "south",
+    "usphone": "ˈsaʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 南(方)的；向南的；从南来的 ad. 在南方；向南方；自南方 n. 南；南方；南风；南部"
+    ]
+  },
+  {
+    "name": "southeast",
+    "usphone": "‚saʊθˈɪːs",
+    "ukphone": "",
+    "trans": [
+      "n. 东南"
+    ]
+  },
+  {
+    "name": "southern",
+    "usphone": "ˈsʌð(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 南部的，南方的"
+    ]
+  },
+  {
+    "name": "southwest",
+    "usphone": "sauθˈwest",
+    "ukphone": "",
+    "trans": [
+      "n. 西南"
+    ]
+  },
+  {
+    "name": "souvenirs",
+    "usphone": "suːvəˈnɪə(r); (US) ˈsuːvənɪər",
+    "ukphone": "",
+    "trans": [
+      "n.旅游纪念品,纪念物"
+    ]
+  },
+  {
+    "name": "sow (sowed, sown 或-ed)",
+    "usphone": "səʊ",
+    "ukphone": "",
+    "trans": [
+      "vt.播种"
+    ]
+  },
+  {
+    "name": "space",
+    "usphone": "speɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 空间"
+    ]
+  },
+  {
+    "name": "spaceship",
+    "usphone": "ˈspeɪsʃɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 宇宙飞船"
+    ]
+  },
+  {
+    "name": "spade",
+    "usphone": "speɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 铲子;纸牌中的黑桃"
+    ]
+  },
+  {
+    "name": "spaghettiv",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 意大利式面条"
+    ]
+  },
+  {
+    "name": "Spain*",
+    "usphone": "speɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 西班牙"
+    ]
+  },
+  {
+    "name": "Spanish",
+    "usphone": "ˈspænɪʃ",
+    "ukphone": "",
+    "trans": [
+      "a. 西班牙人的，西班牙的，西班牙语的 n. 西班牙语"
+    ]
+  },
+  {
+    "name": "spare",
+    "usphone": "speə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 空闲,多余的，剩余的"
+    ]
+  },
+  {
+    "name": "sparrow",
+    "usphone": "ˈspærəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 麻雀，雀型鸟类"
+    ]
+  },
+  {
+    "name": "speak (spoke, spoken)",
+    "usphone": "ˈspærəʊ",
+    "ukphone": "",
+    "trans": [
+      "v. 说，讲；谈话；发言"
+    ]
+  },
+  {
+    "name": "speaker",
+    "usphone": "ˈspiːkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 演讲人，演说家"
+    ]
+  },
+  {
+    "name": "spear",
+    "usphone": "spɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 矛，枪，梭镖"
+    ]
+  },
+  {
+    "name": "special",
+    "usphone": "ˈspeʃ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 特别的，专门的"
+    ]
+  },
+  {
+    "name": "specialist",
+    "usphone": "ˈspeʃəlɪst",
+    "ukphone": "",
+    "trans": [
+      "n. （医学）专家，专科医生；专家；专业人员"
+    ]
+  },
+  {
+    "name": "specific",
+    "usphone": "spɪˈsɪfɪk",
+    "ukphone": "",
+    "trans": [
+      "a.明确的,具体的,独特的"
+    ]
+  },
+  {
+    "name": "speech",
+    "usphone": "spiːtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 演讲"
+    ]
+  },
+  {
+    "name": "speed",
+    "usphone": "spiːd",
+    "ukphone": "",
+    "trans": [
+      "n. 速度 v. （使）加速"
+    ]
+  },
+  {
+    "name": "spell",
+    "usphone": "spiːd",
+    "ukphone": "",
+    "trans": [
+      "vt. 拼写"
+    ]
+  },
+  {
+    "name": "spelling",
+    "usphone": "ˈspelɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 拼写，拼读"
+    ]
+  },
+  {
+    "name": "spend (spent, spent)",
+    "usphone": "ˈspelɪŋ",
+    "ukphone": "",
+    "trans": [
+      "v. 度过；花费（钱、时间等）"
+    ]
+  },
+  {
+    "name": "spin",
+    "usphone": "spɪn",
+    "ukphone": "",
+    "trans": [
+      "v.& n. 纺，（使）快速旋转；旋转，旋转运动"
+    ]
+  },
+  {
+    "name": "spirit",
+    "usphone": "ˈspɪrɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 精神"
+    ]
+  },
+  {
+    "name": "spiritual",
+    "usphone": "ˈspɪrɪtʃʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 精神的； 心灵的"
+    ]
+  },
+  {
+    "name": "spit",
+    "usphone": "spɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 吐唾沫；吐痰"
+    ]
+  },
+  {
+    "name": "splendid",
+    "usphone": "ˈsplendɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 灿烂的，辉煌的；（口语）极好的"
+    ]
+  },
+  {
+    "name": "split",
+    "usphone": "splɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 撕开;切开"
+    ]
+  },
+  {
+    "name": "spoken",
+    "usphone": "ˈspəʊkən",
+    "ukphone": "",
+    "trans": [
+      "a. 口语的"
+    ]
+  },
+  {
+    "name": "spoken man/ woman (pl. spokemen/ women)",
+    "usphone": "ˈspəʊkən mæn",
+    "ukphone": "",
+    "trans": [
+      "n. 发言人"
+    ]
+  },
+  {
+    "name": "sponsor",
+    "usphone": "ˈspɔnsə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 赞助者，赞助商"
+    ]
+  },
+  {
+    "name": "spoon",
+    "usphone": "spuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 匙, 调羹"
+    ]
+  },
+  {
+    "name": "spoonful",
+    "usphone": "ˈspuːnfʊl",
+    "ukphone": "",
+    "trans": [
+      "n. 一匙（的量）"
+    ]
+  },
+  {
+    "name": "sport",
+    "usphone": "spɔːt",
+    "ukphone": "",
+    "trans": [
+      "vn. 体育运动，锻炼；(复，英)运动会"
+    ]
+  },
+  {
+    "name": "spot",
+    "usphone": "spɔt",
+    "ukphone": "",
+    "trans": [
+      "n. 斑点，污点；场所，地点 v. 沾上污渍，弄脏"
+    ]
+  },
+  {
+    "name": "spray",
+    "usphone": "spreɪ",
+    "ukphone": "",
+    "trans": [
+      "n. / v. 水雾,喷雾(器)喷洒"
+    ]
+  },
+  {
+    "name": "spread",
+    "usphone": "spred",
+    "ukphone": "",
+    "trans": [
+      "v. 延伸； 展开"
+    ]
+  },
+  {
+    "name": "spring",
+    "usphone": "sprɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 春天,春季 n. 泉水,泉"
+    ]
+  },
+  {
+    "name": "spy",
+    "usphone": "spaɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 密探,间谍 v.侦探,刺探"
+    ]
+  },
+  {
+    "name": "square",
+    "usphone": "skweə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 广场 a. 平方的；方形的，宽而结实的（体格，肩膀）"
+    ]
+  },
+  {
+    "name": "squeeze",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 挤压，捏，塞"
+    ]
+  },
+  {
+    "name": "squid",
+    "usphone": "skwɪd",
+    "ukphone": "",
+    "trans": [
+      "n. 鱿鱼"
+    ]
+  },
+  {
+    "name": "squirrel",
+    "usphone": "ˈskwɪr(ə)l; (US) ˈskwɜːrəl",
+    "ukphone": "",
+    "trans": [
+      "n. 松鼠"
+    ]
+  },
+  {
+    "name": "stable",
+    "usphone": "ˈsteɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 稳固的，牢固的"
+    ]
+  },
+  {
+    "name": "stadium",
+    "usphone": "ˈsteɪdɪəm",
+    "ukphone": "",
+    "trans": [
+      "n. （露天）体育场"
+    ]
+  },
+  {
+    "name": "staff",
+    "usphone": "stɑːf",
+    "ukphone": "",
+    "trans": [
+      "n. 全体职工（雇员）"
+    ]
+  },
+  {
+    "name": "stage",
+    "usphone": "steɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 舞台；阶段"
+    ]
+  },
+  {
+    "name": "stain",
+    "usphone": "steɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 污点，污渍，染色剂"
+    ]
+  },
+  {
+    "name": "stainless",
+    "usphone": "ˈsteɪnlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 无污点的"
+    ]
+  },
+  {
+    "name": "stainless steel",
+    "usphone": "ˈsteɪnlɪs stiːl",
+    "ukphone": "",
+    "trans": [
+      "不锈钢"
+    ]
+  },
+  {
+    "name": "stair",
+    "usphone": "steə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 楼梯"
+    ]
+  },
+  {
+    "name": "stamp",
+    "usphone": "stæmp",
+    "ukphone": "",
+    "trans": [
+      "n. 邮票"
+    ]
+  },
+  {
+    "name": "stand",
+    "usphone": "stænd",
+    "ukphone": "",
+    "trans": [
+      "n. 站；立；停止；立场；地位；台；坛；摊"
+    ]
+  },
+  {
+    "name": "stand (stood, stood)",
+    "usphone": "stænd",
+    "ukphone": "",
+    "trans": [
+      "v. 站；立；起立；坐落；经受；持久"
+    ]
+  },
+  {
+    "name": "standard",
+    "usphone": "ˈstændəd",
+    "ukphone": "",
+    "trans": [
+      "n. & a. 标准（的）"
+    ]
+  },
+  {
+    "name": "star",
+    "usphone": "stɑː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 星，恒星"
+    ]
+  },
+  {
+    "name": "stare",
+    "usphone": "steə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 盯，凝视"
+    ]
+  },
+  {
+    "name": "start",
+    "usphone": "stɑːt",
+    "ukphone": "",
+    "trans": [
+      "v. 开始，着手；出发"
+    ]
+  },
+  {
+    "name": "starvation",
+    "usphone": "stɑːˈveɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 饥饿； 饿死"
+    ]
+  },
+  {
+    "name": "starve",
+    "usphone": "stɑːv",
+    "ukphone": "",
+    "trans": [
+      "v. 饿死"
+    ]
+  },
+  {
+    "name": "state",
+    "usphone": "steɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 状态； 情形；国家，（美国的）州"
+    ]
+  },
+  {
+    "name": "station",
+    "usphone": "ˈsteɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 站，所，车站；电台"
+    ]
+  },
+  {
+    "name": "statement",
+    "usphone": "ˈsteɪtmənt",
+    "ukphone": "",
+    "trans": [
+      "n.声明，陈诉，说法"
+    ]
+  },
+  {
+    "name": "statesman/ woman (pl. statesmen/ women)",
+    "usphone": "ˈsteɪtsmən",
+    "ukphone": "",
+    "trans": [
+      "n. 政治家"
+    ]
+  },
+  {
+    "name": "statistics",
+    "usphone": "stəˈtɪstɪks",
+    "ukphone": "",
+    "trans": [
+      "n. 统计数字，统计资料，统计学"
+    ]
+  },
+  {
+    "name": "statue",
+    "usphone": "ˈstætjuː",
+    "ukphone": "",
+    "trans": [
+      "n. 法令，法规，章程"
+    ]
+  },
+  {
+    "name": "status",
+    "usphone": "ˈsteɪtəs",
+    "ukphone": "",
+    "trans": [
+      "n. 法律地位（身份）"
+    ]
+  },
+  {
+    "name": "stay",
+    "usphone": "steɪ",
+    "ukphone": "",
+    "trans": [
+      "n.& vi. 停留，逗留，呆"
+    ]
+  },
+  {
+    "name": "steady",
+    "usphone": "ˈstedɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 稳固的；平稳的"
+    ]
+  },
+  {
+    "name": "steak",
+    "usphone": "steɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 牛排，肉排，鱼排"
+    ]
+  },
+  {
+    "name": "steal (stole, stolen)",
+    "usphone": "stiːl",
+    "ukphone": "",
+    "trans": [
+      "vt. 偷, 窃取"
+    ]
+  },
+  {
+    "name": "steam",
+    "usphone": "stiːm",
+    "ukphone": "",
+    "trans": [
+      "n. 汽，水蒸气"
+    ]
+  },
+  {
+    "name": "steel",
+    "usphone": "stiːl",
+    "ukphone": "",
+    "trans": [
+      "n. 钢，钢铁"
+    ]
+  },
+  {
+    "name": "steep",
+    "usphone": "stiːp",
+    "ukphone": "",
+    "trans": [
+      "a. 险峻的； 陡峭的"
+    ]
+  },
+  {
+    "name": "step",
+    "usphone": "step",
+    "ukphone": "",
+    "trans": [
+      "n.脚步,台阶,梯级 vi.走,跨步"
+    ]
+  },
+  {
+    "name": "step-mother",
+    "usphone": "step-ˈmʌðə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 继母"
+    ]
+  },
+  {
+    "name": "steward",
+    "usphone": "ˈstjuːəd; (US) ˈstuːərd",
+    "ukphone": "",
+    "trans": [
+      "n. (火车、飞机、轮船等)男服务员；男乘务员"
+    ]
+  },
+  {
+    "name": "stewardess",
+    "usphone": "stjuːəˈdes, ˈstjuːədɪs",
+    "ukphone": "",
+    "trans": [
+      "n.女乘务员,空中小姐"
+    ]
+  },
+  {
+    "name": "stick (stuck, stuck)",
+    "usphone": "stɪk",
+    "ukphone": "",
+    "trans": [
+      "vi. 粘住，钉住；坚持n. 木棒（棍）,枝条"
+    ]
+  },
+  {
+    "name": "still",
+    "usphone": "stɪl",
+    "ukphone": "",
+    "trans": [
+      "a.不动的,平静的ad.仍然,还"
+    ]
+  },
+  {
+    "name": "stocking",
+    "usphone": "ˈstɔkɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 长统袜"
+    ]
+  },
+  {
+    "name": "stomach",
+    "usphone": "ˈstʌmək",
+    "ukphone": "",
+    "trans": [
+      "n. 胃，胃部"
+    ]
+  },
+  {
+    "name": "stomachache",
+    "usphone": "ˈstʌməkeɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 胃疼"
+    ]
+  },
+  {
+    "name": "stone",
+    "usphone": "stəʊn",
+    "ukphone": "",
+    "trans": [
+      "n. 石头，石料"
+    ]
+  },
+  {
+    "name": "stop",
+    "usphone": "stɔp",
+    "ukphone": "",
+    "trans": [
+      "n. 停；（停车）站 v. 停，停止，阻止"
+    ]
+  },
+  {
+    "name": "stopwatch",
+    "usphone": "ˈstɔpwɔtʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 记秒表；跑表"
+    ]
+  },
+  {
+    "name": "storage",
+    "usphone": "ˈstɔːrɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 贮藏； 储存"
+    ]
+  },
+  {
+    "name": "store",
+    "usphone": "stɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 商店 vt. 储藏，存储"
+    ]
+  },
+  {
+    "name": "storm",
+    "usphone": "stɔːm",
+    "ukphone": "",
+    "trans": [
+      "n. 风暴，暴（风）雨"
+    ]
+  },
+  {
+    "name": "story",
+    "usphone": "ˈstɔːrɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 故事，小说"
+    ]
+  },
+  {
+    "name": "stout",
+    "usphone": "staʊt",
+    "ukphone": "",
+    "trans": [
+      "a. 肥壮的，厚实牢固的"
+    ]
+  },
+  {
+    "name": "stove",
+    "usphone": "stəʊv",
+    "ukphone": "",
+    "trans": [
+      "n. （供烹饪用的 ）火炉，煤炉，电炉"
+    ]
+  },
+  {
+    "name": "straight",
+    "usphone": "streɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 一直的，直的 ad. 一直地，直地"
+    ]
+  },
+  {
+    "name": "straightforward",
+    "usphone": "streɪtˈfɔːwəd",
+    "ukphone": "",
+    "trans": [
+      "a./ ad. 简单的，坦率的"
+    ]
+  },
+  {
+    "name": "strait",
+    "usphone": "streɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 海峡"
+    ]
+  },
+  {
+    "name": "strange",
+    "usphone": "streɪndʒ",
+    "ukphone": "",
+    "trans": [
+      "a. 奇怪,奇特的,陌生的"
+    ]
+  },
+  {
+    "name": "stranger",
+    "usphone": "ˈstreɪndʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 陌生人，外人"
+    ]
+  },
+  {
+    "name": "straw",
+    "usphone": "strɔː",
+    "ukphone": "",
+    "trans": [
+      "n. 稻草"
+    ]
+  },
+  {
+    "name": "strawberry",
+    "usphone": "ˈstrɔːbərɪ; (US) -berɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 草莓"
+    ]
+  },
+  {
+    "name": "stream",
+    "usphone": "striːm",
+    "ukphone": "",
+    "trans": [
+      "n. 小河；溪流"
+    ]
+  },
+  {
+    "name": "street",
+    "usphone": "striːt",
+    "ukphone": "",
+    "trans": [
+      "n. 街，街道"
+    ]
+  },
+  {
+    "name": "strength",
+    "usphone": "streŋθ",
+    "ukphone": "",
+    "trans": [
+      "n. 力量，力气"
+    ]
+  },
+  {
+    "name": "strengthen",
+    "usphone": "ˈstreŋθ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "vt. 加强，增强"
+    ]
+  },
+  {
+    "name": "stress",
+    "usphone": "stres",
+    "ukphone": "",
+    "trans": [
+      "n. 精神压力，心理负担 v. 强调，重读"
+    ]
+  },
+  {
+    "name": "strict",
+    "usphone": "strɪkt",
+    "ukphone": "",
+    "trans": [
+      "a. 严格的，严密的"
+    ]
+  },
+  {
+    "name": "strike",
+    "usphone": "straɪk",
+    "ukphone": "",
+    "trans": [
+      "v.（钟）鸣;敲（响）,罢工"
+    ]
+  },
+  {
+    "name": "strike (struck, struck 或stricken)",
+    "usphone": "straɪk",
+    "ukphone": "",
+    "trans": [
+      "vt. 擦（打）火, 侵袭"
+    ]
+  },
+  {
+    "name": "string",
+    "usphone": "strɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 细绳，线，带"
+    ]
+  },
+  {
+    "name": "strong",
+    "usphone": "strɔŋ; (US) strɔːɡ",
+    "ukphone": "",
+    "trans": [
+      "a. 强(壮)的；坚固的；强烈的；坚强的"
+    ]
+  },
+  {
+    "name": "struggle",
+    "usphone": "ˈstrʌɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "vi. 斗争"
+    ]
+  },
+  {
+    "name": "stubborn",
+    "usphone": "ˈstʌbən",
+    "ukphone": "",
+    "trans": [
+      "a. 固执的，倔强的"
+    ]
+  },
+  {
+    "name": "student",
+    "usphone": "ˈstjuːdənt",
+    "ukphone": "",
+    "trans": [
+      "n. 学生"
+    ]
+  },
+  {
+    "name": "studio",
+    "usphone": "ˈstjuːdɪəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 工作室，演播室"
+    ]
+  },
+  {
+    "name": "study",
+    "usphone": "ˈstʌdɪ",
+    "ukphone": "",
+    "trans": [
+      "v. 学习；研究 n. 书房"
+    ]
+  },
+  {
+    "name": "stupid",
+    "usphone": "ˈstjuːpɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 愚蠢的，笨的"
+    ]
+  },
+  {
+    "name": "style",
+    "usphone": "staɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 方式，作风，款式"
+    ]
+  },
+  {
+    "name": "subject",
+    "usphone": "ˈsʌbdʒɪkt",
+    "ukphone": "",
+    "trans": [
+      "a. 隶属的；受支配的；易受…的；在…条件下 vt. 使隶属；使服从；使受到 n. 题目；主题；学科；主语；主体"
+    ]
+  },
+  {
+    "name": "subjective",
+    "usphone": "səbˈdʒektɪv",
+    "ukphone": "",
+    "trans": [
+      "a. 主观的"
+    ]
+  },
+  {
+    "name": "submit",
+    "usphone": "səbˈmɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 提交，呈递（文件，建议等）"
+    ]
+  },
+  {
+    "name": "subscribe",
+    "usphone": "səbˈskraɪb",
+    "ukphone": "",
+    "trans": [
+      "v.订阅,订购（报刊等）"
+    ]
+  },
+  {
+    "name": "substitute",
+    "usphone": "ˈsʌbstɪtjuːt",
+    "ukphone": "",
+    "trans": [
+      "v. 代替，取代"
+    ]
+  },
+  {
+    "name": "subtraction",
+    "usphone": "səbˈtrɔkʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.（算数中的）减"
+    ]
+  },
+  {
+    "name": "succeed",
+    "usphone": "səkˈsiːd",
+    "ukphone": "",
+    "trans": [
+      "vi. 成功"
+    ]
+  },
+  {
+    "name": "success",
+    "usphone": "səkˈses",
+    "ukphone": "",
+    "trans": [
+      "n. 成功"
+    ]
+  },
+  {
+    "name": "successful",
+    "usphone": "səkˈsesfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 成功的,有成就的"
+    ]
+  },
+  {
+    "name": "such",
+    "usphone": "sʌtʃ",
+    "ukphone": "",
+    "trans": [
+      "ad. 那么 pron. （泛指）人，事物 a.这样的，那样的"
+    ]
+  },
+  {
+    "name": "suck",
+    "usphone": "sʌk",
+    "ukphone": "",
+    "trans": [
+      "vt. 吸吮"
+    ]
+  },
+  {
+    "name": "sudden",
+    "usphone": "ˈsʌd(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 突然的"
+    ]
+  },
+  {
+    "name": "suffer",
+    "usphone": "ˈsʌfə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 受苦，遭受"
+    ]
+  },
+  {
+    "name": "suffering",
+    "usphone": "ˈsʌfərɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 痛苦，苦难"
+    ]
+  },
+  {
+    "name": "sugar",
+    "usphone": "ˈʃʊɡə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 糖"
+    ]
+  },
+  {
+    "name": "suggest",
+    "usphone": "səˈdʒest; (US) səɡˈdʒest",
+    "ukphone": "",
+    "trans": [
+      "vt. 建议，提议"
+    ]
+  },
+  {
+    "name": "suggestion",
+    "usphone": "səˈdʒestʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 建议"
+    ]
+  },
+  {
+    "name": "suit",
+    "usphone": "suːt, sjuːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 适合 n.一套（衣服）"
+    ]
+  },
+  {
+    "name": "suite",
+    "usphone": "swiːt",
+    "ukphone": "",
+    "trans": [
+      "n. 套间；组曲"
+    ]
+  },
+  {
+    "name": "suitable",
+    "usphone": "ˈsjuːtəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 合适的，适宜的"
+    ]
+  },
+  {
+    "name": "suitcase",
+    "usphone": "ˈsjuːtkeɪs",
+    "ukphone": "",
+    "trans": [
+      "n.(旅行用)小提箱,衣箱"
+    ]
+  },
+  {
+    "name": "summary",
+    "usphone": "ˈsʌmərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 摘要，概要"
+    ]
+  },
+  {
+    "name": "summer",
+    "usphone": "ˈsʌmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 夏天，夏季"
+    ]
+  },
+  {
+    "name": "sun",
+    "usphone": "sʌn",
+    "ukphone": "",
+    "trans": [
+      "n. 太阳，阳光"
+    ]
+  },
+  {
+    "name": "sunburnt",
+    "usphone": "ˈsʌnbɜːnt",
+    "ukphone": "",
+    "trans": [
+      "a. 晒黑的"
+    ]
+  },
+  {
+    "name": "Sunday",
+    "usphone": "ˈsʌndeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 星期日"
+    ]
+  },
+  {
+    "name": "sunglasses",
+    "usphone": "ˈsʌnɡlɑːsɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 太阳眼镜，墨镜"
+    ]
+  },
+  {
+    "name": "sunlight",
+    "usphone": "ˈsʌnlaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 日光，阳光"
+    ]
+  },
+  {
+    "name": "sunny",
+    "usphone": "ˈsʌnɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 晴朗的;阳光充足的"
+    ]
+  },
+  {
+    "name": "sunrise",
+    "usphone": "ˈsʌnraɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 黎明，拂晓"
+    ]
+  },
+  {
+    "name": "sunset",
+    "usphone": "ˈsʌnset",
+    "ukphone": "",
+    "trans": [
+      "n. 日落(时分)"
+    ]
+  },
+  {
+    "name": "sunshine",
+    "usphone": "ˈsʌnʃaɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 阳光"
+    ]
+  },
+  {
+    "name": "super",
+    "usphone": "ˈsuːpə(r), ˈsjuːpə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 顶好的，超级的"
+    ]
+  },
+  {
+    "name": "superb",
+    "usphone": "suːˈpɜːb",
+    "ukphone": "",
+    "trans": [
+      "a. 卓越的,质量极高的"
+    ]
+  },
+  {
+    "name": "superior",
+    "usphone": "suːˈpɪərɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 更胜一筹的 n. 上级，上司"
+    ]
+  },
+  {
+    "name": "superman",
+    "usphone": "ˈsuːpəman",
+    "ukphone": "",
+    "trans": [
+      "n. 超人"
+    ]
+  },
+  {
+    "name": "supermarket",
+    "usphone": "ˈsuːpəmɑːkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 超级市场"
+    ]
+  },
+  {
+    "name": "supper",
+    "usphone": "ˈsʌpə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 晚餐，晚饭"
+    ]
+  },
+  {
+    "name": "supply",
+    "usphone": "səˈplaɪ",
+    "ukphone": "",
+    "trans": [
+      "vt.& n. 供给，供应"
+    ]
+  },
+  {
+    "name": "support",
+    "usphone": "səˈpɔːt",
+    "ukphone": "",
+    "trans": [
+      "vt.& n. 支持，赞助"
+    ]
+  },
+  {
+    "name": "suppose",
+    "usphone": "səˈpəʊz",
+    "ukphone": "",
+    "trans": [
+      "vt. 猜想,假定,料想"
+    ]
+  },
+  {
+    "name": "supreme",
+    "usphone": "suːˈpriːm",
+    "ukphone": "",
+    "trans": [
+      "a.至高无上的,最高的"
+    ]
+  },
+  {
+    "name": "sure",
+    "usphone": "ʃʊə(r), ʃɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 确信，肯定 ad. (口语)的确，一定，当然"
+    ]
+  },
+  {
+    "name": "surface",
+    "usphone": "ˈsɜːfɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 表面"
+    ]
+  },
+  {
+    "name": "surgeon",
+    "usphone": "ˈsɜːdʒ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 外科医生"
+    ]
+  },
+  {
+    "name": "surplus",
+    "usphone": "ˈsɜːpləs",
+    "ukphone": "",
+    "trans": [
+      "n. 过剩，剩余"
+    ]
+  },
+  {
+    "name": "surprise",
+    "usphone": "səˈpraɪz",
+    "ukphone": "",
+    "trans": [
+      "vt. 使惊奇,使诧异 n. 惊奇,诧异"
+    ]
+  },
+  {
+    "name": "surround",
+    "usphone": "səˈraʊnd",
+    "ukphone": "",
+    "trans": [
+      "vt. 围绕；包围"
+    ]
+  },
+  {
+    "name": "surrounding",
+    "usphone": "səˈraʊndɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 周围的"
+    ]
+  },
+  {
+    "name": "survival",
+    "usphone": "səˈvaɪv(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 存活，幸存"
+    ]
+  },
+  {
+    "name": "survive",
+    "usphone": "səˈvaɪv",
+    "ukphone": "",
+    "trans": [
+      "v.生存，存活，幸免于难"
+    ]
+  },
+  {
+    "name": "suspect",
+    "usphone": "səˈspekt",
+    "ukphone": "",
+    "trans": [
+      "n. 犯罪嫌疑人"
+    ]
+  },
+  {
+    "name": "suspension",
+    "usphone": "səˈspenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n.暂令停职,推迟,延期"
+    ]
+  },
+  {
+    "name": "swallow",
+    "usphone": "ˈswɔləʊ",
+    "ukphone": "",
+    "trans": [
+      "vt. 吞下；咽下"
+    ]
+  },
+  {
+    "name": "swap",
+    "usphone": "swɔp",
+    "ukphone": "",
+    "trans": [
+      "v. 交换（东西）"
+    ]
+  },
+  {
+    "name": "swear (swore, sworn)",
+    "usphone": "sweə(r)",
+    "ukphone": "",
+    "trans": [
+      "v.咒骂.,诅咒"
+    ]
+  },
+  {
+    "name": "sweat",
+    "usphone": "swet",
+    "ukphone": "",
+    "trans": [
+      "n. 汗，汗水"
+    ]
+  },
+  {
+    "name": "sweater",
+    "usphone": "ˈswetə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 厚运动衫，毛衣 "
+    ]
+  },
+  {
+    "name": "sweep(swept,swept)",
+    "usphone": "swiːp",
+    "ukphone": "",
+    "trans": [
+      "v. 扫除，扫"
+    ]
+  },
+  {
+    "name": "sweet",
+    "usphone": "swiːt",
+    "ukphone": "",
+    "trans": [
+      "n.甜食;蜜饯;甜点;糖果;芳香a.甜的;新鲜的;可爱的;亲切的"
+    ]
+  },
+  {
+    "name": "swell (swelled, swollen)",
+    "usphone": "swel",
+    "ukphone": "",
+    "trans": [
+      "v. 肿胀"
+    ]
+  },
+  {
+    "name": "swift",
+    "usphone": "swɪft",
+    "ukphone": "",
+    "trans": [
+      "a. 快的，迅速的"
+    ]
+  },
+  {
+    "name": "swim",
+    "usphone": "swɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 游泳，游"
+    ]
+  },
+  {
+    "name": "swim (swam, swum)",
+    "usphone": "swɪm",
+    "ukphone": "",
+    "trans": [
+      "vi. 游泳,游"
+    ]
+  },
+  {
+    "name": "swimming",
+    "usphone": "ˈswɪmɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 游泳"
+    ]
+  },
+  {
+    "name": "swimming pool",
+    "usphone": "ˈswɪmɪŋ puːl",
+    "ukphone": "",
+    "trans": [
+      "n. 游泳池"
+    ]
+  },
+  {
+    "name": "swing",
+    "usphone": "swɪŋ",
+    "ukphone": "",
+    "trans": [
+      "vt. 挥舞，摆动 n. 秋千"
+    ]
+  },
+  {
+    "name": "Swiss",
+    "usphone": "swɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 瑞士人的 n. 瑞士人"
+    ]
+  },
+  {
+    "name": "Switzerland",
+    "usphone": "ˈswɪtsələnd",
+    "ukphone": "",
+    "trans": [
+      "* n. 瑞士"
+    ]
+  },
+  {
+    "name": "switch",
+    "usphone": "swɪtʃ",
+    "ukphone": "",
+    "trans": [
+      "v./ n. 开关,转换,改变"
+    ]
+  },
+  {
+    "name": "sword",
+    "usphone": "sɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 剑，刀"
+    ]
+  },
+  {
+    "name": "symbol",
+    "usphone": "ˈsɪmb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 象征"
+    ]
+  },
+  {
+    "name": "sympathy",
+    "usphone": "ˈsɪmpəθɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 同情"
+    ]
+  },
+  {
+    "name": "symphony",
+    "usphone": "ˈsɪmfənɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 交响乐"
+    ]
+  },
+  {
+    "name": "symptom",
+    "usphone": "ˈsɪmfənɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 症状"
+    ]
+  },
+  {
+    "name": "system",
+    "usphone": "ˈsɪstəm",
+    "ukphone": "",
+    "trans": [
+      "n. 体系；系统"
+    ]
+  },
+  {
+    "name": "systematic",
+    "usphone": "sɪstəˈmætɪk",
+    "ukphone": "",
+    "trans": [
+      "a.系统的,有条理的"
+    ]
+  },
+  {
+    "name": "table",
+    "usphone": "ˈteɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 桌子，表格"
+    ]
+  },
+  {
+    "name": "table tennis",
+    "usphone": "ˈteɪb(ə)l ˈtenɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 乒乓球"
+    ]
+  },
+  {
+    "name": "tablet",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 药片"
+    ]
+  },
+  {
+    "name": "tail",
+    "usphone": "teɪl",
+    "ukphone": "",
+    "trans": [
+      "n. (动物的)尾巴"
+    ]
+  },
+  {
+    "name": "tailor",
+    "usphone": "ˈteɪlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 裁缝"
+    ]
+  },
+  {
+    "name": "take (took, taken)",
+    "usphone": "teɪk",
+    "ukphone": "",
+    "trans": [
+      "vt. 拿；拿走；做；服用；乘坐；花费"
+    ]
+  },
+  {
+    "name": "tale",
+    "usphone": "teɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 故事, 传说"
+    ]
+  },
+  {
+    "name": "talent",
+    "usphone": "ˈtælənt",
+    "ukphone": "",
+    "trans": [
+      "n. 天才，天赋"
+    ]
+  },
+  {
+    "name": "talk",
+    "usphone": "tɔːk",
+    "ukphone": "",
+    "trans": [
+      "n.& v.谈话,讲话,演讲,交谈"
+    ]
+  },
+  {
+    "name": "tall",
+    "usphone": "tɔːl",
+    "ukphone": "",
+    "trans": [
+      "a. 高的"
+    ]
+  },
+  {
+    "name": "tank",
+    "usphone": "tæŋk",
+    "ukphone": "",
+    "trans": [
+      "n. 储水容量；坦克"
+    ]
+  },
+  {
+    "name": "tanker",
+    "usphone": "ˈtæŋkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 油船"
+    ]
+  },
+  {
+    "name": "tap",
+    "usphone": "tæp",
+    "ukphone": "",
+    "trans": [
+      "n. (自来水煤气等的)龙头"
+    ]
+  },
+  {
+    "name": "tape",
+    "usphone": "teɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 磁带；录音带"
+    ]
+  },
+  {
+    "name": "tape recorder",
+    "usphone": "teɪp rɪˈkɔːdə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 磁带录音机"
+    ]
+  },
+  {
+    "name": "target",
+    "usphone": "ˈtɑːɡɪt",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 目标，把…作为攻击目标"
+    ]
+  },
+  {
+    "name": "task",
+    "usphone": "tɑːsk; (US) tæsk",
+    "ukphone": "",
+    "trans": [
+      "n. 任务, 工作"
+    ]
+  },
+  {
+    "name": "taste",
+    "usphone": "teɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 品尝, 尝味；味道 vt. 品尝, 尝味"
+    ]
+  },
+  {
+    "name": "tasteless",
+    "usphone": "ˈteɪstlɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 无滋味的"
+    ]
+  },
+  {
+    "name": "tasty",
+    "usphone": "ˈteɪstɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 味道好的"
+    ]
+  },
+  {
+    "name": "tax",
+    "usphone": "tæks",
+    "ukphone": "",
+    "trans": [
+      "n. 税，税款"
+    ]
+  },
+  {
+    "name": "tax-free",
+    "usphone": "tæks friː",
+    "ukphone": "",
+    "trans": [
+      "免税的"
+    ]
+  },
+  {
+    "name": "taxi",
+    "usphone": "ˈtæksɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 出租汽车"
+    ]
+  },
+  {
+    "name": "taxipayer",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 纳税人"
+    ]
+  },
+  {
+    "name": "tea",
+    "usphone": "tiː",
+    "ukphone": "",
+    "trans": [
+      "n. 茶；茶叶 "
+    ]
+  },
+  {
+    "name": "teach(taught,taught)",
+    "usphone": "tiː",
+    "ukphone": "",
+    "trans": [
+      "v. 教书,教"
+    ]
+  },
+  {
+    "name": "teacher",
+    "usphone": "ˈtiːtʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 教师，教员"
+    ]
+  },
+  {
+    "name": "team",
+    "usphone": "tiːm",
+    "ukphone": "",
+    "trans": [
+      "n. 队，组"
+    ]
+  },
+  {
+    "name": "teamwork",
+    "usphone": "ˈtiːmwɜːk",
+    "ukphone": "",
+    "trans": [
+      "n. 合作，协同工作"
+    ]
+  },
+  {
+    "name": "teapot",
+    "usphone": "ˈtiːpɔt",
+    "ukphone": "",
+    "trans": [
+      "n. 茶壶"
+    ]
+  },
+  {
+    "name": "tear",
+    "usphone": "teə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 眼泪 v. 扯破, 撕开"
+    ]
+  },
+  {
+    "name": "tease",
+    "usphone": "tiːz",
+    "ukphone": "",
+    "trans": [
+      "v. 取笑，戏弄，寻开心"
+    ]
+  },
+  {
+    "name": "technical",
+    "usphone": "ˈteknɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 技术的，工艺的"
+    ]
+  },
+  {
+    "name": "technique",
+    "usphone": "ˈteknɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 技术;技巧,方法"
+    ]
+  },
+  {
+    "name": "technology",
+    "usphone": "tekˈnɔlədʒɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 技术"
+    ]
+  },
+  {
+    "name": "teenager",
+    "usphone": "ˈtiːneɪdʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.（13～19岁的）青少年，十几岁的少年"
+    ]
+  },
+  {
+    "name": "telegram",
+    "usphone": "ˈtelɪɡræm",
+    "ukphone": "",
+    "trans": [
+      "n. 电报"
+    ]
+  },
+  {
+    "name": "telegraph",
+    "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf",
+    "ukphone": "",
+    "trans": [
+      "v. (拍) 电报"
+    ]
+  },
+  {
+    "name": "telephone",
+    "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf",
+    "ukphone": "",
+    "trans": [
+      "v. 打电话 n. 电话"
+    ]
+  },
+  {
+    "name": "telephone-booth / telephone-box",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 公用电话间"
+    ]
+  },
+  {
+    "name": "telescope",
+    "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf",
+    "ukphone": "",
+    "trans": [
+      "n. 望远镜"
+    ]
+  },
+  {
+    "name": "television",
+    "usphone": "ˈtelɪɡrɑːf; (US) -ɡræf",
+    "ukphone": "",
+    "trans": [
+      "n. 电视"
+    ]
+  },
+  {
+    "name": "tell (told, told)",
+    "usphone": "tel",
+    "ukphone": "",
+    "trans": [
+      "vt.告诉,讲述,吩咐"
+    ]
+  },
+  {
+    "name": "temperature",
+    "usphone": "ˈtemprɪtʃə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 温度"
+    ]
+  },
+  {
+    "name": "temple",
+    "usphone": "ˈtemp(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 庙宇，寺院"
+    ]
+  },
+  {
+    "name": "temporary",
+    "usphone": "ˈtempərərɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 短暂的，暂时的"
+    ]
+  },
+  {
+    "name": "temptation",
+    "usphone": "tempˈteɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 引诱；诱惑"
+    ]
+  },
+  {
+    "name": "tend",
+    "usphone": "tend",
+    "ukphone": "",
+    "trans": [
+      "v. 往往会，常常就，倾向，趋于"
+    ]
+  },
+  {
+    "name": "tendency",
+    "usphone": "ˈtendənsɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 倾向，偏好，性情"
+    ]
+  },
+  {
+    "name": "tennis",
+    "usphone": "ˈtenɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 网球"
+    ]
+  },
+  {
+    "name": "ten",
+    "usphone": "ten",
+    "ukphone": "",
+    "trans": [
+      "num. 十"
+    ]
+  },
+  {
+    "name": "tense",
+    "usphone": "tens",
+    "ukphone": "",
+    "trans": [
+      "a. 心烦意乱的，紧张的"
+    ]
+  },
+  {
+    "name": "tension",
+    "usphone": "ˈtenʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 紧张局势，矛盾"
+    ]
+  },
+  {
+    "name": "tent",
+    "usphone": "tent",
+    "ukphone": "",
+    "trans": [
+      "n. 帐篷"
+    ]
+  },
+  {
+    "name": "tentative",
+    "usphone": "tent",
+    "ukphone": "",
+    "trans": [
+      "a. 不确定的，踌躇的"
+    ]
+  },
+  {
+    "name": "term",
+    "usphone": "tɜːm",
+    "ukphone": "",
+    "trans": [
+      "n. 学期;术语;条款;项"
+    ]
+  },
+  {
+    "name": "terminal",
+    "usphone": "tɜːm",
+    "ukphone": "",
+    "trans": [
+      "a.(火车汽车飞机)终点站"
+    ]
+  },
+  {
+    "name": "terrible",
+    "usphone": "ˈterɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 可怕的；糟糕的"
+    ]
+  },
+  {
+    "name": "terrify",
+    "usphone": "ˈterɪfaɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 使人感到恐怖"
+    ]
+  },
+  {
+    "name": "terror",
+    "usphone": "ˈterə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 恐惧，惊恐"
+    ]
+  },
+  {
+    "name": "test",
+    "usphone": "test",
+    "ukphone": "",
+    "trans": [
+      "vt.& n. 测试, 考查，试验"
+    ]
+  },
+  {
+    "name": "text",
+    "usphone": "tekst",
+    "ukphone": "",
+    "trans": [
+      "n. 文本，课文"
+    ]
+  },
+  {
+    "name": "textbook",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 课本，教科书"
+    ]
+  },
+  {
+    "name": "than",
+    "usphone": "ðen, ðæn",
+    "ukphone": "",
+    "trans": [
+      "conj. 比"
+    ]
+  },
+  {
+    "name": "thank",
+    "usphone": "θæŋk",
+    "ukphone": "",
+    "trans": [
+      "vt. 感谢，致谢，道谢 n. （复）感谢，谢意"
+    ]
+  },
+  {
+    "name": "thankful",
+    "usphone": "ˈθæŋkfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 感谢的，感激的"
+    ]
+  },
+  {
+    "name": "that",
+    "usphone": "ðæt",
+    "ukphone": "",
+    "trans": [
+      "a.& pron.那，那个 conj. 那，那个（引导宾语从句等）ad. 那么，那样"
+    ]
+  },
+  {
+    "name": "the",
+    "usphone": "ðə, ðɪ, ðiː",
+    "ukphone": "",
+    "trans": [
+      "art. 这（那）个,这（那）些（用于特定人或物，序数词，最高级，专有名词，世上独一 无二事物前）"
+    ]
+  },
+  {
+    "name": "theatre (美theater)",
+    "usphone": "ˈθiətə",
+    "ukphone": "",
+    "trans": [
+      "n. 剧场，戏院"
+    ]
+  },
+  {
+    "name": "theft",
+    "usphone": "θeft",
+    "ukphone": "",
+    "trans": [
+      "n. 盗窃案"
+    ]
+  },
+  {
+    "name": "their",
+    "usphone": "ðeə(r)",
+    "ukphone": "",
+    "trans": [
+      "pron. 他(她,它)们的"
+    ]
+  },
+  {
+    "name": "theirs",
+    "usphone": "ðeəz",
+    "ukphone": "",
+    "trans": [
+      "pron. 他（她,它）们的"
+    ]
+  },
+  {
+    "name": "them",
+    "usphone": "ð(ə)m, ðem",
+    "ukphone": "",
+    "trans": [
+      "pron. 他/她/它们（宾格）"
+    ]
+  },
+  {
+    "name": "theme",
+    "usphone": "θiːm",
+    "ukphone": "",
+    "trans": [
+      "n. 主题"
+    ]
+  },
+  {
+    "name": "themselves",
+    "usphone": "ðəmˈselvz",
+    "ukphone": "",
+    "trans": [
+      "pron.他/她/它们自己"
+    ]
+  },
+  {
+    "name": "then",
+    "usphone": "ðen",
+    "ukphone": "",
+    "trans": [
+      "ad. 当时,那时,然后,那么"
+    ]
+  },
+  {
+    "name": "theoretical",
+    "usphone": "θɪəˈretɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 理论的"
+    ]
+  },
+  {
+    "name": "theory",
+    "usphone": "θɪəˈretɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 理论"
+    ]
+  },
+  {
+    "name": "there",
+    "usphone": "ðeə(r)",
+    "ukphone": "",
+    "trans": [
+      "int. 那！你瞧（表示引起注意） n. 那里，那儿 ad. 在那里，往那里；（作引导词）表”存在\""
+    ]
+  },
+  {
+    "name": "therefore",
+    "usphone": "ˈðeəfɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "ad. 因此，所以"
+    ]
+  },
+  {
+    "name": "thermos",
+    "usphone": "ˈθɜːmɔs",
+    "ukphone": "",
+    "trans": [
+      "n. 热水瓶"
+    ]
+  },
+  {
+    "name": "these",
+    "usphone": "ˈθɜːmɔs",
+    "ukphone": "",
+    "trans": [
+      "a. & pron. 这些"
+    ]
+  },
+  {
+    "name": "they",
+    "usphone": "ðeɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 他（她）们；它们"
+    ]
+  },
+  {
+    "name": "thick",
+    "usphone": "θɪk",
+    "ukphone": "",
+    "trans": [
+      "a. 厚的"
+    ]
+  },
+  {
+    "name": "thief (复thieves)",
+    "usphone": "θiːf",
+    "ukphone": "",
+    "trans": [
+      "n. 窃贼, 小偷"
+    ]
+  },
+  {
+    "name": "thin",
+    "usphone": "θɪn",
+    "ukphone": "",
+    "trans": [
+      "a. 薄的；瘦的；稀的"
+    ]
+  },
+  {
+    "name": "thing",
+    "usphone": "θɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 东西；(复)物品，用品；事情，事件"
+    ]
+  },
+  {
+    "name": "think(thought, thought)",
+    "usphone": "θɪŋk",
+    "ukphone": "",
+    "trans": [
+      "v. 想；认为；考虑"
+    ]
+  },
+  {
+    "name": "thinking",
+    "usphone": "ˈθɪŋkɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 思索;见解;想法"
+    ]
+  },
+  {
+    "name": "third",
+    "usphone": "θɜːd",
+    "ukphone": "",
+    "trans": [
+      "num. 第三"
+    ]
+  },
+  {
+    "name": "thirst",
+    "usphone": "θɜːd",
+    "ukphone": "",
+    "trans": [
+      "n. 渴； 口渴"
+    ]
+  },
+  {
+    "name": "thirsty",
+    "usphone": "ˈθɜːstɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 渴"
+    ]
+  },
+  {
+    "name": "thirteen",
+    "usphone": "θɜːˈtiːn",
+    "ukphone": "",
+    "trans": [
+      "num. 十三"
+    ]
+  },
+  {
+    "name": "thirty",
+    "usphone": "ˈθɜːtɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 三十"
+    ]
+  },
+  {
+    "name": "this",
+    "usphone": "ðɪs",
+    "ukphone": "",
+    "trans": [
+      "a.& pron.这，这个"
+    ]
+  },
+  {
+    "name": "thorough",
+    "usphone": "ˈθʌrə; (US) ˈθʌrəʊ",
+    "ukphone": "",
+    "trans": [
+      "a. 彻底的"
+    ]
+  },
+  {
+    "name": "those",
+    "usphone": "ðəʊz",
+    "ukphone": "",
+    "trans": [
+      "a.& pron.那些"
+    ]
+  },
+  {
+    "name": "though",
+    "usphone": "ðəʊ",
+    "ukphone": "",
+    "trans": [
+      "conj. 虽然，可是"
+    ]
+  },
+  {
+    "name": "thought",
+    "usphone": "θɔːt",
+    "ukphone": "",
+    "trans": [
+      "n. 思考,思想;念头"
+    ]
+  },
+  {
+    "name": "thousand",
+    "usphone": "ˈθaʊzənd",
+    "ukphone": "",
+    "trans": [
+      "num. 千"
+    ]
+  },
+  {
+    "name": "thread",
+    "usphone": "θred",
+    "ukphone": "",
+    "trans": [
+      "n. 线"
+    ]
+  },
+  {
+    "name": "three",
+    "usphone": "θriː",
+    "ukphone": "",
+    "trans": [
+      "num. 三"
+    ]
+  },
+  {
+    "name": "thrill",
+    "usphone": "θrɪl",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 兴奋，激动"
+    ]
+  },
+  {
+    "name": "thriller",
+    "usphone": "ˈθrɪlə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 惊险小说"
+    ]
+  },
+  {
+    "name": "throat",
+    "usphone": "θrəʊt",
+    "ukphone": "",
+    "trans": [
+      "n. 喉咙"
+    ]
+  },
+  {
+    "name": "through",
+    "usphone": "θruː",
+    "ukphone": "",
+    "trans": [
+      "prep.穿（通）过;从始至终 ad.穿(通)过;自始至终,全部"
+    ]
+  },
+  {
+    "name": "throughout",
+    "usphone": "θruːˈaʊt",
+    "ukphone": "",
+    "trans": [
+      "prep. 遍及，贯穿"
+    ]
+  },
+  {
+    "name": "throw(threw,thrown)",
+    "usphone": "θrəʊ",
+    "ukphone": "",
+    "trans": [
+      "v.投,掷,扔"
+    ]
+  },
+  {
+    "name": "thunder",
+    "usphone": "ˈθʌndə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 雷声，打雷"
+    ]
+  },
+  {
+    "name": "thunderstorm",
+    "usphone": "ˈθʌndəstɔːm",
+    "ukphone": "",
+    "trans": [
+      "n.雷电交加暴风雨"
+    ]
+  },
+  {
+    "name": "Thursday",
+    "usphone": "ˈθɜːzdeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 星期四"
+    ]
+  },
+  {
+    "name": "thus",
+    "usphone": "ðʌs",
+    "ukphone": "",
+    "trans": [
+      "ad. 这样；因而"
+    ]
+  },
+  {
+    "name": "Tibet",
+    "usphone": "tiˈbet",
+    "ukphone": "",
+    "trans": [
+      "n. 西藏"
+    ]
+  },
+  {
+    "name": "Tibeta",
+    "usphone": "tiˈbetən",
+    "ukphone": "",
+    "trans": [
+      "n. 西藏人；西藏语"
+    ]
+  },
+  {
+    "name": "tick",
+    "usphone": "tɪk",
+    "ukphone": "",
+    "trans": [
+      "vt. 作记号"
+    ]
+  },
+  {
+    "name": "ticket",
+    "usphone": "ˈtɪkɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 票；卷"
+    ]
+  },
+  {
+    "name": "tidy",
+    "usphone": "ˈtɪkɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 整洁的，干净的 vt. 弄整洁，弄干净"
+    ]
+  },
+  {
+    "name": "tie",
+    "usphone": "taɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. （用绳，线）系，拴，扎 n. 领带，绳子，结；关系"
+    ]
+  },
+  {
+    "name": "tiger",
+    "usphone": "ˈtaɪɡə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 老虎"
+    ]
+  },
+  {
+    "name": "tight",
+    "usphone": "taɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 紧的"
+    ]
+  },
+  {
+    "name": "till",
+    "usphone": "tɪl",
+    "ukphone": "",
+    "trans": [
+      "conj.& prep.直到,直到…为止"
+    ]
+  },
+  {
+    "name": "time",
+    "usphone": "taɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 时间;时期;钟点,次,回 vt.测定…的时间,记录…的时间"
+    ]
+  },
+  {
+    "name": "timetable",
+    "usphone": "ˈtaɪmteɪb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. （火车、公共汽车等）时间表；（学校）课表"
+    ]
+  },
+  {
+    "name": "tin",
+    "usphone": "tɪn",
+    "ukphone": "",
+    "trans": [
+      "n. （英）罐头，听头"
+    ]
+  },
+  {
+    "name": "tiny",
+    "usphone": "ˈtaɪnɪ",
+    "ukphone": "",
+    "trans": [
+      "adj.  tinier, tiniest  a. 极小的，微小的"
+    ]
+  },
+  {
+    "name": "tip",
+    "usphone": "tɪp",
+    "ukphone": "",
+    "trans": [
+      "n.& v.顶端，尖端；告诫； 提示 (给)小费"
+    ]
+  },
+  {
+    "name": "tire",
+    "usphone": "ˈtaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi. 使疲劳"
+    ]
+  },
+  {
+    "name": "tired",
+    "usphone": "ˈtaɪəd",
+    "ukphone": "",
+    "trans": [
+      "a. 疲劳的，累的"
+    ]
+  },
+  {
+    "name": "tiresomev",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a. 令人厌倦的"
+    ]
+  },
+  {
+    "name": "tissue",
+    "usphone": "ˈtɪʃuː, ˈtɪsjuː",
+    "ukphone": "",
+    "trans": [
+      "n. （人，动植物的）组织，纸巾"
+    ]
+  },
+  {
+    "name": "title",
+    "usphone": "ˈtɪʃuː, ˈtɪsjuː",
+    "ukphone": "",
+    "trans": [
+      "n. 标题，题目"
+    ]
+  },
+  {
+    "name": "to",
+    "usphone": "tʊ, tuː",
+    "ukphone": "",
+    "trans": [
+      "prep. （动词不定式符号，无词义）；（表示接受动作的人或物）给；对，向，到；在…之前"
+    ]
+  },
+  {
+    "name": "toast",
+    "usphone": "təʊst",
+    "ukphone": "",
+    "trans": [
+      "v./ n. 烤"
+    ]
+  },
+  {
+    "name": "tobacco",
+    "usphone": "təʊst",
+    "ukphone": "",
+    "trans": [
+      "n. 烟草，烟叶"
+    ]
+  },
+  {
+    "name": "today",
+    "usphone": "təʊst",
+    "ukphone": "",
+    "trans": [
+      "ad.& n.今天;现在,当前"
+    ]
+  },
+  {
+    "name": "together",
+    "usphone": "təʊst",
+    "ukphone": "",
+    "trans": [
+      "ad. 一起，共同"
+    ]
+  },
+  {
+    "name": "toilet",
+    "usphone": "ˈtɔɪlɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 厕所"
+    ]
+  },
+  {
+    "name": "Tokyo",
+    "usphone": "ˈtəʊkjəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 东京"
+    ]
+  },
+  {
+    "name": "tolerate",
+    "usphone": "ˈtɔləreɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 容许，允许，忍受"
+    ]
+  },
+  {
+    "name": "tomato",
+    "usphone": "təˈmɑːtəʊ; (US) təˈmeɪtəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 西红柿，番茄"
+    ]
+  },
+  {
+    "name": "tomb",
+    "usphone": "tuːm",
+    "ukphone": "",
+    "trans": [
+      "n. 坟墓"
+    ]
+  },
+  {
+    "name": "tomorrow",
+    "usphone": "təˈmɔrəʊ",
+    "ukphone": "",
+    "trans": [
+      "ad. & n.明天"
+    ]
+  },
+  {
+    "name": "ton",
+    "usphone": "təˈmɔrəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. （重量单位）吨"
+    ]
+  },
+  {
+    "name": "tongue",
+    "usphone": "tʌŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 舌，舌头"
+    ]
+  },
+  {
+    "name": "tonight",
+    "usphone": "təˈnaɪt",
+    "ukphone": "",
+    "trans": [
+      "ad.& n. 今晚，今夜"
+    ]
+  },
+  {
+    "name": "too",
+    "usphone": "təˈnaɪt",
+    "ukphone": "",
+    "trans": [
+      "ad.也,还,又,太,过分,很,非常"
+    ]
+  },
+  {
+    "name": "tool",
+    "usphone": "tuːl",
+    "ukphone": "",
+    "trans": [
+      "n. 工具，器具"
+    ]
+  },
+  {
+    "name": "tooth (复 teeth)",
+    "usphone": "tuːθ",
+    "ukphone": "",
+    "trans": [
+      "n. 牙齿"
+    ]
+  },
+  {
+    "name": "toothache",
+    "usphone": "ˈtuːθeɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 牙痛"
+    ]
+  },
+  {
+    "name": "toothbrush",
+    "usphone": "ˈtuːθbrʌʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 牙刷"
+    ]
+  },
+  {
+    "name": "toothpaste",
+    "usphone": "ˈtuːθpeɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 牙膏"
+    ]
+  },
+  {
+    "name": "top",
+    "usphone": "tɔp",
+    "ukphone": "",
+    "trans": [
+      "n. 顶部,（物体的）上面"
+    ]
+  },
+  {
+    "name": "topic",
+    "usphone": "ˈtɔpɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 题目，话题"
+    ]
+  },
+  {
+    "name": "tortoise",
+    "usphone": "ˈtɔpɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 乌龟"
+    ]
+  },
+  {
+    "name": "total",
+    "usphone": "ˈtəʊt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 总数的;总括的;完全的,全然的 n.合计,总计 v.合计为"
+    ]
+  },
+  {
+    "name": "totally",
+    "usphone": "ˈtɔt(ə)lɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 总合地，完全地"
+    ]
+  },
+  {
+    "name": "touch",
+    "usphone": "tʌtʃ",
+    "ukphone": "",
+    "trans": [
+      "vt. 触摸，接触"
+    ]
+  },
+  {
+    "name": "tough",
+    "usphone": "ˈtɔt(ə)lɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 坚硬的；结实的；棘手的，难解的"
+    ]
+  },
+  {
+    "name": "tour",
+    "usphone": "tʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 参观, 观光, 旅行"
+    ]
+  },
+  {
+    "name": "tourism",
+    "usphone": "ˈtʊərɪz(ə)m",
+    "ukphone": "",
+    "trans": [
+      "n. 旅游业；观光"
+    ]
+  },
+  {
+    "name": "tourist",
+    "usphone": "ˈtʊərɪst",
+    "ukphone": "",
+    "trans": [
+      "vn. 旅行者，观光者"
+    ]
+  },
+  {
+    "name": "tournament",
+    "usphone": "ˈtʊənəmənt; (US) ˈtɜːrn-",
+    "ukphone": "",
+    "trans": [
+      "n. 锦标赛，联赛"
+    ]
+  },
+  {
+    "name": "toward(s)",
+    "usphone": "təˈwɔːd",
+    "ukphone": "",
+    "trans": [
+      "prep. 向，朝，对于"
+    ]
+  },
+  {
+    "name": "towel",
+    "usphone": "ˈtaʊəl",
+    "ukphone": "",
+    "trans": [
+      "n. 毛巾"
+    ]
+  },
+  {
+    "name": "tower",
+    "usphone": "ˈtaʊə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 塔"
+    ]
+  },
+  {
+    "name": "town",
+    "usphone": "taʊn",
+    "ukphone": "",
+    "trans": [
+      "n. 城镇，城"
+    ]
+  },
+  {
+    "name": "toy",
+    "usphone": "tɔɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 玩具, 玩物"
+    ]
+  },
+  {
+    "name": "track",
+    "usphone": "træk",
+    "ukphone": "",
+    "trans": [
+      "n. 轨道；田径"
+    ]
+  },
+  {
+    "name": "tractor",
+    "usphone": "ˈtræktə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 拖拉机"
+    ]
+  },
+  {
+    "name": "trade",
+    "usphone": "treɪd",
+    "ukphone": "",
+    "trans": [
+      "n.贸易 vt.用…进行交换"
+    ]
+  },
+  {
+    "name": "tradition",
+    "usphone": "trəˈdɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 传统，风俗"
+    ]
+  },
+  {
+    "name": "traditional",
+    "usphone": "trəˈdɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 传统的，风俗的"
+    ]
+  },
+  {
+    "name": "traffic",
+    "usphone": "ˈtræfɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 交通，来往车辆"
+    ]
+  },
+  {
+    "name": "traffic lights",
+    "usphone": "ˈtræfɪk laɪts",
+    "ukphone": "",
+    "trans": [
+      "n.交通指挥灯红绿灯"
+    ]
+  },
+  {
+    "name": "train",
+    "usphone": "treɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 火车 v. 培训,训练"
+    ]
+  },
+  {
+    "name": "trainer",
+    "usphone": "treɪˈnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 训练人；教练"
+    ]
+  },
+  {
+    "name": "training",
+    "usphone": "ˈtreɪnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 培训"
+    ]
+  },
+  {
+    "name": "tram",
+    "usphone": "træm",
+    "ukphone": "",
+    "trans": [
+      "n. 有轨电车"
+    ]
+  },
+  {
+    "name": "transform",
+    "usphone": "trænsˈfɔːm",
+    "ukphone": "",
+    "trans": [
+      "v.使改变形态,使改观"
+    ]
+  },
+  {
+    "name": "translate",
+    "usphone": "trænsˈleɪt",
+    "ukphone": "",
+    "trans": [
+      "vt. 翻译"
+    ]
+  },
+  {
+    "name": "translation",
+    "usphone": "trænsˈleɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 翻译；译文"
+    ]
+  },
+  {
+    "name": "transparent",
+    "usphone": "trænsˈpærənt",
+    "ukphone": "",
+    "trans": [
+      "a.透明的，清澈的"
+    ]
+  },
+  {
+    "name": "translator",
+    "usphone": "trænsˈleitə",
+    "ukphone": "",
+    "trans": [
+      "n. 翻译家，译者"
+    ]
+  },
+  {
+    "name": "transport",
+    "usphone": "trænsˈpɔːt",
+    "ukphone": "",
+    "trans": [
+      "n.& vt.运输"
+    ]
+  },
+  {
+    "name": "trap",
+    "usphone": "træp",
+    "ukphone": "",
+    "trans": [
+      "n. 陷阱 vt. 使陷入困境"
+    ]
+  },
+  {
+    "name": "travel",
+    "usphone": "ˈtræv(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.& vi.旅行"
+    ]
+  },
+  {
+    "name": "traveler",
+    "usphone": "ˈtrævələ(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 旅行者"
+    ]
+  },
+  {
+    "name": "treasure",
+    "usphone": "ˈtreʒə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 金银财宝, 财富"
+    ]
+  },
+  {
+    "name": "treat",
+    "usphone": "triːt",
+    "ukphone": "",
+    "trans": [
+      "vt. 对待，看待"
+    ]
+  },
+  {
+    "name": "treatment",
+    "usphone": "ˈtriːtmənt",
+    "ukphone": "",
+    "trans": [
+      "n. 治疗,疗法"
+    ]
+  },
+  {
+    "name": "tree",
+    "usphone": "triː",
+    "ukphone": "",
+    "trans": [
+      "n. 树"
+    ]
+  },
+  {
+    "name": "tremble",
+    "usphone": "ˈtremb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "v. 颤抖"
+    ]
+  },
+  {
+    "name": "trend",
+    "usphone": "trend",
+    "ukphone": "",
+    "trans": [
+      "n. 趋势，倾向，动态"
+    ]
+  },
+  {
+    "name": "trial",
+    "usphone": "ˈtraɪəl",
+    "ukphone": "",
+    "trans": [
+      "n. 审判；试验；试用"
+    ]
+  },
+  {
+    "name": "triangle",
+    "usphone": "ˈtraɪæŋɡ(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n.& adj.三角形;三角形的"
+    ]
+  },
+  {
+    "name": "trick",
+    "usphone": "trɪk",
+    "ukphone": "",
+    "trans": [
+      "n. 诡计，把戏"
+    ]
+  },
+  {
+    "name": "trip",
+    "usphone": "trɪp",
+    "ukphone": "",
+    "trans": [
+      "n. 旅行，旅程"
+    ]
+  },
+  {
+    "name": "trolley-bus",
+    "usphone": "ˈtrɔlɪ- bʌs",
+    "ukphone": "",
+    "trans": [
+      "n. 无轨电车"
+    ]
+  },
+  {
+    "name": "trooping",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "vi. 成群结队地走"
+    ]
+  },
+  {
+    "name": "troop",
+    "usphone": "truːp",
+    "ukphone": "",
+    "trans": [
+      "n. 部队"
+    ]
+  },
+  {
+    "name": "trouble",
+    "usphone": "ˈtrʌb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "vt. 使苦恼,使忧虑,使麻烦 n.问题,疾病,烦恼,麻烦"
+    ]
+  },
+  {
+    "name": "troublesome",
+    "usphone": "ˈtrʌb(ə)lsəm",
+    "ukphone": "",
+    "trans": [
+      "a.令人烦恼, 讨厌"
+    ]
+  },
+  {
+    "name": "trousers",
+    "usphone": "ˈtraʊzəz",
+    "ukphone": "",
+    "trans": [
+      "n. 裤子，长裤"
+    ]
+  },
+  {
+    "name": "truck",
+    "usphone": "trʌk",
+    "ukphone": "",
+    "trans": [
+      "n. 卡车, 运货车；车皮 v. 装车；用货车运"
+    ]
+  },
+  {
+    "name": "true",
+    "usphone": "truː",
+    "ukphone": "",
+    "trans": [
+      "a. 真的，真实的；忠诚的"
+    ]
+  },
+  {
+    "name": "truly",
+    "usphone": "ˈtruːlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 真正地，真实地"
+    ]
+  },
+  {
+    "name": "trunk",
+    "usphone": "trʌŋk",
+    "ukphone": "",
+    "trans": [
+      "n. 树干；大箱子"
+    ]
+  },
+  {
+    "name": "trust",
+    "usphone": "trʌst",
+    "ukphone": "",
+    "trans": [
+      "vt. 相信，信任，信赖"
+    ]
+  },
+  {
+    "name": "truth",
+    "usphone": "truːθ",
+    "ukphone": "",
+    "trans": [
+      "n. 真理,事实,真相,实际"
+    ]
+  },
+  {
+    "name": "try",
+    "usphone": "truːθ",
+    "ukphone": "",
+    "trans": [
+      "v. 试，试图，努力"
+    ]
+  },
+  {
+    "name": "T-shirt",
+    "usphone": "tiː- ʃɜːt",
+    "ukphone": "",
+    "trans": [
+      "n. T恤衫"
+    ]
+  },
+  {
+    "name": "tube",
+    "usphone": "tjuːb; (US) tuːb",
+    "ukphone": "",
+    "trans": [
+      "n. 管，管状物"
+    ]
+  },
+  {
+    "name": "tune",
+    "usphone": "tjuːn; (US) tuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 曲调，曲子"
+    ]
+  },
+  {
+    "name": "Tuesday",
+    "usphone": "ˈtjuːzdeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 星期二"
+    ]
+  },
+  {
+    "name": "turkey",
+    "usphone": "ˈtɜːkɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 火鸡"
+    ]
+  },
+  {
+    "name": "turn",
+    "usphone": "tɜːn",
+    "ukphone": "",
+    "trans": [
+      "v. 旋转，翻转，转变，转弯 n. 轮流，（轮流的）顺序"
+    ]
+  },
+  {
+    "name": "turning n",
+    "usphone": "ˈtɜːnɪŋ",
+    "ukphone": "",
+    "trans": [
+      ". 拐弯处，拐角处"
+    ]
+  },
+  {
+    "name": "tutor",
+    "usphone": "ˈtjuːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 家庭教师，私人教师，导师"
+    ]
+  },
+  {
+    "name": "TV(缩) = television",
+    "usphone": "‚tiːˈviː",
+    "ukphone": "",
+    "trans": [
+      "n. 电视机"
+    ]
+  },
+  {
+    "name": "twelfth",
+    "usphone": "twelfθ",
+    "ukphone": "",
+    "trans": [
+      "num. 第十二"
+    ]
+  },
+  {
+    "name": "twelve",
+    "usphone": "twelv",
+    "ukphone": "",
+    "trans": [
+      "num. 十二"
+    ]
+  },
+  {
+    "name": "twentieth",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "vnum.第二十"
+    ]
+  },
+  {
+    "name": "twenty",
+    "usphone": "ˈtwentɪ",
+    "ukphone": "",
+    "trans": [
+      "num. 二十"
+    ]
+  },
+  {
+    "name": "twenty-first",
+    "usphone": "ˈtwentɪ- [fɜːst",
+    "ukphone": "",
+    "trans": [
+      "num. 第二十一"
+    ]
+  },
+  {
+    "name": "twenty-one",
+    "usphone": "ˈtwentɪ- wʌn",
+    "ukphone": "",
+    "trans": [
+      "num. 二十一"
+    ]
+  },
+  {
+    "name": "twice",
+    "usphone": "twaɪs",
+    "ukphone": "",
+    "trans": [
+      "ad. 两次；两倍"
+    ]
+  },
+  {
+    "name": "twin",
+    "usphone": "twɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 双胞胎之一"
+    ]
+  },
+  {
+    "name": "twist",
+    "usphone": "twɪst",
+    "ukphone": "",
+    "trans": [
+      "v./ n. 使弯曲，转动"
+    ]
+  },
+  {
+    "name": "two",
+    "usphone": "tuː",
+    "ukphone": "",
+    "trans": [
+      "num. 二"
+    ]
+  },
+  {
+    "name": "type",
+    "usphone": "ˈtaɪp",
+    "ukphone": "",
+    "trans": [
+      "vt. 打字"
+    ]
+  },
+  {
+    "name": "typewriter",
+    "usphone": "ˈtaɪpraɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 打字机"
+    ]
+  },
+  {
+    "name": "typical",
+    "usphone": "ˈtɪpɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 典型的，有代表性的，特有的"
+    ]
+  },
+  {
+    "name": "typhoon",
+    "usphone": "taɪˈfuːn",
+    "ukphone": "",
+    "trans": [
+      "n. 台风"
+    ]
+  },
+  {
+    "name": "typist",
+    "usphone": "ˈtaɪpɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 打字员"
+    ]
+  },
+  {
+    "name": "tyre (美tire)",
+    "usphone": "taɪə",
+    "ukphone": "",
+    "trans": [
+      "n. 轮胎"
+    ]
+  },
+  {
+    "name": "ugly",
+    "usphone": "ˈʌɡlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 丑陋的；难看的"
+    ]
+  },
+  {
+    "name": "U.K./ UK(缩) = United Kingdom",
+    "usphone": "juː ˈkeɪ",
+    "ukphone": "",
+    "trans": [
+      "n.英国，联合王国"
+    ]
+  },
+  {
+    "name": "umbrella",
+    "usphone": "ʌmˈbrelə",
+    "ukphone": "",
+    "trans": [
+      "n. 雨伞"
+    ]
+  },
+  {
+    "name": "U.N./ UN(缩) = the United Nations",
+    "usphone": "juː ˈən",
+    "ukphone": "",
+    "trans": [
+      "n. 联合国"
+    ]
+  },
+  {
+    "name": "unable",
+    "usphone": "juː ˈən",
+    "ukphone": "",
+    "trans": [
+      "a.不能的，不能胜任的"
+    ]
+  },
+  {
+    "name": "unbearable",
+    "usphone": "ʌnˈbeərəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.难耐得,无法接受的"
+    ]
+  },
+  {
+    "name": "unbelievable",
+    "usphone": "ʌnbɪˈliːvəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.难以置信的"
+    ]
+  },
+  {
+    "name": "uncertain",
+    "usphone": "ˈsɜːt(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a.不确定的"
+    ]
+  },
+  {
+    "name": "uncle",
+    "usphone": "ˈʌŋk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 叔,伯,舅,姑夫,姨父"
+    ]
+  },
+  {
+    "name": "uncomfortable",
+    "usphone": "ʌnˈkʌmftəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 令人不舒服的"
+    ]
+  },
+  {
+    "name": "unconditional",
+    "usphone": "ʌnkənˈdɪʃən(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a.无条件，绝对的"
+    ]
+  },
+  {
+    "name": "unconscious",
+    "usphone": "ʌnˈkɔnʃəs",
+    "ukphone": "",
+    "trans": [
+      "a.昏迷,不省人事的"
+    ]
+  },
+  {
+    "name": "under",
+    "usphone": "ˈʌndə(r)",
+    "ukphone": "",
+    "trans": [
+      "ad.& prep.在…下面，向…下面"
+    ]
+  },
+  {
+    "name": "underground",
+    "usphone": "ʌndəˈɡraʊnd",
+    "ukphone": "",
+    "trans": [
+      "a.地下的 n. 地铁"
+    ]
+  },
+  {
+    "name": "underline",
+    "usphone": "ʌndəˈlaɪn",
+    "ukphone": "",
+    "trans": [
+      "v. 在…下划线"
+    ]
+  },
+  {
+    "name": "understand (understood, understood)",
+    "usphone": "ʌndəˈstænd",
+    "ukphone": "",
+    "trans": [
+      "v. 懂得;明白;理解"
+    ]
+  },
+  {
+    "name": "understanding",
+    "usphone": "ʌndəˈstændɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 领会;理解"
+    ]
+  },
+  {
+    "name": "undertake (undertook, undertaken)",
+    "usphone": "ʌndəˈteɪk",
+    "ukphone": "",
+    "trans": [
+      "v. 承担，从事，负责"
+    ]
+  },
+  {
+    "name": "underwear",
+    "usphone": "ˈʌndəweə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 内衣"
+    ]
+  },
+  {
+    "name": "undivided",
+    "usphone": "ʌndɪˈvaɪdɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 没分开的；专一的； 专心的"
+    ]
+  },
+  {
+    "name": "undo",
+    "usphone": "ʌnˈduː",
+    "ukphone": "",
+    "trans": [
+      "v. 解开，松开"
+    ]
+  },
+  {
+    "name": "unemployment",
+    "usphone": "ʌnɪmˈplɔɪmənt",
+    "ukphone": "",
+    "trans": [
+      "n.失业,失业状态"
+    ]
+  },
+  {
+    "name": "unfair",
+    "usphone": "ʌnˈfeə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 不公平的，不公正的"
+    ]
+  },
+  {
+    "name": "unfit",
+    "usphone": "ʌnˈfɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 不合宜的，不相宜的"
+    ]
+  },
+  {
+    "name": "unfold",
+    "usphone": "ʌnˈfəʊld",
+    "ukphone": "",
+    "trans": [
+      "vt. 展开，打开"
+    ]
+  },
+  {
+    "name": "unfortunate",
+    "usphone": "ʌnˈfəʊld",
+    "ukphone": "",
+    "trans": [
+      "a. 不幸的"
+    ]
+  },
+  {
+    "name": "unfortunately",
+    "usphone": "ʌnˈfɔːtjʊnətlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 不幸地"
+    ]
+  },
+  {
+    "name": "unhappy",
+    "usphone": "ʌnˈfɔːtjʊnətlɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 不高兴的,伤心的"
+    ]
+  },
+  {
+    "name": "unhealthy",
+    "usphone": "ʌnˈhelθɪ",
+    "ukphone": "",
+    "trans": [
+      "a.不健康的,不卫生的"
+    ]
+  },
+  {
+    "name": "uniform",
+    "usphone": "ˈjuːnɪfɔːm",
+    "ukphone": "",
+    "trans": [
+      "n. 制服"
+    ]
+  },
+  {
+    "name": "unimportant",
+    "usphone": "ʌnɪmˈpɔːt(e)nt",
+    "ukphone": "",
+    "trans": [
+      "a.不重要的,无意义"
+    ]
+  },
+  {
+    "name": "union",
+    "usphone": "ˈjuːnjən",
+    "ukphone": "",
+    "trans": [
+      "n. 联合,联盟；工会"
+    ]
+  },
+  {
+    "name": "unique",
+    "usphone": "jʊˈniːk",
+    "ukphone": "",
+    "trans": [
+      "a. 惟一的,独一无二的"
+    ]
+  },
+  {
+    "name": "unit",
+    "usphone": "ˈjuːnɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 单元，单位"
+    ]
+  },
+  {
+    "name": "unite",
+    "usphone": "jʊˈnaɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 联合，团结"
+    ]
+  },
+  {
+    "name": "universal",
+    "usphone": "juːnɪˈvɜːs(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 普遍的，全体的"
+    ]
+  },
+  {
+    "name": "universe",
+    "usphone": "ˈjuːnɪvɜːs",
+    "ukphone": "",
+    "trans": [
+      "n. 宇宙"
+    ]
+  },
+  {
+    "name": "university",
+    "usphone": "juːnɪˈvɜːsɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 大学"
+    ]
+  },
+  {
+    "name": "unknown",
+    "usphone": "juːnɪˈvɜːsɪtɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 不知道的"
+    ]
+  },
+  {
+    "name": "unless",
+    "usphone": "ʌnˈles",
+    "ukphone": "",
+    "trans": [
+      "conj. 如果不，除非"
+    ]
+  },
+  {
+    "name": "unlike",
+    "usphone": "ʌnˈlaɪk",
+    "ukphone": "",
+    "trans": [
+      "prep. 不像，和…不同"
+    ]
+  },
+  {
+    "name": "unmarried",
+    "usphone": "ʌnˈmærɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 未婚的，独身的"
+    ]
+  },
+  {
+    "name": "unpleasant",
+    "usphone": "ʌnˈplez(ə)nt",
+    "ukphone": "",
+    "trans": [
+      "a. 使人不愉快的"
+    ]
+  },
+  {
+    "name": "unrest",
+    "usphone": "ʌnˈrest",
+    "ukphone": "",
+    "trans": [
+      "n. 不安；骚动"
+    ]
+  },
+  {
+    "name": "unsafe",
+    "usphone": "ʌnˈseɪf",
+    "ukphone": "",
+    "trans": [
+      "a. 不安全的；危险的"
+    ]
+  },
+  {
+    "name": "unsuccessful",
+    "usphone": "ʌnsəkˈsesfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 不成功,失败的"
+    ]
+  },
+  {
+    "name": "until",
+    "usphone": "ʌnˈtɪl",
+    "ukphone": "",
+    "trans": [
+      "prep.& conj.直到…为止"
+    ]
+  },
+  {
+    "name": "untrue",
+    "usphone": "ʌnˈtruː",
+    "ukphone": "",
+    "trans": [
+      "a. 不真实的，假的"
+    ]
+  },
+  {
+    "name": "unusual",
+    "usphone": "ʌnˈjuːʒʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 不平常的，异常的"
+    ]
+  },
+  {
+    "name": "unwilling",
+    "usphone": "ʌnˈwɪlɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 不愿意的，勉强的"
+    ]
+  },
+  {
+    "name": "up",
+    "usphone": "ʌp",
+    "ukphone": "",
+    "trans": [
+      "ad. 向上；在上方；起来；在…以上 a. 上面的，向上的，上行的 n. 上升；上坡；上行；繁荣 v. 举起；拿起；提高 prep. 向(高处)；向(在)……上(面)游"
+    ]
+  },
+  {
+    "name": "upon",
+    "usphone": "əˈpɔn",
+    "ukphone": "",
+    "trans": [
+      "prep. 在……上面"
+    ]
+  },
+  {
+    "name": "upper",
+    "usphone": "ˈʌpə(r)",
+    "ukphone": "",
+    "trans": [
+      "a. 较高的，较上的"
+    ]
+  },
+  {
+    "name": "upset",
+    "usphone": "ʌpˈset",
+    "ukphone": "",
+    "trans": [
+      "a. 心烦的，苦恼的"
+    ]
+  },
+  {
+    "name": "upstairs",
+    "usphone": "ʌpˈsteəz",
+    "ukphone": "",
+    "trans": [
+      "ad. 在楼上，到楼上"
+    ]
+  },
+  {
+    "name": "upward",
+    "usphone": "ˈʌpwəd",
+    "ukphone": "",
+    "trans": [
+      "ad. 向上；往上"
+    ]
+  },
+  {
+    "name": "urban",
+    "usphone": "ˈɜːbən",
+    "ukphone": "",
+    "trans": [
+      "a. 城市的，都市的"
+    ]
+  },
+  {
+    "name": "urge",
+    "usphone": "ɜːdʒ",
+    "ukphone": "",
+    "trans": [
+      "v. 敦促，催促，力劝"
+    ]
+  },
+  {
+    "name": "urgent",
+    "usphone": "ˈɜːdʒənt",
+    "ukphone": "",
+    "trans": [
+      "a. 紧急的，紧迫的"
+    ]
+  },
+  {
+    "name": "U.S.A./USA(缩) = the United States of America",
+    "usphone": "juː es ˈeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 美国（美利坚合众国）"
+    ]
+  },
+  {
+    "name": "use",
+    "usphone": "juːz",
+    "ukphone": "",
+    "trans": [
+      "n.& vt.利用,使用,应用"
+    ]
+  },
+  {
+    "name": "used",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "a. 用过的;旧的;二手的"
+    ]
+  },
+  {
+    "name": "useful",
+    "usphone": "ˈjuːsfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 有用的，有益的"
+    ]
+  },
+  {
+    "name": "useless",
+    "usphone": "ˈjuːslɪs",
+    "ukphone": "",
+    "trans": [
+      "a. 无用的"
+    ]
+  },
+  {
+    "name": "user",
+    "usphone": "ˈjuːzə",
+    "ukphone": "",
+    "trans": [
+      "n. 使用者；用户"
+    ]
+  },
+  {
+    "name": "usual",
+    "usphone": "ˈjuːʒʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 通常的，平常的"
+    ]
+  },
+  {
+    "name": "usually",
+    "usphone": "ˈjuːʒʊəlɪ",
+    "ukphone": "",
+    "trans": [
+      "ad. 通常，经常"
+    ]
+  },
+  {
+    "name": "vacation",
+    "usphone": "vəˈkeɪʃ(ə)n",
+    "ukphone": "",
+    "trans": [
+      "n. 假期，休假"
+    ]
+  },
+  {
+    "name": "vacant",
+    "usphone": "ˈveɪkənt",
+    "ukphone": "",
+    "trans": [
+      "a. 空缺的，未被占用的"
+    ]
+  },
+  {
+    "name": "vague",
+    "usphone": "veɪɡ",
+    "ukphone": "",
+    "trans": [
+      "a. 含糊的，紧迫的"
+    ]
+  },
+  {
+    "name": "vain",
+    "usphone": "veɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 自负的，自视过高的，徒劳的，无效的"
+    ]
+  },
+  {
+    "name": "valid",
+    "usphone": "ˈvælɪd",
+    "ukphone": "",
+    "trans": [
+      "a.有效的,合理的,有根据的"
+    ]
+  },
+  {
+    "name": "valley",
+    "usphone": "ˈvælɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 山谷, 溪谷"
+    ]
+  },
+  {
+    "name": "valuable",
+    "usphone": "ˈvæljʊəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 值钱的，贵重的"
+    ]
+  },
+  {
+    "name": "value",
+    "usphone": "ˈvæljuː",
+    "ukphone": "",
+    "trans": [
+      "n. 价值，益处"
+    ]
+  },
+  {
+    "name": "vanilla",
+    "usphone": "vəˈnɪlə",
+    "ukphone": "",
+    "trans": [
+      "n. 香草"
+    ]
+  },
+  {
+    "name": "variety",
+    "usphone": "vəˈraɪətɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 种种，种类"
+    ]
+  },
+  {
+    "name": "various",
+    "usphone": "ˈveərɪəs",
+    "ukphone": "",
+    "trans": [
+      "a. 各种各样的，不同的"
+    ]
+  },
+  {
+    "name": "vase",
+    "usphone": "vɑːz; (US) veɪs",
+    "ukphone": "",
+    "trans": [
+      "n. （花）瓶；瓶饰"
+    ]
+  },
+  {
+    "name": "vast",
+    "usphone": "vɑːst; (US) væst",
+    "ukphone": "",
+    "trans": [
+      "a. 巨大的，广阔的"
+    ]
+  },
+  {
+    "name": "VCD = versatile compact disk",
+    "usphone": "",
+    "ukphone": "",
+    "trans": [
+      "n. 影碟光盘"
+    ]
+  },
+  {
+    "name": "veal",
+    "usphone": "viːl",
+    "ukphone": "",
+    "trans": [
+      "n. （食用）小牛肉"
+    ]
+  },
+  {
+    "name": "vegetable",
+    "usphone": "ˈvedʒɪtəb(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 蔬菜"
+    ]
+  },
+  {
+    "name": "vehicle",
+    "usphone": "ˈviːɪk(ə)l; (US) ˈviːhɪkl",
+    "ukphone": "",
+    "trans": [
+      "n. 交通工具，车辆"
+    ]
+  },
+  {
+    "name": "version",
+    "usphone": "ˈvɜːʃ(ə)n; (US) ˈvərʒn",
+    "ukphone": "",
+    "trans": [
+      "n. 变体，变种，改写本"
+    ]
+  },
+  {
+    "name": "vertical",
+    "usphone": "ˈvɜːtɪk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 垂直的，纵向的"
+    ]
+  },
+  {
+    "name": "very",
+    "usphone": "ˈverɪ",
+    "ukphone": "",
+    "trans": [
+      "vad. 很，非常"
+    ]
+  },
+  {
+    "name": "vest",
+    "usphone": "vest",
+    "ukphone": "",
+    "trans": [
+      "n. 背心，内衣"
+    ]
+  },
+  {
+    "name": "via",
+    "usphone": "ˈvaɪə",
+    "ukphone": "",
+    "trans": [
+      "prep. 经过（某地），通过"
+    ]
+  },
+  {
+    "name": "vice",
+    "usphone": "vaɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 罪行，不道德行为"
+    ]
+  },
+  {
+    "name": "victim",
+    "usphone": "ˈvɪktɪm",
+    "ukphone": "",
+    "trans": [
+      "n. 受害者，牺牲品"
+    ]
+  },
+  {
+    "name": "victory",
+    "usphone": "ˈvɪktərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 胜利"
+    ]
+  },
+  {
+    "name": "video",
+    "usphone": "ˈvɪdɪəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 录像，视频"
+    ]
+  },
+  {
+    "name": "videophone",
+    "usphone": "ˈvidiəʊfəʊn",
+    "ukphone": "",
+    "trans": [
+      "n. 可视电话"
+    ]
+  },
+  {
+    "name": "view",
+    "usphone": "vjuː",
+    "ukphone": "",
+    "trans": [
+      "n. 看法,见解;风景,景色"
+    ]
+  },
+  {
+    "name": "viewer",
+    "usphone": "ˈvjuːə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 观看者"
+    ]
+  },
+  {
+    "name": "village",
+    "usphone": "ˈvɪlɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 村庄，乡村"
+    ]
+  },
+  {
+    "name": "villager",
+    "usphone": "ˈvilidʒə",
+    "ukphone": "",
+    "trans": [
+      "n. 村民"
+    ]
+  },
+  {
+    "name": "vinegar",
+    "usphone": "ˈvilidʒə",
+    "ukphone": "",
+    "trans": [
+      "n. 醋"
+    ]
+  },
+  {
+    "name": "violate",
+    "usphone": "ˈvaɪəleɪt",
+    "ukphone": "",
+    "trans": [
+      "v. 违反（法律、协议等），侵犯"
+    ]
+  },
+  {
+    "name": "violence",
+    "usphone": "ˈvaɪələns",
+    "ukphone": "",
+    "trans": [
+      "n. 暴力行为"
+    ]
+  },
+  {
+    "name": "violent",
+    "usphone": "ˈvaɪələnt",
+    "ukphone": "",
+    "trans": [
+      "a. 暴力的"
+    ]
+  },
+  {
+    "name": "violin",
+    "usphone": "vaɪəˈlɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 小提琴"
+    ]
+  },
+  {
+    "name": "violinist",
+    "usphone": "vaɪəˈlɪnɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 提琴家，提琴手"
+    ]
+  },
+  {
+    "name": "virtue",
+    "usphone": "ˈvɜːtjuː",
+    "ukphone": "",
+    "trans": [
+      "n. 美德,正直的品行,德行"
+    ]
+  },
+  {
+    "name": "virus",
+    "usphone": "ˈvaɪərəs",
+    "ukphone": "",
+    "trans": [
+      "n.病毒"
+    ]
+  },
+  {
+    "name": "visa",
+    "usphone": "ˈviːzə",
+    "ukphone": "",
+    "trans": [
+      "n. 签证，背签"
+    ]
+  },
+  {
+    "name": "visit",
+    "usphone": "ˈviːzə",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 参观，访问，拜访"
+    ]
+  },
+  {
+    "name": "visitor",
+    "usphone": "ˈvɪzɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 访问者，参观者"
+    ]
+  },
+  {
+    "name": "visual",
+    "usphone": "ˈvɪʒjʊəl",
+    "ukphone": "",
+    "trans": [
+      "a. 视力的，视觉的"
+    ]
+  },
+  {
+    "name": "vital",
+    "usphone": "ˈvaɪt(ə)l",
+    "ukphone": "",
+    "trans": [
+      "a. 必不可少的，对…极重要的"
+    ]
+  },
+  {
+    "name": "vivid",
+    "usphone": "ˈvɪvɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 生动，逼真的，鲜明的"
+    ]
+  },
+  {
+    "name": "vocabulary",
+    "usphone": "vəˈkæbjʊlərɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 词汇, 词汇表"
+    ]
+  },
+  {
+    "name": "voice",
+    "usphone": "vɔɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 说话声; 语态"
+    ]
+  },
+  {
+    "name": "volcano",
+    "usphone": "vɔlˈkeɪnəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 火山"
+    ]
+  },
+  {
+    "name": "volleyball",
+    "usphone": "vɔlˈkeɪnəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 排球"
+    ]
+  },
+  {
+    "name": "voluntary",
+    "usphone": "ˈvɔləntərɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 自愿的，主动的"
+    ]
+  },
+  {
+    "name": "volunteer",
+    "usphone": "vɔlənˈtɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n./ v. 义工，自愿者，无偿做"
+    ]
+  },
+  {
+    "name": "vote",
+    "usphone": "vəʊt",
+    "ukphone": "",
+    "trans": [
+      "vi. 选举，投票"
+    ]
+  },
+  {
+    "name": "voyage",
+    "usphone": "ˈvɔɪɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 航行，旅行"
+    ]
+  },
+  {
+    "name": "wag",
+    "usphone": "ˈvɔɪɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "v. 摇动；摆动"
+    ]
+  },
+  {
+    "name": "wage",
+    "usphone": "weɪdʒ",
+    "ukphone": "",
+    "trans": [
+      "n. 工资，工钱，报酬"
+    ]
+  },
+  {
+    "name": "waist",
+    "usphone": "weɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 腰，腰部，腰围"
+    ]
+  },
+  {
+    "name": "wait",
+    "usphone": "weɪt",
+    "ukphone": "",
+    "trans": [
+      "vi. 等，等候"
+    ]
+  },
+  {
+    "name": "waiter",
+    "usphone": "ˈweɪtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. （餐厅）男服务员"
+    ]
+  },
+  {
+    "name": "waiting -room",
+    "usphone": "ˈweɪtɪŋ- rʊm",
+    "ukphone": "",
+    "trans": [
+      "n.候诊室,候车室"
+    ]
+  },
+  {
+    "name": "waitress",
+    "usphone": "tres",
+    "ukphone": "",
+    "trans": [
+      "n. 女服务员"
+    ]
+  },
+  {
+    "name": "wake (woke, woken)",
+    "usphone": "weɪk",
+    "ukphone": "",
+    "trans": [
+      "v.醒来,叫醒"
+    ]
+  },
+  {
+    "name": "walk",
+    "usphone": "wɔːk",
+    "ukphone": "",
+    "trans": [
+      "n.& v. 步行；散步"
+    ]
+  },
+  {
+    "name": "walkman",
+    "usphone": "ˈwɔːkmən",
+    "ukphone": "",
+    "trans": [
+      "n. 随身听"
+    ]
+  },
+  {
+    "name": "wall",
+    "usphone": "wɔːl",
+    "ukphone": "",
+    "trans": [
+      "n. 墙"
+    ]
+  },
+  {
+    "name": "wallet",
+    "usphone": "ˈwɔlɪt",
+    "ukphone": "",
+    "trans": [
+      "n. (放钱,证件等的)皮夹"
+    ]
+  },
+  {
+    "name": "walnut",
+    "usphone": "ˈwɔːlnʌt",
+    "ukphone": "",
+    "trans": [
+      "n. 核桃，胡桃"
+    ]
+  },
+  {
+    "name": "wander",
+    "usphone": "ˈwɔndə(r)",
+    "ukphone": "",
+    "trans": [
+      "vi.漫游,游荡,漫步,流浪"
+    ]
+  },
+  {
+    "name": "want",
+    "usphone": "wɔnt; (US) wɔːnt",
+    "ukphone": "",
+    "trans": [
+      "vt. 想,想要,需要,必要"
+    ]
+  },
+  {
+    "name": "war",
+    "usphone": "wɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 战争"
+    ]
+  },
+  {
+    "name": "ward",
+    "usphone": "wɔːd",
+    "ukphone": "",
+    "trans": [
+      "n. 保卫,看护,病房,收容所"
+    ]
+  },
+  {
+    "name": "warehouse",
+    "usphone": "ˈweəhaʊs",
+    "ukphone": "",
+    "trans": [
+      "n. 仓库，货栈"
+    ]
+  },
+  {
+    "name": "warm",
+    "usphone": "wɔːm",
+    "ukphone": "",
+    "trans": [
+      "a. 暖和的,温暖的;热情的"
+    ]
+  },
+  {
+    "name": "warm-hearted",
+    "usphone": "wɔːm- hɑːt",
+    "ukphone": "",
+    "trans": [
+      "a. 热心的"
+    ]
+  },
+  {
+    "name": "warmth",
+    "usphone": "wɔːmθ",
+    "ukphone": "",
+    "trans": [
+      "n. 暖和，温暖"
+    ]
+  },
+  {
+    "name": "war",
+    "usphone": "wɔː(r)",
+    "ukphone": "",
+    "trans": [
+      "n vt. 警告，预先通知"
+    ]
+  },
+  {
+    "name": "warning",
+    "usphone": "ˈwɔːnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 警报"
+    ]
+  },
+  {
+    "name": "wash",
+    "usphone": "ˈwɔːnɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n.洗(涤)冲洗,洗剂,泼溅,洗的衣服 v.洗(涤),冲洗,流过,弄湿"
+    ]
+  },
+  {
+    "name": "washing -machine",
+    "usphone": "ˈwɔʃɪŋ- məˈʃiːn",
+    "ukphone": "",
+    "trans": [
+      "n. 洗衣机"
+    ]
+  },
+  {
+    "name": "washroom",
+    "usphone": "ˈwɔʃrʊm, ˈwɔʃruːm",
+    "ukphone": "",
+    "trans": [
+      "n. 盥洗室"
+    ]
+  },
+  {
+    "name": "waste",
+    "usphone": "weɪst",
+    "ukphone": "",
+    "trans": [
+      "n.& vt. 浪费"
+    ]
+  },
+  {
+    "name": "watch",
+    "usphone": "wɔtʃ",
+    "ukphone": "",
+    "trans": [
+      "vt. 观看，注视；当心，注意 n. 手表，表"
+    ]
+  },
+  {
+    "name": "water",
+    "usphone": "ˈwɔːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 水v. 浇水"
+    ]
+  },
+  {
+    "name": "watermelon",
+    "usphone": "ˈwɔːtəmelən",
+    "ukphone": "",
+    "trans": [
+      "n. 西瓜"
+    ]
+  },
+  {
+    "name": "wave",
+    "usphone": "weɪv",
+    "ukphone": "",
+    "trans": [
+      "n. （热、光、声等的）波，波浪 v. 挥手，挥动，波动"
+    ]
+  },
+  {
+    "name": "wax",
+    "usphone": "wæks",
+    "ukphone": "",
+    "trans": [
+      "n. 蜡"
+    ]
+  },
+  {
+    "name": "way",
+    "usphone": "weɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 路，路线；方式，手段"
+    ]
+  },
+  {
+    "name": "wayside",
+    "usphone": "weɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 路边的"
+    ]
+  },
+  {
+    "name": "we",
+    "usphone": "wiː, wɪ",
+    "ukphone": "",
+    "trans": [
+      "pron. 我们"
+    ]
+  },
+  {
+    "name": "web",
+    "usphone": "web",
+    "ukphone": "",
+    "trans": [
+      "n. 网，网状物"
+    ]
+  },
+  {
+    "name": "website",
+    "usphone": "websaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 网络"
+    ]
+  },
+  {
+    "name": "weak",
+    "usphone": "wiːk",
+    "ukphone": "",
+    "trans": [
+      "a. 差的，弱的，淡的"
+    ]
+  },
+  {
+    "name": "weakness",
+    "usphone": "ˈwiːknɪs",
+    "ukphone": "",
+    "trans": [
+      "n. 软弱"
+    ]
+  },
+  {
+    "name": "wealth",
+    "usphone": "welθ",
+    "ukphone": "",
+    "trans": [
+      "n. 财产，财富"
+    ]
+  },
+  {
+    "name": "wealthy",
+    "usphone": "ˈwelθɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 富的"
+    ]
+  },
+  {
+    "name": "wear (wore, worn)",
+    "usphone": "weə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 穿，戴"
+    ]
+  },
+  {
+    "name": "weather",
+    "usphone": "weə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 天气"
+    ]
+  },
+  {
+    "name": "weatherman",
+    "usphone": "ˈweath·er·man",
+    "ukphone": "",
+    "trans": [
+      "n.气象员,预报天气的人"
+    ]
+  },
+  {
+    "name": "wedding",
+    "usphone": "ˈwedɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 婚礼,结婚"
+    ]
+  },
+  {
+    "name": "Wednesday",
+    "usphone": "ˈwenzdeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 星期三"
+    ]
+  },
+  {
+    "name": "weed",
+    "usphone": "wiːd",
+    "ukphone": "",
+    "trans": [
+      "n. 杂草，野草"
+    ]
+  },
+  {
+    "name": "week",
+    "usphone": "wiːk",
+    "ukphone": "",
+    "trans": [
+      "n. 星期，周"
+    ]
+  },
+  {
+    "name": "weekday",
+    "usphone": "ˈwiːkdeɪ",
+    "ukphone": "",
+    "trans": [
+      "n. 平日"
+    ]
+  },
+  {
+    "name": "weekend",
+    "usphone": "wiːkˈend, ˈwiːkend",
+    "ukphone": "",
+    "trans": [
+      "n. 周末"
+    ]
+  },
+  {
+    "name": "weekly",
+    "usphone": "ˈwiːklɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 每周的"
+    ]
+  },
+  {
+    "name": "weep",
+    "usphone": "wiːp",
+    "ukphone": "",
+    "trans": [
+      "v. 哭泣，流泪"
+    ]
+  },
+  {
+    "name": "weigh",
+    "usphone": "weɪ",
+    "ukphone": "",
+    "trans": [
+      "vt. 称…的重量，重（若干）"
+    ]
+  },
+  {
+    "name": "weight",
+    "usphone": "weɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 重，重量"
+    ]
+  },
+  {
+    "name": "welcome",
+    "usphone": "ˈwelkəm",
+    "ukphone": "",
+    "trans": [
+      "int.n. & v.欢迎 a. 受欢迎的"
+    ]
+  },
+  {
+    "name": "welfare",
+    "usphone": "ˈwelfeə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 幸福，福利"
+    ]
+  },
+  {
+    "name": "well",
+    "usphone": "wel",
+    "ukphone": "",
+    "trans": [
+      "(better, best) ad. 好,令人满意地,完全地 a.好的,,健康的int. 表示惊讶同意或犹豫等,亦用于接话语;好吧,那么,哎呀 n. 井"
+    ]
+  },
+  {
+    "name": "well-known",
+    "usphone": "wel- nəʊn",
+    "ukphone": "",
+    "trans": [
+      "a.出名,众所周知的"
+    ]
+  },
+  {
+    "name": "west",
+    "usphone": "west",
+    "ukphone": "",
+    "trans": [
+      "a. (在)西；向西,从西来的 ad. 在西方,向西方 n.西部；西方"
+    ]
+  },
+  {
+    "name": "western",
+    "usphone": "ˈwest(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 西方的，西部的"
+    ]
+  },
+  {
+    "name": "westerner",
+    "usphone": "ˈwestənə",
+    "ukphone": "",
+    "trans": [
+      "n. 西方人"
+    ]
+  },
+  {
+    "name": "westwards",
+    "usphone": "ˈwestwədz",
+    "ukphone": "",
+    "trans": [
+      "ad. 向西"
+    ]
+  },
+  {
+    "name": "wet",
+    "usphone": "wet",
+    "ukphone": "",
+    "trans": [
+      "a. 湿的,潮的,多雨的"
+    ]
+  },
+  {
+    "name": "whale",
+    "usphone": "weɪl; (US) hweɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 鲸"
+    ]
+  },
+  {
+    "name": "what",
+    "usphone": "wɔt; (US) hwɑt",
+    "ukphone": "",
+    "trans": [
+      "pron. 什么,怎么样 a. 多么，何等；什么"
+    ]
+  },
+  {
+    "name": "whatever",
+    "usphone": "wɔtˈevə(r)",
+    "ukphone": "",
+    "trans": [
+      "conj. & pron.无论什么，不管什么"
+    ]
+  },
+  {
+    "name": "wheat",
+    "usphone": "wiːt; (US) hwiːt",
+    "ukphone": "",
+    "trans": [
+      "n. 小麦"
+    ]
+  },
+  {
+    "name": "wheel",
+    "usphone": "wiːl; (US) hwiːl",
+    "ukphone": "",
+    "trans": [
+      "n. 轮，机轮"
+    ]
+  },
+  {
+    "name": "when",
+    "usphone": "wen",
+    "ukphone": "",
+    "trans": [
+      "conj. 当…的时候 ad. 什么时候，何时"
+    ]
+  },
+  {
+    "name": "whenever",
+    "usphone": "wenˈevə(r)",
+    "ukphone": "",
+    "trans": [
+      "conj. 每当，无论何时"
+    ]
+  },
+  {
+    "name": "where",
+    "usphone": "weə(r); (US) hweər",
+    "ukphone": "",
+    "trans": [
+      "ad. 在哪里；往哪里"
+    ]
+  },
+  {
+    "name": "wherever",
+    "usphone": "weərˈevə(r)",
+    "ukphone": "",
+    "trans": [
+      "conj. 无论在哪里"
+    ]
+  },
+  {
+    "name": "whether",
+    "usphone": "ˈweðə(r); (US) ˈhweðər",
+    "ukphone": "",
+    "trans": [
+      "conj. 是否"
+    ]
+  },
+  {
+    "name": "which",
+    "usphone": "wɪtʃ; (US) hwɪtʃ",
+    "ukphone": "",
+    "trans": [
+      "pron. 那(哪)一个；那(哪)一些 a.这(哪)个；这(哪)些；无论哪个(些)"
+    ]
+  },
+  {
+    "name": "whichever",
+    "usphone": "wɪtʃˈevə(r)",
+    "ukphone": "",
+    "trans": [
+      "pron. 无论哪个;无论哪些"
+    ]
+  },
+  {
+    "name": "while",
+    "usphone": "waɪl; (US) hwaɪl",
+    "ukphone": "",
+    "trans": [
+      "conj.在…的时候,和…同时 n. 一会儿，一段时间"
+    ]
+  },
+  {
+    "name": "whisper",
+    "usphone": "ˈwɪspə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 低语，私下说"
+    ]
+  },
+  {
+    "name": "whistle",
+    "usphone": "waɪt; (US) hwaɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 口哨，口哨声"
+    ]
+  },
+  {
+    "name": "white",
+    "usphone": "waɪt; (US) hwaɪt",
+    "ukphone": "",
+    "trans": [
+      "a. 白色的 n. 白色"
+    ]
+  },
+  {
+    "name": "who",
+    "usphone": "huː",
+    "ukphone": "",
+    "trans": [
+      "pron. 谁"
+    ]
+  },
+  {
+    "name": "whole",
+    "usphone": "həʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 整个的"
+    ]
+  },
+  {
+    "name": "whom",
+    "usphone": "huːm",
+    "ukphone": "",
+    "trans": [
+      "pron. (who的宾格 )"
+    ]
+  },
+  {
+    "name": "whose",
+    "usphone": "huːz",
+    "ukphone": "",
+    "trans": [
+      "pron. 谁的"
+    ]
+  },
+  {
+    "name": "why",
+    "usphone": "waɪ; (US) hwaɪ",
+    "ukphone": "",
+    "trans": [
+      "ad./ int. 为什么, 你难道不知道（表示反驳、不耐烦等）"
+    ]
+  },
+  {
+    "name": "wide",
+    "usphone": "weə(r); (US) hweər",
+    "ukphone": "",
+    "trans": [
+      "a. 宽阔的"
+    ]
+  },
+  {
+    "name": "widespread",
+    "usphone": "ˈwaɪdspred, -ˈspred",
+    "ukphone": "",
+    "trans": [
+      "a.分布广的,普遍的"
+    ]
+  },
+  {
+    "name": "wife",
+    "usphone": "waɪf",
+    "ukphone": "",
+    "trans": [
+      "n. 妻子"
+    ]
+  },
+  {
+    "name": "wild",
+    "usphone": "waɪld",
+    "ukphone": "",
+    "trans": [
+      "a. 未开发的，荒凉的；野生的，野的"
+    ]
+  },
+  {
+    "name": "wildlife",
+    "usphone": "ˈwaɪldlaɪf",
+    "ukphone": "",
+    "trans": [
+      "n. 野生动物"
+    ]
+  },
+  {
+    "name": "will",
+    "usphone": "wɪl",
+    "ukphone": "",
+    "trans": [
+      "n. 意志, 遗嘱"
+    ]
+  },
+  {
+    "name": "will (would)",
+    "usphone": "wɪl",
+    "ukphone": "",
+    "trans": [
+      "modal v. 将,会(表示将来)；愿意，要"
+    ]
+  },
+  {
+    "name": "willing",
+    "usphone": "ˈwɪlɪŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 乐意的； 愿意的"
+    ]
+  },
+  {
+    "name": "willingly",
+    "usphone": "ˈwiliŋli",
+    "ukphone": "",
+    "trans": [
+      "ad. 乐意地"
+    ]
+  },
+  {
+    "name": "willingness",
+    "usphone": "ˈwiliŋnis",
+    "ukphone": "",
+    "trans": [
+      "n. 意愿； 愿望"
+    ]
+  },
+  {
+    "name": "win (won, won)",
+    "usphone": "wɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 获胜，赢得"
+    ]
+  },
+  {
+    "name": "wind",
+    "usphone": "wɪnd",
+    "ukphone": "",
+    "trans": [
+      "n. 风 "
+    ]
+  },
+  {
+    "name": "wind(wound,wound)",
+    "usphone": "wɪnd",
+    "ukphone": "",
+    "trans": [
+      "vt. 缠，连带；蜿蜒，弯曲"
+    ]
+  },
+  {
+    "name": "windbreaker",
+    "usphone": "ˈwind,breikә",
+    "ukphone": "",
+    "trans": [
+      "n.风衣,防风(皮)夹克"
+    ]
+  },
+  {
+    "name": "window",
+    "usphone": "ˈwɪndəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. 窗户；计算机的窗"
+    ]
+  },
+  {
+    "name": "windy",
+    "usphone": "ˈwɪndɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 有风的，多风的"
+    ]
+  },
+  {
+    "name": "wine",
+    "usphone": "waɪn",
+    "ukphone": "",
+    "trans": [
+      "n. 酒"
+    ]
+  },
+  {
+    "name": "wing",
+    "usphone": "wɪŋ",
+    "ukphone": "",
+    "trans": [
+      "n. 机翼，翅膀"
+    ]
+  },
+  {
+    "name": "winner",
+    "usphone": "ˈwɪnə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 获胜者"
+    ]
+  },
+  {
+    "name": "winter",
+    "usphone": "ˈwɪntə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 冬天，冬季"
+    ]
+  },
+  {
+    "name": "wipe",
+    "usphone": "waɪp",
+    "ukphone": "",
+    "trans": [
+      "v. 擦；擦净；擦干"
+    ]
+  },
+  {
+    "name": "wire",
+    "usphone": "ˈwaɪə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 电线"
+    ]
+  },
+  {
+    "name": "wisdom",
+    "usphone": "ˈwɪzdəm",
+    "ukphone": "",
+    "trans": [
+      "n. 智慧"
+    ]
+  },
+  {
+    "name": "wise",
+    "usphone": "waɪz",
+    "ukphone": "",
+    "trans": [
+      "a. 聪明,英明的,有见识的"
+    ]
+  },
+  {
+    "name": "wish",
+    "usphone": "wɪʃ",
+    "ukphone": "",
+    "trans": [
+      "n. 愿望，祝愿 vt. 希望，想要，祝愿"
+    ]
+  },
+  {
+    "name": "with",
+    "usphone": "wɪʃ",
+    "ukphone": "",
+    "trans": [
+      "prep.关于,带有,以,和,用,有"
+    ]
+  },
+  {
+    "name": "withdraw",
+    "usphone": "wɪðˈdrɔː",
+    "ukphone": "",
+    "trans": [
+      "v. 撤回，撤离"
+    ]
+  },
+  {
+    "name": "within",
+    "usphone": "wɪˈðɪn",
+    "ukphone": "",
+    "trans": [
+      "prep. 在……里面"
+    ]
+  },
+  {
+    "name": "without",
+    "usphone": "wɪˈðaʊt",
+    "ukphone": "",
+    "trans": [
+      "prep. 没有"
+    ]
+  },
+  {
+    "name": "witness",
+    "usphone": "ˈwɪtnɪs",
+    "ukphone": "",
+    "trans": [
+      "v./ n. 目击者，见证人"
+    ]
+  },
+  {
+    "name": "wolf（复wolves）",
+    "usphone": "wʊlf",
+    "ukphone": "",
+    "trans": [
+      "n. 狼"
+    ]
+  },
+  {
+    "name": "woman ( 复women)",
+    "usphone": "ˈwʊmən",
+    "ukphone": "",
+    "trans": [
+      "n.妇女女人"
+    ]
+  },
+  {
+    "name": "wonder",
+    "usphone": "ˈwʌndə(r)",
+    "ukphone": "",
+    "trans": [
+      "v. 对…疑惑，感到惊奇,想知道 n. 惊讶,惊叹;奇迹"
+    ]
+  },
+  {
+    "name": "wonderful",
+    "usphone": "ˈwʌndəfʊl",
+    "ukphone": "",
+    "trans": [
+      "a. 美妙的，精彩的；了不起的；太好了"
+    ]
+  },
+  {
+    "name": "wood",
+    "usphone": "ˈwʌndəfʊl",
+    "ukphone": "",
+    "trans": [
+      "n.木头,木材,(复)树木,森林"
+    ]
+  },
+  {
+    "name": "wooden",
+    "usphone": "ˈwʊd(ə)n",
+    "ukphone": "",
+    "trans": [
+      "a. 木制的"
+    ]
+  },
+  {
+    "name": "woo",
+    "usphone": "wʊl",
+    "ukphone": "",
+    "trans": [
+      "l n. 羊毛，羊绒"
+    ]
+  },
+  {
+    "name": "woollen",
+    "usphone": "ˈwulin",
+    "ukphone": "",
+    "trans": [
+      "a. 羊毛的，羊毛制的"
+    ]
+  },
+  {
+    "name": "word",
+    "usphone": "wɜːd",
+    "ukphone": "",
+    "trans": [
+      "n. 词，单词；话"
+    ]
+  },
+  {
+    "name": "work",
+    "usphone": "wɜːk",
+    "ukphone": "",
+    "trans": [
+      "n. 工作,劳动,事情 vi. 工作;(机器、器官等)运转,活动"
+    ]
+  },
+  {
+    "name": "workday",
+    "usphone": "ˈwə:kdei",
+    "ukphone": "",
+    "trans": [
+      "n. 工作日"
+    ]
+  },
+  {
+    "name": "worker",
+    "usphone": "ˈwɜːkə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 工人；工作者"
+    ]
+  },
+  {
+    "name": "workforce",
+    "usphone": "ˈwə:kfɔ:s",
+    "ukphone": "",
+    "trans": [
+      "n. 劳动力"
+    ]
+  },
+  {
+    "name": "workmate",
+    "usphone": "ˈwə:kfɔ:s",
+    "ukphone": "",
+    "trans": [
+      "n. 同事；工友"
+    ]
+  },
+  {
+    "name": "workplace",
+    "usphone": "wɜːkpleɪs",
+    "ukphone": "",
+    "trans": [
+      "n.工作场所，车间"
+    ]
+  },
+  {
+    "name": "works",
+    "usphone": "wɜːks",
+    "ukphone": "",
+    "trans": [
+      "n. 著作，作品"
+    ]
+  },
+  {
+    "name": "world",
+    "usphone": "wɜːld",
+    "ukphone": "",
+    "trans": [
+      "n. 世界"
+    ]
+  },
+  {
+    "name": "world-famous",
+    "usphone": "wɜːld- ˈfeɪməs",
+    "ukphone": "",
+    "trans": [
+      "a. 世界闻名的"
+    ]
+  },
+  {
+    "name": "worldwide",
+    "usphone": "ˈwɜːldwaɪd, -ˈwaɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 遍及全球的，世界范围的"
+    ]
+  },
+  {
+    "name": "worm",
+    "usphone": "wɜːm",
+    "ukphone": "",
+    "trans": [
+      "n. 软体虫,蠕虫(尤指蚯蚓)"
+    ]
+  },
+  {
+    "name": "worn",
+    "usphone": "wɜrn /wɜːm",
+    "ukphone": "",
+    "trans": [
+      "a. 用坏,用旧的,疲惫的"
+    ]
+  },
+  {
+    "name": "worried",
+    "usphone": "ˈwɜrɪd /ˈwʌ-",
+    "ukphone": "",
+    "trans": [
+      "a. 担心的，烦恼的"
+    ]
+  },
+  {
+    "name": "worry",
+    "usphone": "ˈwʌrɪ",
+    "ukphone": "",
+    "trans": [
+      "n.& v.烦恼,担忧,发怒,困扰"
+    ]
+  },
+  {
+    "name": "worse",
+    "usphone": "wɜːs",
+    "ukphone": "",
+    "trans": [
+      "a. (bad的比较级)更坏的"
+    ]
+  },
+  {
+    "name": "worst",
+    "usphone": "wɜːst",
+    "ukphone": "",
+    "trans": [
+      "a. (bad的最高级)最坏的"
+    ]
+  },
+  {
+    "name": "worth",
+    "usphone": "wɜːθ",
+    "ukphone": "",
+    "trans": [
+      "a. 有…的价值,值得…的"
+    ]
+  },
+  {
+    "name": "worthless",
+    "usphone": "ˈwɜːθlɪs",
+    "ukphone": "",
+    "trans": [
+      "a.没有价值,没有用的"
+    ]
+  },
+  {
+    "name": "worthwhile",
+    "usphone": "wɜːθˈwaɪl",
+    "ukphone": "",
+    "trans": [
+      "a. 值得做的"
+    ]
+  },
+  {
+    "name": "worthy",
+    "usphone": "wɜːθˈwaɪl",
+    "ukphone": "",
+    "trans": [
+      "a. 值得的"
+    ]
+  },
+  {
+    "name": "would",
+    "usphone": "wəd, wʊd",
+    "ukphone": "",
+    "trans": [
+      "modal v.（will的过去时）将会，打算，想要，过去常常"
+    ]
+  },
+  {
+    "name": "wound",
+    "usphone": "wuːnd",
+    "ukphone": "",
+    "trans": [
+      "vt.伤,伤害 n.创伤,伤口"
+    ]
+  },
+  {
+    "name": "wounded",
+    "usphone": "wuːndɪd",
+    "ukphone": "",
+    "trans": [
+      "a. 受伤的"
+    ]
+  },
+  {
+    "name": "wrestle",
+    "usphone": "ˈres(ə)l",
+    "ukphone": "",
+    "trans": [
+      "v. 摔跤"
+    ]
+  },
+  {
+    "name": "wrinkle",
+    "usphone": "ˈrɪŋk(ə)l",
+    "ukphone": "",
+    "trans": [
+      "n. 皱纹"
+    ]
+  },
+  {
+    "name": "wrist",
+    "usphone": "rɪst",
+    "ukphone": "",
+    "trans": [
+      "n. 手腕，腕关节"
+    ]
+  },
+  {
+    "name": "write",
+    "usphone": "raɪt",
+    "ukphone": "",
+    "trans": [
+      "(wrote, written) v. 写，书写；写作，著述"
+    ]
+  },
+  {
+    "name": "writing",
+    "usphone": "raɪt",
+    "ukphone": "",
+    "trans": [
+      "n. 书写，写"
+    ]
+  },
+  {
+    "name": "wrong",
+    "usphone": "rɔŋ; (US) rɔːŋ",
+    "ukphone": "",
+    "trans": [
+      "a.错误,不正常,有毛病的"
+    ]
+  },
+  {
+    "name": "X-ray",
+    "usphone": "eks-reɪ",
+    "ukphone": "",
+    "trans": [
+      "n. X射线；X光"
+    ]
+  },
+  {
+    "name": "yard",
+    "usphone": "jɑːd",
+    "ukphone": "",
+    "trans": [
+      "n. 码；院子；场地"
+    ]
+  },
+  {
+    "name": "yawn",
+    "usphone": "jɔːn",
+    "ukphone": "",
+    "trans": [
+      "v. 打哈欠"
+    ]
+  },
+  {
+    "name": "year",
+    "usphone": "jɪə(r), jəː(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 年"
+    ]
+  },
+  {
+    "name": "yell",
+    "usphone": "jel",
+    "ukphone": "",
+    "trans": [
+      "v. 叫喊，吼叫"
+    ]
+  },
+  {
+    "name": "yellow",
+    "usphone": "ˈjeləʊ",
+    "ukphone": "",
+    "trans": [
+      "a. 黄色的"
+    ]
+  },
+  {
+    "name": "yes",
+    "usphone": "jes",
+    "ukphone": "",
+    "trans": [
+      "ad. 是，好，同意"
+    ]
+  },
+  {
+    "name": "yesterday",
+    "usphone": "ˈjestədeɪ",
+    "ukphone": "",
+    "trans": [
+      "n.& ad. 昨天"
+    ]
+  },
+  {
+    "name": "yet",
+    "usphone": "jet",
+    "ukphone": "",
+    "trans": [
+      "ad. 尚，还，仍然"
+    ]
+  },
+  {
+    "name": "yoghurt",
+    "usphone": "ˈjɔgət,ˈjəʊ-",
+    "ukphone": "",
+    "trans": [
+      "n. 酸奶"
+    ]
+  },
+  {
+    "name": "you",
+    "usphone": "juː, jʊ",
+    "ukphone": "",
+    "trans": [
+      "pron. 你；你们"
+    ]
+  },
+  {
+    "name": "young",
+    "usphone": "jʌŋ",
+    "ukphone": "",
+    "trans": [
+      "a. 年轻的"
+    ]
+  },
+  {
+    "name": "your",
+    "usphone": "jʌŋ",
+    "ukphone": "",
+    "trans": [
+      "pron. 你的；你们的"
+    ]
+  },
+  {
+    "name": "yours",
+    "usphone": "jɔːz, jʊəz",
+    "ukphone": "",
+    "trans": [
+      "pron. 你的；你们的"
+    ]
+  },
+  {
+    "name": "yourself",
+    "usphone": "jɔːˈself; (US) jʊərˈself",
+    "ukphone": "",
+    "trans": [
+      "pron. 你自己"
+    ]
+  },
+  {
+    "name": "yourselves",
+    "usphone": "jɔːˈself; (US) jʊərˈself",
+    "ukphone": "",
+    "trans": [
+      "pron. 你们自己"
+    ]
+  },
+  {
+    "name": "youth",
+    "usphone": "juːθ",
+    "ukphone": "",
+    "trans": [
+      "n. 青春；青年"
+    ]
+  },
+  {
+    "name": "yummy",
+    "usphone": "ˈjʌmɪ",
+    "ukphone": "",
+    "trans": [
+      "a. 很好吃的"
+    ]
+  },
+  {
+    "name": "zebra",
+    "usphone": "ˈzebrə, ˈziːbrə",
+    "ukphone": "",
+    "trans": [
+      "n. 斑马"
+    ]
+  },
+  {
+    "name": "zebra -crossing",
+    "usphone": "ˈzebrə-ˈkrɔsɪŋ",
+    "ukphone": "",
+    "trans": [
+      "人行横道线（斑马线）"
+    ]
+  },
+  {
+    "name": "zero",
+    "usphone": "ˈzɪərəʊ",
+    "ukphone": "",
+    "trans": [
+      "n. & num.零,零度,零点"
+    ]
+  },
+  {
+    "name": "zip",
+    "usphone": "zɪp",
+    "ukphone": "",
+    "trans": [
+      "v.& n.拉开(或扣上)……的拉链；拉链"
+    ]
+  },
+  {
+    "name": "zip code(美) =postcode",
+    "usphone": "zɪp kəʊd",
+    "ukphone": "",
+    "trans": [
+      "(英)邮政区号"
+    ]
+  },
+  {
+    "name": "zipper",
+    "usphone": "ˈzɪpə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 拉链"
+    ]
+  },
+  {
+    "name": "zone",
+    "usphone": "zuː",
+    "ukphone": "",
+    "trans": [
+      "n. 区域；范围"
+    ]
+  },
+  {
+    "name": "zoo",
+    "usphone": "zuː",
+    "ukphone": "",
+    "trans": [
+      "n. 动物园"
+    ]
+  },
+  {
+    "name": "zoom",
+    "usphone": "zuːm",
+    "ukphone": "",
+    "trans": [
+      "v. 快速移动，迅速前往，猛涨"
+    ]
+  }
+]

--- a/public/dicts/GaoKao_3500.json
+++ b/public/dicts/GaoKao_3500.json
@@ -1,10 +1,18 @@
 [
   {
-    "name": "a (an)",
-    "usphone": "ə, eɪ(ən)",
+    "name": "a",
+    "usphone": "ə, eɪ",
     "ukphone": "",
     "trans": [
       "art. 一（个、件……）"
+    ]
+  },
+  {
+    "name": "an",
+    "usphone": "æn; ən",
+    "ukphone": "",
+    "trans": [
+      "art. 一（个、件……）用于元音前"
     ]
   },
   {
@@ -760,8 +768,8 @@
     ]
   },
   {
-    "name": "afterward(s)",
-    "usphone": "ˈɑːftəwəd(z)",
+    "name": "afterward",
+    "usphone": "ˈɑːftəwəd",
     "ukphone": "",
     "trans": [
       "ad. 后来"
@@ -1184,11 +1192,11 @@
     ]
   },
   {
-    "name": "ａ.m./A.M.",
+    "name": "ａ.m.",
     "usphone": "",
     "ukphone": "",
     "trans": [
-      "n. 午前，上午"
+      "n. 午前，上午【小写】"
     ]
   },
   {
@@ -1216,11 +1224,19 @@
     ]
   },
   {
-    "name": "ambassador (ambassadress)",
+    "name": "ambassador ambassadress",
     "usphone": "æmˈbæsədə(r)",
     "ukphone": "",
     "trans": [
       "n.大使"
+    ]
+  },
+  {
+    "name": "ambassadress",
+    "usphone": "æmˈbæsədres",
+    "ukphone": "",
+    "trans": [
+      "n.大使夫人；女大使"
     ]
   },
   {
@@ -1872,11 +1888,11 @@
     ]
   },
   {
-    "name": "arise (arose, arisen)",
+    "name": "arise arose arisen",
     "usphone": "əˈraɪz",
     "ukphone": "",
     "trans": [
-      "vi. 起来，升起；出现"
+      "vi. 起来，升起；出现 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -2448,11 +2464,11 @@
     ]
   },
   {
-    "name": "awake (awoke, awoken)",
+    "name": "awake awoke awoken",
     "usphone": "əˈweɪk",
     "ukphone": "",
     "trans": [
-      "v. 唤醒 a. 醒着的"
+      "v. 唤醒, adj. 醒着的 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -2544,7 +2560,7 @@
     ]
   },
   {
-    "name": "backward(s)",
+    "name": "backward",
     "usphone": "ˈbækwəd",
     "ukphone": "",
     "trans": [
@@ -2568,11 +2584,11 @@
     ]
   },
   {
-    "name": "bad (worse, worst)",
+    "name": "bad worse worst",
     "usphone": "bæd",
     "ukphone": "",
     "trans": [
-      "a. 坏的；有害的，不利的；严重的"
+      "adj. 坏的；有害的，不利的；严重的【比较级 最高级】"
     ]
   },
   {
@@ -3016,11 +3032,11 @@
     ]
   },
   {
-    "name": "beat (beat, beaten)",
+    "name": "beat beat beaten",
     "usphone": "biːt",
     "ukphone": "",
     "trans": [
-      "v. 敲打；跳动；打赢 n. （音乐）节拍"
+      "v. 敲打；跳动；打赢 n. （音乐）节拍 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -3048,7 +3064,7 @@
     ]
   },
   {
-    "name": "become (became, be come)",
+    "name": "become",
     "usphone": "bɪˈkʌm",
     "ukphone": "",
     "trans": [
@@ -3136,11 +3152,11 @@
     ]
   },
   {
-    "name": "begin(began,begun)",
+    "name": "begin began begun",
     "usphone": "bɪˈɡɪn",
     "ukphone": "",
     "trans": [
-      " v.开始,着手"
+      "v.开始,着手【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -3264,11 +3280,11 @@
     ]
   },
   {
-    "name": "bend (bent, bent)",
+    "name": "bend bent bent",
     "usphone": "bend",
     "ukphone": "",
     "trans": [
-      "vt. 使弯曲"
+      "adj. 弯曲的，变形的；vt. 使弯曲 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -3320,7 +3336,7 @@
     ]
   },
   {
-    "name": "best（good, well 的最 高级）",
+    "name": "best",
     "usphone": "best",
     "ukphone": "",
     "trans": [
@@ -3328,15 +3344,15 @@
     ]
   },
   {
-    "name": "best--seller",
-    "usphone": "best- ˈselə(r)",
+    "name": "bestseller",
+    "usphone": "ˌbestˈselə(r)",
     "ukphone": "",
     "trans": [
       "n. 畅销书"
     ]
   },
   {
-    "name": "better (good, well 的 比较级)",
+    "name": "better",
     "usphone": "ˈbetə(r)",
     "ukphone": "",
     "trans": [
@@ -3512,11 +3528,11 @@
     ]
   },
   {
-    "name": "bite (bit, bitten)",
+    "name": "bite bit bitten",
     "usphone": "baɪt",
     "ukphone": "",
     "trans": [
-      "v. 咬；叮"
+      "v. 咬；叮 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -3624,11 +3640,11 @@
     ]
   },
   {
-    "name": "blow (blew, blown)",
+    "name": "blow blew blown",
     "usphone": "bləʊ",
     "ukphone": "",
     "trans": [
-      "v. 吹；刮风；吹气"
+      "v. 吹；刮风；吹气 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -3656,8 +3672,8 @@
     ]
   },
   {
-    "name": "boat--race",
-    "usphone": "bəʊt-reɪs",
+    "name": "boatrace",
+    "usphone": "bəʊtˈreɪs",
     "ukphone": "",
     "trans": [
       "n. 划船比赛"
@@ -3672,8 +3688,8 @@
     ]
   },
   {
-    "name": "body--building",
-    "usphone": "ˈbɔdɪ-ˈbɪldɪŋ",
+    "name": "bodybuilding",
+    "usphone": "ˈbɒdibɪldɪŋ",
     "ukphone": "",
     "trans": [
       "n. 健美"
@@ -4032,11 +4048,11 @@
     ]
   },
   {
-    "name": "break (broke, bro ken)",
+    "name": "break broke broken",
     "usphone": "breɪk",
     "ukphone": "",
     "trans": [
-      "v. 打破（断，碎）；损坏，撕开"
+      "v. 打破（断，碎）；损坏，撕开 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -4152,11 +4168,11 @@
     ]
   },
   {
-    "name": "bring (brought, brought)",
+    "name": "bring brought brought",
     "usphone": "brɪŋ",
     "ukphone": "",
     "trans": [
-      "vt. 拿来，带来，取来"
+      "vt. 拿来，带来，取来 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -4200,7 +4216,7 @@
     ]
   },
   {
-    "name": "broadcast（broadcast, broadcast或--ed,--ed）",
+    "name": "broadcast",
     "usphone": "ˈbrɔːdkɑːst",
     "ukphone": "",
     "trans": [
@@ -4312,11 +4328,11 @@
     ]
   },
   {
-    "name": "build (built, built)",
+    "name": "build built built",
     "usphone": "bɪld",
     "ukphone": "",
     "trans": [
-      "v. 建筑；造"
+      "v. 建筑；造 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -4384,7 +4400,7 @@
     ]
   },
   {
-    "name": "burn (--ed, --ed 或 burnt, burnt)",
+    "name": "burn",
     "usphone": "bɜːn",
     "ukphone": "",
     "trans": [
@@ -4440,7 +4456,7 @@
     ]
   },
   {
-    "name": "businessman (pl. businessmen)",
+    "name": "businessman",
     "usphone": "ˈbɪznɪsmæn",
     "ukphone": "",
     "trans": [
@@ -4448,7 +4464,7 @@
     ]
   },
   {
-    "name": "businesswoman (businesswomen)",
+    "name": "businesswoman",
     "usphone": "ˈbɪznɪswʊmæn",
     "ukphone": "",
     "trans": [
@@ -4512,11 +4528,11 @@
     ]
   },
   {
-    "name": "buy (bought,bought)",
+    "name": "buy bought bought",
     "usphone": "baɪ",
     "ukphone": "",
     "trans": [
-      "vt. 买"
+      "vt. 买【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -4552,7 +4568,7 @@
     ]
   },
   {
-    "name": "café",
+    "name": "cafe",
     "usphone": "ˈkæfeɪ; (US) kæˈfeɪ",
     "ukphone": "",
     "trans": [
@@ -4640,7 +4656,7 @@
     ]
   },
   {
-    "name": "can (could) canˈt = can not modal",
+    "name": "can",
     "usphone": "ken, kæn",
     "ukphone": "",
     "trans": [
@@ -4920,7 +4936,7 @@
     ]
   },
   {
-    "name": "cast (cast, cast)",
+    "name": "cast",
     "usphone": "kɑːst; (US) kæst",
     "ukphone": "",
     "trans": [
@@ -4968,11 +4984,11 @@
     ]
   },
   {
-    "name": "catch(caught,caught)",
+    "name": "catch caught caught",
     "usphone": "kætʃ",
     "ukphone": "",
     "trans": [
-      "v. 接住；捉住；赶上；染上（疾病）"
+      "v. 接住；捉住；赶上；染上（疾病） 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -5136,11 +5152,19 @@
     ]
   },
   {
-    "name": "centre (美 center )",
-    "usphone": "",
+    "name": "centre",
+    "usphone": "ˈsentə(r)",
     "ukphone": "",
     "trans": [
-      "n. 中心，中央"
+      "n. 中心，中央(英)"
+    ]
+  },
+  {
+    "name": "center",
+    "usphone": "ˈsentə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 中心，中央(美)"
     ]
   },
   {
@@ -5192,11 +5216,11 @@
     ]
   },
   {
-    "name": "chain store(s)",
+    "name": "chain store",
     "usphone": "tʃeɪn stɔː(r)",
     "ukphone": "",
     "trans": [
-      "连锁店"
+      "连锁店【空格符号】"
     ]
   },
   {
@@ -5216,7 +5240,7 @@
     ]
   },
   {
-    "name": "chairwoman (pl. chairwomen)",
+    "name": "chairwoman",
     "usphone": "ˈtʃɛəˌwumən",
     "ukphone": "",
     "trans": [
@@ -5512,11 +5536,19 @@
     ]
   },
   {
-    "name": "child (复children)",
+    "name": "child",
     "usphone": "tʃaɪld",
     "ukphone": "",
     "trans": [
       "n. 孩子，儿童"
+    ]
+  },
+  {
+    "name": "children",
+    "usphone": "ˈtʃɪldrən",
+    "ukphone": "",
+    "trans": [
+      "n. 孩子们，儿童们"
     ]
   },
   {
@@ -5592,11 +5624,11 @@
     ]
   },
   {
-    "name": "choose (chose, chosen)",
+    "name": "choose chose chosen",
     "usphone": "tʃuːz",
     "ukphone": "",
     "trans": [
-      "vt. 选择"
+      "vt. 选择 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -6096,7 +6128,7 @@
     ]
   },
   {
-    "name": "cold--blooded",
+    "name": "coldblooded",
     "usphone": "kəʊld blʌdɪd",
     "ukphone": "",
     "trans": [
@@ -6152,11 +6184,19 @@
     ]
   },
   {
-    "name": "colour (美color)",
+    "name": "colour",
     "usphone": "ˈkʌlə",
     "ukphone": "",
     "trans": [
-      "n. 颜色 vt.给…着色，涂色"
+      "n. 颜色 vt.给…着色，涂色【英】"
+    ]
+  },
+  {
+    "name": "color",
+    "usphone": "ˈkʌlə",
+    "ukphone": "",
+    "trans": [
+      "n. 颜色 vt.给…着色，涂色【美】"
     ]
   },
   {
@@ -6176,11 +6216,11 @@
     ]
   },
   {
-    "name": "come (came, come)",
+    "name": "come came come",
     "usphone": "kʌm",
     "ukphone": "",
     "trans": [
-      "vi. 来，来到"
+      "vi. 来，来到 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -7024,7 +7064,7 @@
     ]
   },
   {
-    "name": "cost (cost, cost)",
+    "name": "cost",
     "usphone": "kɔst; (US) kɔːst",
     "ukphone": "",
     "trans": [
@@ -7180,7 +7220,7 @@
     "usphone": "ˈkəʊ ˈwɜːkə(r)",
     "ukphone": "",
     "trans": [
-      "n. 合作者；同事"
+      "n. 合作者；同事【连字符】"
     ]
   },
   {
@@ -7264,11 +7304,11 @@
     ]
   },
   {
-    "name": "criterion (pl. criteria)",
+    "name": "criterion criteria",
     "usphone": "kraɪˈtɪərɪən",
     "ukphone": "",
     "trans": [
-      "n. 标准，准则，原则"
+      "n. 标准，准则，原则【单数 复数】"
     ]
   },
   {
@@ -7456,7 +7496,7 @@
     ]
   },
   {
-    "name": "cut (cut, cut)",
+    "name": "cut",
     "usphone": "kʌt",
     "ukphone": "",
     "trans": [
@@ -7808,11 +7848,11 @@
     ]
   },
   {
-    "name": "defence (美defense)",
+    "name": "defence defences",
     "usphone": "diˈfens",
     "ukphone": "",
     "trans": [
-      "n. & v. 防御；防务"
+      "n. & v. 防御；防务【单数 复数】"
     ]
   },
   {
@@ -7912,7 +7952,7 @@
     ]
   },
   {
-    "name": "department(缩Dept.)",
+    "name": "department",
     "usphone": "dɪˈpɑːtmənt",
     "ukphone": "",
     "trans": [
@@ -7920,11 +7960,11 @@
     ]
   },
   {
-    "name": "department -store",
+    "name": "department-store",
     "usphone": "dɪˈpɑːtmənt-stɔː(r)",
     "ukphone": "",
     "trans": [
-      "n. 百货商场"
+      "n. 百货商场【连字符】"
     ]
   },
   {
@@ -8120,11 +8160,19 @@
     ]
   },
   {
-    "name": "dialogue (美 dialog)",
-    "usphone": "ˈdaɪəlɔɡ; (US) ˈdaɪəlɔːɡ",
+    "name": "dialogue",
+    "usphone": "ˈdaɪəlɔɡ",
     "ukphone": "",
     "trans": [
-      "n. 对话"
+      "n. 对话【英】"
+    ]
+  },
+  {
+    "name": "dialog",
+    "usphone": "ˈdaɪəlɔɡ",
+    "ukphone": "",
+    "trans": [
+      "n. 对话【美】"
     ]
   },
   {
@@ -8216,11 +8264,11 @@
     ]
   },
   {
-    "name": "dig (dug, dug)",
+    "name": "dig dug dug",
     "usphone": "dɪɡ",
     "ukphone": "",
     "trans": [
-      "v. 挖（洞沟）,掘"
+      "v. 挖（洞沟）,掘 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -8276,7 +8324,7 @@
     "usphone": "ˈdainiŋ-rʊm",
     "ukphone": "",
     "trans": [
-      "食堂，饭厅"
+      "食堂，饭厅【连字符】"
     ]
   },
   {
@@ -8664,7 +8712,7 @@
     ]
   },
   {
-    "name": "do (did, done) donˈt=do not",
+    "name": "do",
     "usphone": "dʊ, duː",
     "ukphone": "",
     "trans": [
@@ -8808,7 +8856,7 @@
     ]
   },
   {
-    "name": "Dr(缩) = Doctor",
+    "name": "doctor",
     "usphone": "",
     "ukphone": "",
     "trans": [
@@ -8832,11 +8880,11 @@
     ]
   },
   {
-    "name": "draw (drew, drawn)",
+    "name": "draw drew drawn",
     "usphone": "drɔː",
     "ukphone": "",
     "trans": [
-      "v. 绘画；绘制；拉，拖；提取（金钱）"
+      "v. 绘画；绘制；拉，拖；提取（金钱） 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -8864,7 +8912,7 @@
     ]
   },
   {
-    "name": "dream (dreamt, dreamt 或--ed, --ed)",
+    "name": "dream",
     "usphone": "driːm",
     "ukphone": "",
     "trans": [
@@ -8904,19 +8952,19 @@
     ]
   },
   {
-    "name": "drink(drank,drunk)",
+    "name": "drink drank drunk",
     "usphone": "drɪŋk",
     "ukphone": "",
     "trans": [
-      "v. 喝，饮"
+      "v. 喝，饮 【一般现在 过去式 过去分词】"
     ]
   },
   {
-    "name": "drive(drove,driven)",
+    "name": "drive drove driven",
     "usphone": "draɪv",
     "ukphone": "",
     "trans": [
-      "v. 驾驶，开（车）；驱赶"
+      "v. 驾驶，开（车）；驱赶 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -9200,7 +9248,7 @@
     ]
   },
   {
-    "name": "easy--going",
+    "name": "easygoing",
     "usphone": "ˈiːzɪ-ˈɡəʊɪŋ",
     "ukphone": "",
     "trans": [
@@ -9208,11 +9256,11 @@
     ]
   },
   {
-    "name": "eat (ate, eaten)",
+    "name": "eat ate eaten",
     "usphone": "iːt",
     "ukphone": "",
     "trans": [
-      "v. 吃"
+      "v. 吃 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -9304,7 +9352,7 @@
     ]
   },
   {
-    "name": "Egypt*",
+    "name": "Egypt",
     "usphone": "ˈiːdʒɪpt",
     "ukphone": "",
     "trans": [
@@ -9448,7 +9496,7 @@
     ]
   },
   {
-    "name": "e-mail/email",
+    "name": "email",
     "usphone": "iː- meɪl",
     "ukphone": "",
     "trans": [
@@ -9592,7 +9640,7 @@
     ]
   },
   {
-    "name": "England*",
+    "name": "England",
     "usphone": "ˈɪŋɡlənd",
     "ukphone": "",
     "trans": [
@@ -9608,11 +9656,11 @@
     ]
   },
   {
-    "name": "English -speaking",
+    "name": "English-speaking",
     "usphone": "ˈɪŋɡlɪʃ-spiːk",
     "ukphone": "",
     "trans": [
-      "a.说英语的"
+      "a.说英语的【连字符】"
     ]
   },
   {
@@ -9816,7 +9864,7 @@
     ]
   },
   {
-    "name": "Europe*",
+    "name": "Europe",
     "usphone": "ˈjʊərəp",
     "ukphone": "",
     "trans": [
@@ -10288,8 +10336,8 @@
     ]
   },
   {
-    "name": "f (缩) =female (或 =foot,feet)",
-    "usphone": "ef",
+    "name": "female",
+    "usphone": "ˈfiːmeɪl",
     "ukphone": "",
     "trans": [
       "n. 女(的)；雌(的)； 英尺"
@@ -10616,19 +10664,19 @@
     ]
   },
   {
-    "name": "feed (fed, fed)",
+    "name": "feed fed fed",
     "usphone": "fiːd",
     "ukphone": "",
     "trans": [
-      "vt. 喂（养）；饲（养）"
+      "vt. 喂（养）；饲（养） 【一般现在 过去式 过去分词】"
     ]
   },
   {
-    "name": "feel (felt, felt)",
+    "name": "feel felt felt",
     "usphone": "fiːl",
     "ukphone": "",
     "trans": [
-      "v.& link 感觉，觉得；摸，触"
+      "v.& link 感觉，觉得；摸，触 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -11152,11 +11200,11 @@
     ]
   },
   {
-    "name": "fly (flew, flown)",
+    "name": "fly flew flown",
     "usphone": "flaɪ",
     "ukphone": "",
     "trans": [
-      "vi. （鸟、飞机）飞；（人乘飞机）飞行；（旗子等）飘动 vt. 空运（乘客，货物等）；放（风筝、飞机模型等）"
+      "vi. （鸟、飞机）飞；（人乘飞机）飞行；（旗子等）飘动 vt. 空运（乘客，货物等）；放（风筝、飞机模型等） 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -11248,11 +11296,11 @@
     ]
   },
   {
-    "name": "foot (复 feet)",
+    "name": "foot feet",
     "usphone": "fʊt",
     "ukphone": "",
     "trans": [
-      "n. 足，脚；英尺"
+      "n. 足，脚；英尺【单数 复数】"
     ]
   },
   {
@@ -11504,7 +11552,7 @@
     ]
   },
   {
-    "name": "France*",
+    "name": "France",
     "usphone": "fræns",
     "ukphone": "",
     "trans": [
@@ -12032,15 +12080,15 @@
     ]
   },
   {
-    "name": "get (got , got)",
+    "name": "get got got",
     "usphone": "ɡet",
     "ukphone": "",
     "trans": [
-      "vt. 成为；得到；具有；到达"
+      "vt. 成为；得到；具有；到达 【一般现在 过去式 过去分词】"
     ]
   },
   {
-    "name": "get--together",
+    "name": "gettogether",
     "usphone": "ɡet-təˈɡeðə(r)",
     "ukphone": "",
     "trans": [
@@ -12080,11 +12128,11 @@
     ]
   },
   {
-    "name": "give (gave, given)",
+    "name": "give gave given",
     "usphone": "ɡɪv",
     "ukphone": "",
     "trans": [
-      "vt. 给,递给,付出,给予"
+      "vt. 给,递给,付出,给予 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -12160,11 +12208,11 @@
     ]
   },
   {
-    "name": "go (went, gone)",
+    "name": "go went gone",
     "usphone": "ɡəʊ",
     "ukphone": "",
     "trans": [
-      "vi. 去；走；驶；通到；到达 n. 尝试（做某事）"
+      "vi. 去；走；驶；通到；到达 n. 尝试（做某事） 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -12224,11 +12272,11 @@
     ]
   },
   {
-    "name": "good (better ,best)",
+    "name": "good better best",
     "usphone": "ɡʊd",
     "ukphone": "",
     "trans": [
-      "a. 好；良好"
+      "a. 好；良好【比较级 最高级】"
     ]
   },
   {
@@ -12236,7 +12284,7 @@
     "usphone": "ɡʊd- baɪ",
     "ukphone": "",
     "trans": [
-      "int. 再见；再会"
+      "int. 再见；再会【连字符】"
     ]
   },
   {
@@ -12256,11 +12304,11 @@
     ]
   },
   {
-    "name": "goose (复 geese)",
+    "name": "goose geese",
     "usphone": "ɡuːs",
     "ukphone": "",
     "trans": [
-      "n. 鹅"
+      "n. 鹅【单数 复数】"
     ]
   },
   {
@@ -12560,11 +12608,11 @@
     ]
   },
   {
-    "name": "grow (grew, grown)",
+    "name": "grow grew grown",
     "usphone": "ɡrəʊ",
     "ukphone": "",
     "trans": [
-      "v. 生长；发育；种植；变成"
+      "v. 生长；发育；种植；变成 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -12816,11 +12864,11 @@
     ]
   },
   {
-    "name": "hang (hung, hung)",
+    "name": "hang hung hung",
     "usphone": "hæŋ",
     "ukphone": "",
     "trans": [
-      "v.悬挂，吊着；把……吊起"
+      "v.悬挂，吊着；把……吊起 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -12856,11 +12904,19 @@
     ]
   },
   {
-    "name": "harbour (美harbor)",
-    "usphone": "ˈhɑ:bə",
+    "name": "harbour",
+    "usphone": "ˈhɑːbə(r)",
     "ukphone": "",
     "trans": [
-      "n. 港口"
+      "n. 港口【英】"
+    ]
+  },
+  {
+    "name": "harbor",
+    "usphone": "ˈhɑːbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 港口【美】"
     ]
   },
   {
@@ -12960,11 +13016,11 @@
     ]
   },
   {
-    "name": "have (has, had, had)",
+    "name": "have has had had",
     "usphone": "hæv",
     "ukphone": "",
     "trans": [
-      "vt.有；吃；喝；进行；经受"
+      "vt.有；吃；喝；进行；经受【一般现在 第三人称单数 过去式 过去分词】"
     ]
   },
   {
@@ -13064,11 +13120,11 @@
     ]
   },
   {
-    "name": "hear (heard, heard)",
+    "name": "hear heard heard",
     "usphone": "hɪə(r)",
     "ukphone": "",
     "trans": [
-      "v. 听见；听说,得知"
+      "v. 听见；听说,得知【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -13272,11 +13328,11 @@
     ]
   },
   {
-    "name": "hide (hid, hidden)",
+    "name": "hide hid hidden",
     "usphone": "haɪd",
     "ukphone": "",
     "trans": [
-      "v. 把…藏起来，隐藏"
+      "v. 把…藏起来，隐藏【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -13368,11 +13424,11 @@
     ]
   },
   {
-    "name": "hit (hit, hit)",
+    "name": "hit hit hit",
     "usphone": "hɪt",
     "ukphone": "",
     "trans": [
-      "n.& vt. 打,撞,击中"
+      "n.& vt. 打,撞,击中【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -13392,7 +13448,7 @@
     ]
   },
   {
-    "name": "hold (held, held)",
+    "name": "hold held held",
     "usphone": "həʊld",
     "ukphone": "",
     "trans": [
@@ -13480,11 +13536,19 @@
     ]
   },
   {
-    "name": "honour (美honor)",
+    "name": "honour",
     "usphone": "ˈɔnə",
     "ukphone": "",
     "trans": [
-      "n. 荣誉，光荣 vt. 尊敬，给予荣誉"
+      "n. 荣誉，光荣 vt. 尊敬，给予荣誉【英】"
+    ]
+  },
+  {
+    "name": "honor",
+    "usphone": "ˈɔnə",
+    "ukphone": "",
+    "trans": [
+      "n. 荣誉，光荣 vt. 尊敬，给予荣誉【美】"
     ]
   },
   {
@@ -13688,11 +13752,19 @@
     ]
   },
   {
-    "name": "humour (美humor)",
-    "usphone": "ˈhju:mə",
+    "name": "humour",
+    "usphone": "ˈhjuːmə(r)",
     "ukphone": "",
     "trans": [
-      "n.幽默,幽默感"
+      "n.幽默,幽默感【英】"
+    ]
+  },
+  {
+    "name": "humor",
+    "usphone": "ˈhjuːmə(r)",
+    "ukphone": "",
+    "trans": [
+      "n.幽默,幽默感【美】"
     ]
   },
   {
@@ -13752,11 +13824,11 @@
     ]
   },
   {
-    "name": "hurt (hurt, hurt)",
+    "name": "hurt hurt hurt",
     "usphone": "hɜːt",
     "ukphone": "",
     "trans": [
-      "vt. 伤害，受伤；伤人感情"
+      "vt. 伤害，受伤；伤人感情 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -13792,11 +13864,11 @@
     ]
   },
   {
-    "name": "ice--cream",
+    "name": "ice-cream",
     "usphone": "aɪs- kriːm",
     "ukphone": "",
     "trans": [
-      "n. 冰淇淋"
+      "n. 冰淇淋【连字符】"
     ]
   },
   {
@@ -14808,11 +14880,11 @@
     ]
   },
   {
-    "name": "keep (kept, kept)",
+    "name": "keep kept kept",
     "usphone": "kiːp",
     "ukphone": "",
     "trans": [
-      "v. 保持；保存；继续不断 vt. 培育，饲养"
+      "v. 保持；保存；继续不断 vt. 培育，饲养 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -14916,7 +14988,7 @@
     "usphone": "kaɪnd- ˈhɑ:tid",
     "ukphone": "",
     "trans": [
-      "a. 好心的"
+      "a. 好心的【连字符】"
     ]
   },
   {
@@ -14992,11 +15064,11 @@
     ]
   },
   {
-    "name": "know(knew,known)",
+    "name": "know knew known",
     "usphone": "nəʊ",
     "ukphone": "",
     "trans": [
-      "v. 知道，了解；认识；懂得"
+      "v. 知道，了解；认识；懂得 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -15016,15 +15088,23 @@
     ]
   },
   {
-    "name": "labour (美labor)",
+    "name": "labour",
     "usphone": "ˈleɪbə(r)",
     "ukphone": "",
     "trans": [
-      "n. 劳动"
+      "n. 劳动【英】"
     ]
   },
   {
-    "name": "labourer (laborer)",
+    "name": "labor",
+    "usphone": "ˈleɪbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 劳动【美】"
+    ]
+  },
+  {
+    "name": "labourer",
     "usphone": "ˈleibərə",
     "ukphone": "",
     "trans": [
@@ -15232,11 +15312,11 @@
     ]
   },
   {
-    "name": "lay (laid, laid)",
+    "name": "lay laid laid",
     "usphone": "leɪ",
     "ukphone": "",
     "trans": [
-      "vt. 放，搁"
+      "vt. 放，搁 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -15248,11 +15328,11 @@
     ]
   },
   {
-    "name": "lead (led, led)",
+    "name": "lead led led",
     "usphone": "liːd",
     "ukphone": "",
     "trans": [
-      "v. 领导，带领 n. 铅"
+      "v. 领导，带领 n. 铅 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -15272,11 +15352,11 @@
     ]
   },
   {
-    "name": "leaf (复 leaves)",
+    "name": "leaf leaves",
     "usphone": "liːf",
     "ukphone": "",
     "trans": [
-      "n. （树，菜）叶"
+      "n. （树，菜）叶【单数 复数】"
     ]
   },
   {
@@ -15296,7 +15376,7 @@
     ]
   },
   {
-    "name": "learn (learnt, learnt；--ed --ed)",
+    "name": "learn",
     "usphone": "lɜːn",
     "ukphone": "",
     "trans": [
@@ -15328,11 +15408,11 @@
     ]
   },
   {
-    "name": "leave (left, left)",
+    "name": "leave left left",
     "usphone": "liːv",
     "ukphone": "",
     "trans": [
-      "v. 离开;把…留下，剩下"
+      "v. 离开;把…留下，剩下 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -15356,7 +15436,7 @@
     "usphone": "left- ˈ hændid",
     "ukphone": "",
     "trans": [
-      "a. 惯用左手的"
+      "a. 惯用左手的【连字符】"
     ]
   },
   {
@@ -15372,7 +15452,7 @@
     "usphone": "left-wɪŋ",
     "ukphone": "",
     "trans": [
-      "n. 左翼的"
+      "n. 左翼的【连字符】"
     ]
   },
   {
@@ -15408,11 +15488,11 @@
     ]
   },
   {
-    "name": "lend (lent, lent)",
+    "name": "lend lent lent",
     "usphone": "lend",
     "ukphone": "",
     "trans": [
-      "vt.借(出),把…借给"
+      "vt.借(出),把…借给 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -15424,11 +15504,11 @@
     ]
   },
   {
-    "name": "less（little的比较级）",
+    "name": "less",
     "usphone": "les",
     "ukphone": "",
     "trans": [
-      "a.& ad. 少于,小于"
+      "a.& ad. 少于,小于（little的比较级）"
     ]
   },
   {
@@ -15440,7 +15520,7 @@
     ]
   },
   {
-    "name": "let (let, let)",
+    "name": "let",
     "usphone": "let",
     "ukphone": "",
     "trans": [
@@ -15460,7 +15540,7 @@
     "usphone": "ˈletə(r)- bɔks",
     "ukphone": "",
     "trans": [
-      "n. 信箱"
+      "n. 信箱【连字符】"
     ]
   },
   {
@@ -15528,19 +15608,19 @@
     ]
   },
   {
-    "name": "lie (lay, lain)",
+    "name": "lie lay lain",
     "usphone": "laɪ",
     "ukphone": "",
     "trans": [
-      "v. 躺;卧;平放;位于n.& vi. 谎言; 说谎"
+      "v. 躺;卧;平放;位于n.& vi. 谎言; 说谎 【一般现在 过去式 过去分词】"
     ]
   },
   {
-    "name": "life (复lives)",
+    "name": "life lives",
     "usphone": "laɪf",
     "ukphone": "",
     "trans": [
-      "n. 生命；生涯；生活；人生；生物"
+      "n. 生命；生涯；生活；人生；生物【单数 复数】"
     ]
   },
   {
@@ -15672,11 +15752,19 @@
     ]
   },
   {
-    "name": "litre (美liter)",
+    "name": "litre",
     "usphone": "liːtə(r)",
     "ukphone": "",
     "trans": [
-      "n. 升； 公升"
+      "n. 升； 公升【英】"
+    ]
+  },
+  {
+    "name": "liter",
+    "usphone": "liːtə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 升； 公升【美】"
     ]
   },
   {
@@ -15688,11 +15776,11 @@
     ]
   },
   {
-    "name": "little (less, least)",
+    "name": "little less least",
     "usphone": "ˈlɪt(ə)l",
     "ukphone": "",
     "trans": [
-      "a.小的,少的 ad. 很少地, 稍许 n.没有多少,一点"
+      "a.小的,少的 ad. 很少地, 稍许 n.没有多少,一点【比较级 最高级】"
     ]
   },
   {
@@ -15816,11 +15904,11 @@
     ]
   },
   {
-    "name": "lose (lost, lost)",
+    "name": "lose lost lost",
     "usphone": "luːz",
     "ukphone": "",
     "trans": [
-      "vt. 失去，丢失"
+      "vt. 失去，丢失 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -16032,11 +16120,11 @@
     ]
   },
   {
-    "name": "make (made,made)",
+    "name": "make made made",
     "usphone": "meɪk",
     "ukphone": "",
     "trans": [
-      "vt.制造,做;使得 n. 样式；制造"
+      "vt.制造,做;使得 n. 样式；制造 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -16048,11 +16136,11 @@
     ]
   },
   {
-    "name": "man (复men)",
+    "name": "man men",
     "usphone": "mæn",
     "ukphone": "",
     "trans": [
-      "n. 成年男人;人类"
+      "n. 成年男人;人类【单数 复数】"
     ]
   },
   {
@@ -16084,7 +16172,7 @@
     "usphone": "mæn- meɪd",
     "ukphone": "",
     "trans": [
-      "a. 人造的，人工的"
+      "a. 人造的，人工的【连字符】"
     ]
   },
   {
@@ -16104,11 +16192,11 @@
     ]
   },
   {
-    "name": "many (more, most)",
+    "name": "many more most",
     "usphone": "ˈmenɪ",
     "ukphone": "",
     "trans": [
-      "pron. 许多人（或物）a. 许多的"
+      "pron. 许多人（或物）a. 许多的【比较级 最高级】"
     ]
   },
   {
@@ -16328,11 +16416,11 @@
     ]
   },
   {
-    "name": "mean(meant,meant)",
+    "name": "mean meant meant",
     "usphone": "miːn",
     "ukphone": "",
     "trans": [
-      "vt.意思,意指"
+      "vt.意思,意指 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -16424,11 +16512,11 @@
     ]
   },
   {
-    "name": "meet (met, met)",
+    "name": "meet met met",
     "usphone": "miːt",
     "ukphone": "",
     "trans": [
-      "vt./ n. 遇见，见到 会；集会"
+      "vt./ n. 遇见，见到 会；集会 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -16600,11 +16688,19 @@
     ]
   },
   {
-    "name": "metre (美meter)",
+    "name": "metre",
     "usphone": "ˈmi:tə",
     "ukphone": "",
     "trans": [
-      "n. 米，公尺"
+      "n. 米，公尺【英】"
+    ]
+  },
+  {
+    "name": "meter",
+    "usphone": "ˈmi:tə",
+    "ukphone": "",
+    "trans": [
+      "n. 米，公尺【美】"
     ]
   },
   {
@@ -16652,7 +16748,7 @@
     "usphone": "mɪd- ˈɔːtəm",
     "ukphone": "",
     "trans": [
-      "n. 中秋"
+      "n. 中秋【连字符】"
     ]
   },
   {
@@ -16864,11 +16960,11 @@
     ]
   },
   {
-    "name": "mistake (mistook, mistaken)",
+    "name": "mistake mistook mistaken",
     "usphone": "mɪsˈteɪk",
     "ukphone": "",
     "trans": [
-      "n. 错误 vt. 弄错"
+      "n. 错误 vt. 弄错 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -16880,7 +16976,7 @@
     ]
   },
   {
-    "name": "misunderstand (-stood, -stood)",
+    "name": "misunderstand",
     "usphone": "mɪsʌndəˈstænd",
     "ukphone": "",
     "trans": [
@@ -16904,8 +17000,8 @@
     ]
   },
   {
-    "name": "mm (缩) = millimetre",
-    "usphone": "ˈmiliˌmi:tə(r)",
+    "name": "millimetre",
+    "usphone": "ˈmɪlimiːtə(r)",
     "ukphone": "",
     "trans": [
       "n. 毫米"
@@ -17064,11 +17160,11 @@
     ]
   },
   {
-    "name": "more（much或many 的比较级）",
+    "name": "more",
     "usphone": "mɔː(r)",
     "ukphone": "",
     "trans": [
-      "a./ ad.另外的；附加的；较多的再；另外；而且；更 n. 更多的量；另外的一些"
+      "a./ ad.另外的；附加的；较多的再；另外；而且；更 n. 更多的量；另外的一些（much或many 的比较级）"
     ]
   },
   {
@@ -17104,7 +17200,7 @@
     ]
   },
   {
-    "name": "most (much或many 的最高级)",
+    "name": "most",
     "usphone": "məʊst; (US) mɔːst",
     "ukphone": "",
     "trans": [
@@ -17168,7 +17264,7 @@
     ]
   },
   {
-    "name": "mountain(s)",
+    "name": "mountain",
     "usphone": "ˈmaʊntɪn(z)",
     "ukphone": "",
     "trans": [
@@ -17192,11 +17288,11 @@
     ]
   },
   {
-    "name": "mouse (复mice)",
+    "name": "mouse mice",
     "usphone": "maʊs",
     "ukphone": "",
     "trans": [
-      "n. 鼠，耗子；（计算机）鼠标"
+      "n. 鼠，耗子；（计算机）鼠标【单数 复数】"
     ]
   },
   {
@@ -17256,7 +17352,7 @@
     ]
   },
   {
-    "name": "Mr. (mister)",
+    "name": "Mr.",
     "usphone": "ˈmɪstə(r)",
     "ukphone": "",
     "trans": [
@@ -17264,7 +17360,7 @@
     ]
   },
   {
-    "name": "Mrs. (mistress)",
+    "name": "Mrs.",
     "usphone": "ˈmɪsɪz",
     "ukphone": "",
     "trans": [
@@ -17280,11 +17376,11 @@
     ]
   },
   {
-    "name": "much (more，most)",
+    "name": "much more most",
     "usphone": "mʌtʃ",
     "ukphone": "",
     "trans": [
-      "a. 许多的，大量的 ad. 非常；更加 n. 许多，大量，非常"
+      "a. 许多的，大量的 ad. 非常；更加 n. 许多，大量，非常【比较级 最高级】"
     ]
   },
   {
@@ -17576,19 +17672,27 @@
     ]
   },
   {
-    "name": "neighbour (美neighbor)",
+    "name": "neighbour",
     "usphone": "ˈneɪbə(r)",
     "ukphone": "",
     "trans": [
-      "n. 邻居，邻人"
+      "n. 邻居，邻人【英】"
     ]
   },
   {
-    "name": "neighbourhood (美neighborhood)",
+    "name": "neighbor",
+    "usphone": "ˈneɪbə(r)",
+    "ukphone": "",
+    "trans": [
+      "n. 邻居，邻人 【美】"
+    ]
+  },
+  {
+    "name": "neighbourhood",
     "usphone": "ˈneibəhud",
     "ukphone": "",
     "trans": [
-      "n. 四邻；邻近地区"
+      "n. 四邻；邻近地区 (美neighborhood)"
     ]
   },
   {
@@ -17732,7 +17836,7 @@
     "usphone": "naɪt-klʌb",
     "ukphone": "",
     "trans": [
-      "n. 夜总会"
+      "n. 夜总会【连字符】"
     ]
   },
   {
@@ -17776,7 +17880,7 @@
     ]
   },
   {
-    "name": "No.(缩) = number",
+    "name": "number",
     "usphone": "ˈnʌmbə(r)",
     "ukphone": "",
     "trans": [
@@ -17844,7 +17948,7 @@
     "usphone": "nʌn-stɔp",
     "ukphone": "",
     "trans": [
-      "a.& ad.不停的,不断地"
+      "a.& ad.不停的,不断地【连字符】"
     ]
   },
   {
@@ -17852,7 +17956,7 @@
     "usphone": "nɔn-ˈvaɪələnt",
     "ukphone": "",
     "trans": [
-      "a. 非暴力的"
+      "a. 非暴力的【连字符】"
     ]
   },
   {
@@ -18160,7 +18264,7 @@
     ]
   },
   {
-    "name": "Oceania*",
+    "name": "Oceania",
     "usphone": "",
     "ukphone": "",
     "trans": [
@@ -18304,7 +18408,7 @@
     ]
   },
   {
-    "name": "Olympic(s)",
+    "name": "Olympic",
     "usphone": "əˈlɪmpɪk",
     "ukphone": "",
     "trans": [
@@ -18552,15 +18656,23 @@
     ]
   },
   {
-    "name": "organise(美organize)",
-    "usphone": "ˈɔ:gənaiz",
+    "name": "organise",
+    "usphone": "ˈɔːrɡənaɪz",
     "ukphone": "",
     "trans": [
-      "vt. 组织"
+      "vt. 组织【英】"
     ]
   },
   {
-    "name": "organiser (organizer)",
+    "name": "organize",
+    "usphone": "ˈɔːrɡənaɪz",
+    "ukphone": "",
+    "trans": [
+      "vt. 组织【美】"
+    ]
+  },
+  {
+    "name": "organiser",
     "usphone": "ˈɔ:gənaizə",
     "ukphone": "",
     "trans": [
@@ -18736,7 +18848,7 @@
     ]
   },
   {
-    "name": "outward(s)",
+    "name": "outward",
     "usphone": "ˈaʊtwəd",
     "ukphone": "",
     "trans": [
@@ -18832,11 +18944,11 @@
     ]
   },
   {
-    "name": "ox (复oxen)",
+    "name": "ox oxen",
     "usphone": "ɔks",
     "ukphone": "",
     "trans": [
-      "n. 牛；公牛"
+      "n. 牛；公牛【单数 复数】"
     ]
   },
   {
@@ -19148,7 +19260,7 @@
     "usphone": "pɑːt -taɪm",
     "ukphone": "",
     "trans": [
-      "a.& ad. 兼职的； 部分时间的（地）"
+      "a.& ad. 兼职的； 部分时间的（地）【连字符】"
     ]
   },
   {
@@ -19272,19 +19384,19 @@
     ]
   },
   {
-    "name": "P.E.(缩) =physical education",
+    "name": "P.E.",
     "usphone": "piːiː",
     "ukphone": "",
     "trans": [
-      "体育"
+      "体育(缩) =physical education"
     ]
   },
   {
-    "name": "P.C.(缩) =personal computer",
+    "name": "P.C.",
     "usphone": "piːsiː",
     "ukphone": "",
     "trans": [
-      "个人电脑"
+      "个人电脑(缩) =personal computer"
     ]
   },
   {
@@ -19364,7 +19476,7 @@
     "usphone": "ˈpens(ə)l -bɔks",
     "ukphone": "",
     "trans": [
-      "n. 铅笔盒"
+      "n. 铅笔盒【连字符】"
     ]
   },
   {
@@ -19372,7 +19484,7 @@
     "usphone": "pen- friend",
     "ukphone": "",
     "trans": [
-      "n. 笔友"
+      "n. 笔友【连字符】"
     ]
   },
   {
@@ -19576,7 +19688,7 @@
     ]
   },
   {
-    "name": "phenomenon (pl. phenomena)",
+    "name": "phenomenon",
     "usphone": "fɪˈnɔmɪnən; (US) -nɔn-",
     "ukphone": "",
     "trans": [
@@ -19596,7 +19708,7 @@
     "usphone": "fəʊn-buːð",
     "ukphone": "",
     "trans": [
-      "n. 公用电话间"
+      "n. 公用电话间【连字符】"
     ]
   },
   {
@@ -19788,7 +19900,7 @@
     "usphone": "pɪŋ-pɔɡ",
     "ukphone": "",
     "trans": [
-      "n. 乒乓球"
+      "n. 乒乓球【连字符】"
     ]
   },
   {
@@ -20008,7 +20120,7 @@
     ]
   },
   {
-    "name": "p.m./pm, P.M. /PM",
+    "name": "p.m.",
     "usphone": "piːem",
     "ukphone": "",
     "trans": [
@@ -20072,11 +20184,19 @@
     ]
   },
   {
-    "name": "the North (South) Pole",
-    "usphone": "ðə nɔːθpəʊ",
+    "name": "the North Pole",
+    "usphone": "ðə ˌnɔːθ ˈpəʊl",
     "ukphone": "",
     "trans": [
-      "（地球的）极，极地 北（南）极"
+      "（地球的）极，极地 北极"
+    ]
+  },
+  {
+    "name": "the South Pole",
+    "usphone": "ðə ˌsaʊθ ˈpəʊl",
+    "ukphone": "",
+    "trans": [
+      "（地球的）极，极地 南极"
     ]
   },
   {
@@ -20088,7 +20208,7 @@
     ]
   },
   {
-    "name": "policeman (复-men)",
+    "name": "policeman",
     "usphone": "pəˈliːsmən",
     "ukphone": "",
     "trans": [
@@ -20440,7 +20560,7 @@
     ]
   },
   {
-    "name": "practice(s)e",
+    "name": "practice",
     "usphone": "ˈpræktɪs",
     "ukphone": "",
     "trans": [
@@ -20848,11 +20968,11 @@
     ]
   },
   {
-    "name": "programme (美program)",
+    "name": "programme",
     "usphone": "",
     "ukphone": "",
     "trans": [
-      "n. 节目；项目"
+      "n. 节目；项目 (美program)"
     ]
   },
   {
@@ -21136,7 +21256,7 @@
     ]
   },
   {
-    "name": "put (put, put)",
+    "name": "put",
     "usphone": "pʊt",
     "ukphone": "",
     "trans": [
@@ -21536,7 +21656,7 @@
     ]
   },
   {
-    "name": "read (read, read)",
+    "name": "read",
     "usphone": "riːd",
     "ukphone": "",
     "trans": [
@@ -21576,11 +21696,19 @@
     ]
   },
   {
-    "name": "realise (美realize)",
+    "name": "realise",
     "usphone": "ˈrɪəlaɪz",
     "ukphone": "",
     "trans": [
-      "vt.认识到,实现"
+      "vt.认识到,实现【英】"
+    ]
+  },
+  {
+    "name": "realize",
+    "usphone": "ˈriːəlaɪz",
+    "ukphone": "",
+    "trans": [
+      "vt.认识到,实现 【美】"
     ]
   },
   {
@@ -21680,11 +21808,19 @@
     ]
   },
   {
-    "name": "recognise (美recognize)",
+    "name": "recognise",
     "usphone": "ˈrekəɡnaɪz",
     "ukphone": "",
     "trans": [
-      "vt.认出"
+      "vt.认出【英】"
+    ]
+  },
+  {
+    "name": "recognize",
+    "usphone": "ˈrekəɡnaɪz",
+    "ukphone": "",
+    "trans": [
+      "vt.认出【美】"
     ]
   },
   {
@@ -22424,7 +22560,7 @@
     ]
   },
   {
-    "name": "rid (rid, rid / ridded, ridded)",
+    "name": "rid",
     "usphone": "rɪd",
     "ukphone": "",
     "trans": [
@@ -22448,11 +22584,11 @@
     ]
   },
   {
-    "name": "ride (rode, ridden)",
+    "name": "ride rode ridden",
     "usphone": "raɪd",
     "ukphone": "",
     "trans": [
-      "v. 骑（马、自行车）；乘车 n. 乘车旅行"
+      "v. 骑（马、自行车）；乘车 n. 乘车旅行 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -22468,7 +22604,7 @@
     "usphone": "raɪt-hænd",
     "ukphone": "",
     "trans": [
-      "a. 惯用右手的"
+      "a. 惯用右手的【连字符】"
     ]
   },
   {
@@ -22476,15 +22612,15 @@
     "usphone": "raɪt-wɪŋ",
     "ukphone": "",
     "trans": [
-      "n. 右翼"
+      "n. 右翼【连字符】"
     ]
   },
   {
-    "name": "ring (rang, rung)",
+    "name": "ring rang rung",
     "usphone": "rɪŋ",
     "ukphone": "",
     "trans": [
-      "v. （钟、铃等）响；打电话 n. 电话，铃声 n. 环形物（如环、圈、戒指等）"
+      "v. （钟、铃等）响；打电话 n. 电话，铃声 n. 环形物（如环、圈、戒指等） 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -22492,7 +22628,7 @@
     "usphone": "rɪŋ-rəʊd",
     "ukphone": "",
     "trans": [
-      "n. 环形公路"
+      "n. 环形公路【连字符】"
     ]
   },
   {
@@ -22520,11 +22656,11 @@
     ]
   },
   {
-    "name": "rise (rose, risen)",
+    "name": "rise rose risen",
     "usphone": "raɪz",
     "ukphone": "",
     "trans": [
-      "vi. 上升，上涨"
+      "vi. 上升，上涨 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -22784,11 +22920,11 @@
     ]
   },
   {
-    "name": "run (ran, run)",
+    "name": "run ran run",
     "usphone": "rʌn",
     "ukphone": "",
     "trans": [
-      "vi. 跑，奔跑；（颜色）褪色"
+      "vi. 跑，奔跑；（颜色）褪色 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23072,11 +23208,11 @@
     ]
   },
   {
-    "name": "say (said, said)",
+    "name": "say said said",
     "usphone": "seɪ",
     "ukphone": "",
     "trans": [
-      "vt. 说，讲"
+      "vt. 说，讲 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23136,7 +23272,7 @@
     ]
   },
   {
-    "name": "sceptical (AmE skeptical)",
+    "name": "sceptical",
     "usphone": "ˈskeptɪkl",
     "ukphone": "",
     "trans": [
@@ -23188,7 +23324,7 @@
     "usphone": "skuːl-",
     "ukphone": "",
     "trans": [
-      "n.(英)学校毕业生"
+      "n.(英)学校毕业生【连字符】"
     ]
   },
   {
@@ -23440,11 +23576,11 @@
     ]
   },
   {
-    "name": "see (saw, seen)",
+    "name": "see saw seen",
     "usphone": "siː",
     "ukphone": "",
     "trans": [
-      "vt. 看见，看到；领会；拜会"
+      "vt. 看见，看到；领会；拜会 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23464,11 +23600,11 @@
     ]
   },
   {
-    "name": "seek (sought, sought)",
+    "name": "seek sought sought",
     "usphone": "siːk",
     "ukphone": "",
     "trans": [
-      "vt.试图;探寻"
+      "vt.试图;探寻 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23484,7 +23620,7 @@
     "usphone": "siː-sɔː",
     "ukphone": "",
     "trans": [
-      "n. 跷跷板（游戏）"
+      "n. 跷跷板（游戏）【连字符】"
     ]
   },
   {
@@ -23536,11 +23672,11 @@
     ]
   },
   {
-    "name": "sell (sold, sold)",
+    "name": "sell sold sold",
     "usphone": "sel",
     "ukphone": "",
     "trans": [
-      "v. 卖，售"
+      "v. 卖，售 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23552,11 +23688,11 @@
     ]
   },
   {
-    "name": "send (sent, sent)",
+    "name": "send sent sent",
     "usphone": "send",
     "ukphone": "",
     "trans": [
-      "v. 打发，派遣；送，邮寄"
+      "v. 打发，派遣；送，邮寄 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23660,7 +23796,7 @@
     "usphone": "ˈsɜːvɪs-tʃɑːdʒ",
     "ukphone": "",
     "trans": [
-      "n. 服务费,小费"
+      "n. 服务费,小费【连字符】"
     ]
   },
   {
@@ -23672,11 +23808,11 @@
     ]
   },
   {
-    "name": "set (set, set)",
+    "name": "set set set",
     "usphone": "set",
     "ukphone": "",
     "trans": [
-      "vt. 释放，安置 n. 装备，设备"
+      "vt. 释放，安置 n. 装备，设备 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23752,7 +23888,7 @@
     ]
   },
   {
-    "name": "sew (sewed, sewn 或sewed)",
+    "name": "sew",
     "usphone": "səʊ",
     "ukphone": "",
     "trans": [
@@ -23792,19 +23928,19 @@
     ]
   },
   {
-    "name": "shake (shook, shak en)",
+    "name": "shake shook shaken",
     "usphone": "ʃeɪk",
     "ukphone": "",
     "trans": [
-      "v. （使）动摇，震动"
+      "v. （使）动摇，震动 【一般现在 过去式 过去分词】"
     ]
   },
   {
-    "name": "shall (should)",
+    "name": "shall should",
     "usphone": "ʃæl, ʃ(ə)l",
     "ukphone": "",
     "trans": [
-      "v. aux. （表示将来）将要，会；……好吗"
+      "v. aux. （表示将来）将要，会；……好吗 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -23880,15 +24016,15 @@
     ]
   },
   {
-    "name": "pencil- sharpener",
+    "name": "pencil-sharpener",
     "usphone": "ˈpens(ə)l-ˈʃɑːpənə(r)",
     "ukphone": "",
     "trans": [
-      "转笔刀"
+      "转笔刀【连字符】"
     ]
   },
   {
-    "name": "shave (shaved, shaved 或 shaven)",
+    "name": "shave",
     "usphone": "ʃeɪv",
     "ukphone": "",
     "trans": [
@@ -23912,7 +24048,7 @@
     ]
   },
   {
-    "name": "sheep (复sheep)",
+    "name": "sheep",
     "usphone": "ʃiːp",
     "ukphone": "",
     "trans": [
@@ -23928,11 +24064,11 @@
     ]
   },
   {
-    "name": "shelf (复 shelves)",
+    "name": "shelf shelves",
     "usphone": "ʃelf",
     "ukphone": "",
     "trans": [
-      "n. 架子；搁板；格层；礁；陆架"
+      "n. 架子；搁板；格层；礁；陆架【单数 复数】"
     ]
   },
   {
@@ -23952,7 +24088,7 @@
     ]
   },
   {
-    "name": "shine (shone, shone 或-d, -d)",
+    "name": "shine",
     "usphone": "ʃaɪn",
     "ukphone": "",
     "trans": [
@@ -24080,131 +24216,115 @@
     ]
   },
   {
-    "name": "short wave",
-    "usphone": "ʃɔːt",
+    "name": "shortwave",
+    "usphone": "ˈʃɔːtˈweɪv",
     "ukphone": "",
     "trans": [
-      ""
+      "n. 短波"
     ]
   },
   {
-    "name": "[weɪv]",
-    "usphone": "n. 短波",
+    "name": "shoot",
+    "usphone": "[ʃɔt]",
     "ukphone": "",
     "trans": [
-      "shot"
+      "n. 射击，开枪，开炮，射击声；子弹"
     ]
   },
   {
-    "name": "[ʃɔt]",
-    "usphone": "n. 射击，开枪，开炮，射击声；子弹",
+    "name": "should",
+    "usphone": "[ʃɔt]",
     "ukphone": "",
     "trans": [
-      "should"
+      "v. mod. 应当，应该，会 v. aux.会,应该（shall的过去时态）"
     ]
   },
   {
-    "name": "[ʃɔt]",
-    "usphone": "v. mod. 应当，应该，会 v. aux.会,应该（shall的过去时态）",
+    "name": "shoulder",
+    "usphone": "[ˈʃəʊldə(r)]",
     "ukphone": "",
     "trans": [
-      "shoulder"
+      "n. 肩膀,(道路的)路肩"
     ]
   },
   {
-    "name": "[ˈʃəʊldə(r)]",
-    "usphone": "n. 肩膀,(道路的)路肩",
+    "name": "shout",
+    "usphone": "[ˈʃəʊldə(r)]",
     "ukphone": "",
     "trans": [
-      "shout"
+      "n.& v. 喊，高声呼喊"
     ]
   },
   {
-    "name": "[ˈʃəʊldə(r)]",
-    "usphone": "n.& v. 喊，高声呼喊",
+    "name": "show",
+    "usphone": "[ʃəʊ]",
     "ukphone": "",
     "trans": [
-      "show"
+      "n. 展示,展览（会）;演出show"
     ]
   },
   {
-    "name": "[ʃəʊ]",
-    "usphone": "n. 展示,展览（会）;演出",
+    "name": "shower",
+    "usphone": "[ˈʃaʊə(r)]",
     "ukphone": "",
     "trans": [
-      "show"
+      "n. 阵雨；淋浴"
     ]
   },
   {
-    "name": "[ʃəʊ]",
-    "usphone": "(showed, shown 或 showed) v. 给…看,出示,显示",
+    "name": "shrink",
+    "usphone": "[ʃrɪŋk]",
     "ukphone": "",
     "trans": [
-      "shower"
+      "v. 缩小，收缩，减少"
     ]
   },
   {
-    "name": "[ˈʃaʊə(r)]",
-    "usphone": "n. 阵雨；淋浴",
+    "name": "shut",
+    "usphone": "[ʃʌt]",
     "ukphone": "",
     "trans": [
-      "shrink (shrank, shrunk / shrunk, shrunken)"
+      "v. / n. 关上，封闭；禁闭；"
     ]
   },
   {
-    "name": "[ʃrɪŋk]",
-    "usphone": "v. 缩小，收缩，减少",
+    "name": "shuttle",
+    "usphone": "[ˈʃʌt(ə)l]",
     "ukphone": "",
     "trans": [
-      "shut (shut, shut)"
+      "vn. 合拢 （往返与两个定点之间的）（火车汽车飞机）班车/机"
     ]
   },
   {
-    "name": "[ʃʌt]",
-    "usphone": "v. / n. 关上，封闭；禁闭；",
+    "name": "shy",
+    "usphone": "[ʃaɪ]",
     "ukphone": "",
     "trans": [
-      "shuttle"
+      "a. 害羞的"
     ]
   },
   {
-    "name": "[ˈʃʌt(ə)l]",
-    "usphone": "vn. 合拢 （往返与两个定点之间的）（火车汽车飞机）班车/机",
+    "name": "sick",
+    "usphone": "[sɪk]",
     "ukphone": "",
     "trans": [
-      "shyv"
+      "a.有病的,患病的"
     ]
   },
   {
-    "name": "[ʃaɪ]",
-    "usphone": "a. 害羞的",
+    "name": "sickness",
+    "usphone": "[ˈsɪknɪs]",
     "ukphone": "",
     "trans": [
-      "sick"
+      "n. 疾病,（想）呕吐"
     ]
   },
   {
-    "name": "[sɪk]",
-    "usphone": "a.有病,患病的,（想）呕吐",
+    "name": "side",
+    "usphone": "[saɪd]",
     "ukphone": "",
     "trans": [
-      "sickness"
-    ]
-  },
-  {
-    "name": "[ˈsɪknɪs]",
-    "usphone": "n. 疾病",
-    "ukphone": "",
-    "trans": [
-      "side"
-    ]
-  },
-  {
-    "name": "[ˈsɪknɪs]",
-    "usphone": "n. 边，旁边，面，侧面",
-    "ukphone": "",
-    "trans": [
-      "sideroad (AmE sidewalk) n.人行道"
+      "n. 边，旁边，面，侧面"
     ]
   },
   {
@@ -24212,7 +24332,7 @@
     "usphone": "ˈsaɪdweɪz",
     "ukphone": "",
     "trans": [
-      "n. 岔路，旁路"
+      "n.人行道 n. 岔路，旁路"
     ]
   },
   {
@@ -24340,7 +24460,7 @@
     "usphone": "ˈsɪmp(ə)l maɪndɪ",
     "ukphone": "",
     "trans": [
-      "a.纯朴,头脑简单"
+      "a.纯朴,头脑简单【连字符】"
     ]
   },
   {
@@ -24376,11 +24496,11 @@
     ]
   },
   {
-    "name": "sing (sang, sung)",
+    "name": "sing sang sung",
     "usphone": "sɪŋ",
     "ukphone": "",
     "trans": [
-      "v. 唱，唱歌"
+      "v. 唱，唱歌 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -24408,11 +24528,11 @@
     ]
   },
   {
-    "name": "sink (sank, sunk)",
+    "name": "sink sank sunk",
     "usphone": "sɪŋk",
     "ukphone": "",
     "trans": [
-      "vi. 下沉；消沉"
+      "vi. 下沉；消沉 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -24440,11 +24560,11 @@
     ]
   },
   {
-    "name": "sit (sat, sat)",
+    "name": "sit sat sat",
     "usphone": "sɪt",
     "ukphone": "",
     "trans": [
-      "vi. 坐"
+      "vi. 坐 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -24632,11 +24752,11 @@
     ]
   },
   {
-    "name": "sleep (slept, slept)",
+    "name": "sleep slept slept",
     "usphone": "sliːp",
     "ukphone": "",
     "trans": [
-      "vi. 睡觉"
+      "vi. 睡觉 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -24720,7 +24840,7 @@
     ]
   },
   {
-    "name": "smell (smelt, smelt 或-ed,-ed)",
+    "name": "smell",
     "usphone": "smel",
     "ukphone": "",
     "trans": [
@@ -24968,163 +25088,163 @@
     ]
   },
   {
-    "name": "soft sɔft; (US) sɔːft]",
-    "usphone": "a. 软的，柔和的",
-    "ukphone": "",
+    "name": "soft",
+    "usphone": "sɒft",
+    "ukphone": "sɔːft",
     "trans": [
-      "software"
+      "a. 软的，柔和的"
     ]
   },
   {
-    "name": "[sɔft; (US) sɔːft]",
-    "usphone": "n. 软件",
+    "name": "software",
+    "usphone": "software",
     "ukphone": "",
     "trans": [
-      "soft drink"
+      "n. 软件"
     ]
   },
   {
-    "name": "[sɔft drɪŋk]",
-    "usphone": "n. (不含酒精)清凉饮料",
+    "name": "softdrink",
+    "usphone": "[sɔft drɪŋk]",
     "ukphone": "",
     "trans": [
-      "softball"
+      "n. (不含酒精)清凉饮料"
     ]
   },
   {
-    "name": "[ˈsɔftbɔːl]",
-    "usphone": "n. 垒球",
+    "name": "softball",
+    "usphone": "[ˈsɔftbɔːl]",
     "ukphone": "",
     "trans": [
-      "soil"
+      "n. 垒球"
     ]
   },
   {
-    "name": "[sɔɪl]",
-    "usphone": "n. 土壤，土地",
+    "name": "soil",
+    "usphone": "[sɔɪl]",
     "ukphone": "",
     "trans": [
-      "solar"
+      "n. 土壤，土地"
     ]
   },
   {
-    "name": "[ˈsəʊlə(r)]",
-    "usphone": "a. 太阳的",
+    "name": "solar",
+    "usphone": "[ˈsəʊlə(r)]",
     "ukphone": "",
     "trans": [
-      "soldier"
+      "a. 太阳的"
     ]
   },
   {
-    "name": "[ˈsəʊldʒə(r)]",
-    "usphone": "n. 士兵，战士",
+    "name": "soldier",
+    "usphone": "[ˈsəʊldʒə(r)]",
     "ukphone": "",
     "trans": [
-      "solid"
+      "n. 士兵，战士"
     ]
   },
   {
-    "name": "[ˈsɔlɪd]",
-    "usphone": "a. 结实的,固体的 n.固体",
+    "name": "solid",
+    "usphone": "[ˈsɔlɪd]",
     "ukphone": "",
     "trans": [
-      "some"
+      "a. 结实的,固体的 n.固体"
     ]
   },
   {
-    "name": "[sʌm]",
-    "usphone": "a. 一些，若干；有些；某一 pron. 若干，一些",
+    "name": "some",
+    "usphone": "[sʌm]",
     "ukphone": "",
     "trans": [
-      "somebody"
+      "a. 一些，若干；有些；某一 pron. 若干，一些"
     ]
   },
   {
-    "name": "[ˈsʌmbʌdɪ; ˈsʌmbədɪ]",
-    "usphone": "pron. 某人；有人；有名气的人",
+    "name": "somebody",
+    "usphone": "[ˈsʌmbʌdɪ; ˈsʌmbədɪ]",
     "ukphone": "",
     "trans": [
-      "someone"
+      "pron. 某人；有人；有名气的人"
     ]
   },
   {
-    "name": "[ˈsʌmwʌn]",
-    "usphone": "pron. 某一个人",
+    "name": "someone",
+    "usphone": "[ˈsʌmwʌn]",
     "ukphone": "",
     "trans": [
-      "something"
+      "pron. 某一个人"
     ]
   },
   {
-    "name": "[ˈsʌmθɪŋ]",
-    "usphone": "pron. 某事；某物",
+    "name": "something",
+    "usphone": "[ˈsʌmθɪŋ]",
     "ukphone": "",
     "trans": [
-      "sometimes"
+      "pron. 某事；某物"
     ]
   },
   {
-    "name": "[ˈsʌmtaɪmz]",
-    "usphone": "ad. 有时",
+    "name": "sometimes",
+    "usphone": "[ˈsʌmtaɪmz]",
     "ukphone": "",
     "trans": [
-      "somewhere"
+      "ad. 有时"
     ]
   },
   {
-    "name": "[ˈsʌmtaɪmz]",
-    "usphone": "ad. 在某处",
+    "name": "somewhere",
+    "usphone": "[ˈsʌmtaɪmz]",
     "ukphone": "",
     "trans": [
-      "son"
+      "ad. 在某处"
     ]
   },
   {
-    "name": "[sʌn]",
-    "usphone": "n. 儿子",
+    "name": "son",
+    "usphone": "[sʌn]",
     "ukphone": "",
     "trans": [
-      "song"
+      "n. 儿子"
     ]
   },
   {
-    "name": "[sʌn]",
-    "usphone": "n. 歌唱；歌曲",
+    "name": "song",
+    "usphone": "[sʌn]",
     "ukphone": "",
     "trans": [
-      "soon"
+      "n. 歌唱；歌曲"
     ]
   },
   {
-    "name": "[sʌn]",
-    "usphone": "ad. 不久,很快,一会儿",
+    "name": "soon",
+    "usphone": "[sʌn]",
     "ukphone": "",
     "trans": [
-      "sorrow"
+      "ad. 不久,很快,一会儿"
     ]
   },
   {
-    "name": "[ˈsɔrəʊ]",
-    "usphone": "n. 悲伤，悲痛",
+    "name": "sorrow",
+    "usphone": "[ˈsɔrəʊ]",
     "ukphone": "",
     "trans": [
-      "sorry"
+      "n. 悲伤，悲痛"
     ]
   },
   {
-    "name": "[ˈsɔrɪ]",
-    "usphone": "a. 对不起,抱歉;难过的",
+    "name": "sorry",
+    "usphone": "[ˈsɔrɪ]",
     "ukphone": "",
     "trans": [
-      "sort"
+      "a. 对不起,抱歉;难过的"
     ]
   },
   {
-    "name": "[sɔːt]",
-    "usphone": "v",
+    "name": "sort",
+    "usphone": "[sɔːt]",
     "ukphone": "",
     "trans": [
-      "t. 把…分类，拣选 n. 种类，类别"
+      "vt. 把…分类，拣选 n. 种类，类别"
     ]
   },
   {
@@ -25208,7 +25328,7 @@
     ]
   },
   {
-    "name": "sow (sowed, sown 或-ed)",
+    "name": "sow",
     "usphone": "səʊ",
     "ukphone": "",
     "trans": [
@@ -25248,7 +25368,7 @@
     ]
   },
   {
-    "name": "Spain*",
+    "name": "Spain",
     "usphone": "speɪn",
     "ukphone": "",
     "trans": [
@@ -25280,11 +25400,11 @@
     ]
   },
   {
-    "name": "speak (spoke, spoken)",
+    "name": "speak spoke spoken",
     "usphone": "ˈspærəʊ",
     "ukphone": "",
     "trans": [
-      "v. 说，讲；谈话；发言"
+      "v. 说，讲；谈话；发言 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -25360,11 +25480,11 @@
     ]
   },
   {
-    "name": "spend (spent, spent)",
+    "name": "spend spent spent",
     "usphone": "ˈspelɪŋ",
     "ukphone": "",
     "trans": [
-      "v. 度过；花费（钱、时间等）"
+      "v. 度过；花费（钱、时间等） 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -25424,7 +25544,7 @@
     ]
   },
   {
-    "name": "spoken man/ woman (pl. spokemen/ women)",
+    "name": "spokesman",
     "usphone": "ˈspəʊkən mæn",
     "ukphone": "",
     "trans": [
@@ -25616,11 +25736,11 @@
     ]
   },
   {
-    "name": "stand (stood, stood)",
+    "name": "stand stood stood",
     "usphone": "stænd",
     "ukphone": "",
     "trans": [
-      "v. 站；立；起立；坐落；经受；持久"
+      "v. 站；立；起立；坐落；经受；持久 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -25696,7 +25816,7 @@
     ]
   },
   {
-    "name": "statesman/ woman (pl. statesmen/ women)",
+    "name": "statesman",
     "usphone": "ˈsteɪtsmən",
     "ukphone": "",
     "trans": [
@@ -25752,11 +25872,11 @@
     ]
   },
   {
-    "name": "steal (stole, stolen)",
+    "name": "steal stole stolen",
     "usphone": "stiːl",
     "ukphone": "",
     "trans": [
-      "vt. 偷, 窃取"
+      "vt. 偷, 窃取 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -25796,7 +25916,7 @@
     "usphone": "step-ˈmʌðə(r)",
     "ukphone": "",
     "trans": [
-      "n. 继母"
+      "n. 继母【连字符】"
     ]
   },
   {
@@ -25816,11 +25936,11 @@
     ]
   },
   {
-    "name": "stick (stuck, stuck)",
+    "name": "stick stuck stuck",
     "usphone": "stɪk",
     "ukphone": "",
     "trans": [
-      "vi. 粘住，钉住；坚持n. 木棒（棍）,枝条"
+      "vi. 粘住，钉住；坚持n. 木棒（棍）,枝条 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -26040,7 +26160,7 @@
     ]
   },
   {
-    "name": "strike (struck, struck 或stricken)",
+    "name": "strike",
     "usphone": "straɪk",
     "ukphone": "",
     "trans": [
@@ -26560,11 +26680,11 @@
     ]
   },
   {
-    "name": "swear (swore, sworn)",
+    "name": "swear swore sworn",
     "usphone": "sweə(r)",
     "ukphone": "",
     "trans": [
-      "v.咒骂.,诅咒"
+      "v.咒骂.,诅咒 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -26584,11 +26704,11 @@
     ]
   },
   {
-    "name": "sweep(swept,swept)",
+    "name": "sweep swept swept",
     "usphone": "swiːp",
     "ukphone": "",
     "trans": [
-      "v. 扫除，扫"
+      "v. 扫除，扫 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -26600,11 +26720,11 @@
     ]
   },
   {
-    "name": "swell (swelled, swollen)",
+    "name": "swell swelled swollen",
     "usphone": "swel",
     "ukphone": "",
     "trans": [
-      "v. 肿胀"
+      "v. 肿胀 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -26624,11 +26744,11 @@
     ]
   },
   {
-    "name": "swim (swam, swum)",
+    "name": "swim swam swum",
     "usphone": "swɪm",
     "ukphone": "",
     "trans": [
-      "vi. 游泳,游"
+      "vi. 游泳,游 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -26776,11 +26896,11 @@
     ]
   },
   {
-    "name": "take (took, taken)",
+    "name": "take took taken",
     "usphone": "teɪk",
     "ukphone": "",
     "trans": [
-      "vt. 拿；拿走；做；服用；乘坐；花费"
+      "vt. 拿；拿走；做；服用；乘坐；花费 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -26936,7 +27056,7 @@
     ]
   },
   {
-    "name": "teach(taught,taught)",
+    "name": "teach taught taught",
     "usphone": "tiː",
     "ukphone": "",
     "trans": [
@@ -27048,11 +27168,11 @@
     ]
   },
   {
-    "name": "telephone-booth / telephone-box",
+    "name": "telephone-booth",
     "usphone": "",
     "ukphone": "",
     "trans": [
-      "n. 公用电话间"
+      "n. 公用电话间（也可写作 / telephone-box）【连字符】"
     ]
   },
   {
@@ -27072,11 +27192,11 @@
     ]
   },
   {
-    "name": "tell (told, told)",
+    "name": "tell told told",
     "usphone": "tel",
     "ukphone": "",
     "trans": [
-      "vt.告诉,讲述,吩咐"
+      "vt.告诉,讲述,吩咐 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -27280,11 +27400,19 @@
     ]
   },
   {
-    "name": "theatre (美theater)",
+    "name": "theatre",
     "usphone": "ˈθiətə",
     "ukphone": "",
     "trans": [
-      "n. 剧场，戏院"
+      "n. 剧场，戏院 【英】"
+    ]
+  },
+  {
+    "name": "theater",
+    "usphone": "ˈθiətə",
+    "ukphone": "",
+    "trans": [
+      "n. 剧场，戏院 【美】"
     ]
   },
   {
@@ -27408,11 +27536,11 @@
     ]
   },
   {
-    "name": "thief (复thieves)",
+    "name": "thief thieves",
     "usphone": "θiːf",
     "ukphone": "",
     "trans": [
-      "n. 窃贼, 小偷"
+      "n. 窃贼, 小偷【单数 复数】"
     ]
   },
   {
@@ -27432,11 +27560,11 @@
     ]
   },
   {
-    "name": "think(thought, thought)",
+    "name": "think thought thought",
     "usphone": "θɪŋk",
     "ukphone": "",
     "trans": [
-      "v. 想；认为；考虑"
+      "v. 想；认为；考虑 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -27592,11 +27720,11 @@
     ]
   },
   {
-    "name": "throw(threw,thrown)",
+    "name": "throw threw thrown",
     "usphone": "θrəʊ",
     "ukphone": "",
     "trans": [
-      "v.投,掷,扔"
+      "v.投,掷,扔 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -27912,11 +28040,11 @@
     ]
   },
   {
-    "name": "tooth (复 teeth)",
+    "name": "tooth teeth",
     "usphone": "tuːθ",
     "ukphone": "",
     "trans": [
-      "n. 牙齿"
+      "n. 牙齿【单数 复数】"
     ]
   },
   {
@@ -28032,7 +28160,7 @@
     ]
   },
   {
-    "name": "toward(s)",
+    "name": "toward",
     "usphone": "təˈwɔːd",
     "ukphone": "",
     "trans": [
@@ -28480,11 +28608,11 @@
     ]
   },
   {
-    "name": "TV(缩) = television",
+    "name": "TV",
     "usphone": "‚tiːˈviː",
     "ukphone": "",
     "trans": [
-      "n. 电视机"
+      "n. 电视机 television的缩写"
     ]
   },
   {
@@ -28608,11 +28736,19 @@
     ]
   },
   {
-    "name": "tyre (美tire)",
+    "name": "tyre",
     "usphone": "taɪə",
     "ukphone": "",
     "trans": [
-      "n. 轮胎"
+      "n. 轮胎【英】"
+    ]
+  },
+  {
+    "name": "tire",
+    "usphone": "ˈtaɪər",
+    "ukphone": "",
+    "trans": [
+      "n. 轮胎【美】"
     ]
   },
   {
@@ -28624,11 +28760,11 @@
     ]
   },
   {
-    "name": "U.K./ UK(缩) = United Kingdom",
+    "name": "U.K.",
     "usphone": "juː ˈkeɪ",
     "ukphone": "",
     "trans": [
-      "n.英国，联合王国"
+      "n.英国，联合王国（缩写）"
     ]
   },
   {
@@ -28640,11 +28776,11 @@
     ]
   },
   {
-    "name": "U.N./ UN(缩) = the United Nations",
+    "name": "U.N.",
     "usphone": "juː ˈən",
     "ukphone": "",
     "trans": [
-      "n. 联合国"
+      "n. 联合国（缩写）"
     ]
   },
   {
@@ -28736,11 +28872,11 @@
     ]
   },
   {
-    "name": "understand (understood, understood)",
+    "name": "understand understood understood",
     "usphone": "ʌndəˈstænd",
     "ukphone": "",
     "trans": [
-      "v. 懂得;明白;理解"
+      "v. 懂得;明白;理解 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -28752,11 +28888,11 @@
     ]
   },
   {
-    "name": "undertake (undertook, undertaken)",
+    "name": "undertake undertook undertaken",
     "usphone": "ʌndəˈteɪk",
     "ukphone": "",
     "trans": [
-      "v. 承担，从事，负责"
+      "v. 承担，从事，负责 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -29088,7 +29224,7 @@
     ]
   },
   {
-    "name": "U.S.A./USA(缩) = the United States of America",
+    "name": "U.S.A.",
     "usphone": "juː es ˈeɪ",
     "ukphone": "",
     "trans": [
@@ -29616,7 +29752,7 @@
     ]
   },
   {
-    "name": "waiting -room",
+    "name": "waiting-room",
     "usphone": "ˈweɪtɪŋ- rʊm",
     "ukphone": "",
     "trans": [
@@ -29632,7 +29768,7 @@
     ]
   },
   {
-    "name": "wake (woke, woken)",
+    "name": "wake woke woken",
     "usphone": "weɪk",
     "ukphone": "",
     "trans": [
@@ -29768,11 +29904,11 @@
     ]
   },
   {
-    "name": "washing -machine",
+    "name": "washing-machine",
     "usphone": "ˈwɔʃɪŋ- məˈʃiːn",
     "ukphone": "",
     "trans": [
-      "n. 洗衣机"
+      "n. 洗衣机【连字符】"
     ]
   },
   {
@@ -29904,11 +30040,11 @@
     ]
   },
   {
-    "name": "wear (wore, worn)",
+    "name": "wear wore worn",
     "usphone": "weə(r)",
     "ukphone": "",
     "trans": [
-      "v. 穿，戴"
+      "v. 穿，戴 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -30296,7 +30432,7 @@
     ]
   },
   {
-    "name": "will (would)",
+    "name": "will",
     "usphone": "wɪl",
     "ukphone": "",
     "trans": [
@@ -30328,11 +30464,11 @@
     ]
   },
   {
-    "name": "win (won, won)",
+    "name": "win won won",
     "usphone": "wɪn",
     "ukphone": "",
     "trans": [
-      "n. 获胜，赢得"
+      "n. 获胜，赢得 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -30344,11 +30480,11 @@
     ]
   },
   {
-    "name": "wind(wound,wound)",
+    "name": "wind wound wound",
     "usphone": "wɪnd",
     "ukphone": "",
     "trans": [
-      "vt. 缠，连带；蜿蜒，弯曲"
+      "vt. 缠，连带；蜿蜒，弯曲 【一般现在 过去式 过去分词】"
     ]
   },
   {
@@ -30488,19 +30624,19 @@
     ]
   },
   {
-    "name": "wolf（复wolves）",
+    "name": "wolf wolves",
     "usphone": "wʊlf",
     "ukphone": "",
     "trans": [
-      "n. 狼"
+      "n. 狼【单数 复数】"
     ]
   },
   {
-    "name": "woman ( 复women)",
+    "name": "woman women",
     "usphone": "ˈwʊmən",
     "ukphone": "",
     "trans": [
-      "n.妇女女人"
+      "n.妇女女人【单数 复数】"
     ]
   },
   {
@@ -30944,11 +31080,11 @@
     ]
   },
   {
-    "name": "zebra -crossing",
+    "name": "zebra-crossing",
     "usphone": "ˈzebrə-ˈkrɔsɪŋ",
     "ukphone": "",
     "trans": [
-      "人行横道线（斑马线）"
+      "人行横道线（斑马线）【连字符】"
     ]
   },
   {
@@ -30968,11 +31104,11 @@
     ]
   },
   {
-    "name": "zip code(美) =postcode",
+    "name": "zipcode",
     "usphone": "zɪp kəʊd",
     "ukphone": "",
     "trans": [
-      "(英)邮政区号"
+      "(英)邮政区号，也可写作 postcode"
     ]
   },
   {


### PR DESCRIPTION
**做了以下更改**
- 词库数据格式化
- 单词错行问题
- 英美两种单词会分开并提示【英】【美】
- 组成词有三种方式：空格、连接线-、连词，空格和[连字符（hyphen）](https://www.zhihu.com/question/20332423/answer/15367631)会增加提示（`【空格符号】`，`【连字符】`）
- 错误单词：`café` => `cafe`
- 分开两个词 a an
- 去掉双连接线`--`：`best--seller` => `bestseller`
- 加s的去掉s：`afterward(s)` => `afterward`
- 多种时态使用空格分割并提示：`arise (arose, arisen)` => `arise arose arisen` 提示`【一般现在 过去式 过去分词】`
- 多个词
  - `ａ.m./A.M.` => "ａ.m." 并在解释里提示`【小写】`
  - 不唯一的情况直接去掉只保留一种情况`broadcast（broadcast, broadcast或--ed,--ed）` => `broadcast`（牺牲了一些信息，使该词库更易用）
- 其他细节调整

**提示符**
【过去式 过去分词】
【单数 复数】
【比较级 最高级】
【中间使用空格连接】
【英】
【美】
