### PR TITLE
fix: 修复章节切换时数据未更新

### DIFF
--- a/src/pages/Typing/index.tsx
+++ b/src/pages/Typing/index.tsx
@@ -117,8 +117,9 @@ const App: React.FC = () => {
     if (wordList === undefined) {
       return
     }
+    // 优先更新数据
+    setCorrectCount((count) => count + wordList.words[order].name.trim().length)
     if (switcherState.loop) {
-      setCorrectCount((count) => count + wordList.words[order].name.trim().length)
       return
     }
     if (order === wordList.words.length - 1) {
@@ -145,7 +146,6 @@ const App: React.FC = () => {
       }
     } else {
       setOrder((order) => order + 1)
-      setCorrectCount((count) => count + wordList.words[order].name.trim().length)
     }
   }
 


### PR DESCRIPTION
之前有提到，章节末尾计数不正常：[正确词数计数问题 \#236](https://github.com/Kaiyiwing/qwerty-learner/issues/236)，
调整了一下顺序，提升优先级