### PR TITLE
style: add max-width for summary page

### DIFF
--- a/src/components/ResultScreen/index.tsx
+++ b/src/components/ResultScreen/index.tsx
@@ -96,7 +96,7 @@ const ResultScreen: React.FC<ResultScreenProps> = ({
         leaveTo="opacity-0"
       >
         <div className="flex items-center justify-center h-screen">
-          <div className="w-[90vw] md:w-4/5 lg:w-3/5 px-10 pt-10 pb-14 card bg-white dark:bg-gray-800 rounded-3xl shadow-lg fixed flex flex-col overflow-hidden">
+          <div className="max-w-6xl w-[90vw] md:w-4/5 lg:w-3/5 px-10 pt-10 pb-14 card bg-white dark:bg-gray-800 rounded-3xl shadow-lg fixed flex flex-col overflow-hidden">
             <div className="text-center font-sans font-normal text-gray-900 text-xl md:text-2xl dark:text-gray-400">
               {wordList ? `${wordList.dictName}  第 ${wordList.chapter + 1} 章` : ' '}
             </div>


### PR DESCRIPTION
![2](https://user-images.githubusercontent.com/119289307/219873573-fa1329a2-994a-4e36-b1b2-d5441a8339da.png)
![1](https://user-images.githubusercontent.com/119289307/219873576-0c4f3927-8c9c-429a-8578-14b9b4d6e138.png)



Added max-width to resultscreen for better outlook on ultra-wide screens