### PR TITLE
修复无法输入%等特殊字符的bug

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import { Howl } from 'howler'
 
-export const isLegal = (val: string): boolean => /^[a-z_A-Z_._(_)_0-9'!,='?\-;[\]\\/]$/.test(val)
+export const isLegal = (val: string): boolean => /^[a-z_A-Z_._(_)_{_}_<_>_+_0-9'"!,='@#$%`:~^&*?\-;[\]\\/]$/.test(val)
 export const isChineseSymbol = (val: string): boolean =>
   /[\u3002|\uff1f|\uff01|\uff0c|\u3001|\uff1b|\uff1a|\u201c|\u201d|\u2018|\u2019|\uff08|\uff09|\u300a|\u300b|\u3008|\u3009|\u3010|\u3011|\u300e|\u300f|\u300c|\u300d|\ufe43|\ufe44|\u3014|\u3015|\u2026|\u2014|\uff5e|\ufe4f|\uffe5]/.test(
     val,


### PR DESCRIPTION
现在已经支持 ~@#$%^&*{}<>:"` 的输入