### PR TITLE
dict: add「Public English Test System (PETS-3)」high-frequency dictionary

### DIFF
--- a/public/dicts/PETS_3.json
+++ b/public/dicts/PETS_3.json
@@ -1,0 +1,15523 @@
+[
+  {
+    "name": "ability",
+    "usphone": "ə'bɪləti",
+    "ukphone": "ə'bɪlɪtɪ",
+    "trans": [
+      "n.能力；才能；技能"
+    ]
+  },
+  {
+    "name": "able",
+    "usphone": "'ebl",
+    "ukphone": "'eɪb(ə)l",
+    "trans": [
+      "adj.能够的，有能力的"
+    ]
+  },
+  {
+    "name": "above",
+    "usphone": "ə'bʌv",
+    "ukphone": "ə'bʌv",
+    "trans": [
+      "prep.在...上方"
+    ]
+  },
+  {
+    "name": "absent",
+    "usphone": "ˈæbsənt",
+    "ukphone": "'æbs(ə)nt",
+    "trans": [
+      "adj.缺席的,不在场的"
+    ]
+  },
+  {
+    "name": "accept",
+    "usphone": "ækˈsɛpt; əkˈsɛpt",
+    "ukphone": "ə'ksept",
+    "trans": [
+      "v.认可，接受"
+    ]
+  },
+  {
+    "name": "access",
+    "usphone": "'æksɛs",
+    "ukphone": "'ækses",
+    "trans": [
+      "n.接近，进入；入口"
+    ]
+  },
+  {
+    "name": "accident",
+    "usphone": "'æksədənt",
+    "ukphone": "'æksɪdənt",
+    "trans": [
+      "n.事故"
+    ]
+  },
+  {
+    "name": "accommodate",
+    "usphone": "ə'kɑmədet",
+    "ukphone": "ə'kɒmədeɪt",
+    "trans": [
+      "v.留宿，收容；供应，供给；容纳"
+    ]
+  },
+  {
+    "name": "accompany",
+    "usphone": "ə'kʌmpəni",
+    "ukphone": "ə'kʌmpənɪ",
+    "trans": [
+      "v.陪伴，陪同"
+    ]
+  },
+  {
+    "name": "account",
+    "usphone": "ə'kaʊnt",
+    "ukphone": "ə'kaʊnt",
+    "trans": [
+      "n.账户"
+    ]
+  },
+  {
+    "name": "accustom",
+    "usphone": "ə'kʌstəm",
+    "ukphone": "ə'kʌstəm",
+    "trans": [
+      "v.(to) 使习惯"
+    ]
+  },
+  {
+    "name": "achieve",
+    "usphone": "ə'tʃiv",
+    "ukphone": "ə'tʃiːv",
+    "trans": [
+      "v.完成，达到；获得"
+    ]
+  },
+  {
+    "name": "acquaintance",
+    "usphone": "ə'kwentəns",
+    "ukphone": "ə'kweɪnt(ə)ns",
+    "trans": [
+      "n.熟人；熟悉"
+    ]
+  },
+  {
+    "name": "across",
+    "usphone": "ə'krɔs",
+    "ukphone": "ə'krɒs",
+    "trans": [
+      "prep.穿过；在另一边，在对面 adv.横越"
+    ]
+  },
+  {
+    "name": "act",
+    "usphone": "ækt",
+    "ukphone": "ækt",
+    "trans": [
+      "v.行动；做"
+    ]
+  },
+  {
+    "name": "action",
+    "usphone": "'ækʃən",
+    "ukphone": "'ækʃ(ə)n",
+    "trans": [
+      "n.行动，行为;动作，活动"
+    ]
+  },
+  {
+    "name": "active",
+    "usphone": "'æktɪv",
+    "ukphone": "'æktɪv",
+    "trans": [
+      "adj. 活动的，活泼的，活跃的"
+    ]
+  },
+  {
+    "name": "activity",
+    "usphone": "æk'tɪviti",
+    "ukphone": "æk'tɪvɪtɪ",
+    "trans": [
+      "n.活动"
+    ]
+  },
+  {
+    "name": "actor",
+    "usphone": "'æktɚ",
+    "ukphone": "'æktə",
+    "trans": [
+      "n.男演员"
+    ]
+  },
+  {
+    "name": "add",
+    "usphone": "æd",
+    "ukphone": "æd",
+    "trans": [
+      "v.加"
+    ]
+  },
+  {
+    "name": "addition",
+    "usphone": "ə'dɪʃən",
+    "ukphone": "ə'dɪʃ(ə)n",
+    "trans": [
+      "n.加，加法；附加物"
+    ]
+  },
+  {
+    "name": "additional",
+    "usphone": "ə'dɪʃənl",
+    "ukphone": "ə'dɪʃ(ə)n(ə)l",
+    "trans": [
+      "adj.附加的，另外的"
+    ]
+  },
+  {
+    "name": "administration",
+    "usphone": "əd,mɪnɪ'streʃən",
+    "ukphone": "ədmɪnɪ'streɪʃ(ə)n",
+    "trans": [
+      "n.管理，经营； 行政(机关，部门)"
+    ]
+  },
+  {
+    "name": "admire",
+    "usphone": "ədˈmaɪr",
+    "ukphone": "əd'maɪə",
+    "trans": [
+      "v.羡慕，赞赏，钦佩"
+    ]
+  },
+  {
+    "name": "admit",
+    "usphone": "əd'mɪt",
+    "ukphone": "əd'mɪt",
+    "trans": [
+      "v.承认"
+    ]
+  },
+  {
+    "name": "adult",
+    "usphone": "'ædʌlt",
+    "ukphone": "'ædʌlt; ə'dʌlt",
+    "trans": [
+      "n.成人 adj.成年人的;成熟的"
+    ]
+  },
+  {
+    "name": "advance",
+    "usphone": "əd'væns",
+    "ukphone": "əd'vɑːns",
+    "trans": [
+      "v.前进；取得进展"
+    ]
+  },
+  {
+    "name": "advantage",
+    "usphone": "əd'væntɪdʒ",
+    "ukphone": "əd'vɑːntɪdʒ",
+    "trans": [
+      "n.优点，优势"
+    ]
+  },
+  {
+    "name": "advertise",
+    "usphone": "'ædvɚtaɪz",
+    "ukphone": "'ædvətaɪz",
+    "trans": [
+      "v.做广告"
+    ]
+  },
+  {
+    "name": "advice",
+    "usphone": "ædˈvaɪs; əd'vaɪs",
+    "ukphone": "əd'vaɪs",
+    "trans": [
+      "n.忠告；建议"
+    ]
+  },
+  {
+    "name": "affair",
+    "usphone": "ə'fɛr",
+    "ukphone": "ə'feə",
+    "trans": [
+      "n.事，事情，事件"
+    ]
+  },
+  {
+    "name": "affect",
+    "usphone": "ə'fɛkt",
+    "ukphone": "ə'fekt",
+    "trans": [
+      "v.影响，传染"
+    ]
+  },
+  {
+    "name": "afford",
+    "usphone": "ə'fɔrd",
+    "ukphone": "ə'fɔːd",
+    "trans": [
+      "v.买得起，担负得起"
+    ]
+  },
+  {
+    "name": "afraid",
+    "usphone": "ə'fred",
+    "ukphone": "ə'freɪd",
+    "trans": [
+      "adj.恐怕的；担心的；害怕的"
+    ]
+  },
+  {
+    "name": "Africa",
+    "usphone": "ˈæfrɪkə",
+    "ukphone": "'æfrɪkə",
+    "trans": [
+      "n.非洲"
+    ]
+  },
+  {
+    "name": "after",
+    "usphone": "'æftɚ",
+    "ukphone": "'ɑːftə",
+    "trans": [
+      "prep.在...以后 conj.在...以后 adv.以后"
+    ]
+  },
+  {
+    "name": "afternoon",
+    "usphone": ",æftɚ'nun",
+    "ukphone": "ɑːftə'nuːn",
+    "trans": [
+      "n.下午"
+    ]
+  },
+  {
+    "name": "again",
+    "usphone": "ə'ɡɛn",
+    "ukphone": "ə'gen; ə'geɪn",
+    "trans": [
+      "adv.又，再"
+    ]
+  },
+  {
+    "name": "against",
+    "usphone": "ə'ɡɛnst",
+    "ukphone": "ə'genst; ə'geɪnst",
+    "trans": [
+      "prep.反对"
+    ]
+  },
+  {
+    "name": "age",
+    "usphone": "edʒ",
+    "ukphone": "eɪdʒ",
+    "trans": [
+      "n.年龄"
+    ]
+  },
+  {
+    "name": "agency",
+    "usphone": "'edʒənsi",
+    "ukphone": "'eɪdʒ(ə)nsɪ",
+    "trans": [
+      "n.经办；媒介；代理处"
+    ]
+  },
+  {
+    "name": "agent",
+    "usphone": "'edʒənt",
+    "ukphone": "'eɪdʒ(ə)nt",
+    "trans": [
+      "n.代理人，代表"
+    ]
+  },
+  {
+    "name": "ago",
+    "usphone": "ə'ɡo",
+    "ukphone": "ə'gəʊ",
+    "trans": [
+      "adv.以前"
+    ]
+  },
+  {
+    "name": "agree",
+    "usphone": "ə'ɡri",
+    "ukphone": "ə'griː",
+    "trans": [
+      "v.同意"
+    ]
+  },
+  {
+    "name": "agriculture",
+    "usphone": "'æɡrɪkʌltʃɚ",
+    "ukphone": "'ægrɪkʌltʃə",
+    "trans": [
+      "adj. 农业的"
+    ]
+  },
+  {
+    "name": "aim",
+    "usphone": "em",
+    "ukphone": "eɪm",
+    "trans": [
+      "v.把...瞄准，把...对准"
+    ]
+  },
+  {
+    "name": "air",
+    "usphone": "ɛr",
+    "ukphone": "eə",
+    "trans": [
+      "n.空气；天空"
+    ]
+  },
+  {
+    "name": "airline",
+    "usphone": "'ɛrlaɪn",
+    "ukphone": "'eəlaɪn",
+    "trans": [
+      "n.航线；航空公司"
+    ]
+  },
+  {
+    "name": "airport",
+    "usphone": "'ɛr'pɔrt",
+    "ukphone": "'eəpɔːt",
+    "trans": [
+      "n.机场"
+    ]
+  },
+  {
+    "name": "alarm",
+    "usphone": "ə'lɑrm",
+    "ukphone": "ə'lɑːm",
+    "trans": [
+      "n.闹钟；警报"
+    ]
+  },
+  {
+    "name": "alcohol",
+    "usphone": "'ælkəhɔl",
+    "ukphone": "'ælkəhɒl",
+    "trans": [
+      "n.酒精，乙醇"
+    ]
+  },
+  {
+    "name": "alert",
+    "usphone": "ə'lɝt",
+    "ukphone": "ə'lɜːt",
+    "trans": [
+      "n.警报"
+    ]
+  },
+  {
+    "name": "all",
+    "usphone": "ɔl",
+    "ukphone": "ɔːl",
+    "trans": [
+      "adj.所有的 adv.都，全部地 pron.所有，全部"
+    ]
+  },
+  {
+    "name": "allow",
+    "usphone": "ə'laʊ",
+    "ukphone": "ə'laʊ",
+    "trans": [
+      "v.允许"
+    ]
+  },
+  {
+    "name": "almost",
+    "usphone": "'ɔlmost",
+    "ukphone": "'ɔːlməʊst",
+    "trans": [
+      "adv.几乎"
+    ]
+  },
+  {
+    "name": "alone",
+    "usphone": "ə'lon",
+    "ukphone": "ə'ləʊn",
+    "trans": [
+      "adj.独自一人的 adv.单独；只有，仅仅"
+    ]
+  },
+  {
+    "name": "along",
+    "usphone": "ə'lɔŋ",
+    "ukphone": "ə'lɒŋ",
+    "trans": [
+      "adv.向前;和...一起,一同 prep.沿着，顺着"
+    ]
+  },
+  {
+    "name": "already",
+    "usphone": "ɔl'rɛdi",
+    "ukphone": "ɔːl'redɪ",
+    "trans": [
+      "adv.已经"
+    ]
+  },
+  {
+    "name": "also",
+    "usphone": "'ɔlso",
+    "ukphone": "'ɔːlsəʊ",
+    "trans": [
+      "adv.也"
+    ]
+  },
+  {
+    "name": "although",
+    "usphone": "ɔl'ðo",
+    "ukphone": "ɔːl'ðəʊ; ɒl-",
+    "trans": [
+      "conj.虽然；尽管；即使"
+    ]
+  },
+  {
+    "name": "always",
+    "usphone": "'ɔlwez",
+    "ukphone": "'ɔːlweɪz; -ɪz",
+    "trans": [
+      "adv.总是；始终"
+    ]
+  },
+  {
+    "name": "ambition",
+    "usphone": "æm'bɪʃən",
+    "ukphone": "æm'bɪʃ(ə)n",
+    "trans": [
+      "n.雄心，野心"
+    ]
+  },
+  {
+    "name": "ambitious",
+    "usphone": "æm'bɪʃəs",
+    "ukphone": "æm'bɪʃəs",
+    "trans": [
+      "adj.有雄心的"
+    ]
+  },
+  {
+    "name": "America",
+    "usphone": "əˈmɛrɪkə",
+    "ukphone": "ə'merɪkə",
+    "trans": [
+      "n.美洲；美国"
+    ]
+  },
+  {
+    "name": "American",
+    "usphone": "əˈmɛrɪkən",
+    "ukphone": "əmerɪkən",
+    "trans": [
+      "adj.美国的 n.美国人"
+    ]
+  },
+  {
+    "name": "among",
+    "usphone": "ə'mʌŋ",
+    "ukphone": "ə'mʌŋ",
+    "trans": [
+      "prep.在...之中"
+    ]
+  },
+  {
+    "name": "amount",
+    "usphone": "ə'maʊnt",
+    "ukphone": "ə'maʊnt",
+    "trans": [
+      "n.数量"
+    ]
+  },
+  {
+    "name": "amusement",
+    "usphone": "ə'mjuzmənt",
+    "ukphone": "ə'mjuːzm(ə)nt",
+    "trans": [
+      "n.娱乐"
+    ]
+  },
+  {
+    "name": "analysis",
+    "usphone": "ə'næləsɪs",
+    "ukphone": "ə'nælɪsɪs",
+    "trans": [
+      "n.分析，分解"
+    ]
+  },
+  {
+    "name": "ancient",
+    "usphone": "ˈeɪnʃənt",
+    "ukphone": "'eɪnʃ(ə)nt",
+    "trans": [
+      "adj.古代的，古老的"
+    ]
+  },
+  {
+    "name": "angry",
+    "usphone": "'æŋɡri",
+    "ukphone": "'æŋgrɪ",
+    "trans": [
+      "adj.生气的"
+    ]
+  },
+  {
+    "name": "anger",
+    "usphone": "'æŋɡɚ",
+    "ukphone": "'æŋgə",
+    "trans": [
+      "v.使发怒，激怒 n.愤怒，气愤"
+    ]
+  },
+  {
+    "name": "annoy",
+    "usphone": "ə'nɔɪ",
+    "ukphone": "ə'nɒɪ",
+    "trans": [
+      "v.使恼怒，使生气；打扰，干扰"
+    ]
+  },
+  {
+    "name": "animal",
+    "usphone": "'ænɪml",
+    "ukphone": "'ænɪm(ə)l",
+    "trans": [
+      "n.动物"
+    ]
+  },
+  {
+    "name": "annual",
+    "usphone": "'ænjuəl",
+    "ukphone": "'ænjʊəl",
+    "trans": [
+      "adj.每年的，年度的；一年一次的 n.年报，年刊"
+    ]
+  },
+  {
+    "name": "anniversary",
+    "usphone": ",ænɪ'vɝsəri",
+    "ukphone": "ænɪ'vɜːs(ə)rɪ",
+    "trans": [
+      "n.周年(纪念日) adj.周年的"
+    ]
+  },
+  {
+    "name": "another",
+    "usphone": "ə'nʌðɚ",
+    "ukphone": "ə'nʌðə",
+    "trans": [
+      "adj.另一，再一；别的 pron.另一个"
+    ]
+  },
+  {
+    "name": "answer",
+    "usphone": "'ænsɚ",
+    "ukphone": "'ɑːnsə",
+    "trans": [
+      "n./v.回答；答复 n.答案"
+    ]
+  },
+  {
+    "name": "anything",
+    "usphone": "'ɛnɪ'θɪŋ",
+    "ukphone": "'enɪθɪŋ",
+    "trans": [
+      "pron.任何事物"
+    ]
+  },
+  {
+    "name": "anyway",
+    "usphone": "'ɛnɪ'we",
+    "ukphone": "'enɪweɪ",
+    "trans": [
+      "adv.无论如何"
+    ]
+  },
+  {
+    "name": "apology",
+    "usphone": "ə'pɑlədʒi",
+    "ukphone": "ə'pɒlədʒɪ",
+    "trans": [
+      "n.道歉，认错"
+    ]
+  },
+  {
+    "name": "apologize",
+    "usphone": "ə'pɑlədʒaɪz",
+    "ukphone": "ə'pɒlədʒaɪz",
+    "trans": [
+      "v.道歉，认错"
+    ]
+  },
+  {
+    "name": "appeal",
+    "usphone": "ə'pil",
+    "ukphone": "ə'piːl",
+    "trans": [
+      "v.呼吁，请求；上诉，申诉"
+    ]
+  },
+  {
+    "name": "apply",
+    "usphone": "ə'plaɪ",
+    "ukphone": "ə'plaɪ",
+    "trans": [
+      "v.申请"
+    ]
+  },
+  {
+    "name": "application",
+    "usphone": "ˌæpləˈkeʃən",
+    "ukphone": "ˌæplɪ'keɪʃ(ə)n",
+    "trans": [
+      "n.请求;申请书;应用"
+    ]
+  },
+  {
+    "name": "appreciate",
+    "usphone": "ə'priʃɪet",
+    "ukphone": "ə'priːʃɪeɪt; -sɪ-",
+    "trans": [
+      "v.感谢，感激；欣赏，赏识"
+    ]
+  },
+  {
+    "name": "approach",
+    "usphone": "ə'protʃ",
+    "ukphone": "ə'prəʊtʃ",
+    "trans": [
+      "v.靠近，接近，临近 n.方法，途径；探讨"
+    ]
+  },
+  {
+    "name": "April",
+    "usphone": "'eprəl",
+    "ukphone": "'eɪprəl",
+    "trans": [
+      "n.四月"
+    ]
+  },
+  {
+    "name": "architecture",
+    "usphone": "'ɑrkə'tɛktʃɚ",
+    "ukphone": "'ɑːkɪtektʃə",
+    "trans": [
+      "n.建筑(式样，风格);建筑学"
+    ]
+  },
+  {
+    "name": "architect",
+    "usphone": "'ɑrkɪtɛkt",
+    "ukphone": "'ɑːkɪtekt",
+    "trans": [
+      "n.建筑师；设计师"
+    ]
+  },
+  {
+    "name": "area",
+    "usphone": "'ɛrɪə",
+    "ukphone": "'eərɪə",
+    "trans": [
+      "n.地区"
+    ]
+  },
+  {
+    "name": "argue",
+    "usphone": "'ɑrgjʊ",
+    "ukphone": "'ɑːgjuː",
+    "trans": [
+      "vi.论证，认定；争论，争吵"
+    ]
+  },
+  {
+    "name": "arm",
+    "usphone": "ɑrm",
+    "ukphone": "ɑːm",
+    "trans": [
+      "n.胳膊"
+    ]
+  },
+  {
+    "name": "army",
+    "usphone": "'ɑrmi",
+    "ukphone": "'ɑːmɪ",
+    "trans": [
+      "n.军队，军"
+    ]
+  },
+  {
+    "name": "around",
+    "usphone": "ə'raʊnd",
+    "ukphone": "ə'raʊnd",
+    "trans": [
+      "prep.在...各处,到处 adv.大约,到处"
+    ]
+  },
+  {
+    "name": "arouse",
+    "usphone": "ə'raʊz",
+    "ukphone": "ə'raʊz",
+    "trans": [
+      "v. 唤醒；激起"
+    ]
+  },
+  {
+    "name": "arrive",
+    "usphone": "ə'raɪv",
+    "ukphone": "ə'raɪv",
+    "trans": [
+      "v.到达"
+    ]
+  },
+  {
+    "name": "arrival",
+    "usphone": "ə'raɪvəl",
+    "ukphone": "ə'raɪv(ə)l",
+    "trans": [
+      "n.到达，到来；到达的人或物"
+    ]
+  },
+  {
+    "name": "art",
+    "usphone": "ɑrt",
+    "ukphone": "ɑːt",
+    "trans": [
+      "n.艺术"
+    ]
+  },
+  {
+    "name": "artist",
+    "usphone": "'ɑrtɪst",
+    "ukphone": "'ɑːtɪst",
+    "trans": [
+      "n.美术家；艺术家"
+    ]
+  },
+  {
+    "name": "ash",
+    "usphone": "æʃ",
+    "ukphone": "æʃ",
+    "trans": [
+      "n.灰，灰末"
+    ]
+  },
+  {
+    "name": "ashamed",
+    "usphone": "ə'ʃemd",
+    "ukphone": "ə'ʃeɪmd",
+    "trans": [
+      "adj.惭愧的，害臊的"
+    ]
+  },
+  {
+    "name": "Asia",
+    "usphone": "ˈeʒə;ˈeʃə",
+    "ukphone": "ˈeɪʒə;ˈeɪʃə",
+    "trans": [
+      "n.亚洲"
+    ]
+  },
+  {
+    "name": "Asian",
+    "usphone": "ˈeʒən, ˈeʃən",
+    "ukphone": "'eiʃən",
+    "trans": [
+      "adj.亚洲的；亚洲人的 n.亚洲人"
+    ]
+  },
+  {
+    "name": "ask",
+    "usphone": "æsk",
+    "ukphone": "ɑːsk",
+    "trans": [
+      "v.问，询问"
+    ]
+  },
+  {
+    "name": "asleep",
+    "usphone": "ə'slip",
+    "ukphone": "ə'sliːp",
+    "trans": [
+      "adj.睡着的"
+    ]
+  },
+  {
+    "name": "assignment",
+    "usphone": "ə'saɪnmənt",
+    "ukphone": "ə'saɪnm(ə)nt",
+    "trans": [
+      "n.分配,委派;任务,(课外)作业"
+    ]
+  },
+  {
+    "name": "assist",
+    "usphone": "ə'sɪst",
+    "ukphone": "ə'sɪst",
+    "trans": [
+      "v.帮助，援助，协助"
+    ]
+  },
+  {
+    "name": "assistance",
+    "usphone": "ə'sɪstəns",
+    "ukphone": "ə'sɪst(ə)ns",
+    "trans": [
+      "n.帮助，援助"
+    ]
+  },
+  {
+    "name": "assistant",
+    "usphone": "ə'sɪstənt",
+    "ukphone": "ə'sɪst(ə)nt",
+    "trans": [
+      "n.助理，助手"
+    ]
+  },
+  {
+    "name": "associate",
+    "usphone": "ə'soʃɪet",
+    "ukphone": "ə'səʊʃɪeɪt; -sɪeɪt",
+    "trans": [
+      "v.(with) 使联系；交往，结合 n.合作人,伙伴,同事,同行 adj.合伙的;副的"
+    ]
+  },
+  {
+    "name": "association",
+    "usphone": "ə,soʃɪ'eʃən",
+    "ukphone": "əsəʊsɪ'eɪʃ(ə)n; -ʃɪ-",
+    "trans": [
+      "n.协会,团体;联合"
+    ]
+  },
+  {
+    "name": "assume",
+    "usphone": "ə'sum",
+    "ukphone": "ə'sjuːm",
+    "trans": [
+      "v.假装；假定，设想；采取，承担"
+    ]
+  },
+  {
+    "name": "attack",
+    "usphone": "ə'tæk",
+    "ukphone": "ə'tæk",
+    "trans": [
+      "v.攻击，进攻 n.攻击，进攻；(病) 发作"
+    ]
+  },
+  {
+    "name": "attain",
+    "usphone": "ə'ten",
+    "ukphone": "ə'teɪn",
+    "trans": [
+      "v.达到；获得；完成"
+    ]
+  },
+  {
+    "name": "attend",
+    "usphone": "ə'tɛnd",
+    "ukphone": "ə'tend",
+    "trans": [
+      "v.出席，参加(会议等)"
+    ]
+  },
+  {
+    "name": "attention",
+    "usphone": "ə'tɛnʃən",
+    "ukphone": "ə'tenʃ(ə)n",
+    "trans": [
+      "n.注意，留心"
+    ]
+  },
+  {
+    "name": "attitude",
+    "usphone": "'ætɪtʊd",
+    "ukphone": "'ætɪtjuːd",
+    "trans": [
+      "n.(to, towards) 态度，看法"
+    ]
+  },
+  {
+    "name": "attorney",
+    "usphone": "ə'tɝni",
+    "ukphone": "ə'tɜːnɪ",
+    "trans": [
+      "n.律师；代理人"
+    ]
+  },
+  {
+    "name": "attract",
+    "usphone": "ə'trækt",
+    "ukphone": "ə'trækt",
+    "trans": [
+      "v.吸引 n.标准，规范"
+    ]
+  },
+  {
+    "name": "attractive",
+    "usphone": "ə'træktɪv",
+    "ukphone": "ə'træktɪv",
+    "trans": [
+      "adj.有吸引力的"
+    ]
+  },
+  {
+    "name": "Australia",
+    "usphone": "ɒˈstreɪliə",
+    "ukphone": "ɔ'streiliə",
+    "trans": [
+      "n.澳大利亚"
+    ]
+  },
+  {
+    "name": "Australian",
+    "usphone": "ɑ'strelɪən",
+    "trans": [
+      "adj.澳大利亚的，澳洲区的；澳大利亚人的 n.澳大利亚人"
+    ]
+  },
+  {
+    "name": "author",
+    "usphone": "'ɔθɚ",
+    "ukphone": "'ɔːθə",
+    "trans": [
+      "n.作者"
+    ]
+  },
+  {
+    "name": "authority",
+    "usphone": "ə'θɔrəti",
+    "ukphone": "ɔː'θɒrɪtɪ",
+    "trans": [
+      "n.权力，权威；权威者"
+    ]
+  },
+  {
+    "name": "autumn",
+    "usphone": "'ɔtəm",
+    "ukphone": "'ɔːtəm",
+    "trans": [
+      "n.秋天"
+    ]
+  },
+  {
+    "name": "available",
+    "usphone": "ə'veləbl",
+    "ukphone": "ə'veɪləb(ə)l",
+    "trans": [
+      "adj.可用的，可得到的"
+    ]
+  },
+  {
+    "name": "avenue",
+    "usphone": "'ævənu",
+    "ukphone": "'æv(ə)njuː",
+    "trans": [
+      "n.林荫道,大街;途径，手段"
+    ]
+  },
+  {
+    "name": "avoid",
+    "usphone": "ə'vɔɪd",
+    "ukphone": "ə'vɒɪd",
+    "trans": [
+      "v.避免；回避，躲开"
+    ]
+  },
+  {
+    "name": "award",
+    "usphone": "ə'wɔrd",
+    "ukphone": "ə'wɔːd",
+    "trans": [
+      "n.奖(品) v.授予，奖给"
+    ]
+  },
+  {
+    "name": "aware",
+    "usphone": "ə'wɛr",
+    "ukphone": "ə'weə",
+    "trans": [
+      "adj.(of) 知道的，意识到的"
+    ]
+  },
+  {
+    "name": "away",
+    "usphone": "əˈwe",
+    "ukphone": "ə'weɪ",
+    "trans": [
+      "adv.离，远离"
+    ]
+  },
+  {
+    "name": "awful",
+    "usphone": "'ɔfl",
+    "ukphone": "'ɔːfʊl",
+    "trans": [
+      "adj.糟糕的;令人恐惧的;可怕的"
+    ]
+  },
+  {
+    "name": "back",
+    "usphone": "bæk",
+    "ukphone": "bæk",
+    "trans": [
+      "n.后部；背面；脊背 adj.最后面的 adv.向后"
+    ]
+  },
+  {
+    "name": "background",
+    "usphone": "'bækɡraʊnd",
+    "ukphone": "'bækgraʊnd",
+    "trans": [
+      "n.背景"
+    ]
+  },
+  {
+    "name": "bad",
+    "usphone": "bæd",
+    "ukphone": "bæd",
+    "trans": [
+      "adj.不好，坏的，糟糕的"
+    ]
+  },
+  {
+    "name": "bag",
+    "usphone": "bæɡ",
+    "ukphone": "bæg",
+    "trans": [
+      "n.包"
+    ]
+  },
+  {
+    "name": "balance",
+    "usphone": "'bæləns",
+    "ukphone": "'bæl(ə)ns",
+    "trans": [
+      "n.平衡；余额"
+    ]
+  },
+  {
+    "name": "bank",
+    "usphone": "bæŋk",
+    "ukphone": "bæŋk",
+    "trans": [
+      "n.银行，河岸"
+    ]
+  },
+  {
+    "name": "bargain",
+    "usphone": "ˈbɑːɡɪn",
+    "ukphone": "ˈbɑːɡɪn",
+    "trans": [
+      "n.特价商品，便宜货 v.认讲价还价；达成协议"
+    ]
+  },
+  {
+    "name": "base",
+    "usphone": "bes",
+    "ukphone": "beɪs",
+    "trans": [
+      "n.基(础)，底(座)；基地 v.(on) 把...建立在...基础上"
+    ]
+  },
+  {
+    "name": "basic",
+    "usphone": "'besɪk",
+    "ukphone": "'beɪsɪk",
+    "trans": [
+      "adj.基础的，根本的；主要的"
+    ]
+  },
+  {
+    "name": "basis",
+    "usphone": "'besɪs",
+    "ukphone": "'beɪsɪs",
+    "trans": [
+      "n.基础，根据；主干"
+    ]
+  },
+  {
+    "name": "beach",
+    "usphone": "bitʃ",
+    "ukphone": "biːtʃ",
+    "trans": [
+      "n.海滨，海滩"
+    ]
+  },
+  {
+    "name": "bear",
+    "usphone": "bɛr",
+    "ukphone": "beə",
+    "trans": [
+      "n.熊； v.生育；忍受；负担"
+    ]
+  },
+  {
+    "name": "beautiful",
+    "usphone": "'bjʊtəfəl",
+    "ukphone": "'bjuːtɪfʊl; -f(ə)l",
+    "trans": [
+      "adj.美丽的"
+    ]
+  },
+  {
+    "name": "beauty",
+    "usphone": "'bjuti",
+    "ukphone": "'bjuːtɪ",
+    "trans": [
+      "n.美，美丽；美人；美的东西"
+    ]
+  },
+  {
+    "name": "because",
+    "usphone": "bɪ'kɔz",
+    "ukphone": "bɪ'kɒz",
+    "trans": [
+      "conj.因为"
+    ]
+  },
+  {
+    "name": "become",
+    "usphone": "bɪ'kʌm",
+    "ukphone": "bɪ'kʌm",
+    "trans": [
+      "v.变成；成为"
+    ]
+  },
+  {
+    "name": "before",
+    "usphone": "bɪ'fɔr",
+    "ukphone": "bɪ'fɔː",
+    "trans": [
+      "prep.&conj. 在...之前 adv.以前"
+    ]
+  },
+  {
+    "name": "begin",
+    "usphone": "bɪ'ɡɪn",
+    "ukphone": "bɪ'gɪn",
+    "trans": [
+      "v.开始"
+    ]
+  },
+  {
+    "name": "behave",
+    "usphone": "bɪ'hev",
+    "ukphone": "bɪ'heɪv",
+    "trans": [
+      "v.举止，表现；运转"
+    ]
+  },
+  {
+    "name": "behind",
+    "usphone": "bɪ'haɪnd",
+    "ukphone": "bɪ'haɪnd",
+    "trans": [
+      "prep.在...的背后，在...后面，落后于 adv.在背后，向后，落在后面"
+    ]
+  },
+  {
+    "name": "believe",
+    "usphone": "bɪ'liv",
+    "ukphone": "bɪ'liːv",
+    "trans": [
+      "v.相信，认为"
+    ]
+  },
+  {
+    "name": "belief",
+    "usphone": "bɪ'lif",
+    "ukphone": "bɪ'liːf",
+    "trans": [
+      "n.信仰；相信，信念"
+    ]
+  },
+  {
+    "name": "belong",
+    "usphone": "bɪ'lɔŋ",
+    "ukphone": "bɪ'lɒŋ",
+    "trans": [
+      "v.(to) 属于"
+    ]
+  },
+  {
+    "name": "below",
+    "usphone": "bɪ'lo",
+    "ukphone": "bɪ'ləʊ",
+    "trans": [
+      "prep.在下面，在下方；低于..."
+    ]
+  },
+  {
+    "name": "bend",
+    "usphone": "bɛnd",
+    "ukphone": "bend",
+    "trans": [
+      "n.弯曲(处)v.(使)弯曲"
+    ]
+  },
+  {
+    "name": "benefit",
+    "usphone": "'bɛnɪfɪt",
+    "ukphone": "'benɪfɪt",
+    "trans": [
+      "n.利益，好处；恩惠 v.有益于；(from, by) 受益"
+    ]
+  },
+  {
+    "name": "besides",
+    "usphone": "bɪ'saɪdz",
+    "ukphone": "bɪ'saɪdz",
+    "trans": [
+      "adv.而且，还有 prep.除...之外"
+    ]
+  },
+  {
+    "name": "beside",
+    "usphone": "bɪ'saɪd",
+    "ukphone": "bɪ'saɪd",
+    "trans": [
+      "prep.在...旁边(或附近)；和...相比"
+    ]
+  },
+  {
+    "name": "best",
+    "usphone": "bɛst",
+    "ukphone": "best",
+    "trans": [
+      "adv.&adj.最好(的)"
+    ]
+  },
+  {
+    "name": "better",
+    "usphone": "'bɛtɚ",
+    "ukphone": "'betə",
+    "trans": [
+      "adj.较好的，更好的 adv.更好地"
+    ]
+  },
+  {
+    "name": "between",
+    "usphone": "bɪ'twin",
+    "ukphone": "bɪ'twiːn",
+    "trans": [
+      "prep./adv.在(两者)之间；在...之间"
+    ]
+  },
+  {
+    "name": "beyond",
+    "usphone": "bɪ'jɑnd",
+    "ukphone": "bɪ'jɒnd",
+    "trans": [
+      "prep.在(或向)...的那边；超过 adv.在更远处"
+    ]
+  },
+  {
+    "name": "big",
+    "usphone": "bɪɡ",
+    "ukphone": "bɪg",
+    "trans": [
+      "adj.大的"
+    ]
+  },
+  {
+    "name": "bill",
+    "usphone": "bɪl",
+    "ukphone": "bɪl",
+    "trans": [
+      "n.账单"
+    ]
+  },
+  {
+    "name": "billion",
+    "usphone": "'bɪljən",
+    "ukphone": "'bɪljən",
+    "trans": [
+      "n.(美) 十亿"
+    ]
+  },
+  {
+    "name": "bird",
+    "usphone": "bɝd",
+    "ukphone": "bɜːd",
+    "trans": [
+      "n.鸟"
+    ]
+  },
+  {
+    "name": "birth",
+    "usphone": "bɝθ",
+    "ukphone": "bɜːθ",
+    "trans": [
+      "n.出生，分娩；起源，根源"
+    ]
+  },
+  {
+    "name": "bit",
+    "usphone": "bɪt",
+    "ukphone": "bɪt",
+    "trans": [
+      "n.一点"
+    ]
+  },
+  {
+    "name": "black",
+    "usphone": "blæk",
+    "ukphone": "blæk",
+    "trans": [
+      "adj.黑的，黑色的 n.黑色"
+    ]
+  },
+  {
+    "name": "blame",
+    "usphone": "blem",
+    "ukphone": "bleɪm",
+    "trans": [
+      "v.责备，责怪；(on, onto) 把...归咎于 n.责任；责怪，责备"
+    ]
+  },
+  {
+    "name": "blank",
+    "usphone": "blæŋk",
+    "ukphone": "blæŋk",
+    "trans": [
+      "adj.空白的;空虚的 n.空白"
+    ]
+  },
+  {
+    "name": "block",
+    "usphone": "blɑk",
+    "ukphone": "blɒk",
+    "trans": [
+      "n.街区"
+    ]
+  },
+  {
+    "name": "blood",
+    "usphone": "blʌd",
+    "ukphone": "blʌd",
+    "trans": [
+      "n.血，血液"
+    ]
+  },
+  {
+    "name": "blow",
+    "usphone": "blo",
+    "ukphone": "bləʊ",
+    "trans": [
+      "v.刮，吹"
+    ]
+  },
+  {
+    "name": "boast",
+    "usphone": "bost",
+    "ukphone": "bəʊst",
+    "trans": [
+      "v.(of, about) 自夸，夸耀 n.自夸的话，大话；夸耀的事"
+    ]
+  },
+  {
+    "name": "body",
+    "usphone": "'bɑdi",
+    "ukphone": "'bɒdɪ",
+    "trans": [
+      "n.身体,躯体,主体；物体；尸体"
+    ]
+  },
+  {
+    "name": "bond",
+    "usphone": "bɑnd",
+    "ukphone": "bɒnd",
+    "trans": [
+      "n.结合(物)，黏结(剂)，联结；证券"
+    ]
+  },
+  {
+    "name": "bone",
+    "usphone": "bon",
+    "ukphone": "bəʊn",
+    "trans": [
+      "n.骨，骨骼"
+    ]
+  },
+  {
+    "name": "book",
+    "usphone": "bʊk",
+    "ukphone": "bʊk",
+    "trans": [
+      "n.书，书本 v.预订"
+    ]
+  },
+  {
+    "name": "boss",
+    "usphone": "bɑs",
+    "ukphone": "bɒs",
+    "trans": [
+      "n.老板"
+    ]
+  },
+  {
+    "name": "both",
+    "usphone": "boθ",
+    "ukphone": "bəʊθ",
+    "trans": [
+      "pron.两者，双方；两人 adj.双方的"
+    ]
+  },
+  {
+    "name": "bow",
+    "usphone": "baʊ",
+    "ukphone": "baʊ",
+    "trans": [
+      "n.弓；鞠躬；点头"
+    ]
+  },
+  {
+    "name": "bowl",
+    "usphone": "bol",
+    "ukphone": "bəʊl",
+    "trans": [
+      "n.碗"
+    ]
+  },
+  {
+    "name": "box",
+    "usphone": "bɑks",
+    "ukphone": "bɒks",
+    "trans": [
+      "n.盒子，箱子"
+    ]
+  },
+  {
+    "name": "boy",
+    "usphone": "bɔɪ",
+    "ukphone": "bɒɪ",
+    "trans": [
+      "n.男孩"
+    ]
+  },
+  {
+    "name": "brain",
+    "usphone": "bren",
+    "ukphone": "breɪn",
+    "trans": [
+      "n.脑，脑髓"
+    ]
+  },
+  {
+    "name": "branch",
+    "usphone": "bræntʃ",
+    "ukphone": "brɑːn(t)ʃ",
+    "trans": [
+      "n.树枝，分枝；(机构的) 分部；分支"
+    ]
+  },
+  {
+    "name": "brand",
+    "usphone": "brænd",
+    "ukphone": "brænd",
+    "trans": [
+      "n.商标，标记；烙印 v.使铭记；打烙印"
+    ]
+  },
+  {
+    "name": "break",
+    "usphone": "brek",
+    "ukphone": "breɪk",
+    "trans": [
+      "n.(课间或工间)休息时间 v.打破，打碎"
+    ]
+  },
+  {
+    "name": "breakfast",
+    "usphone": "'brɛkfəst",
+    "ukphone": "'brekfəst",
+    "trans": [
+      "n.早餐"
+    ]
+  },
+  {
+    "name": "brick",
+    "usphone": "brɪk",
+    "ukphone": "brɪk",
+    "trans": [
+      "n.砖，砖状物"
+    ]
+  },
+  {
+    "name": "bright",
+    "usphone": "braɪt",
+    "ukphone": "braɪt",
+    "trans": [
+      "adj.明亮的，晴朗的"
+    ]
+  },
+  {
+    "name": "bring",
+    "usphone": "brɪŋ",
+    "ukphone": "brɪŋ",
+    "trans": [
+      "v.带来；拿来"
+    ]
+  },
+  {
+    "name": "Britain",
+    "usphone": "ˈbrɪt(ə)",
+    "ukphone": "'britən",
+    "trans": [
+      "n.英国；不列颠"
+    ]
+  },
+  {
+    "name": "British",
+    "usphone": "'brɪtɪʃ",
+    "ukphone": "'brɪtɪʃ",
+    "trans": [
+      "adj.(大) 不列颠(人) 的，英国(人) 的 n.总称 英国人(与the连用)"
+    ]
+  },
+  {
+    "name": "broad",
+    "usphone": "brɔd",
+    "ukphone": "brɔːd",
+    "trans": [
+      "adj.宽的,广阔的,辽阔的"
+    ]
+  },
+  {
+    "name": "brother",
+    "usphone": "'brʌðɚ",
+    "ukphone": "'brʌðə",
+    "trans": [
+      "n. 兄弟"
+    ]
+  },
+  {
+    "name": "bud",
+    "usphone": "bʌd",
+    "ukphone": "bʌd",
+    "trans": [
+      "v.发芽，含苞欲放 n.芽，花苞"
+    ]
+  },
+  {
+    "name": "budget",
+    "usphone": "'bʌdʒɪt",
+    "ukphone": "'bʌdʒɪt",
+    "trans": [
+      "n.预算 v.做预算，安排 adj.合算的"
+    ]
+  },
+  {
+    "name": "build",
+    "usphone": "bɪld",
+    "ukphone": "bɪld",
+    "trans": [
+      "v.建立，修建，建造"
+    ]
+  },
+  {
+    "name": "bulb",
+    "usphone": "bʌlb",
+    "ukphone": "bʌlb",
+    "trans": [
+      "n.灯泡，球状物"
+    ]
+  },
+  {
+    "name": "burn",
+    "usphone": "bɝn",
+    "ukphone": "bɜːn",
+    "trans": [
+      "v.烧(掉),烧毁；烧焦 n.灼伤；烧伤处"
+    ]
+  },
+  {
+    "name": "bus",
+    "usphone": "bʌs",
+    "ukphone": "bʌs",
+    "trans": [
+      "n.公共汽车"
+    ]
+  },
+  {
+    "name": "business",
+    "usphone": "ˈbɪznəs",
+    "ukphone": "ˈbɪznɪs",
+    "trans": [
+      "n.商业，生意，营业；事情，职责"
+    ]
+  },
+  {
+    "name": "busy",
+    "usphone": "'bɪzi",
+    "ukphone": "'bɪzɪ",
+    "trans": [
+      "adj.忙"
+    ]
+  },
+  {
+    "name": "call",
+    "usphone": "kɔl",
+    "ukphone": "kɔːl",
+    "trans": [
+      "vt.叫，称呼；招呼；电话通知 n.电话"
+    ]
+  },
+  {
+    "name": "calm",
+    "usphone": "kɑm",
+    "ukphone": "kɑːm",
+    "trans": [
+      "adj.平静的，安静的"
+    ]
+  },
+  {
+    "name": "camera",
+    "usphone": "'kæmərə",
+    "ukphone": "'kæm(ə)rə",
+    "trans": [
+      "n.照相机，摄影机"
+    ]
+  },
+  {
+    "name": "camp",
+    "usphone": "kæmp",
+    "ukphone": "kæmp",
+    "trans": [
+      "n.野营；营地 v.设营，宿营"
+    ]
+  },
+  {
+    "name": "campaign",
+    "usphone": "kæm'pen",
+    "ukphone": "kæm'peɪn",
+    "trans": [
+      "n.战役；运动"
+    ]
+  },
+  {
+    "name": "cancer",
+    "usphone": "'kænsɚ",
+    "ukphone": "'kænsə",
+    "trans": [
+      "n.癌症；肿瘤"
+    ]
+  },
+  {
+    "name": "candidate",
+    "usphone": "ˈkændɪˌdet, -dɪt",
+    "ukphone": "'kændɪdeɪt; -dət",
+    "trans": [
+      "n.候选人,候补者;报考者;申请者"
+    ]
+  },
+  {
+    "name": "cap",
+    "usphone": "kæp",
+    "ukphone": "kæp",
+    "trans": [
+      "n.帽子；(笔、瓶等的) 盖套 v.覆盖于...顶端"
+    ]
+  },
+  {
+    "name": "capacity",
+    "usphone": "kə'pæsəti",
+    "ukphone": "kə'pæsɪtɪ",
+    "trans": [
+      "v.容量,容积；才能,能力；接受力"
+    ]
+  },
+  {
+    "name": "capable",
+    "usphone": "'kepəbl",
+    "ukphone": "'keɪpəb(ə)l",
+    "trans": [
+      "adj.能干的，有能力的"
+    ]
+  },
+  {
+    "name": "capital",
+    "usphone": "'kæpɪtl",
+    "ukphone": "'kæpɪt(ə)l",
+    "trans": [
+      "n.首都"
+    ]
+  },
+  {
+    "name": "capture",
+    "usphone": "'kæptʃɚ",
+    "ukphone": "'kæptʃə",
+    "trans": [
+      "n.捕获,俘获 v.夺得,占领；捕获，俘虏"
+    ]
+  },
+  {
+    "name": "car",
+    "usphone": "kɑr",
+    "ukphone": "kɑː",
+    "trans": [
+      "n.小汽车"
+    ]
+  },
+  {
+    "name": "card",
+    "usphone": "kɑrd",
+    "ukphone": "kɑːd",
+    "trans": [
+      "n.卡片"
+    ]
+  },
+  {
+    "name": "care",
+    "usphone": "kɛr",
+    "ukphone": "keə",
+    "trans": [
+      "v.关心，介意  n.小心，谨慎，注意"
+    ]
+  },
+  {
+    "name": "careful",
+    "usphone": "'kɛrfl",
+    "ukphone": "'keəfʊl; -f(ə)l",
+    "trans": [
+      "adj.小心的；谨慎的"
+    ]
+  },
+  {
+    "name": "careless",
+    "usphone": "'kɛrləs",
+    "ukphone": "'keələs",
+    "trans": [
+      "adj.粗心的，疏忽的"
+    ]
+  },
+  {
+    "name": "career",
+    "usphone": "kə'rɪr",
+    "ukphone": "kə'rɪə",
+    "trans": [
+      "n.生涯，经历；专业，职业"
+    ]
+  },
+  {
+    "name": "carry",
+    "usphone": "'kæri",
+    "ukphone": "'kærɪ",
+    "trans": [
+      "vt.携带；运送"
+    ]
+  },
+  {
+    "name": "carve",
+    "usphone": "kɑrv",
+    "ukphone": "kɑːv",
+    "trans": [
+      "v.(雕) 刻"
+    ]
+  },
+  {
+    "name": "case",
+    "usphone": "kes",
+    "ukphone": "keɪs",
+    "trans": [
+      "n.情况，情形，事实；案件"
+    ]
+  },
+  {
+    "name": "cash",
+    "usphone": "kæʃ",
+    "ukphone": "kæʃ",
+    "trans": [
+      "n.现金，现款，现钱 v.兑现，兑付"
+    ]
+  },
+  {
+    "name": "catch",
+    "usphone": "kætʃ",
+    "ukphone": "kætʃ",
+    "trans": [
+      "v.赶，追"
+    ]
+  },
+  {
+    "name": "cause",
+    "usphone": "kɔz",
+    "ukphone": "kɔːz",
+    "trans": [
+      "n.原因，理由；事业，(奋斗的) 目标 v.使产生，引起"
+    ]
+  },
+  {
+    "name": "cautious",
+    "usphone": "'kɔʃəs",
+    "ukphone": "'kɔːʃəs",
+    "trans": [
+      "adj.(of) 小心的，谨慎的"
+    ]
+  },
+  {
+    "name": "caution",
+    "usphone": "'kɔʃən",
+    "ukphone": "'kɔːʃ(ə)n",
+    "trans": [
+      "n.小心，谨慎；警告，告诫 v.警告"
+    ]
+  },
+  {
+    "name": "celebrate",
+    "usphone": "'sɛlɪbret",
+    "ukphone": "'selɪbreɪt",
+    "trans": [
+      "v.庆祝；庆贺"
+    ]
+  },
+  {
+    "name": "cell",
+    "usphone": "sɛl",
+    "ukphone": "sel",
+    "trans": [
+      "n.细胞"
+    ]
+  },
+  {
+    "name": "cement",
+    "usphone": "sə'mɛnt",
+    "ukphone": "sɪ'ment",
+    "trans": [
+      "n.水泥;胶泥,胶接剂 v.胶合;巩固，加强"
+    ]
+  },
+  {
+    "name": "central",
+    "usphone": "'sɛntrəl",
+    "ukphone": "'sentr(ə)l",
+    "trans": [
+      "adj.中心的,中央的,中部的；中枢的"
+    ]
+  },
+  {
+    "name": "center",
+    "usphone": "'sɛntɚ",
+    "ukphone": "'sentə",
+    "trans": [
+      "(=centre)n.中心,中央"
+    ]
+  },
+  {
+    "name": "century",
+    "usphone": "'sɛntʃəri",
+    "ukphone": "ˈsentʃərɪ",
+    "trans": [
+      "n.世纪"
+    ]
+  },
+  {
+    "name": "certain",
+    "usphone": "'sɝtn",
+    "ukphone": "'sɜːt(ə)n; -tɪn",
+    "trans": [
+      "adj.确凿的，无疑的；某一；一些"
+    ]
+  },
+  {
+    "name": "chain",
+    "usphone": "tʃen",
+    "ukphone": "tʃeɪn",
+    "trans": [
+      "n.链，链条；一连串"
+    ]
+  },
+  {
+    "name": "chair",
+    "usphone": "tʃɛr",
+    "ukphone": "tʃeə",
+    "trans": [
+      "n.椅子"
+    ]
+  },
+  {
+    "name": "chairman",
+    "usphone": "'tʃɛrmən",
+    "ukphone": "'tʃeəmən",
+    "trans": [
+      "n.主席"
+    ]
+  },
+  {
+    "name": "chalk",
+    "usphone": "tʃɔk",
+    "ukphone": "tʃɔːk",
+    "trans": [
+      "v.用粉笔写或画 n.粉笔"
+    ]
+  },
+  {
+    "name": "challenge",
+    "usphone": "'tʃælɪndʒ",
+    "ukphone": "'tʃælɪn(d)ʒ",
+    "trans": [
+      "n.挑战(书);艰巨任务 v.挑战;要求比试"
+    ]
+  },
+  {
+    "name": "chance",
+    "usphone": "tʃæns",
+    "ukphone": "tʃɑːns",
+    "trans": [
+      "n.机会"
+    ]
+  },
+  {
+    "name": "change",
+    "usphone": "tʃendʒ",
+    "ukphone": "tʃeɪn(d)ʒ",
+    "trans": [
+      "n.零钱 v./n.变化，改变"
+    ]
+  },
+  {
+    "name": "changeable",
+    "usphone": "'tʃendʒəbl",
+    "ukphone": "'tʃeɪn(d)ʒəb(ə)l",
+    "trans": [
+      "adj.变化的,易变的"
+    ]
+  },
+  {
+    "name": "character",
+    "usphone": "'kærəktɚ",
+    "ukphone": "'kærəktə",
+    "trans": [
+      "n.性格, 人物"
+    ]
+  },
+  {
+    "name": "characteristic",
+    "usphone": ",kærəktə'rɪstɪk",
+    "ukphone": "kærəktə'rɪstɪk",
+    "trans": [
+      "adj.独特的 n.特性，特征"
+    ]
+  },
+  {
+    "name": "charge",
+    "usphone": "tʃɑrdʒ",
+    "ukphone": "tʃɑːdʒ",
+    "trans": [
+      "v.收费，索价 n.费用，价格"
+    ]
+  },
+  {
+    "name": "chat",
+    "usphone": "tʃæt",
+    "ukphone": "tʃæt",
+    "trans": [
+      "v.&n.闲谈，聊天"
+    ]
+  },
+  {
+    "name": "cheap",
+    "usphone": "tʃip",
+    "ukphone": "tʃiːp",
+    "trans": [
+      "adj.便宜的"
+    ]
+  },
+  {
+    "name": "cheat",
+    "usphone": "tʃit",
+    "ukphone": "tʃiːt",
+    "trans": [
+      "v.欺骗；作弊 n.骗子；欺骗行为"
+    ]
+  },
+  {
+    "name": "check",
+    "usphone": "tʃɛk",
+    "ukphone": "tʃek",
+    "trans": [
+      "v.&n.检查；核对 n.支票"
+    ]
+  },
+  {
+    "name": "cheer",
+    "usphone": "tʃɪr",
+    "ukphone": "tʃɪə",
+    "trans": [
+      "v.(使) 振奋；(使) 高兴；欢呼，喝彩 n.振奋；欢呼，喝彩"
+    ]
+  },
+  {
+    "name": "chemistry",
+    "usphone": "'kɛmɪstri",
+    "ukphone": "'kemɪstrɪ",
+    "trans": [
+      "n.化学"
+    ]
+  },
+  {
+    "name": "chemical",
+    "usphone": "'kɛmɪkl",
+    "ukphone": "'kemɪk(ə)l",
+    "trans": [
+      "adj.化学的"
+    ]
+  },
+  {
+    "name": "chest",
+    "usphone": "tʃɛst",
+    "ukphone": "tʃest",
+    "trans": [
+      "n.胸部，胸腔"
+    ]
+  },
+  {
+    "name": "child",
+    "usphone": "tʃaɪld",
+    "ukphone": "tʃaɪld",
+    "trans": [
+      "n.儿童（单数）"
+    ]
+  },
+  {
+    "name": "children",
+    "usphone": "'tʃɪldrən",
+    "ukphone": "'tʃɪldrən",
+    "trans": [
+      "n. 孩子们"
+    ]
+  },
+  {
+    "name": "childhood",
+    "usphone": "'tʃaɪldhʊd",
+    "ukphone": "'tʃaɪldhʊd",
+    "trans": [
+      "n.幼年，童年"
+    ]
+  },
+  {
+    "name": "childish",
+    "usphone": "'tʃaɪldɪʃ",
+    "ukphone": "'tʃaɪldɪʃ",
+    "trans": [
+      "adj.孩子气的，幼稚的"
+    ]
+  },
+  {
+    "name": "China",
+    "usphone": "'tʃainə",
+    "ukphone": "'tʃainə",
+    "trans": [
+      "n.中国"
+    ]
+  },
+  {
+    "name": "Chinese",
+    "ukphone": ",tʃai'ni:z",
+    "trans": [
+      "adj.中国的；中国人的,汉语的 n.中国人；汉语"
+    ]
+  },
+  {
+    "name": "chip",
+    "usphone": "tʃɪp",
+    "ukphone": "tʃɪp",
+    "trans": [
+      "n.切屑，碎片；(土豆等的)薄片"
+    ]
+  },
+  {
+    "name": "choose",
+    "usphone": "tʃuz",
+    "ukphone": "tʃuːz",
+    "trans": [
+      "v.选择"
+    ]
+  },
+  {
+    "name": "choice",
+    "usphone": "tʃɔɪs",
+    "ukphone": "tʃɒɪs",
+    "trans": [
+      "n.选择,挑选,抉择"
+    ]
+  },
+  {
+    "name": "Christmas",
+    "ukphone": "ˈkrɪsməs",
+    "trans": [
+      "n.圣诞节"
+    ]
+  },
+  {
+    "name": "cigarette",
+    "usphone": "ˌsɪɡəˈrɛt, ˈsɪɡəˌrɛt",
+    "ukphone": "sɪgə'ret",
+    "trans": [
+      "n.香烟"
+    ]
+  },
+  {
+    "name": "circle",
+    "usphone": "'sɝkl",
+    "ukphone": "'sɜːk(ə)l",
+    "trans": [
+      "n.圆圈，圆，圆周；周期，循环"
+    ]
+  },
+  {
+    "name": "circulate",
+    "usphone": "'sɝkjəlet",
+    "ukphone": "'sɜːkjʊleɪt",
+    "trans": [
+      "v.(使) 循环；(使) 流通"
+    ]
+  },
+  {
+    "name": "circumstance",
+    "usphone": "'sɝkəmstæns",
+    "ukphone": "ˈsɜːkəmstəns; ˈsɜːkəmstɑːns; ˈsɜːkəmstæns",
+    "trans": [
+      "n.情况，形势，环境"
+    ]
+  },
+  {
+    "name": "city",
+    "usphone": "'sɪti",
+    "ukphone": "'sɪtɪ",
+    "trans": [
+      "n.城市"
+    ]
+  },
+  {
+    "name": "citizen",
+    "usphone": "'sɪtɪzn",
+    "ukphone": "'sɪtɪz(ə)n",
+    "trans": [
+      "n.公民，市民，平民"
+    ]
+  },
+  {
+    "name": "civilization",
+    "usphone": ",sivilai'zeiʃɚn",
+    "ukphone": ",sivilai'zeiʃɚn",
+    "trans": [
+      "n.文明"
+    ]
+  },
+  {
+    "name": "civilize",
+    "usphone": "'sivilaiz",
+    "ukphone": "'sivilaiz",
+    "trans": [
+      "v.使文明，开化；开导"
+    ]
+  },
+  {
+    "name": "civil",
+    "usphone": "'sɪvl",
+    "ukphone": "'sɪv(ə)l; -ɪl",
+    "trans": [
+      "adj.办公民的，市民的"
+    ]
+  },
+  {
+    "name": "claim",
+    "usphone": "klem",
+    "ukphone": "kleɪm",
+    "trans": [
+      "v.要求；声称，主张；索赔"
+    ]
+  },
+  {
+    "name": "class",
+    "usphone": "klæs",
+    "ukphone": "klɑːs",
+    "trans": [
+      "n.班级, 课,等级, 阶级 v.分类"
+    ]
+  },
+  {
+    "name": "classic",
+    "usphone": "'klæsɪk",
+    "ukphone": "'klæsɪk",
+    "trans": [
+      "n.(pl.) 经典作品，名著 adj.一流的，不朽的；古典的"
+    ]
+  },
+  {
+    "name": "clean",
+    "usphone": "klin",
+    "ukphone": "kliːn",
+    "trans": [
+      "adj.清洁的，干净的 v.把...弄干净，除去...的污垢"
+    ]
+  },
+  {
+    "name": "clear",
+    "usphone": "klɪr",
+    "ukphone": "klɪə",
+    "trans": [
+      "adj.清澈的，清楚的，清晰的，明亮的"
+    ]
+  },
+  {
+    "name": "clerk",
+    "usphone": "klɝk",
+    "ukphone": "klɑːk",
+    "trans": [
+      "n.工作人员；职员"
+    ]
+  },
+  {
+    "name": "clever",
+    "usphone": "'klɛvɚ",
+    "ukphone": "'klevə",
+    "trans": [
+      "adj.聪明的，机灵的"
+    ]
+  },
+  {
+    "name": "client",
+    "usphone": "'klaɪənt",
+    "ukphone": "'klaɪənt",
+    "trans": [
+      "n.顾客；(诉讼) 委托人"
+    ]
+  },
+  {
+    "name": "climb",
+    "usphone": "klaɪm",
+    "ukphone": "klaɪm",
+    "trans": [
+      "v.&n.攀登，爬"
+    ]
+  },
+  {
+    "name": "clock",
+    "usphone": "klɑk",
+    "ukphone": "klɒk",
+    "trans": [
+      "n.钟"
+    ]
+  },
+  {
+    "name": "close",
+    "usphone": "kloz",
+    "ukphone": "kləʊs",
+    "trans": [
+      "v.关,合拢;停业 adj.靠近的,亲密的,密切的"
+    ]
+  },
+  {
+    "name": "clothe",
+    "usphone": "kləʊðz",
+    "ukphone": "kloʊð",
+    "trans": [
+      "n. 衣服"
+    ]
+  },
+  {
+    "name": "club",
+    "usphone": "klʌb",
+    "ukphone": "klʌb",
+    "trans": [
+      "n.俱乐部"
+    ]
+  },
+  {
+    "name": "coach",
+    "usphone": "kotʃ",
+    "ukphone": "kəʊtʃ",
+    "trans": [
+      "n.长途汽车；教练 v.辅导，训练"
+    ]
+  },
+  {
+    "name": "coin",
+    "usphone": "kɔɪn",
+    "ukphone": "kɒɪn",
+    "trans": [
+      "v.铸造 n.硬币，货币"
+    ]
+  },
+  {
+    "name": "cold",
+    "usphone": "kold",
+    "ukphone": "kəʊld",
+    "trans": [
+      "adj.冷的；寒冷的"
+    ]
+  },
+  {
+    "name": "collapse",
+    "usphone": "kə'læps",
+    "ukphone": "kə'læps",
+    "trans": [
+      "v.&n.倒坍，崩溃；垮台"
+    ]
+  },
+  {
+    "name": "colleague",
+    "usphone": "'kɑliɡ",
+    "ukphone": "'kɒliːg",
+    "trans": [
+      "n.同事，同僚"
+    ]
+  },
+  {
+    "name": "collect",
+    "usphone": "kə'lɛkt",
+    "ukphone": "kə'lekt",
+    "trans": [
+      "v.收集"
+    ]
+  },
+  {
+    "name": "collection",
+    "usphone": "kə'lɛkʃən",
+    "ukphone": "kə'lekʃ(ə)n",
+    "trans": [
+      "n.收集物；收藏"
+    ]
+  },
+  {
+    "name": "college",
+    "usphone": "'kɑlɪdʒ",
+    "ukphone": "'kɒlɪdʒ",
+    "trans": [
+      "n.学院"
+    ]
+  },
+  {
+    "name": "colour",
+    "usphone": "'kʌlɚ",
+    "ukphone": "'kʌlə",
+    "trans": [
+      "n.颜色"
+    ]
+  },
+  {
+    "name": "combat",
+    "usphone": "'kɑmbæt",
+    "ukphone": "'kɒmbæt; 'kʌm-",
+    "trans": [
+      "v.&n.战斗，反对，格斗"
+    ]
+  },
+  {
+    "name": "combine",
+    "usphone": "kəm'baɪn",
+    "ukphone": "kəm'baɪn",
+    "trans": [
+      "v.(with)(使) 结合,联合；(使)化合"
+    ]
+  },
+  {
+    "name": "combination",
+    "usphone": ",kɑmbɪ'neʃən",
+    "ukphone": "kɒmbɪ'neɪʃ(ə)n",
+    "trans": [
+      "n.结合,联合"
+    ]
+  },
+  {
+    "name": "come",
+    "usphone": "kʌm",
+    "ukphone": "kʌm",
+    "trans": [
+      "v.来"
+    ]
+  },
+  {
+    "name": "comedy",
+    "usphone": "'kɑmədi",
+    "ukphone": "'kɒmɪdɪ",
+    "trans": [
+      "n.喜剧"
+    ]
+  },
+  {
+    "name": "comfortable",
+    "usphone": "'kʌmftəbl",
+    "ukphone": "ˈkʌmftəbl",
+    "trans": [
+      "adj.舒适的，舒服的"
+    ]
+  },
+  {
+    "name": "comfort",
+    "usphone": "'kʌmfɚt",
+    "ukphone": "'kʌmfət",
+    "trans": [
+      "n.安慰；舒适 v.使舒适；安慰"
+    ]
+  },
+  {
+    "name": "command",
+    "usphone": "kə'mænd",
+    "ukphone": "kə'mɑːnd",
+    "trans": [
+      "n.命令，指令；统帅，指挥(权) v.命令；指挥"
+    ]
+  },
+  {
+    "name": "comment",
+    "usphone": "'kɑmɛnt",
+    "ukphone": "'kɒment",
+    "trans": [
+      "n.注释,评论,意见 v.(on) 注释;评论"
+    ]
+  },
+  {
+    "name": "commercial",
+    "usphone": "kə'mɝʃəl",
+    "ukphone": "kə'mɜːʃ(ə)l",
+    "trans": [
+      "adj.商业的，贸易的"
+    ]
+  },
+  {
+    "name": "commerce",
+    "usphone": "'kɑmɝs",
+    "ukphone": "'kɒmɜːs",
+    "trans": [
+      "n.商业，贸易"
+    ]
+  },
+  {
+    "name": "commission",
+    "usphone": "kə'mɪʃən",
+    "ukphone": "kə'mɪʃ(ə)n",
+    "trans": [
+      "n.委员会；委任，委托(书)；佣金"
+    ]
+  },
+  {
+    "name": "committee",
+    "usphone": "kə'mɪti",
+    "ukphone": "kə'mɪtɪ",
+    "trans": [
+      "n.委员会"
+    ]
+  },
+  {
+    "name": "commit",
+    "usphone": "kə'mɪt",
+    "ukphone": "kə'mɪt",
+    "trans": [
+      "v. 犯错误，干坏事"
+    ]
+  },
+  {
+    "name": "common",
+    "usphone": "'kɑmən",
+    "ukphone": "'kɒmən",
+    "trans": [
+      "adj.共同的"
+    ]
+  },
+  {
+    "name": "communicate",
+    "usphone": "kə'mjunɪket",
+    "ukphone": "kə'mjuːnɪkeɪt",
+    "trans": [
+      "vi.交流 vt.传染；传播"
+    ]
+  },
+  {
+    "name": "communication",
+    "usphone": "kə,mjunɪ'keʃən",
+    "ukphone": "kəmjuːnɪ'keɪʃ(ə)n",
+    "trans": [
+      "n.交流，联系"
+    ]
+  },
+  {
+    "name": "community",
+    "usphone": "kə'mjʊnəti",
+    "ukphone": "kə'mjuːnɪtɪ",
+    "trans": [
+      "n.社会，社区；共同体；公众"
+    ]
+  },
+  {
+    "name": "company",
+    "usphone": "'kʌmpəni",
+    "ukphone": "'kʌmp(ə)nɪ",
+    "trans": [
+      "n.公司"
+    ]
+  },
+  {
+    "name": "compare",
+    "usphone": "kəm'pɛr",
+    "ukphone": "kəm'peə",
+    "trans": [
+      "v.比较，对照"
+    ]
+  },
+  {
+    "name": "comparison",
+    "usphone": "kəm'pærɪsn",
+    "ukphone": "kəm'pærɪs(ə)n",
+    "trans": [
+      "n.比较，对照；比拟"
+    ]
+  },
+  {
+    "name": "compensate",
+    "usphone": "'kɑmpɛnset",
+    "ukphone": "'kɒmpenseɪt",
+    "trans": [
+      "v.(for) 补偿，赔偿"
+    ]
+  },
+  {
+    "name": "compensation",
+    "usphone": ",kɑmpɛn'seʃən",
+    "ukphone": "kɒmpen'seɪʃ(ə)n",
+    "trans": [
+      "n.补偿，赔偿"
+    ]
+  },
+  {
+    "name": "competition",
+    "usphone": ",kɑmpə'tɪʃən",
+    "ukphone": "kɒmpɪ'tɪʃ(ə)n",
+    "trans": [
+      "n.竞赛，竞争"
+    ]
+  },
+  {
+    "name": "complain",
+    "usphone": "kəm'plen",
+    "ukphone": "kəm'pleɪn",
+    "trans": [
+      "v.抱怨；申诉"
+    ]
+  },
+  {
+    "name": "complaint",
+    "usphone": "kəm'plent",
+    "ukphone": "kəm'pleɪnt",
+    "trans": [
+      "n.抱怨；申诉"
+    ]
+  },
+  {
+    "name": "complete",
+    "usphone": "kəm'plit",
+    "ukphone": "kəm'pliːt",
+    "trans": [
+      "adj.完整的，完全的；完成的 v.完成，使完整"
+    ]
+  },
+  {
+    "name": "complement",
+    "usphone": "ˈkɑːmplɪment",
+    "ukphone": "'kɒmplɪm(ə)nt",
+    "trans": [
+      "v.补充，补足"
+    ]
+  },
+  {
+    "name": "complex",
+    "usphone": "kəm'plɛks; 'kɑm,plɛks",
+    "ukphone": "'kɒmpleks",
+    "trans": [
+      "adj.复杂的；合成的，综合的"
+    ]
+  },
+  {
+    "name": "complicate",
+    "usphone": "'kɑmplɪket",
+    "ukphone": "'kɒmplɪkeɪt",
+    "trans": [
+      "v.(使) 变复杂"
+    ]
+  },
+  {
+    "name": "complicated",
+    "usphone": "'kɑmplɪketɪd",
+    "ukphone": "'kɒmplɪkeɪtɪd",
+    "trans": [
+      "adj.错综复杂的"
+    ]
+  },
+  {
+    "name": "component",
+    "usphone": "kəm'ponənt",
+    "ukphone": "kəm'pəʊnənt",
+    "trans": [
+      "n.组成部分，成分，元件"
+    ]
+  },
+  {
+    "name": "composition",
+    "usphone": ",kɑmpə'zɪʃən",
+    "ukphone": "kɒmpə'zɪʃ(ə)n",
+    "trans": [
+      "n.作文，写作；乐曲；构成，组成"
+    ]
+  },
+  {
+    "name": "compound",
+    "usphone": "'kɑmpaʊnd",
+    "ukphone": "'kɒmpaʊnd",
+    "trans": [
+      "n.混合物，化合物 adj.混合的，化合的，复合的 v.使复合，使混合；和解"
+    ]
+  },
+  {
+    "name": "comprehension",
+    "usphone": ",kɑmprɪ'hɛnʃən",
+    "ukphone": "kɒmprɪ'henʃ(ə)n",
+    "trans": [
+      "n.理解"
+    ]
+  },
+  {
+    "name": "comprehensive",
+    "usphone": "ˌkɑːmprɪˈhensɪv",
+    "ukphone": "kɒmprɪ'hensɪv",
+    "trans": [
+      "adj.内容广泛的， 综合的；理解的"
+    ]
+  },
+  {
+    "name": "comprise",
+    "usphone": "kəm'praɪz",
+    "ukphone": "kəm'praɪz",
+    "trans": [
+      "v.包含，构成"
+    ]
+  },
+  {
+    "name": "compromise",
+    "usphone": "'kɑmprəmaɪz",
+    "ukphone": "'kɒmprəmaɪz",
+    "trans": [
+      "v.妥协；折衷"
+    ]
+  },
+  {
+    "name": "computer",
+    "usphone": "kəm'pjutɚ",
+    "ukphone": "kəm'pjuːtə",
+    "trans": [
+      "n.计算机"
+    ]
+  },
+  {
+    "name": "concentrate",
+    "usphone": "'kɑnsn'tret",
+    "ukphone": "'kɒns(ə)ntreɪt",
+    "trans": [
+      "v.(on)集中,专心;浓缩"
+    ]
+  },
+  {
+    "name": "concept",
+    "usphone": "'kɑnsɛpt",
+    "ukphone": "'kɒnsept",
+    "trans": [
+      "n.概念，观念；思想"
+    ]
+  },
+  {
+    "name": "concern",
+    "usphone": "kən'sɝn",
+    "ukphone": "kən'sɜːn",
+    "trans": [
+      "v.涉及，关系到；(使) 担心，(使) 关切 n.关心，挂念；(利害) 关系"
+    ]
+  },
+  {
+    "name": "conclusion",
+    "usphone": "kən'kluʒn",
+    "ukphone": "kən'kluːʒ(ə)n",
+    "trans": [
+      "n.结束，终结；结论，推论"
+    ]
+  },
+  {
+    "name": "conclude",
+    "usphone": "kən'klud",
+    "ukphone": "kən'kluːd",
+    "trans": [
+      "v.结束 终止;断定"
+    ]
+  },
+  {
+    "name": "condition",
+    "usphone": "kən'dɪʃən",
+    "ukphone": "kən'dɪʃ(ə)n",
+    "trans": [
+      "vt.使习惯；训练 n.条件"
+    ]
+  },
+  {
+    "name": "conduct",
+    "usphone": "kən'dʌkt",
+    "ukphone": "'kɒndʌkt",
+    "trans": [
+      "n.行为，品行，表现"
+    ]
+  },
+  {
+    "name": "confident",
+    "usphone": "'kɑnfɪdənt",
+    "ukphone": "'kɒnfɪd(ə)nt",
+    "trans": [
+      "adj.确信的"
+    ]
+  },
+  {
+    "name": "confidence",
+    "usphone": "'kɑnfɪdəns",
+    "ukphone": "'kɒnfɪd(ə)ns",
+    "trans": [
+      "n.信心，自信"
+    ]
+  },
+  {
+    "name": "conflict",
+    "usphone": "'kɑnflɪkt",
+    "ukphone": "'kɒnflɪkt",
+    "trans": [
+      "n.斗争；冲突，分歧 v.(with) 抵触，冲突"
+    ]
+  },
+  {
+    "name": "congratulate",
+    "usphone": "kən'ɡrætʃulet",
+    "ukphone": "kən'grætjʊleɪt",
+    "trans": [
+      "v.祝贺，致祝贺词"
+    ]
+  },
+  {
+    "name": "congratulation",
+    "usphone": "kən,ɡrætʃu'leʃən",
+    "ukphone": "kəngrætjʊ'leɪʃ(ə)n",
+    "trans": [
+      "n.祝贺"
+    ]
+  },
+  {
+    "name": "connection",
+    "usphone": "kə'nɛkʃən",
+    "ukphone": "kəˈnekʃn",
+    "trans": [
+      "n.(=connexion)联系；连接； 连接点"
+    ]
+  },
+  {
+    "name": "connect",
+    "usphone": "kə'nɛkt",
+    "ukphone": "kə'nekt",
+    "trans": [
+      "v.连接，联系"
+    ]
+  },
+  {
+    "name": "conquer",
+    "usphone": "'kɑŋkɚ",
+    "ukphone": "'kɒŋkə",
+    "trans": [
+      "v.征服，占领；克服"
+    ]
+  },
+  {
+    "name": "conscious",
+    "usphone": "'kɑnʃəs",
+    "ukphone": "'kɒnʃəs",
+    "trans": [
+      "adj.(of)意识到的,自觉的；有意识的"
+    ]
+  },
+  {
+    "name": "consequence",
+    "usphone": "'kɑnsəkwɛns",
+    "ukphone": "'kɒnsɪkw(ə)ns",
+    "trans": [
+      "n.结果，影响；重要性"
+    ]
+  },
+  {
+    "name": "consider",
+    "usphone": "kən'sɪdɚ",
+    "ukphone": "kən'sɪdə",
+    "trans": [
+      "v.考虑；认为"
+    ]
+  },
+  {
+    "name": "considerable",
+    "usphone": "kən'sɪdərəbl",
+    "ukphone": "kən'sɪd(ə)rəb(ə)l",
+    "trans": [
+      "adj.相当可观的；值得考虑的"
+    ]
+  },
+  {
+    "name": "consideration",
+    "usphone": "kən,sɪdə'reʃən",
+    "ukphone": "kənsɪdə'reɪʃ(ə)n",
+    "trans": [
+      "n.考虑，思考；体谅，照顾"
+    ]
+  },
+  {
+    "name": "consist",
+    "usphone": "kən'sɪst",
+    "ukphone": "kən'sɪst",
+    "trans": [
+      "v.在于，存在于；由...组成"
+    ]
+  },
+  {
+    "name": "consistent",
+    "usphone": "kən'sɪstənt",
+    "ukphone": "kən'sɪst(ə)nt",
+    "trans": [
+      "adj.前后一致的，始终如一的"
+    ]
+  },
+  {
+    "name": "constant",
+    "usphone": "'kɑnstənt",
+    "ukphone": "'kɒnst(ə)nt",
+    "trans": [
+      "adj.经常的，不断的；永恒的"
+    ]
+  },
+  {
+    "name": "construction",
+    "usphone": "kən'strʌkʃən",
+    "ukphone": "kən'strʌkʃ(ə)n",
+    "trans": [
+      "n.建设；建筑(物)"
+    ]
+  },
+  {
+    "name": "consume",
+    "usphone": "kənˈsum",
+    "ukphone": "kən'sjuːm",
+    "trans": [
+      "v.消费"
+    ]
+  },
+  {
+    "name": "contact",
+    "usphone": "'kɑntækt",
+    "ukphone": "'kɒntækt",
+    "trans": [
+      "vt.联系"
+    ]
+  },
+  {
+    "name": "contain",
+    "usphone": "kən'ten",
+    "ukphone": "kən'teɪn",
+    "trans": [
+      "v.包含，含有，容纳"
+    ]
+  },
+  {
+    "name": "content",
+    "usphone": "'kɑntɛnt",
+    "ukphone": "kən'tent",
+    "trans": [
+      "n.内容"
+    ]
+  },
+  {
+    "name": "contest",
+    "usphone": "kən'tɛst",
+    "ukphone": "'kɒntest",
+    "trans": [
+      "v.&n.竞争，竞赛，比赛"
+    ]
+  },
+  {
+    "name": "continent",
+    "usphone": "'kɑntɪnənt",
+    "ukphone": "'kɒntɪnənt",
+    "trans": [
+      "n.大陆，洲"
+    ]
+  },
+  {
+    "name": "continue",
+    "usphone": "kən'tɪnju",
+    "ukphone": "kən'tɪnjuː",
+    "trans": [
+      "v.继续，延伸"
+    ]
+  },
+  {
+    "name": "continual",
+    "usphone": "kən'tɪnjuəl",
+    "ukphone": "kən'tɪnjʊəl",
+    "trans": [
+      "adj.不断的，连续的"
+    ]
+  },
+  {
+    "name": "contrary",
+    "usphone": "'kɑntrɛri",
+    "ukphone": "'kɒntrərɪ",
+    "trans": [
+      "adj.相反的，矛盾的，对抗的 n.反对，矛盾；相反"
+    ]
+  },
+  {
+    "name": "contrast",
+    "usphone": "'kɑntræst",
+    "ukphone": "'kɒntrɑːst",
+    "trans": [
+      "v.对比，对照"
+    ]
+  },
+  {
+    "name": "contribute",
+    "usphone": "kən'trɪbjut",
+    "ukphone": "kən'trɪbjuːt; 'kɒntrɪbjuːt",
+    "trans": [
+      "v.贡献，捐助"
+    ]
+  },
+  {
+    "name": "control",
+    "usphone": "kən'trol",
+    "ukphone": "kən'trəʊl",
+    "trans": [
+      "v.&n.控制，支配；克制"
+    ]
+  },
+  {
+    "name": "controversial",
+    "usphone": ",kɑntrə'vɝʃl",
+    "ukphone": "kɒntrə'vɜːʃ(ə)l",
+    "trans": [
+      "adj.(爱)争论的；引起争论的"
+    ]
+  },
+  {
+    "name": "convenient",
+    "usphone": "kən'vinɪənt",
+    "ukphone": "kən'viːnɪənt",
+    "trans": [
+      "adj.方便的，舒适的"
+    ]
+  },
+  {
+    "name": "convention",
+    "usphone": "kən'vɛnʃən",
+    "ukphone": "kən'venʃ(ə)n",
+    "trans": [
+      "n.大会,惯例,习俗,公约，协定"
+    ]
+  },
+  {
+    "name": "conversation",
+    "usphone": ",kɑnvɚ'seʃən",
+    "ukphone": "kɒnvə'seɪʃ(ə)n",
+    "trans": [
+      "n.会话，闲谈"
+    ]
+  },
+  {
+    "name": "convince",
+    "usphone": "kən'vɪns",
+    "ukphone": "kən'vɪns",
+    "trans": [
+      "v.使信服，使确信"
+    ]
+  },
+  {
+    "name": "cook",
+    "usphone": "kʊk",
+    "ukphone": "kʊk",
+    "trans": [
+      "v.烹调，煮，做饭等 n.厨师，炊事员"
+    ]
+  },
+  {
+    "name": "cool",
+    "usphone": "kul",
+    "ukphone": "kuːl",
+    "trans": [
+      "adj.凉爽的，凉快的；冷静的；冷淡的 v.使变冷，使冷却；使镇静"
+    ]
+  },
+  {
+    "name": "cooperation",
+    "usphone": "ko,ɑpə'reʃən",
+    "ukphone": "kəʊ,ɒpə'reɪʃ(ə)n",
+    "trans": [
+      "n.合作"
+    ]
+  },
+  {
+    "name": "cope",
+    "usphone": "kop",
+    "ukphone": "kəʊp",
+    "trans": [
+      "v. 应付"
+    ]
+  },
+  {
+    "name": "copy",
+    "usphone": "'kɑpi",
+    "ukphone": "'kɒpɪ",
+    "trans": [
+      "n.抄件,副本；(一)本,(一)份 v.抄写；复印"
+    ]
+  },
+  {
+    "name": "core",
+    "usphone": "kɔr",
+    "ukphone": "kɔː",
+    "trans": [
+      "n.果核；中心"
+    ]
+  },
+  {
+    "name": "corporation",
+    "usphone": ",kɔrpə'reʃən",
+    "ukphone": "kɔːpə'reɪʃ(ə)n",
+    "trans": [
+      "n.公司，企业；团体"
+    ]
+  },
+  {
+    "name": "correct",
+    "usphone": "kə'rɛkt",
+    "ukphone": "kə'rekt",
+    "trans": [
+      "adj.正确的，无误的；恰当的 v.改正"
+    ]
+  },
+  {
+    "name": "cost",
+    "usphone": "kɔst",
+    "ukphone": "kɒst",
+    "trans": [
+      "v.花费，值  n.价钱，价格，费用"
+    ]
+  },
+  {
+    "name": "costly",
+    "usphone": "'kɔstli",
+    "ukphone": "'kɒs(t)lɪ",
+    "trans": [
+      "adj.昂贵的，豪华的"
+    ]
+  },
+  {
+    "name": "count",
+    "usphone": "kaʊnt",
+    "ukphone": "kaʊnt",
+    "trans": [
+      "v.数"
+    ]
+  },
+  {
+    "name": "counter",
+    "usphone": "'kaʊntɚ",
+    "ukphone": "'kaʊntə",
+    "trans": [
+      "n.柜台"
+    ]
+  },
+  {
+    "name": "country",
+    "usphone": "'kʌntri",
+    "ukphone": "'kʌntrɪ",
+    "trans": [
+      "n.乡下，国家；农村"
+    ]
+  },
+  {
+    "name": "countryside",
+    "usphone": "'kʌntrɪsaɪd",
+    "ukphone": "'kʌntrɪsaɪd",
+    "trans": [
+      "n.农村，田野，乡下"
+    ]
+  },
+  {
+    "name": "county",
+    "usphone": "'kaʊnti",
+    "ukphone": "'kaʊntɪ",
+    "trans": [
+      "n.郡，县"
+    ]
+  },
+  {
+    "name": "couple",
+    "usphone": "'kʌpl",
+    "ukphone": "'kʌp(ə)l",
+    "trans": [
+      "n.夫妻；一对"
+    ]
+  },
+  {
+    "name": "course",
+    "usphone": "kɔrs",
+    "ukphone": "kɔːs",
+    "trans": [
+      "n.过程"
+    ]
+  },
+  {
+    "name": "cover",
+    "usphone": "'kʌvɚ",
+    "ukphone": "'kʌvə",
+    "trans": [
+      "v.盖，包，掩盖 n.盖子，罩，套子；封面"
+    ]
+  },
+  {
+    "name": "create",
+    "usphone": "krɪ'et",
+    "ukphone": "kriː'eɪt",
+    "trans": [
+      "v.创造，创作；引起，产生；建立"
+    ]
+  },
+  {
+    "name": "credit",
+    "usphone": "'krɛdɪt",
+    "ukphone": "'kredɪt",
+    "trans": [
+      "n.信用，信誉"
+    ]
+  },
+  {
+    "name": "creep",
+    "usphone": "krip",
+    "ukphone": "kriːp",
+    "trans": [
+      "v.爬行；蔓延"
+    ]
+  },
+  {
+    "name": "crew",
+    "usphone": "krʊ",
+    "ukphone": "kruː",
+    "trans": [
+      "n.全体船员(乘务员)"
+    ]
+  },
+  {
+    "name": "criminal",
+    "usphone": "'krɪmɪnl",
+    "ukphone": "'krɪmɪn(ə)l",
+    "trans": [
+      "n.罪犯  adj.犯罪的，刑事上的"
+    ]
+  },
+  {
+    "name": "crime",
+    "usphone": "kraɪm",
+    "ukphone": "kraɪm",
+    "trans": [
+      "n.罪行；犯罪"
+    ]
+  },
+  {
+    "name": "critical",
+    "usphone": "'krɪtɪkl",
+    "ukphone": "'krɪtɪk(ə)l",
+    "trans": [
+      "adj.批评的，评论(性) 的；危急的"
+    ]
+  },
+  {
+    "name": "criticism",
+    "usphone": "'krɪtə'sɪzəm",
+    "ukphone": "'krɪtɪsɪz(ə)m",
+    "trans": [
+      "n.批评，评论"
+    ]
+  },
+  {
+    "name": "cross",
+    "usphone": "krɔs",
+    "ukphone": "krɒs",
+    "trans": [
+      "v.穿过,越过；(使)交叉,(使)相交"
+    ]
+  },
+  {
+    "name": "crowd",
+    "usphone": "kraʊd",
+    "ukphone": "kraʊd",
+    "trans": [
+      "n.人群；群众 v.拥挤；挤满"
+    ]
+  },
+  {
+    "name": "crown",
+    "usphone": "kraʊn",
+    "ukphone": "kraʊn",
+    "trans": [
+      "n.王冠,冕；君权 v.为...加冕；立...为王"
+    ]
+  },
+  {
+    "name": "crucial",
+    "usphone": "'krʊʃəl",
+    "ukphone": "'kruːʃ(ə)l",
+    "trans": [
+      "adj.至关重要的，决定性的"
+    ]
+  },
+  {
+    "name": "cry",
+    "usphone": "kraɪ",
+    "ukphone": "kraɪ",
+    "trans": [
+      "v.哭，哭泣；叫喊 n.哭，哭声；叫喊，喊声"
+    ]
+  },
+  {
+    "name": "cultivate",
+    "usphone": "'kʌltɪvet",
+    "ukphone": "'kʌltɪveɪt",
+    "trans": [
+      "v.耕作，栽培，养殖；培养，教养"
+    ]
+  },
+  {
+    "name": "culture",
+    "usphone": "'kʌltʃɚ",
+    "ukphone": "'kʌltʃə",
+    "trans": [
+      "n.文化，文明"
+    ]
+  },
+  {
+    "name": "cup",
+    "usphone": "kʌp",
+    "ukphone": "kʌp",
+    "trans": [
+      "n.杯子"
+    ]
+  },
+  {
+    "name": "cupboard",
+    "usphone": "'kʌbɚd",
+    "ukphone": "'kʌbəd",
+    "trans": [
+      "n.碗柜；橱柜"
+    ]
+  },
+  {
+    "name": "cure",
+    "usphone": "kjʊr",
+    "ukphone": "kjʊə; kjɔː",
+    "trans": [
+      "v.治疗，治好；纠正，矫正 n.疗，治愈；疗法，良药"
+    ]
+  },
+  {
+    "name": "curious",
+    "usphone": "'kjʊrɪəs",
+    "ukphone": "'kjʊərɪəs",
+    "trans": [
+      "adj.好奇的"
+    ]
+  },
+  {
+    "name": "current",
+    "usphone": "kɝ​ənt",
+    "ukphone": "'kʌr(ə)nt",
+    "trans": [
+      "adj.时下的,当今的"
+    ]
+  },
+  {
+    "name": "customer",
+    "usphone": "'kʌstəmɚ",
+    "ukphone": "'kʌstəmə",
+    "trans": [
+      "n.顾客"
+    ]
+  },
+  {
+    "name": "cut",
+    "usphone": "kʌt",
+    "ukphone": "kʌt",
+    "trans": [
+      "v.割，切，剪，削，砍，削减"
+    ]
+  },
+  {
+    "name": "daily",
+    "usphone": "'delɪ",
+    "ukphone": "'deɪlɪ",
+    "trans": [
+      "adj.每日的，日常的"
+    ]
+  },
+  {
+    "name": "dangerous",
+    "usphone": "'dendʒərəs",
+    "ukphone": "'deɪn(d)ʒ(ə)rəs",
+    "trans": [
+      "adj.危险的，不安全的"
+    ]
+  },
+  {
+    "name": "danger",
+    "usphone": "'dendʒɚ",
+    "ukphone": "'deɪn(d)ʒə",
+    "trans": [
+      "n.危险，威胁"
+    ]
+  },
+  {
+    "name": "dare",
+    "usphone": "dɛr",
+    "ukphone": "deə",
+    "trans": [
+      "v.敢，竟敢；向...挑战"
+    ]
+  },
+  {
+    "name": "dark",
+    "usphone": "dɑrk",
+    "ukphone": "dɑːk",
+    "trans": [
+      "adj.黑暗的"
+    ]
+  },
+  {
+    "name": "date",
+    "usphone": "det",
+    "ukphone": "deɪt",
+    "trans": [
+      "n.日期"
+    ]
+  },
+  {
+    "name": "daughter",
+    "usphone": "'dɔtɚ",
+    "ukphone": "'dɔːtə",
+    "trans": [
+      "n.女儿"
+    ]
+  },
+  {
+    "name": "day",
+    "usphone": "de",
+    "ukphone": "deɪ",
+    "trans": [
+      "n.天，日子；白天"
+    ]
+  },
+  {
+    "name": "deal",
+    "usphone": "dil",
+    "ukphone": "diːl",
+    "trans": [
+      "n.交易 v.给予，分给；交易"
+    ]
+  },
+  {
+    "name": "dear",
+    "usphone": "dɪr",
+    "ukphone": "dɪə",
+    "trans": [
+      "adj.亲爱的"
+    ]
+  },
+  {
+    "name": "death",
+    "usphone": "dɛθ",
+    "ukphone": "deθ",
+    "trans": [
+      "n.死，死亡"
+    ]
+  },
+  {
+    "name": "die",
+    "usphone": "daɪ",
+    "ukphone": "daɪ",
+    "trans": [
+      "v. 死亡"
+    ]
+  },
+  {
+    "name": "dying",
+    "usphone": "'daiiŋ",
+    "ukphone": "'daiiŋ",
+    "trans": [
+      "adj.垂死的，临终的"
+    ]
+  },
+  {
+    "name": "debate",
+    "usphone": "dɪ'bet",
+    "ukphone": "dɪ'beɪt",
+    "trans": [
+      "v.&n.争论，讨论"
+    ]
+  },
+  {
+    "name": "debt",
+    "usphone": "dɛt",
+    "ukphone": "det",
+    "trans": [
+      "n.债务，欠款"
+    ]
+  },
+  {
+    "name": "decade",
+    "usphone": "'dɛked",
+    "ukphone": "'dekeɪd; dɪ'keɪd",
+    "trans": [
+      "n.十年；一组(十个)"
+    ]
+  },
+  {
+    "name": "deceive",
+    "usphone": "dɪ'siv",
+    "ukphone": "dɪ'siːv",
+    "trans": [
+      "v.欺骗，蒙蔽，诓骗"
+    ]
+  },
+  {
+    "name": "decide",
+    "usphone": "dɪ'saɪd",
+    "ukphone": "dɪ'saɪd",
+    "trans": [
+      "v.决定；下决心"
+    ]
+  },
+  {
+    "name": "decided",
+    "usphone": "di'saidid",
+    "ukphone": "di'saidid",
+    "trans": [
+      "adj.确定的，坚决的"
+    ]
+  },
+  {
+    "name": "decision",
+    "usphone": "dɪ'sɪʒn",
+    "ukphone": "dɪ'sɪʒ(ə)n",
+    "trans": [
+      "n.决定"
+    ]
+  },
+  {
+    "name": "decline",
+    "usphone": "dɪ'klaɪn",
+    "ukphone": "dɪ'klaɪn",
+    "trans": [
+      "n.谢绝；下降，衰落；斜面 v.下降，下垂，衰落；拒绝，谢绝"
+    ]
+  },
+  {
+    "name": "decorate",
+    "usphone": "'dɛkəret",
+    "ukphone": "'dekəreɪt",
+    "trans": [
+      "v.装饰，装潢；布置"
+    ]
+  },
+  {
+    "name": "decrease",
+    "usphone": "dɪ'kris",
+    "ukphone": "dɪ'kriːs",
+    "trans": [
+      "v.&n.减少，减小"
+    ]
+  },
+  {
+    "name": "dedicate",
+    "usphone": "'dɛdɪket",
+    "ukphone": "'dedɪkeɪt",
+    "trans": [
+      "v.(to) 奉献；专注于"
+    ]
+  },
+  {
+    "name": "deem",
+    "usphone": "dim",
+    "ukphone": "diːm",
+    "trans": [
+      "v.认为；相信"
+    ]
+  },
+  {
+    "name": "deep",
+    "usphone": "dip",
+    "ukphone": "diːp",
+    "trans": [
+      "adj.深的；深切的 adv.深深地"
+    ]
+  },
+  {
+    "name": "defeat",
+    "usphone": "dɪ'fit",
+    "ukphone": "dɪ'fiːt",
+    "trans": [
+      "v.&n.战胜，挫败，击败"
+    ]
+  },
+  {
+    "name": "definite",
+    "usphone": "'dɛfɪnət",
+    "ukphone": "'defɪnɪt",
+    "trans": [
+      "adj.明确的"
+    ]
+  },
+  {
+    "name": "degree",
+    "usphone": "dɪ'ɡri",
+    "ukphone": "dɪ'griː",
+    "trans": [
+      "n.等级；程度；学位"
+    ]
+  },
+  {
+    "name": "delicious",
+    "usphone": "dɪ'lɪʃəs",
+    "ukphone": "dɪ'lɪʃəs",
+    "trans": [
+      "adj.可口的,美味的,好吃的"
+    ]
+  },
+  {
+    "name": "deliver",
+    "usphone": "dɪ'lɪvɚ",
+    "ukphone": "dɪ'lɪvə",
+    "trans": [
+      "v.送交，递送；释放"
+    ]
+  },
+  {
+    "name": "demand",
+    "usphone": "dɪ'mænd",
+    "ukphone": "dɪ'mɑːnd",
+    "trans": [
+      "v.要求，强令；需要；询问，查问 n.要求；需要，需求(量)"
+    ]
+  },
+  {
+    "name": "democratic",
+    "usphone": "'dɛmə'krætɪk",
+    "ukphone": "demə'krætɪk",
+    "trans": [
+      "adj.民主(主义) 的"
+    ]
+  },
+  {
+    "name": "democracy",
+    "usphone": "dɪˈmɑkrəsi",
+    "ukphone": "dɪ'mɒkrəsɪ",
+    "trans": [
+      "n.民主(制);民主国家"
+    ]
+  },
+  {
+    "name": "density",
+    "usphone": "'dɛnsəti",
+    "ukphone": "'densɪtɪ",
+    "trans": [
+      "n.密集；密度，浓度"
+    ]
+  },
+  {
+    "name": "dentist",
+    "usphone": "'dɛntɪst",
+    "ukphone": "'dentɪst",
+    "trans": [
+      "n.牙科医生"
+    ]
+  },
+  {
+    "name": "deny",
+    "usphone": "dɪ'nai",
+    "ukphone": "dɪ'naɪ",
+    "trans": [
+      "v.否认，否定；拒绝"
+    ]
+  },
+  {
+    "name": "department",
+    "usphone": "dɪ'pɑrtmənt",
+    "ukphone": "dɪ'pɑːtm(ə)nt",
+    "trans": [
+      "n.部门"
+    ]
+  },
+  {
+    "name": "depend",
+    "usphone": "dɪ'pɛnd",
+    "ukphone": "dɪ'pend",
+    "trans": [
+      "v.(on, upon) 依靠，依赖；决定于"
+    ]
+  },
+  {
+    "name": "derive",
+    "usphone": "dɪ'raɪv",
+    "ukphone": "dɪ'raɪv",
+    "trans": [
+      "v.取得，导出，起源"
+    ]
+  },
+  {
+    "name": "describe",
+    "usphone": "dɪ'skraɪb",
+    "ukphone": "dɪ'skraɪb",
+    "trans": [
+      "v.形容，描写"
+    ]
+  },
+  {
+    "name": "description",
+    "usphone": "dɪ'skrɪpʃən",
+    "ukphone": "dɪ'skrɪpʃ(ə)n",
+    "trans": [
+      "n.描述，描绘，形容"
+    ]
+  },
+  {
+    "name": "deserve",
+    "usphone": "dɪ'zɝv",
+    "ukphone": "dɪ'zɜːv",
+    "trans": [
+      "v.应受，应得，值得"
+    ]
+  },
+  {
+    "name": "design",
+    "usphone": "dɪ'zaɪn",
+    "ukphone": "dɪ'zaɪn",
+    "trans": [
+      "v.设计,计划 n.设计,图样"
+    ]
+  },
+  {
+    "name": "desire",
+    "usphone": "dɪ'zaɪɚ",
+    "ukphone": "dɪ'zaɪə",
+    "trans": [
+      "v.愿望，渴望；要求 n.愿望，欲望"
+    ]
+  },
+  {
+    "name": "desirable",
+    "usphone": "dɪ'zaɪərəbl",
+    "ukphone": "dɪ'zaɪərəb(ə)l",
+    "trans": [
+      "adj.称心的，期望得到的"
+    ]
+  },
+  {
+    "name": "despite",
+    "usphone": "dɪ'spaɪt",
+    "ukphone": "dɪ'spaɪt",
+    "trans": [
+      "prep.不管，不顾；尽管 n.憎恨，轻蔑"
+    ]
+  },
+  {
+    "name": "destination",
+    "usphone": ",dɛstɪ'neʃən",
+    "ukphone": ",destɪ'neɪʃ(ə)n",
+    "trans": [
+      "n.目的地，终点"
+    ]
+  },
+  {
+    "name": "destiny",
+    "usphone": "'dɛstəni",
+    "ukphone": "'destɪnɪ",
+    "trans": [
+      "n.命运；天数"
+    ]
+  },
+  {
+    "name": "destroy",
+    "usphone": "dɪ'strɔɪ",
+    "ukphone": "dɪ'strɒɪ",
+    "trans": [
+      "v.破坏,摧毁;消灭,扑灭;打破,粉碎"
+    ]
+  },
+  {
+    "name": "destruction",
+    "usphone": "dɪ'strʌkʃən",
+    "ukphone": "dɪ'strʌkʃ(ə)n",
+    "trans": [
+      "n.破坏，消灭"
+    ]
+  },
+  {
+    "name": "detail",
+    "usphone": "'ditel",
+    "ukphone": "'diːteɪl",
+    "trans": [
+      "v.详细讲述，详谈 n.详细的情况，细节；枝节，琐碎"
+    ]
+  },
+  {
+    "name": "determine",
+    "usphone": "dɪ'tɝmɪn",
+    "ukphone": "dɪ'tɜːmɪn",
+    "trans": [
+      "v.决定；确定；测定"
+    ]
+  },
+  {
+    "name": "develop",
+    "usphone": "dɪ'vɛləp",
+    "ukphone": "dɪ'veləp",
+    "trans": [
+      "v.发展"
+    ]
+  },
+  {
+    "name": "development",
+    "usphone": "dɪ'vɛləpmənt",
+    "ukphone": "dɪ'veləpm(ə)nt",
+    "trans": [
+      "n.发展,开发"
+    ]
+  },
+  {
+    "name": "device",
+    "usphone": "dɪ'vaɪs",
+    "ukphone": "dɪ'vaɪs",
+    "trans": [
+      "n.装置，设备，仪表；方法，设计"
+    ]
+  },
+  {
+    "name": "dial",
+    "usphone": "'daɪəl",
+    "ukphone": "'daɪəl",
+    "trans": [
+      "v.拨号,打电话"
+    ]
+  },
+  {
+    "name": "dialogue",
+    "usphone": "'daɪəlɑɡ",
+    "ukphone": "'daɪəlɒg",
+    "trans": [
+      "n.对话"
+    ]
+  },
+  {
+    "name": "dictionary",
+    "usphone": "'dɪkʃə'nɛri",
+    "ukphone": "'dɪkʃ(ə)n(ə)rɪ",
+    "trans": [
+      "n.词典，字典"
+    ]
+  },
+  {
+    "name": "diet",
+    "usphone": "'daɪət",
+    "ukphone": "'daɪət",
+    "trans": [
+      "n.饮食"
+    ]
+  },
+  {
+    "name": "different",
+    "usphone": "'dɪfrənt",
+    "ukphone": "'dɪf(ə)r(ə)nt",
+    "trans": [
+      "adj.不同的"
+    ]
+  },
+  {
+    "name": "difference",
+    "usphone": "'dɪfrəns",
+    "ukphone": "'dɪf(ə)r(ə)ns",
+    "trans": [
+      "n.区别"
+    ]
+  },
+  {
+    "name": "differ",
+    "usphone": "'dɪfɚ",
+    "ukphone": "'dɪfə",
+    "trans": [
+      "v.(from) 与...不同 (with) 与...意见不同"
+    ]
+  },
+  {
+    "name": "difficult",
+    "usphone": "'dɪfɪkəlt",
+    "ukphone": "'dɪfɪk(ə)lt",
+    "trans": [
+      "adj.困难的"
+    ]
+  },
+  {
+    "name": "dig",
+    "usphone": "dɪɡ",
+    "ukphone": "dɪg",
+    "trans": [
+      "v.掘，挖"
+    ]
+  },
+  {
+    "name": "digital",
+    "usphone": "'dɪdʒɪtl",
+    "ukphone": "'dɪdʒɪt(ə)l",
+    "trans": [
+      "adj.数字的"
+    ]
+  },
+  {
+    "name": "dinner",
+    "usphone": "'dɪnɚ",
+    "ukphone": "'dɪnə",
+    "trans": [
+      "n.晚餐"
+    ]
+  },
+  {
+    "name": "dip",
+    "usphone": "dɪp",
+    "ukphone": "dɪp",
+    "trans": [
+      "v.浸，蘸"
+    ]
+  },
+  {
+    "name": "direct",
+    "usphone": "dɪˈrɛkt; daɪˈrɛkt",
+    "ukphone": "dəˈrekt; daɪˈrekt",
+    "trans": [
+      "adj.直的；率直的  adv.直接地；坦率地"
+    ]
+  },
+  {
+    "name": "directly",
+    "usphone": "dəˈrektli",
+    "ukphone": "dɪ'rektlɪ; daɪ-",
+    "trans": [
+      "adv.直接地,立即;正好地"
+    ]
+  },
+  {
+    "name": "direction",
+    "usphone": "dəˈrɛkʃən; (also) daɪˈrɛkʃən",
+    "ukphone": "dɪˈrɛkʃən; daɪ-",
+    "trans": [
+      "n.方向；方位"
+    ]
+  },
+  {
+    "name": "dirty",
+    "usphone": "ˈdɝ​tɪ",
+    "ukphone": "'dɜːtɪ",
+    "trans": [
+      "adj.肮脏的；下流的"
+    ]
+  },
+  {
+    "name": "disadvantage",
+    "usphone": ",dɪsəd'væntɪdʒ",
+    "ukphone": "dɪsəd'vɑːntɪdʒ",
+    "trans": [
+      "n.不便,不利条件；损害"
+    ]
+  },
+  {
+    "name": "disagree",
+    "usphone": ",dɪsə'ɡri",
+    "ukphone": "dɪsə'griː",
+    "trans": [
+      "v.(with)意见不同;不一致,不同意"
+    ]
+  },
+  {
+    "name": "disappear",
+    "usphone": "'dɪsə'pɪr",
+    "ukphone": "dɪsə'pɪə",
+    "trans": [
+      "v.消失，失踪"
+    ]
+  },
+  {
+    "name": "disappoint",
+    "usphone": "'dɪsə'pɔɪnt",
+    "ukphone": "dɪsə'pɒɪnt",
+    "trans": [
+      "v.使失望，使扫兴"
+    ]
+  },
+  {
+    "name": "discharge",
+    "usphone": "dɪs'tʃɑrdʒ",
+    "ukphone": "dɪs'tʃɑːdʒ",
+    "trans": [
+      "n.卸货，解除；排出，发射；解雇 v.排出，发射；释放，遣散"
+    ]
+  },
+  {
+    "name": "discount",
+    "usphone": "dɪs'kaʊnt",
+    "ukphone": "'dɪskaʊnt",
+    "trans": [
+      "v.&n.折扣"
+    ]
+  },
+  {
+    "name": "discover",
+    "usphone": "dɪ'skʌvɚ",
+    "ukphone": "dɪ'skʌvə",
+    "trans": [
+      "v.发现；暴露，显示"
+    ]
+  },
+  {
+    "name": "discovery",
+    "usphone": "dɪ'skʌvəri",
+    "ukphone": "dɪ'skʌv(ə)rɪ",
+    "trans": [
+      "n.发现,发现物"
+    ]
+  },
+  {
+    "name": "discuss",
+    "usphone": "dɪ'skʌs",
+    "ukphone": "dɪ'skʌs",
+    "trans": [
+      "v.讨论"
+    ]
+  },
+  {
+    "name": "discussion",
+    "usphone": "dɪ'skʌʃən",
+    "ukphone": "dɪ'skʌʃ(ə)n",
+    "trans": [
+      "n.讨论，谈论"
+    ]
+  },
+  {
+    "name": "disease",
+    "usphone": "dɪ'ziz",
+    "ukphone": "dɪ'ziːz",
+    "trans": [
+      "n.疾病"
+    ]
+  },
+  {
+    "name": "dislike",
+    "usphone": "dɪs'laɪk",
+    "ukphone": "dɪs'laɪk",
+    "trans": [
+      "v.&n.不喜欢，厌恶"
+    ]
+  },
+  {
+    "name": "disorder",
+    "usphone": "dɪs'ɔrdɚ",
+    "ukphone": "dɪs'ɔːdə",
+    "trans": [
+      "n.混乱，骚乱；疾病"
+    ]
+  },
+  {
+    "name": "distance",
+    "usphone": "'dɪstəns",
+    "ukphone": "'dɪst(ə)ns",
+    "trans": [
+      "n.距离"
+    ]
+  },
+  {
+    "name": "distinct",
+    "usphone": "dɪ'stɪŋkt",
+    "ukphone": "dɪ'stɪŋ(k)t",
+    "trans": [
+      "adj.清楚的,明显的；不同的,独特的"
+    ]
+  },
+  {
+    "name": "distinguish",
+    "usphone": "dɪ'stɪŋɡwɪʃ",
+    "ukphone": "dɪ'stɪŋgwɪʃ",
+    "trans": [
+      "v.区别，辨别"
+    ]
+  },
+  {
+    "name": "distinction",
+    "usphone": "dɪ'stɪŋkʃən",
+    "ukphone": "dɪ'stɪŋ(k)ʃ(ə)n",
+    "trans": [
+      "n.差别,区分"
+    ]
+  },
+  {
+    "name": "distress",
+    "usphone": "dɪ'strɛs",
+    "ukphone": "dɪ'stres",
+    "trans": [
+      "n.苦恼；危难；不幸"
+    ]
+  },
+  {
+    "name": "distribute",
+    "usphone": "dɪ'strɪbjut",
+    "ukphone": "dɪ'strɪbjuːt; 'dɪstrɪbjuːt",
+    "trans": [
+      "v.分配;分布;(over)散布"
+    ]
+  },
+  {
+    "name": "disturb",
+    "usphone": "dɪ'stɝb",
+    "ukphone": "dɪ'stɜːb",
+    "trans": [
+      "v.扰乱，弄乱，妨碍；打扰"
+    ]
+  },
+  {
+    "name": "divorce",
+    "usphone": "dɪ'vɔrs",
+    "ukphone": "dɪ'vɔːs",
+    "trans": [
+      "v.离婚；分离"
+    ]
+  },
+  {
+    "name": "doctor",
+    "usphone": "'dɑktɚ",
+    "ukphone": "'dɒktə",
+    "trans": [
+      "n.医生；博士"
+    ]
+  },
+  {
+    "name": "doctrine",
+    "usphone": "'dɑktrɪn",
+    "ukphone": "'dɒktrɪn",
+    "trans": [
+      "n.教条，主义，学说"
+    ]
+  },
+  {
+    "name": "dollar",
+    "usphone": "'dɑlɚ",
+    "ukphone": "'dɒlə",
+    "trans": [
+      "n.美元"
+    ]
+  },
+  {
+    "name": "domestic",
+    "usphone": "də'mɛstɪk",
+    "ukphone": "də'mestɪk",
+    "trans": [
+      "adj.家庭的;本国的,国内的;驯养的"
+    ]
+  },
+  {
+    "name": "donate",
+    "usphone": "'donet",
+    "ukphone": "də(ʊ)'neɪt",
+    "trans": [
+      "v.捐赠，赠送"
+    ]
+  },
+  {
+    "name": "door",
+    "usphone": "dɔr",
+    "ukphone": "dɔː",
+    "trans": [
+      "n.门"
+    ]
+  },
+  {
+    "name": "doubt",
+    "usphone": "daʊt",
+    "ukphone": "daʊt",
+    "trans": [
+      "n.疑惑，疑问 v.怀疑，不相信"
+    ]
+  },
+  {
+    "name": "doubtful",
+    "usphone": "'daʊtfəl",
+    "ukphone": "'daʊtfʊl; -f(ə)l",
+    "trans": [
+      "adj.怀疑的；可疑的"
+    ]
+  },
+  {
+    "name": "down",
+    "usphone": "daʊn",
+    "ukphone": "daʊn",
+    "trans": [
+      "adv.向下，在下面；处于低落状态 prep.沿着...而下"
+    ]
+  },
+  {
+    "name": "downstairs",
+    "usphone": "'daʊn'stɛrz",
+    "ukphone": "daʊn'steəz",
+    "trans": [
+      "adv.在楼下；往楼下 adj. 楼下的 n. 楼下"
+    ]
+  },
+  {
+    "name": "downtown",
+    "usphone": "'daʊn'taʊn",
+    "ukphone": "'daʊntaʊn",
+    "trans": [
+      "adj.往市中心的 adv.向市中心区 n.城镇中心区"
+    ]
+  },
+  {
+    "name": "drama",
+    "usphone": "'drɑ:mə",
+    "ukphone": "'drɑ:mə",
+    "trans": [
+      "n.剧本；戏剧"
+    ]
+  },
+  {
+    "name": "dramatic",
+    "usphone": "drə'mætɪk",
+    "ukphone": "drə'mætɪk",
+    "trans": [
+      "adj.戏剧的,戏剧性的"
+    ]
+  },
+  {
+    "name": "draw",
+    "usphone": "drɔ",
+    "ukphone": "drɔː",
+    "trans": [
+      "v.画，绘制"
+    ]
+  },
+  {
+    "name": "dread",
+    "usphone": "drɛd",
+    "ukphone": "dred",
+    "trans": [
+      "v.&n.恐惧，担心，害怕"
+    ]
+  },
+  {
+    "name": "dreadful",
+    "usphone": "'drɛdfəl",
+    "ukphone": "'dredfʊl; -f(ə)l",
+    "trans": [
+      "adj.可怕的，令人惊骇的"
+    ]
+  },
+  {
+    "name": "dream",
+    "usphone": "drim",
+    "ukphone": "driːm",
+    "trans": [
+      "n.梦想，愿望 v.向往；做梦"
+    ]
+  },
+  {
+    "name": "dress",
+    "usphone": "drɛs",
+    "ukphone": "dres",
+    "trans": [
+      "n.服装"
+    ]
+  },
+  {
+    "name": "drink",
+    "usphone": "drɪŋk",
+    "ukphone": "drɪŋk",
+    "trans": [
+      "v.喝 n.饮料"
+    ]
+  },
+  {
+    "name": "drive",
+    "usphone": "draɪv",
+    "ukphone": "draɪv",
+    "trans": [
+      "v.开车，驱赶, 迫使"
+    ]
+  },
+  {
+    "name": "driver",
+    "usphone": "'draɪvɚ",
+    "ukphone": "'draɪvə",
+    "trans": [
+      "n.驾驶员，司机"
+    ]
+  },
+  {
+    "name": "drop",
+    "usphone": "drɑp",
+    "ukphone": "drɒp",
+    "trans": [
+      "v.(使)滴下；(使)落下；(使)下降 n.滴"
+    ]
+  },
+  {
+    "name": "due",
+    "usphone": "du",
+    "ukphone": "djuː",
+    "trans": [
+      "adj.到期的；应付的 n.应得的东西"
+    ]
+  },
+  {
+    "name": "during",
+    "usphone": "'dʊrɪŋ",
+    "ukphone": "'djʊərɪŋ",
+    "trans": [
+      "prep.在...期间"
+    ]
+  },
+  {
+    "name": "duty",
+    "usphone": "'dʊti",
+    "ukphone": "'djuːtɪ",
+    "trans": [
+      "n.责任，职责"
+    ]
+  },
+  {
+    "name": "each",
+    "usphone": "itʃ",
+    "ukphone": "iːtʃ",
+    "trans": [
+      "adj.每，各 pron.每人，各自"
+    ]
+  },
+  {
+    "name": "eager",
+    "usphone": "'igɚ",
+    "ukphone": "'iːgə",
+    "trans": [
+      "adj.热切的，渴望的"
+    ]
+  },
+  {
+    "name": "early",
+    "usphone": "'ɝli",
+    "ukphone": "'ɜːlɪ",
+    "trans": [
+      "adj./adv.早的(地)"
+    ]
+  },
+  {
+    "name": "earn",
+    "usphone": "ɝn",
+    "ukphone": "ɜːn",
+    "trans": [
+      "v.挣得，赚得，获得"
+    ]
+  },
+  {
+    "name": "earth",
+    "usphone": "ɝθ",
+    "ukphone": "ɜːθ",
+    "trans": [
+      "n.地球，土地"
+    ]
+  },
+  {
+    "name": "earthquake",
+    "usphone": "'ɝθ'kwek",
+    "ukphone": "'ɜːθkweɪk",
+    "trans": [
+      "n.地震"
+    ]
+  },
+  {
+    "name": "easy",
+    "usphone": "'izi",
+    "ukphone": "'iːzɪ",
+    "trans": [
+      "adj.容易的"
+    ]
+  },
+  {
+    "name": "easily",
+    "usphone": "'izəli",
+    "ukphone": "'iːzɪlɪ",
+    "trans": [
+      "adv.容易地"
+    ]
+  },
+  {
+    "name": "ease",
+    "usphone": "iz",
+    "ukphone": "iːz",
+    "trans": [
+      "v.减轻；使舒适 n.容易；舒适"
+    ]
+  },
+  {
+    "name": "eat",
+    "usphone": "it",
+    "ukphone": "iːt",
+    "trans": [
+      "v.吃"
+    ]
+  },
+  {
+    "name": "echo",
+    "usphone": "'ɛko",
+    "ukphone": "'ekəʊ",
+    "trans": [
+      "v.出回声；反响，共鸣 n.回声；反响，共鸣"
+    ]
+  },
+  {
+    "name": "economy",
+    "usphone": "ɪ'kɑnəmi",
+    "ukphone": "ɪ'kɒnəmɪ",
+    "trans": [
+      "n.节约，节省；经济"
+    ]
+  },
+  {
+    "name": "economic",
+    "usphone": "ˌikəˈnɑmɪk, ˌɛkəˈ-nɑmɪk",
+    "ukphone": ",iːkə'nɒmɪk; ek-",
+    "trans": [
+      "adj.经济的；经济学的"
+    ]
+  },
+  {
+    "name": "editor",
+    "usphone": "'ɛdɪtɚ",
+    "ukphone": "'edɪtə",
+    "trans": [
+      "n.编辑，编者"
+    ]
+  },
+  {
+    "name": "edition",
+    "usphone": "ɪ'dɪʃən",
+    "ukphone": "ɪ'dɪʃ(ə)n",
+    "trans": [
+      "n.版本，版次"
+    ]
+  },
+  {
+    "name": "education",
+    "usphone": ",ɛdʒu'keʃən",
+    "ukphone": "edjʊ'keɪʃ(ə)n",
+    "trans": [
+      "n.教育，培养"
+    ]
+  },
+  {
+    "name": "effect",
+    "usphone": "ɪ'fɛkt",
+    "ukphone": "ɪ'fekt",
+    "trans": [
+      "v.产生  n.结果，效果；影响，作用"
+    ]
+  },
+  {
+    "name": "effective",
+    "usphone": "ɪ'fɛktɪv",
+    "ukphone": "ɪ'fektɪv",
+    "trans": [
+      "adj.有效的，生效的"
+    ]
+  },
+  {
+    "name": "effort",
+    "usphone": "'ɛfɚt",
+    "ukphone": "'efət",
+    "trans": [
+      "n.努力"
+    ]
+  },
+  {
+    "name": "elder",
+    "usphone": "'ɛldɚ",
+    "ukphone": "'eldə",
+    "trans": [
+      "adj.年龄较大的,年长的 n.(pl.)长者，长辈"
+    ]
+  },
+  {
+    "name": "elect",
+    "usphone": "ɪ'lɛkt",
+    "ukphone": "ɪ'lekt",
+    "trans": [
+      "v.选举，推选；作出选择"
+    ]
+  },
+  {
+    "name": "election",
+    "usphone": "ɪ'lɛkʃən",
+    "ukphone": "ɪ'lekʃ(ə)n",
+    "trans": [
+      "n.选举"
+    ]
+  },
+  {
+    "name": "electric",
+    "usphone": "ɪ'lɛktrɪk",
+    "ukphone": "ɪ'lektrɪk",
+    "trans": [
+      "adj.电动的，电的"
+    ]
+  },
+  {
+    "name": "electricity",
+    "usphone": "ɪ'lɛk'trɪsəti",
+    "ukphone": ",ɪlek'trɪsɪtɪ; ,el-; ,iːl-",
+    "trans": [
+      "n. 电"
+    ]
+  },
+  {
+    "name": "elevator",
+    "usphone": "'ɛlɪvetɚ",
+    "ukphone": "'elɪveɪtə",
+    "trans": [
+      "n.电梯，升降机"
+    ]
+  },
+  {
+    "name": "else",
+    "usphone": "ɛls",
+    "ukphone": "els",
+    "trans": [
+      "adv.其他，另外；此外，别的"
+    ]
+  },
+  {
+    "name": "emergency",
+    "usphone": "ɪ'mɝdʒənsi",
+    "ukphone": "ɪ'mɜːdʒ(ə)nsɪ",
+    "trans": [
+      "n.紧急情况,突然事件"
+    ]
+  },
+  {
+    "name": "emigrate",
+    "usphone": "'ɛmɪɡret",
+    "ukphone": "'emɪgreɪt",
+    "trans": [
+      "v.移居"
+    ]
+  },
+  {
+    "name": "emotion",
+    "usphone": "ɪ'moʃən",
+    "ukphone": "ɪ'məʊʃ(ə)n",
+    "trans": [
+      "n.情绪，情感"
+    ]
+  },
+  {
+    "name": "emphasize",
+    "usphone": "'ɛmfəsaɪz",
+    "ukphone": "'emfəsaɪz",
+    "trans": [
+      "v.强调；着重"
+    ]
+  },
+  {
+    "name": "emphasis",
+    "usphone": "'ɛmfəsɪs",
+    "ukphone": "'emfəsɪs",
+    "trans": [
+      "n.强调，重点"
+    ]
+  },
+  {
+    "name": "employ",
+    "usphone": "ɪm'plɔɪ",
+    "ukphone": "ɪm'plɒɪ; em-",
+    "trans": [
+      "v.雇佣；用，使用"
+    ]
+  },
+  {
+    "name": "employee",
+    "usphone": "ɪm'plɔɪi",
+    "ukphone": "emplɒɪ'iː; em'plɒɪiː; ɪm-",
+    "trans": [
+      "n.雇工，雇员"
+    ]
+  },
+  {
+    "name": "employer",
+    "usphone": "ɪm'plɔɪɚ",
+    "ukphone": "ɪm'plɒɪə; em-",
+    "trans": [
+      "n.雇主，老板"
+    ]
+  },
+  {
+    "name": "employment",
+    "usphone": "ɪm'plɔɪmənt",
+    "ukphone": "ɪm'plɒɪm(ə)nt; em-",
+    "trans": [
+      "n.雇佣"
+    ]
+  },
+  {
+    "name": "empty",
+    "usphone": "ˈɛmptɪ",
+    "ukphone": "'em(p)tɪ",
+    "trans": [
+      "adj.空的"
+    ]
+  },
+  {
+    "name": "enable",
+    "usphone": "ɪ'nebl",
+    "ukphone": "ɪn'eɪb(ə)l; en-",
+    "trans": [
+      "v.使能够，使成为可能，使实现"
+    ]
+  },
+  {
+    "name": "encounter",
+    "usphone": "ɪn'kaʊntɚ",
+    "ukphone": "ɪn'kaʊntə; en-",
+    "trans": [
+      "v.&n.遇到，遭遇"
+    ]
+  },
+  {
+    "name": "encourage",
+    "usphone": "ɪn'kɝrɪdʒ",
+    "ukphone": "ɪn'kʌrɪdʒ; en-",
+    "trans": [
+      "v.鼓励，支持；助长"
+    ]
+  },
+  {
+    "name": "end",
+    "usphone": "ɛnd",
+    "ukphone": "end",
+    "trans": [
+      "n.末尾，尽头，终点；完结，终止"
+    ]
+  },
+  {
+    "name": "energy",
+    "usphone": "'ɛnɚdʒi",
+    "ukphone": "'enədʒɪ",
+    "trans": [
+      "n.精力，力气，活力；能(量)"
+    ]
+  },
+  {
+    "name": "energetic",
+    "usphone": ",ɛnɚ'dʒɛtɪk",
+    "ukphone": ",enə'dʒetɪk",
+    "trans": [
+      "adj.精力充沛的"
+    ]
+  },
+  {
+    "name": "enforce",
+    "usphone": "ɪn'fɔrs",
+    "ukphone": "ɪn'fɔːs; en-",
+    "trans": [
+      "v.实行，执行；强制"
+    ]
+  },
+  {
+    "name": "engage",
+    "usphone": "ɪn'ɡedʒ",
+    "ukphone": "ɪn'geɪdʒ; en-",
+    "trans": [
+      "v.(in)(使) 从事于；订婚"
+    ]
+  },
+  {
+    "name": "engineering",
+    "usphone": "'ɛndʒə'nɪrɪŋ",
+    "ukphone": "endʒɪ'nɪərɪŋ",
+    "trans": [
+      "n.工程学，工程技术"
+    ]
+  },
+  {
+    "name": "engineer",
+    "usphone": ",ɛndʒɪ'nɪr",
+    "ukphone": "endʒɪ'nɪə",
+    "trans": [
+      "n.工程师"
+    ]
+  },
+  {
+    "name": "English",
+    "usphone": "ɪŋɡlɪʃ",
+    "ukphone": "'ɪŋɡlɪʃ",
+    "trans": [
+      "adj.英国的；英国人的 n.英语"
+    ]
+  },
+  {
+    "name": "England",
+    "usphone": "'iŋɡlənd",
+    "ukphone": "ˈɪŋɡlənd",
+    "trans": [
+      "n.英格兰；英国"
+    ]
+  },
+  {
+    "name": "enjoy",
+    "usphone": "ɪn'dʒɔɪ",
+    "ukphone": "ɪn'dʒɒɪ; en-",
+    "trans": [
+      "v.享受"
+    ]
+  },
+  {
+    "name": "enough",
+    "usphone": "ɪ'nʌf",
+    "ukphone": "ɪ'nʌf",
+    "trans": [
+      "adj./adv.足够的/地，充分的/地 n.充足,足够"
+    ]
+  },
+  {
+    "name": "ensure",
+    "usphone": "ɪn'ʃʊr",
+    "ukphone": "ɪn'ʃɔː; -'ʃʊə; en-",
+    "trans": [
+      "v.确保，保证；保护"
+    ]
+  },
+  {
+    "name": "enterprise",
+    "usphone": "'ɛntɚ'praɪz",
+    "ukphone": "'entəpraɪz",
+    "trans": [
+      "n.事业；企(事) 业单位；事业心"
+    ]
+  },
+  {
+    "name": "entertainment",
+    "usphone": "'ɛntɚ'tenmənt",
+    "ukphone": "entə'teɪnm(ə)nt",
+    "trans": [
+      "n.娱乐"
+    ]
+  },
+  {
+    "name": "enthusiasm",
+    "usphone": "ɪn'θuzɪæzəm",
+    "ukphone": "ɪn'θjuːzɪæz(ə)m; en-",
+    "trans": [
+      "n.热情，热心，积极性"
+    ]
+  },
+  {
+    "name": "enthusiastic",
+    "usphone": "ɪn,θuzɪ'æstɪk",
+    "ukphone": "ɪn,θjuːzɪ'æstɪk; en-",
+    "trans": [
+      "adj.热情的"
+    ]
+  },
+  {
+    "name": "entire",
+    "usphone": "ɪn'taɪɚ",
+    "ukphone": "ɪn'taɪə; en-",
+    "trans": [
+      "adj.全部的，整个的"
+    ]
+  },
+  {
+    "name": "environment",
+    "usphone": "ɪn'vaɪrənmənt",
+    "ukphone": "ɪn'vaɪrənm(ə)nt; en-",
+    "trans": [
+      "n.环境,外界"
+    ]
+  },
+  {
+    "name": "envy",
+    "usphone": "'ɛnvi",
+    "ukphone": "'envɪ",
+    "trans": [
+      "v.&n.羡慕，妒忌"
+    ]
+  },
+  {
+    "name": "especially",
+    "usphone": "ɪ'spɛʃəli",
+    "ukphone": "ɪ'speʃ(ə)lɪ; e-",
+    "trans": [
+      "adv.特别，尤其，格外"
+    ]
+  },
+  {
+    "name": "essay",
+    "usphone": "'ɛse",
+    "ukphone": "'eseɪ",
+    "trans": [
+      "n.论文, 短评, 散文, 文章，随笔"
+    ]
+  },
+  {
+    "name": "essential",
+    "usphone": "ɪ'sɛnʃl",
+    "ukphone": "ɪ'senʃ(ə)l",
+    "trans": [
+      "adj.(to) 必要的，本质的；n.要素"
+    ]
+  },
+  {
+    "name": "estate",
+    "usphone": "ɪ'stet",
+    "ukphone": "ɪ'steɪt; e-",
+    "trans": [
+      "n.所有地，房地产，住宅"
+    ]
+  },
+  {
+    "name": "estimate",
+    "usphone": "'ɛstə,met",
+    "ukphone": "'estɪmeɪt",
+    "trans": [
+      "v.估计，估量 n.估计,估价,估计数"
+    ]
+  },
+  {
+    "name": "Europe",
+    "usphone": "'jʊrəp",
+    "ukphone": "'jʊrəp",
+    "trans": [
+      "n.欧洲"
+    ]
+  },
+  {
+    "name": "European",
+    "usphone": "'jʊrə'piən",
+    "ukphone": "jʊərə'piːən",
+    "trans": [
+      "adj.欧洲的 n.欧洲人"
+    ]
+  },
+  {
+    "name": "even",
+    "usphone": "'ivən",
+    "ukphone": "'iːv(ə)n",
+    "trans": [
+      "adv.甚至"
+    ]
+  },
+  {
+    "name": "evening",
+    "usphone": "'ivnɪŋ",
+    "ukphone": "'iːv(ə)nɪŋ",
+    "trans": [
+      "n.傍晚，晚上"
+    ]
+  },
+  {
+    "name": "event",
+    "usphone": "ɪ'vɛnt",
+    "ukphone": "ɪ'vent",
+    "trans": [
+      "n.事件，大事；比赛项目"
+    ]
+  },
+  {
+    "name": "eventually",
+    "usphone": "ɪ'vɛntʃuəli",
+    "ukphone": "ɪ'ventʃʊəlɪ",
+    "trans": [
+      "adv.终于，最后"
+    ]
+  },
+  {
+    "name": "ever",
+    "usphone": "'ɛvɚ",
+    "ukphone": "'evə",
+    "trans": [
+      "adv.曾经，在任何时候"
+    ]
+  },
+  {
+    "name": "every",
+    "usphone": "'ɛvri",
+    "ukphone": "'evrɪ",
+    "trans": [
+      "adj.每一；每个的"
+    ]
+  },
+  {
+    "name": "everybody",
+    "usphone": "'ɛvrɪbɑdi",
+    "ukphone": "'evrɪbɒdɪ",
+    "trans": [
+      "pron.每人"
+    ]
+  },
+  {
+    "name": "everyday",
+    "usphone": "'ɛvrɪde",
+    "ukphone": "'evrɪdeɪ; -'deɪ",
+    "trans": [
+      "adj.每日的，日常的"
+    ]
+  },
+  {
+    "name": "everyone",
+    "usphone": "'ɛvrɪwʌn",
+    "ukphone": "'evrɪwʌn",
+    "trans": [
+      "pron.每人，人人"
+    ]
+  },
+  {
+    "name": "everything",
+    "usphone": "'ɛvrɪ'θɪŋ",
+    "ukphone": "'evrɪθɪŋ",
+    "trans": [
+      "pron.每件事，事事"
+    ]
+  },
+  {
+    "name": "everywhere",
+    "usphone": "'ɛvrɪwɛr",
+    "ukphone": "'evrɪweə",
+    "trans": [
+      "adv.到处；处处"
+    ]
+  },
+  {
+    "name": "evidence",
+    "usphone": "'ɛvɪdəns",
+    "ukphone": "'evɪd(ə)ns",
+    "trans": [
+      "n.证据，根据，物证"
+    ]
+  },
+  {
+    "name": "evident",
+    "usphone": "'ɛvɪdənt",
+    "ukphone": "'evɪd(ə)nt",
+    "trans": [
+      "adj.明显的，明白的"
+    ]
+  },
+  {
+    "name": "exactly",
+    "usphone": "ɪɡ'zæktli",
+    "ukphone": "ɪg'zæk(t)lɪ; eg-",
+    "trans": [
+      "adv.确切地，精确地，恰好地"
+    ]
+  },
+  {
+    "name": "example",
+    "usphone": "ɪg'zæmpl",
+    "ukphone": "ɪg'zɑːmp(ə)l; eg-",
+    "trans": [
+      "n.例子"
+    ]
+  },
+  {
+    "name": "excellent",
+    "usphone": "'ɛksələnt",
+    "ukphone": "'eks(ə)l(ə)nt",
+    "trans": [
+      "adj.优秀的，杰出的"
+    ]
+  },
+  {
+    "name": "except",
+    "usphone": "ɪk'sɛpt",
+    "ukphone": "ɪk'sept; ek-",
+    "trans": [
+      "prep.除...外"
+    ]
+  },
+  {
+    "name": "exchange",
+    "usphone": "ɪks'tʃendʒ",
+    "ukphone": "ɪks'tʃeɪndʒ; eks-",
+    "trans": [
+      "v./n.交换,兑换"
+    ]
+  },
+  {
+    "name": "exciting",
+    "usphone": "ɪk'saɪtɪŋ",
+    "ukphone": "ɪk'saɪtɪŋ; ek-",
+    "trans": [
+      "adj.激动人心的"
+    ]
+  },
+  {
+    "name": "excuse",
+    "usphone": "ɪk'skjʊs",
+    "ukphone": "ɪk'skjuːz; ek-",
+    "trans": [
+      "v.原谅；宽恕 n.借口，理由"
+    ]
+  },
+  {
+    "name": "exercise",
+    "usphone": "'ɛksɚsaɪz",
+    "ukphone": "'eksəsaɪz",
+    "trans": [
+      "n.锻炼，运动；做操；练习，习题"
+    ]
+  },
+  {
+    "name": "exhaust",
+    "usphone": "ɪɡ'zɔst",
+    "ukphone": "ɪg'zɔːst; eg-",
+    "trans": [
+      "v.使筋疲力尽，耗尽；抽完，吸干"
+    ]
+  },
+  {
+    "name": "exhibition",
+    "usphone": ",ɛksɪ'bɪʃən",
+    "ukphone": "eksɪ'bɪʃ(ə)n",
+    "trans": [
+      "n.展览(会)"
+    ]
+  },
+  {
+    "name": "exhibit",
+    "usphone": "ɪɡ'zɪbɪt",
+    "ukphone": "ɪg'zɪbɪt; eg-",
+    "trans": [
+      "v.展出，陈列"
+    ]
+  },
+  {
+    "name": "exist",
+    "usphone": "ɪɡ'zɪst",
+    "ukphone": "ɪg'zɪst; eg-",
+    "trans": [
+      "v.在，存在"
+    ]
+  },
+  {
+    "name": "expand",
+    "usphone": "ɪk'spænd",
+    "ukphone": "ɪk'spænd; ek-",
+    "trans": [
+      "v.(使) 膨胀，(使)扩张；张开，展开"
+    ]
+  },
+  {
+    "name": "expansion",
+    "usphone": "ɪk'spænʃən",
+    "ukphone": "ɪk'spænʃ(ə)n; ek-",
+    "trans": [
+      "n.扩大，膨胀；张开"
+    ]
+  },
+  {
+    "name": "expect",
+    "usphone": "ɪk'spɛkt",
+    "ukphone": "ɪk'spekt; ek-",
+    "trans": [
+      "v.期待；预期"
+    ]
+  },
+  {
+    "name": "expectation",
+    "usphone": ",ɛkspɛk'teʃən",
+    "ukphone": "ekspek'teɪʃ(ə)n",
+    "trans": [
+      "n.预期，期望，指望"
+    ]
+  },
+  {
+    "name": "expensive",
+    "usphone": "ɪk'spɛnsɪv",
+    "ukphone": "ɪk'spensɪv; ek-",
+    "trans": [
+      "adj.贵的，昂贵的"
+    ]
+  },
+  {
+    "name": "expense",
+    "usphone": "ɪk'spɛns",
+    "ukphone": "ɪk'spens; ek-",
+    "trans": [
+      "n.花费，消耗，消费"
+    ]
+  },
+  {
+    "name": "experience",
+    "usphone": "ɪk'spɪrɪəns",
+    "ukphone": "ɪk'spɪərɪəns; ek-",
+    "trans": [
+      "n.经历，体验；经验"
+    ]
+  },
+  {
+    "name": "expert",
+    "usphone": "'ɛkspɝt; (for adj., also) ɛksˈpɝt ; ɪkˈspɝt",
+    "ukphone": "'ekspɜːt",
+    "trans": [
+      "n.专家,能手 adj.熟练的,有经验的;内行的"
+    ]
+  },
+  {
+    "name": "explain",
+    "usphone": "ɪk'splen",
+    "ukphone": "ɪk'spleɪn",
+    "trans": [
+      "v.解释，说明"
+    ]
+  },
+  {
+    "name": "export",
+    "usphone": "ˈekspɔːrt；ɪkˈ-",
+    "ukphone": "ˈekspɔːt；ɪkˈ-",
+    "trans": [
+      "n.输出,出口；出口商品 v.输出，出口"
+    ]
+  },
+  {
+    "name": "expose",
+    "usphone": "ɪk'spoz；ek-",
+    "ukphone": "ɪk'spəʊz; ek-",
+    "trans": [
+      "v.(to) 使暴露；使曝光，揭露"
+    ]
+  },
+  {
+    "name": "express",
+    "usphone": "ɪk'sprɛs",
+    "ukphone": "ɪk'spres; ek-",
+    "trans": [
+      "v.表达"
+    ]
+  },
+  {
+    "name": "expression",
+    "usphone": "ɪk'sprɛʃən",
+    "ukphone": "ɪkˈspreʃn",
+    "trans": [
+      "n.表达,表示,表现；表情"
+    ]
+  },
+  {
+    "name": "extra",
+    "usphone": "'ɛkstrə",
+    "ukphone": "'ekstrə",
+    "trans": [
+      "adj.额外的，特别的，另加的"
+    ]
+  },
+  {
+    "name": "extraordinary",
+    "usphone": "ɛkˈstrɔrdənˌɛri; ɪkˈstrɔrdəˌnɛri; ˌɛkstrəˈɔrdəˌnɛri",
+    "ukphone": "ɪkˈstrɔːd(ə)n(ə)ri; ekˈstrɔːd(ə)n(ə)ri; ˌekstrəˈɔːdɪn(ə)ri",
+    "trans": [
+      "adj.格外的，特别的"
+    ]
+  },
+  {
+    "name": "extremely",
+    "usphone": "ɪk'strimli",
+    "ukphone": "ɪk'striːmlɪ; ek-",
+    "trans": [
+      "adv.极端地，非常"
+    ]
+  },
+  {
+    "name": "extreme",
+    "usphone": "ɪk'strim",
+    "ukphone": "ɪk'striːm; ek-",
+    "trans": [
+      "adj.极度的,极端的 n.极端"
+    ]
+  },
+  {
+    "name": "face",
+    "usphone": "fes",
+    "ukphone": "feɪs",
+    "trans": [
+      "n.脸"
+    ]
+  },
+  {
+    "name": "facility",
+    "usphone": "fə'sɪləti",
+    "ukphone": "fə'sɪləti",
+    "trans": [
+      "n.灵巧，熟练；(pl.)设备，设施；便利"
+    ]
+  },
+  {
+    "name": "fact",
+    "usphone": "fækt",
+    "ukphone": "fækt",
+    "trans": [
+      "n.事实"
+    ]
+  },
+  {
+    "name": "factor",
+    "usphone": "'fæktɚ",
+    "ukphone": "'fæktə",
+    "trans": [
+      "n.因素，要素"
+    ]
+  },
+  {
+    "name": "factory",
+    "usphone": "'fæktri",
+    "ukphone": "'fækt(ə)rɪ",
+    "trans": [
+      "n.工厂"
+    ]
+  },
+  {
+    "name": "fail",
+    "usphone": "fel",
+    "ukphone": "feɪl",
+    "trans": [
+      "v.失败，不及格，未能通过考试"
+    ]
+  },
+  {
+    "name": "failure",
+    "usphone": "'feljɚ",
+    "ukphone": "'feɪljə",
+    "trans": [
+      "n.失败，不及格"
+    ]
+  },
+  {
+    "name": "faint",
+    "usphone": "fent",
+    "ukphone": "feɪnt",
+    "trans": [
+      "adj.微弱的，无力的，模糊的 v.昏倒，昏厥"
+    ]
+  },
+  {
+    "name": "fair",
+    "usphone": "fɛr",
+    "ukphone": "feə",
+    "trans": [
+      "n.集市；游乐场；博览会，展销会 adj.公平的"
+    ]
+  },
+  {
+    "name": "fairly",
+    "usphone": "'fɛrli",
+    "ukphone": "'feəlɪ",
+    "trans": [
+      "adv.相当；公正地"
+    ]
+  },
+  {
+    "name": "faith",
+    "usphone": "feθ",
+    "ukphone": "feɪθ",
+    "trans": [
+      "n.信任，信心；信仰"
+    ]
+  },
+  {
+    "name": "faithful",
+    "usphone": "'feθfəl",
+    "ukphone": "'feɪθfʊl; -f(ə)l",
+    "trans": [
+      "adj.守信的，忠实的，可靠的"
+    ]
+  },
+  {
+    "name": "fall",
+    "usphone": "fɔl",
+    "ukphone": "fɔːl",
+    "trans": [
+      "v.下跌；下降，减弱 n.落下，下降"
+    ]
+  },
+  {
+    "name": "fame",
+    "usphone": "fem",
+    "ukphone": "feɪm",
+    "trans": [
+      "n.声誉，名声，名气"
+    ]
+  },
+  {
+    "name": "family",
+    "usphone": "'fæməli",
+    "ukphone": "'fæmɪlɪ; -m(ə)l-",
+    "trans": [
+      "n.家人，家庭"
+    ]
+  },
+  {
+    "name": "familiar",
+    "usphone": "fə'mɪljɚ",
+    "ukphone": "fə'mɪlɪə",
+    "trans": [
+      "adj.熟悉的"
+    ]
+  },
+  {
+    "name": "famous",
+    "usphone": "'feməs",
+    "ukphone": "'feɪməs",
+    "trans": [
+      "adj.著名的"
+    ]
+  },
+  {
+    "name": "fancy",
+    "usphone": "'fænsi",
+    "ukphone": "'fænsɪ",
+    "trans": [
+      "n.幻想；喜爱，迷恋"
+    ]
+  },
+  {
+    "name": "far",
+    "usphone": "fɑr",
+    "ukphone": "fɑː",
+    "trans": [
+      "adj.远的"
+    ]
+  },
+  {
+    "name": "farm",
+    "usphone": "fɑrm",
+    "ukphone": "fɑːm",
+    "trans": [
+      "n.农场，农庄"
+    ]
+  },
+  {
+    "name": "farmer",
+    "usphone": "'fɑmɚ",
+    "ukphone": "'fɑːmə",
+    "trans": [
+      "n.农民"
+    ]
+  },
+  {
+    "name": "fascinate",
+    "usphone": "'fæsə'net",
+    "ukphone": "'fæsɪneɪt",
+    "trans": [
+      "v.迷住，强烈吸引，使入迷"
+    ]
+  },
+  {
+    "name": "fashion",
+    "usphone": "'fæʃən",
+    "ukphone": "'fæʃ(ə)n",
+    "trans": [
+      "n.时装，流行，风尚，时髦"
+    ]
+  },
+  {
+    "name": "fashionable",
+    "usphone": "'fæʃnəbl",
+    "ukphone": "'fæʃ(ə)nəb(ə)l",
+    "trans": [
+      "n.流行的，时髦的"
+    ]
+  },
+  {
+    "name": "fast",
+    "usphone": "fæst",
+    "ukphone": "fɑːst",
+    "trans": [
+      "adv.快"
+    ]
+  },
+  {
+    "name": "fatal",
+    "usphone": "'fetl",
+    "ukphone": "'feɪt(ə)l",
+    "trans": [
+      "adj.致命的，毁灭性的；命运的"
+    ]
+  },
+  {
+    "name": "fate",
+    "usphone": "fet",
+    "ukphone": "feɪt",
+    "trans": [
+      "n.命运；灾难"
+    ]
+  },
+  {
+    "name": "fault",
+    "usphone": "fɔlt",
+    "ukphone": "fɔːlt; fɒlt",
+    "trans": [
+      "n.过失，过错；缺点，毛病；故障"
+    ]
+  },
+  {
+    "name": "faulty",
+    "usphone": "'fɔlti",
+    "ukphone": "'fɔːltɪ; 'fɒltɪ",
+    "trans": [
+      "adj.有缺点的，有错误的；不完善的"
+    ]
+  },
+  {
+    "name": "fax",
+    "usphone": "fæks",
+    "ukphone": "fæks",
+    "trans": [
+      "n.传真(机)；传真件 v.传真"
+    ]
+  },
+  {
+    "name": "fear",
+    "usphone": "fɪr",
+    "ukphone": "fɪə",
+    "trans": [
+      "v.＆n.害怕，恐惧"
+    ]
+  },
+  {
+    "name": "feature",
+    "usphone": "'fitʃɚ",
+    "ukphone": "'fiːtʃə",
+    "trans": [
+      "n.特征，特色；面貌，相貌 v.以...为特色；(电影)由...主演"
+    ]
+  },
+  {
+    "name": "federal",
+    "usphone": "'fɛdərəl",
+    "ukphone": "'fed(ə)r(ə)l",
+    "trans": [
+      "adj.联邦的,联盟的 v.组成联邦"
+    ]
+  },
+  {
+    "name": "feedback",
+    "usphone": "'fidbæk",
+    "ukphone": "'fiːdbæk",
+    "trans": [
+      "n.反馈"
+    ]
+  },
+  {
+    "name": "feel",
+    "usphone": "fiːl",
+    "ukphone": "fiːl",
+    "trans": [
+      "v.感觉"
+    ]
+  },
+  {
+    "name": "feeling",
+    "usphone": "'filɪŋ",
+    "ukphone": "'fiːlɪŋ",
+    "trans": [
+      "n.感觉，知觉；感情"
+    ]
+  },
+  {
+    "name": "fellow",
+    "usphone": "'fɛlo",
+    "ukphone": "'feləʊ",
+    "trans": [
+      "n.人；家伙，小伙子 adj.同伴的，同类的"
+    ]
+  },
+  {
+    "name": "female",
+    "usphone": "'fimel",
+    "ukphone": "'fiːmeɪl",
+    "trans": [
+      "adj.女性的，雌性的 n.女性，雌性"
+    ]
+  },
+  {
+    "name": "festival",
+    "usphone": "ˈfɛstəvəl",
+    "ukphone": "'festɪv(ə)l",
+    "trans": [
+      "n.节日"
+    ]
+  },
+  {
+    "name": "fiction",
+    "usphone": "'fɪkʃən",
+    "ukphone": "'fɪkʃ(ə)n",
+    "trans": [
+      "n.小说"
+    ]
+  },
+  {
+    "name": "field",
+    "usphone": "fild",
+    "ukphone": "fiːld",
+    "trans": [
+      "n.田地，场地；(矿产)产地"
+    ]
+  },
+  {
+    "name": "fight",
+    "usphone": "faɪt",
+    "ukphone": "faɪt",
+    "trans": [
+      "v./n.打仗，斗争，作战，战斗"
+    ]
+  },
+  {
+    "name": "figure",
+    "usphone": "'fɪɡjɚ",
+    "ukphone": "'fɪgə",
+    "trans": [
+      "n.体形，外形；轮廓；人物；数字"
+    ]
+  },
+  {
+    "name": "fill",
+    "usphone": "fɪl",
+    "ukphone": "fɪl",
+    "trans": [
+      "v.填"
+    ]
+  },
+  {
+    "name": "film",
+    "usphone": "fɪlm",
+    "ukphone": "fɪlm",
+    "trans": [
+      "n.电影；胶卷"
+    ]
+  },
+  {
+    "name": "finally",
+    "usphone": "'faɪnəli",
+    "ukphone": "'faɪnəlɪ",
+    "trans": [
+      "adv.最后"
+    ]
+  },
+  {
+    "name": "finance",
+    "usphone": "'faɪnæns",
+    "ukphone": "faɪ'næns; fɪ-; 'faɪnæns",
+    "trans": [
+      "n.财政，金融；(pl.)资金 v.提供资金"
+    ]
+  },
+  {
+    "name": "financial",
+    "usphone": "faɪ'nænʃl",
+    "ukphone": "faɪ'nænʃ(ə)l; fɪ-",
+    "trans": [
+      "adj.财政的，金融的"
+    ]
+  },
+  {
+    "name": "find",
+    "usphone": "faɪnd",
+    "ukphone": "faɪnd",
+    "trans": [
+      "v.发现,找到,认为,裁决,判定 n.发现"
+    ]
+  },
+  {
+    "name": "fine",
+    "usphone": "faɪn",
+    "ukphone": "faɪn",
+    "trans": [
+      "adj.好的，(天气)晴朗的"
+    ]
+  },
+  {
+    "name": "finish",
+    "usphone": "'fɪnɪʃ",
+    "ukphone": "'fɪnɪʃ",
+    "trans": [
+      "v.结束"
+    ]
+  },
+  {
+    "name": "fire",
+    "usphone": "faɪr",
+    "ukphone": "'faɪə",
+    "trans": [
+      "n.火；火灾"
+    ]
+  },
+  {
+    "name": "firm",
+    "usphone": "fɝm",
+    "ukphone": "fɜːm",
+    "trans": [
+      "n.商行，公司 adj.结实的，坚固的；坚定的"
+    ]
+  },
+  {
+    "name": "first",
+    "usphone": "fɝst",
+    "ukphone": "fɜːst",
+    "trans": [
+      "adj./adv.第一；最初;首次 n.开始 pron.第一名"
+    ]
+  },
+  {
+    "name": "fish",
+    "usphone": "fɪʃ",
+    "ukphone": "fɪʃ",
+    "trans": [
+      "n.鱼"
+    ]
+  },
+  {
+    "name": "fist",
+    "usphone": "fɪst",
+    "ukphone": "fɪst",
+    "trans": [
+      "n.拳头"
+    ]
+  },
+  {
+    "name": "fit",
+    "usphone": "fɪt",
+    "ukphone": "fɪt",
+    "trans": [
+      "adj.合适的；恰当的；合身的 v.合适"
+    ]
+  },
+  {
+    "name": "fix",
+    "usphone": "fɪks",
+    "ukphone": "fɪks",
+    "trans": [
+      "v.固定；修理"
+    ]
+  },
+  {
+    "name": "flavour",
+    "usphone": "'fleivə",
+    "ukphone": "'fleɪvə",
+    "trans": [
+      "n.味道；风味，特色 vt.给...调味"
+    ]
+  },
+  {
+    "name": "flee",
+    "usphone": "fli",
+    "ukphone": "fliː",
+    "trans": [
+      "v.逃走；逃避；消失"
+    ]
+  },
+  {
+    "name": "flexible",
+    "usphone": "'flɛksəbl",
+    "ukphone": "'fleksɪb(ə)l",
+    "trans": [
+      "adj.柔韧的，易弯曲的，灵活的"
+    ]
+  },
+  {
+    "name": "flight",
+    "usphone": "flaɪt",
+    "ukphone": "flaɪt",
+    "trans": [
+      "n.航班"
+    ]
+  },
+  {
+    "name": "flood",
+    "usphone": "flʌd",
+    "ukphone": "flʌd",
+    "trans": [
+      "n.洪水"
+    ]
+  },
+  {
+    "name": "floor",
+    "usphone": "flɔr",
+    "ukphone": "flɔː",
+    "trans": [
+      "n.楼层，地板"
+    ]
+  },
+  {
+    "name": "flourish",
+    "usphone": "ˈflɜːrɪʃ",
+    "ukphone": "'flʌrɪʃ",
+    "trans": [
+      "v.繁荣，兴旺"
+    ]
+  },
+  {
+    "name": "flower",
+    "usphone": "'flaʊɚ",
+    "ukphone": "'flaʊə",
+    "trans": [
+      "n.花"
+    ]
+  },
+  {
+    "name": "fly",
+    "usphone": "flaɪ",
+    "ukphone": "flaɪ",
+    "trans": [
+      "v.飞；飞行；乘飞机旅行"
+    ]
+  },
+  {
+    "name": "focus",
+    "usphone": "'fokəs",
+    "ukphone": "'fəʊkəs",
+    "trans": [
+      "n.焦点，中心 v.(on)使聚集，集中；对焦"
+    ]
+  },
+  {
+    "name": "follow",
+    "usphone": "'fɑlo",
+    "ukphone": "'fɒləʊ",
+    "trans": [
+      "v.跟随，追随"
+    ]
+  },
+  {
+    "name": "food",
+    "usphone": "fud",
+    "ukphone": "fuːd",
+    "trans": [
+      "n.食物"
+    ]
+  },
+  {
+    "name": "foot",
+    "usphone": "fʊt",
+    "ukphone": "fʊt",
+    "trans": [
+      "n.足，脚；英尺"
+    ]
+  },
+  {
+    "name": "football",
+    "usphone": "'fʊtbɔl",
+    "ukphone": "'fʊtbɔːl",
+    "trans": [
+      "n.足球"
+    ]
+  },
+  {
+    "name": "forbid",
+    "usphone": "fɚ'bɪd",
+    "ukphone": "fə'bɪd",
+    "trans": [
+      "v.禁止，不让，阻止"
+    ]
+  },
+  {
+    "name": "force",
+    "usphone": "fɔrs",
+    "ukphone": "fɔːs",
+    "trans": [
+      "n.力，力量；武力；军队 v.强迫；推动"
+    ]
+  },
+  {
+    "name": "forecast",
+    "usphone": "'fɔrkæst",
+    "ukphone": "'fɔːkɑːst",
+    "trans": [
+      "v.＆n.预言，预报"
+    ]
+  },
+  {
+    "name": "foreign",
+    "usphone": "'fɔrən",
+    "ukphone": "'fɒrɪn",
+    "trans": [
+      "adj.外国的"
+    ]
+  },
+  {
+    "name": "foreigner",
+    "usphone": "'fɔrənɚ",
+    "ukphone": "'fɒrɪnə",
+    "trans": [
+      "n.外国人"
+    ]
+  },
+  {
+    "name": "forest",
+    "usphone": "'fɔrɪst",
+    "ukphone": "'fɒrɪst",
+    "trans": [
+      "n.森林"
+    ]
+  },
+  {
+    "name": "forever",
+    "usphone": "fɚ'ɛvɚ",
+    "ukphone": "fə'revə",
+    "trans": [
+      "adv.永远"
+    ]
+  },
+  {
+    "name": "forget",
+    "usphone": "fɚ'ɡɛt",
+    "ukphone": "fə'get",
+    "trans": [
+      "v.忘记"
+    ]
+  },
+  {
+    "name": "forgive",
+    "usphone": "fɚ'ɡɪv",
+    "ukphone": "fə'gɪv",
+    "trans": [
+      "v.原谅，宽恕"
+    ]
+  },
+  {
+    "name": "form",
+    "usphone": "fɔrm",
+    "ukphone": "fɔːm",
+    "trans": [
+      "n.表格，形式"
+    ]
+  },
+  {
+    "name": "formal",
+    "usphone": "'fɔrml",
+    "ukphone": "'fɔːm(ə)l",
+    "trans": [
+      "adj.正式的；形式的"
+    ]
+  },
+  {
+    "name": "former",
+    "usphone": "'fɔrmɚ",
+    "ukphone": "'fɔːmə",
+    "trans": [
+      "pron.前者 adj.以前的 n.形成者，创造者"
+    ]
+  },
+  {
+    "name": "forward",
+    "usphone": "'fɔrwɚd",
+    "ukphone": "'fɔːwəd",
+    "trans": [
+      "adv.向前"
+    ]
+  },
+  {
+    "name": "found",
+    "usphone": "faʊnd",
+    "ukphone": "faʊnd",
+    "trans": [
+      "v.建立，创立，成立"
+    ]
+  },
+  {
+    "name": "foundation",
+    "usphone": "faʊn'deʃən",
+    "ukphone": "faʊn'deɪʃ(ə)n",
+    "trans": [
+      "n.基础,建/创立,地基"
+    ]
+  },
+  {
+    "name": "France",
+    "usphone": "frɑ:ns",
+    "ukphone": "frɑ:ns",
+    "trans": [
+      "n.法国"
+    ]
+  },
+  {
+    "name": "French",
+    "ukphone": "fren(t)ʃ",
+    "trans": [
+      "adj.法国的；法国人的 n.法语"
+    ]
+  },
+  {
+    "name": "free",
+    "usphone": "fri",
+    "ukphone": "friː",
+    "trans": [
+      "adj.自由的，空闲的"
+    ]
+  },
+  {
+    "name": "freedom",
+    "usphone": "'fridəm",
+    "ukphone": "'friːdəm",
+    "trans": [
+      "n.自由"
+    ]
+  },
+  {
+    "name": "freeze",
+    "usphone": "friz",
+    "ukphone": "friːz",
+    "trans": [
+      "v.(使)冻结；(使)结冰"
+    ]
+  },
+  {
+    "name": "fresh",
+    "usphone": "frɛʃ",
+    "ukphone": "freʃ",
+    "trans": [
+      "adj.清新的；新鲜的"
+    ]
+  },
+  {
+    "name": "Friday",
+    "ukphone": "'fraɪdeɪ; (occas.,) ˈfraɪdi",
+    "trans": [
+      "n.星期五"
+    ]
+  },
+  {
+    "name": "friend",
+    "usphone": "frɛnd",
+    "ukphone": "frend",
+    "trans": [
+      "n.朋友"
+    ]
+  },
+  {
+    "name": "friendly",
+    "usphone": "'frɛndli",
+    "ukphone": "'fren(d)lɪ",
+    "trans": [
+      "adj.友好的"
+    ]
+  },
+  {
+    "name": "friendship",
+    "usphone": "'frɛndʃɪp",
+    "ukphone": "'fren(d)ʃɪp",
+    "trans": [
+      "n.友谊，友情"
+    ]
+  },
+  {
+    "name": "front",
+    "usphone": "frʌnt",
+    "ukphone": "frʌnt",
+    "trans": [
+      "n.前面"
+    ]
+  },
+  {
+    "name": "fuel",
+    "usphone": "'fjuəl",
+    "ukphone": "fjʊəl",
+    "trans": [
+      "n.燃料"
+    ]
+  },
+  {
+    "name": "full",
+    "usphone": "fʊl",
+    "ukphone": "fʊl",
+    "trans": [
+      "adj.满的"
+    ]
+  },
+  {
+    "name": "fun",
+    "usphone": "fʌn",
+    "ukphone": "fʌn",
+    "trans": [
+      "n.乐事，趣事"
+    ]
+  },
+  {
+    "name": "funny",
+    "usphone": "'fʌni",
+    "ukphone": "'fʌnɪ",
+    "trans": [
+      "adj.滑稽的，有趣的，可笑的"
+    ]
+  },
+  {
+    "name": "function",
+    "usphone": "'fʌŋkʃən",
+    "ukphone": "'fʌŋ(k)ʃ(ə)n",
+    "trans": [
+      "n.功能,职责；仪式 v.起作用,运行"
+    ]
+  },
+  {
+    "name": "fund",
+    "usphone": "fʌnd",
+    "ukphone": "fʌnd",
+    "trans": [
+      "n.资金，基金，专款"
+    ]
+  },
+  {
+    "name": "future",
+    "usphone": "'fjʊtʃɚ",
+    "ukphone": "'fjuːtʃə",
+    "trans": [
+      "n. 未来；前途；期货；将来时 adj. 将来的，未来的"
+    ]
+  },
+  {
+    "name": "gain",
+    "usphone": "ɡen",
+    "ukphone": "geɪn",
+    "trans": [
+      "v.获得，赢得；增加 n.收获，获利；增加"
+    ]
+  },
+  {
+    "name": "gap",
+    "usphone": "ɡæp",
+    "ukphone": "gæp",
+    "trans": [
+      "n.间隙，缺口；空白点"
+    ]
+  },
+  {
+    "name": "garden",
+    "usphone": "'ɡɑrdn",
+    "ukphone": "'gɑːd(ə)n",
+    "trans": [
+      "n.花园"
+    ]
+  },
+  {
+    "name": "gas",
+    "usphone": "ɡæs",
+    "ukphone": "gæs",
+    "trans": [
+      "n.气体，煤气"
+    ]
+  },
+  {
+    "name": "gather",
+    "usphone": "'ɡæðɚ",
+    "ukphone": "'gæðə",
+    "trans": [
+      "v.集合，收集；积累；收割"
+    ]
+  },
+  {
+    "name": "general",
+    "usphone": "'dʒɛnrəl",
+    "ukphone": "'dʒen(ə)r(ə)l",
+    "trans": [
+      "adj.一般的，首要的"
+    ]
+  },
+  {
+    "name": "generous",
+    "usphone": "'dʒɛnərəs",
+    "ukphone": "'dʒen(ə)rəs",
+    "trans": [
+      "adj.慷慨的，大度的；丰富的"
+    ]
+  },
+  {
+    "name": "genuine",
+    "usphone": "'dʒɛnjʊɪn",
+    "ukphone": "'dʒenjʊɪn",
+    "trans": [
+      "adj.真正的，名副其实的"
+    ]
+  },
+  {
+    "name": "German",
+    "ukphone": "'dʒɜːmən",
+    "trans": [
+      "adj.德国(人)的;德语的 n.德国人;德语"
+    ]
+  },
+  {
+    "name": "Germany",
+    "usphone": "'dʒə:məni",
+    "ukphone": "'dʒɜːrməni",
+    "trans": [
+      "n.德国"
+    ]
+  },
+  {
+    "name": "gesture",
+    "usphone": "'dʒɛstʃɚ",
+    "ukphone": "'dʒestʃə",
+    "trans": [
+      "n.姿势，姿态，手势 v.做手势"
+    ]
+  },
+  {
+    "name": "giant",
+    "usphone": "'dʒaɪənt",
+    "ukphone": "'dʒaɪənt",
+    "trans": [
+      "n.巨人，庞然大物 adj.巨大的"
+    ]
+  },
+  {
+    "name": "gift",
+    "usphone": "ɡɪft",
+    "ukphone": "gɪft",
+    "trans": [
+      "n.礼物"
+    ]
+  },
+  {
+    "name": "give",
+    "usphone": "ɡɪv",
+    "ukphone": "gɪv",
+    "trans": [
+      "v.给"
+    ]
+  },
+  {
+    "name": "glare",
+    "usphone": "ɡlɛr",
+    "ukphone": "gleə",
+    "trans": [
+      "n.怒视；炫目的光 v.闪耀；怒视"
+    ]
+  },
+  {
+    "name": "global",
+    "usphone": "'ɡlobl",
+    "ukphone": "'gləʊb(ə)l",
+    "trans": [
+      "adj.全球的"
+    ]
+  },
+  {
+    "name": "glow",
+    "usphone": "ɡlo",
+    "ukphone": "gləʊ",
+    "trans": [
+      "v.发热，发光，发红"
+    ]
+  },
+  {
+    "name": "goal",
+    "usphone": "ɡol",
+    "ukphone": "gəʊl",
+    "trans": [
+      "n.终点；目标"
+    ]
+  },
+  {
+    "name": "gold",
+    "usphone": "ɡold",
+    "ukphone": "gəʊld",
+    "trans": [
+      "n.金子"
+    ]
+  },
+  {
+    "name": "golden",
+    "usphone": "'ɡoldən",
+    "ukphone": "'gəʊld(ə)n",
+    "trans": [
+      "adj.金的，金色的，如黄金的"
+    ]
+  },
+  {
+    "name": "government",
+    "usphone": "'ɡʌvɚnmənt",
+    "ukphone": "'gʌv(ə)n,m(ə)nt; 'gʌvəm(ə)nt",
+    "trans": [
+      "n.政府"
+    ]
+  },
+  {
+    "name": "govern",
+    "usphone": "'ɡʌvɚn",
+    "ukphone": "'gʌv(ə)n",
+    "trans": [
+      "v.统治，管理"
+    ]
+  },
+  {
+    "name": "grade",
+    "usphone": "ɡred",
+    "ukphone": "greɪd",
+    "trans": [
+      "n.等级；分数"
+    ]
+  },
+  {
+    "name": "gradually",
+    "usphone": "'grædʒʊəli",
+    "ukphone": "'grædʒʊlɪ; 'grædjʊəlɪ",
+    "trans": [
+      "adv.逐渐地，逐步地"
+    ]
+  },
+  {
+    "name": "gradual",
+    "usphone": "'ɡrædʒuəl",
+    "ukphone": "'grædʒʊəl",
+    "trans": [
+      "adj.逐渐的，逐步的"
+    ]
+  },
+  {
+    "name": "graduate",
+    "usphone": "ˈɡrædʒuˌet",
+    "ukphone": "ˈɡradʒʊeɪt",
+    "trans": [
+      "v.毕业"
+    ]
+  },
+  {
+    "name": "grant",
+    "usphone": "ɡrænt",
+    "ukphone": "grɑːnt",
+    "trans": [
+      "v./n. 同意，准予；给予，授予"
+    ]
+  },
+  {
+    "name": "grasp",
+    "usphone": "ɡræsp",
+    "ukphone": "grɑːsp",
+    "trans": [
+      "v.抓住，抓紧；掌握，领会"
+    ]
+  },
+  {
+    "name": "great",
+    "usphone": "ɡret",
+    "ukphone": "greɪt",
+    "trans": [
+      "adj.伟大的;重要的;大量的；美好的"
+    ]
+  },
+  {
+    "name": "grateful",
+    "usphone": "'ɡretfl",
+    "ukphone": "'greɪtfʊl; -f(ə)l",
+    "trans": [
+      "adj.感激的，感谢的"
+    ]
+  },
+  {
+    "name": "green",
+    "usphone": "ɡrin",
+    "ukphone": "griːn",
+    "trans": [
+      "n./adj.绿色的"
+    ]
+  },
+  {
+    "name": "greenhouse",
+    "usphone": "'ɡrinhaʊs",
+    "ukphone": "'griːnhaʊs",
+    "trans": [
+      "n.温室"
+    ]
+  },
+  {
+    "name": "grind",
+    "usphone": "ɡraɪnd",
+    "ukphone": "graɪnd",
+    "trans": [
+      "v.磨(碎)，碾(碎)；压迫，折磨"
+    ]
+  },
+  {
+    "name": "grocery",
+    "usphone": "'ɡrosəri",
+    "ukphone": "'grəʊs(ə)rɪ",
+    "trans": [
+      "n.杂货店"
+    ]
+  },
+  {
+    "name": "ground",
+    "usphone": "ɡraʊnd",
+    "ukphone": "graʊnd",
+    "trans": [
+      "n.地面；地上"
+    ]
+  },
+  {
+    "name": "group",
+    "usphone": "ɡrup",
+    "ukphone": "gruːp",
+    "trans": [
+      "n.组，群"
+    ]
+  },
+  {
+    "name": "grow",
+    "usphone": "ɡro",
+    "ukphone": "grəʊ",
+    "trans": [
+      "v.生长，发育；种植"
+    ]
+  },
+  {
+    "name": "growth",
+    "usphone": "ɡroθ",
+    "ukphone": "grəʊθ",
+    "trans": [
+      "n.生长，增长，发展"
+    ]
+  },
+  {
+    "name": "guarantee",
+    "usphone": ",ɡærən'ti",
+    "ukphone": "ˌgærən'tiː",
+    "trans": [
+      "n.保证,保证书,保修单 v.保证,担保"
+    ]
+  },
+  {
+    "name": "guess",
+    "usphone": "ɡɛs",
+    "ukphone": "ges",
+    "trans": [
+      "v.推测，猜测"
+    ]
+  },
+  {
+    "name": "guest",
+    "usphone": "ɡɛst",
+    "ukphone": "gest",
+    "trans": [
+      "n.客人"
+    ]
+  },
+  {
+    "name": "guide",
+    "usphone": "ɡaɪd",
+    "ukphone": "gaɪd",
+    "trans": [
+      "n.导游,向导 v.引导,指导"
+    ]
+  },
+  {
+    "name": "guidance",
+    "usphone": "'gaɪdns",
+    "ukphone": "'gaɪd(ə)ns",
+    "trans": [
+      "n.引导，指导"
+    ]
+  },
+  {
+    "name": "guilty",
+    "usphone": "'ɡɪlti",
+    "ukphone": "'gɪltɪ",
+    "trans": [
+      "adj.有罪的，犯罪的；内疚的"
+    ]
+  },
+  {
+    "name": "habit",
+    "usphone": "'hæbɪt",
+    "ukphone": "'hæbɪt",
+    "trans": [
+      "n.习惯"
+    ]
+  },
+  {
+    "name": "hair",
+    "usphone": "hɛr",
+    "ukphone": "heə",
+    "trans": [
+      "n.毛发"
+    ]
+  },
+  {
+    "name": "haircut",
+    "usphone": "'hɛrkʌt",
+    "ukphone": "'heəkʌt",
+    "trans": [
+      "n.理发"
+    ]
+  },
+  {
+    "name": "half",
+    "usphone": "hæf",
+    "ukphone": "hɑːf",
+    "trans": [
+      "n.一半"
+    ]
+  },
+  {
+    "name": "hand",
+    "usphone": "hænd",
+    "ukphone": "hænd",
+    "trans": [
+      "n.手"
+    ]
+  },
+  {
+    "name": "handbook",
+    "usphone": "'hændbʊk",
+    "ukphone": "'hæn(d)bʊk",
+    "trans": [
+      "n.手册，指南"
+    ]
+  },
+  {
+    "name": "handwriting",
+    "usphone": "'hænd'raɪtɪŋ",
+    "ukphone": "'hændraɪtɪŋ",
+    "trans": [
+      "n.笔迹，书法；手稿"
+    ]
+  },
+  {
+    "name": "handle",
+    "usphone": "'hændl",
+    "ukphone": "'hænd(ə)l",
+    "trans": [
+      "v.处理，掌握"
+    ]
+  },
+  {
+    "name": "happen",
+    "usphone": "'hæpən",
+    "ukphone": "'hæp(ə)n",
+    "trans": [
+      "v.发生"
+    ]
+  },
+  {
+    "name": "happiness",
+    "usphone": "ˈhæpinəs",
+    "ukphone": "ˈhæpinəs",
+    "trans": [
+      "n.幸福，愉快"
+    ]
+  },
+  {
+    "name": "hard",
+    "usphone": "hɑrd",
+    "ukphone": "hɑːd",
+    "trans": [
+      "adj.艰苦的，困难的；努力的；坚硬的"
+    ]
+  },
+  {
+    "name": "hard-working",
+    "usphone": "ˌhɑːd ˈwɜːkɪŋ",
+    "ukphone": "ˌhɑːrd ˈwɜːrkɪŋ",
+    "trans": [
+      "adj.尽心尽力的；努力工作的"
+    ]
+  },
+  {
+    "name": "hardware",
+    "usphone": "'hɑrdwɛr",
+    "ukphone": "'hɑːdweə",
+    "trans": [
+      "n.五金；(计算机)硬件"
+    ]
+  },
+  {
+    "name": "harm",
+    "usphone": "hɑrm",
+    "ukphone": "hɑːm",
+    "trans": [
+      "v.&n.伤害，损害，危害"
+    ]
+  },
+  {
+    "name": "harvest",
+    "usphone": "'hɑrvɪst",
+    "ukphone": "'hɑːvɪst",
+    "trans": [
+      "n.收获(物)；收获期 v.收获，收割"
+    ]
+  },
+  {
+    "name": "hate",
+    "usphone": "het",
+    "ukphone": "heɪt",
+    "trans": [
+      "v.不愿，不喜欢，憎恨"
+    ]
+  },
+  {
+    "name": "head",
+    "usphone": "hɛd",
+    "ukphone": "hed",
+    "trans": [
+      "n.头"
+    ]
+  },
+  {
+    "name": "headache",
+    "usphone": "ˈhɛdˌek",
+    "ukphone": "'hedeɪk",
+    "trans": [
+      "n.头疼"
+    ]
+  },
+  {
+    "name": "headmaster",
+    "usphone": ",hɛd'mæstɚ",
+    "ukphone": "hed'mɑːstə",
+    "trans": [
+      "n.校长"
+    ]
+  },
+  {
+    "name": "headquarters",
+    "usphone": "'hɛdkwɔrtɚz",
+    "ukphone": "hed'kwɔːtəz",
+    "trans": [
+      "n.总部"
+    ]
+  },
+  {
+    "name": "heal",
+    "usphone": "hil",
+    "ukphone": "hiːl",
+    "trans": [
+      "v.使愈合"
+    ]
+  },
+  {
+    "name": "health",
+    "usphone": "hɛlθ",
+    "ukphone": "helθ",
+    "trans": [
+      "n.健康"
+    ]
+  },
+  {
+    "name": "healthy",
+    "usphone": "'hɛlθi",
+    "ukphone": "'helθɪ",
+    "trans": [
+      "adj.健康的"
+    ]
+  },
+  {
+    "name": "hear",
+    "usphone": "hɪr",
+    "ukphone": "hɪə",
+    "trans": [
+      "v.听，听到"
+    ]
+  },
+  {
+    "name": "heart",
+    "usphone": "hɑrt",
+    "ukphone": "hɑːt",
+    "trans": [
+      "n.心脏；核心"
+    ]
+  },
+  {
+    "name": "heat",
+    "usphone": "hit",
+    "ukphone": "hiːt",
+    "trans": [
+      "n.热，热烈，激烈 v.加热；发热"
+    ]
+  },
+  {
+    "name": "heavy",
+    "usphone": "'hɛvi",
+    "ukphone": "'hevɪ",
+    "trans": [
+      "adj.重的；多的,大量的"
+    ]
+  },
+  {
+    "name": "help",
+    "usphone": "hɛlp",
+    "ukphone": "help",
+    "trans": [
+      "v./n.帮助"
+    ]
+  },
+  {
+    "name": "helpful",
+    "usphone": "'hɛlpfl",
+    "ukphone": "'helpfʊl; -f(ə)l",
+    "trans": [
+      "adj.有帮助的；有用的"
+    ]
+  },
+  {
+    "name": "heritage",
+    "usphone": "'hɛrɪtɪdʒ",
+    "ukphone": "'herɪtɪdʒ",
+    "trans": [
+      "n.(文化、历史的)遗产"
+    ]
+  },
+  {
+    "name": "herself",
+    "usphone": "hɝ'sɛlf",
+    "ukphone": "hɜː'self",
+    "trans": [
+      "pron.她自己"
+    ]
+  },
+  {
+    "name": "himself",
+    "usphone": "hɪm'sɛlf",
+    "ukphone": "hɪm'self",
+    "trans": [
+      "pron.他自己"
+    ]
+  },
+  {
+    "name": "hide",
+    "usphone": "haɪd",
+    "ukphone": "haɪd",
+    "trans": [
+      "v.躲藏，隐藏"
+    ]
+  },
+  {
+    "name": "high",
+    "usphone": "haɪ",
+    "ukphone": "haɪ",
+    "trans": [
+      "adj./adv.高的(地)"
+    ]
+  },
+  {
+    "name": "height",
+    "usphone": "haɪt",
+    "ukphone": "haɪt",
+    "trans": [
+      "n.高，高度；高处"
+    ]
+  },
+  {
+    "name": "hint",
+    "usphone": "hɪnt",
+    "ukphone": "hɪnt",
+    "trans": [
+      "v.&n.暗示，示意"
+    ]
+  },
+  {
+    "name": "hire",
+    "usphone": "'haɪɚ",
+    "ukphone": "'haɪə",
+    "trans": [
+      "v.&n.雇佣；租借"
+    ]
+  },
+  {
+    "name": "history",
+    "usphone": "ˈhɪstəri; ˈhɪstri",
+    "ukphone": "'hɪst(ə)rɪ",
+    "trans": [
+      "n.历史"
+    ]
+  },
+  {
+    "name": "hit",
+    "usphone": "hɪt",
+    "ukphone": "hɪt",
+    "trans": [
+      "n.击打"
+    ]
+  },
+  {
+    "name": "hobby",
+    "usphone": "'hɑbi",
+    "ukphone": "'hɒbɪ",
+    "trans": [
+      "n.爱好"
+    ]
+  },
+  {
+    "name": "hold",
+    "usphone": "hold",
+    "ukphone": "həʊld",
+    "trans": [
+      "v.握住；举行，进行"
+    ]
+  },
+  {
+    "name": "hole",
+    "usphone": "hol",
+    "ukphone": "həʊl",
+    "trans": [
+      "n.洞，窟窿"
+    ]
+  },
+  {
+    "name": "holiday",
+    "usphone": "'hɑləde",
+    "ukphone": "'hɒlɪdeɪ; -dɪ",
+    "trans": [
+      "n.假日"
+    ]
+  },
+  {
+    "name": "hollow",
+    "usphone": "'hɑlo",
+    "ukphone": "'hɒləʊ",
+    "trans": [
+      "adj.空的，空洞的，空虚的"
+    ]
+  },
+  {
+    "name": "home",
+    "usphone": "hom",
+    "ukphone": "həʊm",
+    "trans": [
+      "n.家"
+    ]
+  },
+  {
+    "name": "homework",
+    "usphone": "'hom'wɝk",
+    "ukphone": "'həʊmwɜːk",
+    "trans": [
+      "n.家庭作业"
+    ]
+  },
+  {
+    "name": "honest",
+    "usphone": "'ɑnɪst",
+    "ukphone": "'ɒnɪst",
+    "trans": [
+      "adj.诚实的，正直的，老实的"
+    ]
+  },
+  {
+    "name": "hope",
+    "usphone": "hop",
+    "ukphone": "həʊp",
+    "trans": [
+      "v./n.希望"
+    ]
+  },
+  {
+    "name": "hopeful",
+    "usphone": "'hopfl",
+    "ukphone": "'həʊpfʊl; -f(ə)l",
+    "trans": [
+      "adj.有希望的"
+    ]
+  },
+  {
+    "name": "hospital",
+    "usphone": "'hɑspɪtl",
+    "ukphone": "'hɒspɪt(ə)l",
+    "trans": [
+      "n.医院"
+    ]
+  },
+  {
+    "name": "host",
+    "usphone": "host",
+    "ukphone": "həʊst",
+    "trans": [
+      "n.主人；节目主持人"
+    ]
+  },
+  {
+    "name": "hospitality",
+    "usphone": ",hɑspɪ'tæləti",
+    "ukphone": "hɒspɪ'tælɪtɪ",
+    "trans": [
+      "n. 好 客"
+    ]
+  },
+  {
+    "name": "hostile",
+    "usphone": "ˈhɑstəl",
+    "ukphone": "'hɒstaɪl",
+    "trans": [
+      "adj.敌方的，敌意的，敌对的"
+    ]
+  },
+  {
+    "name": "hotel",
+    "usphone": "ho'tɛl",
+    "ukphone": "həʊ'tel; əʊ-",
+    "trans": [
+      "n.旅馆"
+    ]
+  },
+  {
+    "name": "hour",
+    "usphone": "'aʊɚ",
+    "ukphone": "'aʊə",
+    "trans": [
+      "n.小时；钟点"
+    ]
+  },
+  {
+    "name": "house",
+    "usphone": "haʊs",
+    "ukphone": "haʊs",
+    "trans": [
+      "n.房子"
+    ]
+  },
+  {
+    "name": "housework",
+    "usphone": "'haʊs'wɝk",
+    "ukphone": "'haʊswɜːk",
+    "trans": [
+      "n.家务活"
+    ]
+  },
+  {
+    "name": "however",
+    "usphone": "haʊ'ɛvɚ",
+    "ukphone": "haʊ'evə",
+    "trans": [
+      "conj.然而"
+    ]
+  },
+  {
+    "name": "huge",
+    "usphone": "hjudʒ",
+    "ukphone": "hjuːdʒ",
+    "trans": [
+      "adj.巨大的"
+    ]
+  },
+  {
+    "name": "human",
+    "usphone": "'hjumən",
+    "ukphone": "'hjuːmən",
+    "trans": [
+      "adj.人的，人类的"
+    ]
+  },
+  {
+    "name": "humour",
+    "usphone": "'hju:mə",
+    "ukphone": "'hjuːmə",
+    "trans": [
+      "n.幽默，诙谐"
+    ]
+  },
+  {
+    "name": "hundred",
+    "usphone": "'hʌndrəd",
+    "ukphone": "'hʌndrəd",
+    "trans": [
+      "n.百"
+    ]
+  },
+  {
+    "name": "hungry",
+    "usphone": "'hʌŋɡri",
+    "ukphone": "'hʌŋgrɪ",
+    "trans": [
+      "adj.饥饿的"
+    ]
+  },
+  {
+    "name": "hunt",
+    "usphone": "hʌnt",
+    "ukphone": "hʌnt",
+    "trans": [
+      "v.狩猎"
+    ]
+  },
+  {
+    "name": "hurry",
+    "usphone": "'hɝrɪ",
+    "ukphone": "'hʌrɪ",
+    "trans": [
+      "n./v.赶紧，急忙"
+    ]
+  },
+  {
+    "name": "hurt",
+    "usphone": "hɝ​t",
+    "ukphone": "hɜːt",
+    "trans": [
+      "v.疼痛；刺痛；伤害"
+    ]
+  },
+  {
+    "name": "husband",
+    "usphone": "'hʌzbənd",
+    "ukphone": "'hʌzbənd",
+    "trans": [
+      "n.丈夫"
+    ]
+  },
+  {
+    "name": "idea",
+    "usphone": "aɪ'diə",
+    "ukphone": "aɪ'dɪə",
+    "trans": [
+      "n.主意, 观点"
+    ]
+  },
+  {
+    "name": "ideal",
+    "usphone": "aɪ'diəl",
+    "ukphone": "aɪ'dɪəl; aɪ'diːəl",
+    "trans": [
+      "adj.理想的，完美的"
+    ]
+  },
+  {
+    "name": "ignore",
+    "usphone": "ɪɡ'nɔr",
+    "ukphone": "ɪg'nɔː",
+    "trans": [
+      "v.不理，不顾，忽视"
+    ]
+  },
+  {
+    "name": "ignorant",
+    "usphone": "'ɪɡnərənt",
+    "ukphone": "'ɪgn(ə)r(ə)nt",
+    "trans": [
+      "adj.无知的，愚昧的"
+    ]
+  },
+  {
+    "name": "ill",
+    "usphone": "ɪl",
+    "ukphone": "ɪl",
+    "trans": [
+      "adj.有病的；坏的"
+    ]
+  },
+  {
+    "name": "illness",
+    "usphone": "'ɪlnəs",
+    "ukphone": "ˈɪlnəs",
+    "trans": [
+      "n.病，疾病"
+    ]
+  },
+  {
+    "name": "image",
+    "usphone": "'ɪmɪdʒ",
+    "ukphone": "'ɪmɪdʒ",
+    "trans": [
+      "n.形象；肖像；影像"
+    ]
+  },
+  {
+    "name": "imagine",
+    "usphone": "ɪ'mædʒɪn",
+    "ukphone": "ɪ'mædʒɪn",
+    "trans": [
+      "v.想象"
+    ]
+  },
+  {
+    "name": "imagination",
+    "usphone": "ɪ,mædʒɪ'neʃən",
+    "ukphone": "ɪ,mædʒɪ'neɪʃ(ə)n",
+    "trans": [
+      "n.想像，想像力"
+    ]
+  },
+  {
+    "name": "immediate",
+    "usphone": "ɪ'midɪət",
+    "ukphone": "ɪ'miːdɪət",
+    "trans": [
+      "adj.立即的"
+    ]
+  },
+  {
+    "name": "immigrant",
+    "usphone": "'ɪmɪɡrənt",
+    "ukphone": "'ɪmɪgr(ə)nt",
+    "trans": [
+      "adj.移民的 n.移民，侨民"
+    ]
+  },
+  {
+    "name": "impact",
+    "usphone": "ɪm'pækt",
+    "ukphone": "'ɪmpækt",
+    "trans": [
+      "n.冲击，碰撞"
+    ]
+  },
+  {
+    "name": "imply",
+    "usphone": "ɪm'plai",
+    "ukphone": "ɪm'plaɪ",
+    "trans": [
+      "v.意指，暗示"
+    ]
+  },
+  {
+    "name": "import",
+    "usphone": "'ɪmpɔt",
+    "ukphone": "ɪm'pɔːt; 'ɪm-",
+    "trans": [
+      "v.进口，输入 n.进口，输入"
+    ]
+  },
+  {
+    "name": "important",
+    "usphone": "ɪm'pɔrtnt",
+    "ukphone": "ɪm'pɔːt(ə)nt",
+    "trans": [
+      "adj.重要的"
+    ]
+  },
+  {
+    "name": "importance",
+    "usphone": "ɪm'pɔrtns",
+    "ukphone": "ɪm'pɔːt(ə)ns",
+    "trans": [
+      "n.重要，重要性"
+    ]
+  },
+  {
+    "name": "impression",
+    "usphone": "ɪm'prɛʃən",
+    "ukphone": "ɪm'preʃ(ə)n",
+    "trans": [
+      "n.印象"
+    ]
+  },
+  {
+    "name": "impress",
+    "usphone": "ɪm'prɛs",
+    "ukphone": "ɪm'pres",
+    "trans": [
+      "v.打动，感动"
+    ]
+  },
+  {
+    "name": "improve",
+    "usphone": "ɪm'pruv",
+    "ukphone": "ɪm'pruːv",
+    "trans": [
+      "v.改善，改进"
+    ]
+  },
+  {
+    "name": "include",
+    "usphone": "ɪn'klud",
+    "ukphone": "ɪn'kluːd",
+    "trans": [
+      "v.包括"
+    ]
+  },
+  {
+    "name": "income",
+    "usphone": "'ɪnkʌm",
+    "ukphone": "'ɪnkʌm",
+    "trans": [
+      "n.收入，所得"
+    ]
+  },
+  {
+    "name": "increase",
+    "usphone": "'ɪnkris",
+    "ukphone": "ɪn'kriːs",
+    "trans": [
+      "v.&n.增加，增长，增进"
+    ]
+  },
+  {
+    "name": "indeed",
+    "usphone": "ɪn'did",
+    "ukphone": "ɪn'diːd",
+    "trans": [
+      "adv.真正地,的确"
+    ]
+  },
+  {
+    "name": "independent",
+    "usphone": "'ɪndɪ'pɛndənt",
+    "ukphone": ",ɪndɪ'pendənt",
+    "trans": [
+      "adj.(of)独立的，自主的"
+    ]
+  },
+  {
+    "name": "India",
+    "usphone": "'indjə",
+    "ukphone": "'indjə",
+    "trans": [
+      "n.印度"
+    ]
+  },
+  {
+    "name": "indicate",
+    "usphone": "'ɪndɪket",
+    "ukphone": "'ɪndɪkeɪt",
+    "trans": [
+      "v.指出，指示；表明，暗示"
+    ]
+  },
+  {
+    "name": "individual",
+    "usphone": ",ɪndɪ'vɪdʒuəl",
+    "ukphone": "ɪndɪ'vɪdjʊ(ə)l",
+    "trans": [
+      "adj.个人的,单独的"
+    ]
+  },
+  {
+    "name": "indoors",
+    "usphone": ",ɪn'dɔrz",
+    "ukphone": "ɪn'dɔːz",
+    "trans": [
+      "adv.在户内，在室内"
+    ]
+  },
+  {
+    "name": "industry",
+    "usphone": "'ɪndəstri",
+    "ukphone": "'ɪndəstrɪ",
+    "trans": [
+      "n.工业"
+    ]
+  },
+  {
+    "name": "industrial",
+    "usphone": "ɪn'dʌstrɪəl",
+    "ukphone": "ɪn'dʌstrɪəl",
+    "trans": [
+      "adj.工业的"
+    ]
+  },
+  {
+    "name": "inevitable",
+    "usphone": "ɪn'ɛvɪtəbl",
+    "ukphone": "ɪn'evɪtəb(ə)l",
+    "trans": [
+      "adj.不可避免的，必然发生的"
+    ]
+  },
+  {
+    "name": "infinite",
+    "usphone": "'ɪnfɪnət",
+    "ukphone": "'ɪnfɪnət",
+    "trans": [
+      "adj.无限的，无穷的；无数的"
+    ]
+  },
+  {
+    "name": "influence",
+    "usphone": "'ɪnfluəns",
+    "ukphone": "'ɪnflʊəns",
+    "trans": [
+      "n.(on)影响力,势力 v.影响,感染"
+    ]
+  },
+  {
+    "name": "information",
+    "usphone": "'ɪnfɚ'meʃən",
+    "ukphone": "ɪnfə'meɪʃ(ə)n",
+    "trans": [
+      "n.信息"
+    ]
+  },
+  {
+    "name": "inhabitant",
+    "usphone": "ɪn'hæbɪtənt",
+    "ukphone": "ɪn'hæbɪt(ə)nt",
+    "trans": [
+      "n.居民，住户"
+    ]
+  },
+  {
+    "name": "injure",
+    "usphone": "'ɪndʒɚ",
+    "ukphone": "'ɪndʒə",
+    "trans": [
+      "v.损害，损伤，伤害"
+    ]
+  },
+  {
+    "name": "innocent",
+    "usphone": "'ɪnəsnt",
+    "ukphone": "'ɪnəs(ə)nt",
+    "trans": [
+      "adj.清白的,无罪的；天真的,无知的"
+    ]
+  },
+  {
+    "name": "insight",
+    "usphone": "'ɪn'saɪt",
+    "ukphone": "'ɪnsaɪt",
+    "trans": [
+      "n.洞察力，见识"
+    ]
+  },
+  {
+    "name": "insist",
+    "usphone": "ɪn'sɪst",
+    "ukphone": "ɪn'sɪst",
+    "trans": [
+      "v.(on)坚持"
+    ]
+  },
+  {
+    "name": "instead",
+    "usphone": "ɪn'stɛd",
+    "ukphone": "ɪn'sted",
+    "trans": [
+      "adv.代替，顶替"
+    ]
+  },
+  {
+    "name": "institution",
+    "usphone": ",ɪnstɪ'tuʃən",
+    "ukphone": "ɪnstɪ'tjuːʃ(ə)n",
+    "trans": [
+      "n.协会，公共机构"
+    ]
+  },
+  {
+    "name": "institute",
+    "usphone": "'ɪnstɪtut",
+    "ukphone": "'ɪnstɪtjuːt",
+    "trans": [
+      "n.大学,学会,研究所 v.设立,制定"
+    ]
+  },
+  {
+    "name": "instinct",
+    "usphone": "'ɪnstɪŋkt",
+    "ukphone": "'ɪnstɪŋ(k)t",
+    "trans": [
+      "n.本能，直觉，天性"
+    ]
+  },
+  {
+    "name": "instruction",
+    "usphone": "ɪn'strʌkʃən",
+    "ukphone": "ɪn'strʌkʃ(ə)n",
+    "trans": [
+      "n.指导;指示"
+    ]
+  },
+  {
+    "name": "insurance",
+    "usphone": "ɪn'ʃʊrəns",
+    "ukphone": "ɪn'ʃʊər(ə)ns",
+    "trans": [
+      "n.保险，保险费"
+    ]
+  },
+  {
+    "name": "intelligence",
+    "usphone": "ɪn'tɛlɪdʒəns",
+    "ukphone": "ɪn'telɪdʒ(ə)ns",
+    "trans": [
+      "n.智力；理解力"
+    ]
+  },
+  {
+    "name": "intend",
+    "usphone": "ɪn'tɛnd",
+    "ukphone": "ɪn'tend",
+    "trans": [
+      "v.想要，打算，企图"
+    ]
+  },
+  {
+    "name": "intention",
+    "usphone": "ɪn'tɛnʃən",
+    "ukphone": "ɪn'tenʃ(ə)n",
+    "trans": [
+      "n.意图，意向，目的"
+    ]
+  },
+  {
+    "name": "interested",
+    "usphone": "'ɪntrəstɪd",
+    "ukphone": "'ɪnt(ə)rɪstɪd",
+    "trans": [
+      "adj.有兴趣的；感兴趣的"
+    ]
+  },
+  {
+    "name": "interest",
+    "usphone": "'ɪntrəst",
+    "ukphone": "'ɪnt(ə)rɪst",
+    "trans": [
+      "n.兴趣"
+    ]
+  },
+  {
+    "name": "interior",
+    "usphone": "ɪn'tɪrɪɚ",
+    "ukphone": "ɪn'tɪɜːrɪə",
+    "trans": [
+      "adj.内部的 .里面的 n.内部,内地，里面"
+    ]
+  },
+  {
+    "name": "international",
+    "usphone": ",ɪntɚ'næʃnəl",
+    "ukphone": "ɪntə'næʃ(ə)n(ə)l",
+    "trans": [
+      "adj.国际的，世界的"
+    ]
+  },
+  {
+    "name": "internet",
+    "usphone": "'intə:net",
+    "ukphone": "'intə:net",
+    "trans": [
+      "n.互联网"
+    ]
+  },
+  {
+    "name": "interview",
+    "usphone": "'ɪntɚvju",
+    "ukphone": "'ɪntəvjuː",
+    "trans": [
+      "n./v.面试；面谈；会见"
+    ]
+  },
+  {
+    "name": "intimate",
+    "usphone": "ˈɪntəmɪt",
+    "ukphone": "'ɪntɪmət",
+    "trans": [
+      "adj.亲密的，密切的"
+    ]
+  },
+  {
+    "name": "into",
+    "usphone": "ˈɪntu",
+    "ukphone": "'ɪntʊ; 'ɪntə",
+    "trans": [
+      "prep.到...内"
+    ]
+  },
+  {
+    "name": "introduce",
+    "usphone": "ˌɪntrə'dus",
+    "ukphone": "ɪntrə'djuːs",
+    "trans": [
+      "v.介绍"
+    ]
+  },
+  {
+    "name": "invent",
+    "usphone": "ɪn'vɛnt",
+    "ukphone": "ɪn'vent",
+    "trans": [
+      "v.发明"
+    ]
+  },
+  {
+    "name": "invention",
+    "usphone": "ɪn'vɛnʃən",
+    "ukphone": "ɪn'venʃ(ə)n",
+    "trans": [
+      "n.发明，创造；发明物；创造力"
+    ]
+  },
+  {
+    "name": "investment",
+    "usphone": "ɪn'vɛstmənt",
+    "ukphone": "ɪn'ves(t)m(ə)nt",
+    "trans": [
+      "n. 投资；投入"
+    ]
+  },
+  {
+    "name": "invest",
+    "usphone": "ɪn'vɛst",
+    "ukphone": "ɪn'vest",
+    "trans": [
+      "v.投资；授予"
+    ]
+  },
+  {
+    "name": "invite",
+    "usphone": "ɪn'vaɪt",
+    "ukphone": "ɪn'vaɪt",
+    "trans": [
+      "v.邀请"
+    ]
+  },
+  {
+    "name": "issue",
+    "usphone": "'ɪʃu",
+    "ukphone": "'ɪʃuː; 'ɪsjuː",
+    "trans": [
+      "v.发行，发表，公布"
+    ]
+  },
+  {
+    "name": "item",
+    "usphone": "'aɪtəm",
+    "ukphone": "'aɪtəm",
+    "trans": [
+      "n.条款，项目"
+    ]
+  },
+  {
+    "name": "jam",
+    "usphone": "dʒæm",
+    "ukphone": "dʒæm",
+    "trans": [
+      "n.果酱"
+    ]
+  },
+  {
+    "name": "Japan",
+    "usphone": "dʒə'pæn",
+    "ukphone": "dʒə'pæn",
+    "trans": [
+      "n.日本"
+    ]
+  },
+  {
+    "name": "Japanese",
+    "usphone": ",dʒæpə'niz",
+    "ukphone": "ˌdʒæpə'ni:z",
+    "trans": [
+      "adj.日本的 n.日本人；日语"
+    ]
+  },
+  {
+    "name": "jar",
+    "usphone": "dʒɑr",
+    "ukphone": "dʒɑː",
+    "trans": [
+      "n.罐，坛"
+    ]
+  },
+  {
+    "name": "jealous",
+    "usphone": "'dʒɛləs",
+    "ukphone": "'dʒeləs",
+    "trans": [
+      "adj.(of) 妒忌的"
+    ]
+  },
+  {
+    "name": "jet",
+    "usphone": "dʒɛt",
+    "ukphone": "jɛt",
+    "trans": [
+      "n.喷气发动机"
+    ]
+  },
+  {
+    "name": "job",
+    "ukphone": "dʒɒb",
+    "trans": [
+      "n.工作"
+    ]
+  },
+  {
+    "name": "join",
+    "usphone": "dʒɔɪn",
+    "ukphone": "dʒɒɪn",
+    "trans": [
+      "v.接合，结合，连接；加入，参加"
+    ]
+  },
+  {
+    "name": "joke",
+    "usphone": "dʒok",
+    "ukphone": "dʒəʊk",
+    "trans": [
+      "n.笑话，玩笑"
+    ]
+  },
+  {
+    "name": "journey",
+    "usphone": "'dʒɝni",
+    "ukphone": "'dʒɜːnɪ",
+    "trans": [
+      "n.旅行；旅程"
+    ]
+  },
+  {
+    "name": "joy",
+    "usphone": "dʒɔɪ",
+    "ukphone": "dʒɒɪ",
+    "trans": [
+      "n.喜悦，乐趣"
+    ]
+  },
+  {
+    "name": "judge",
+    "usphone": "dʒʌdʒ",
+    "ukphone": "dʒʌdʒ",
+    "trans": [
+      "n.法官，裁判 v.审判，判断，断定"
+    ]
+  },
+  {
+    "name": "jump",
+    "usphone": "dʒʌmp",
+    "ukphone": "dʒʌmp",
+    "trans": [
+      "v.&n.跳"
+    ]
+  },
+  {
+    "name": "June",
+    "usphone": "dʒun",
+    "ukphone": "dʒu:n",
+    "trans": [
+      "n.六月"
+    ]
+  },
+  {
+    "name": "junior",
+    "usphone": "'dʒunɪɚ",
+    "ukphone": "'dʒuːnɪə",
+    "trans": [
+      "adj.初级的"
+    ]
+  },
+  {
+    "name": "just",
+    "usphone": "dʒʌst",
+    "ukphone": "dʒʌst",
+    "trans": [
+      "adv.刚刚，刚才；正好；不过；仅仅"
+    ]
+  },
+  {
+    "name": "justice",
+    "usphone": "'dʒʌstɪs",
+    "ukphone": "'dʒʌstɪs",
+    "trans": [
+      "n.公正，公平；审判，司法"
+    ]
+  },
+  {
+    "name": "keep",
+    "usphone": "kip",
+    "ukphone": "kiːp",
+    "trans": [
+      "v.保持；保存；继续"
+    ]
+  },
+  {
+    "name": "key",
+    "ukphone": "kiː",
+    "trans": [
+      "n.钥匙 adj. 关键的"
+    ]
+  },
+  {
+    "name": "keyboard",
+    "usphone": "'ki'bɔrd",
+    "ukphone": "'kiːbɔːd",
+    "trans": [
+      "n.键盘"
+    ]
+  },
+  {
+    "name": "kick",
+    "usphone": "kɪk",
+    "ukphone": "kɪk",
+    "trans": [
+      "v.&n.蹋"
+    ]
+  },
+  {
+    "name": "kid",
+    "usphone": "kɪd",
+    "ukphone": "kɪd",
+    "trans": [
+      "n.小孩 v. 戏弄"
+    ]
+  },
+  {
+    "name": "kilometer",
+    "usphone": "kɪˈlɒmɪtə(r)",
+    "ukphone": "kɪˈlɑːmɪtər",
+    "trans": [
+      "n.=kilometre 公里"
+    ]
+  },
+  {
+    "name": "kind",
+    "usphone": "kaɪnd",
+    "ukphone": "kaɪnd",
+    "trans": [
+      "adj.善良的，好心的 n.种类，类型"
+    ]
+  },
+  {
+    "name": "kindness",
+    "usphone": "'kaɪndnəs",
+    "ukphone": "'kaɪn(d)nɪs",
+    "trans": [
+      "n.仁慈，亲切；友好行为"
+    ]
+  },
+  {
+    "name": "kindergarten",
+    "usphone": "'kɪndɚɡɑrtn",
+    "ukphone": "'kɪndə,gɑːt(ə)n",
+    "trans": [
+      "n.幼儿园"
+    ]
+  },
+  {
+    "name": "king",
+    "usphone": "kɪŋ",
+    "ukphone": "kɪŋ",
+    "trans": [
+      "n.国王"
+    ]
+  },
+  {
+    "name": "kingdom",
+    "usphone": "'kɪŋdəm",
+    "ukphone": "'kɪŋdəm",
+    "trans": [
+      "n.王国；领域"
+    ]
+  },
+  {
+    "name": "kitchen",
+    "usphone": "'kɪtʃɪn",
+    "ukphone": "'kɪtʃɪn; -tʃ(ə)n",
+    "trans": [
+      "n.厨房"
+    ]
+  },
+  {
+    "name": "know",
+    "usphone": "no",
+    "ukphone": "nəʊ",
+    "trans": [
+      "v.知道；了解"
+    ]
+  },
+  {
+    "name": "knowledge",
+    "usphone": "'nɑlɪdʒ",
+    "ukphone": "'nɒlɪdʒ",
+    "trans": [
+      "n.知识，学问"
+    ]
+  },
+  {
+    "name": "lack",
+    "usphone": "læk",
+    "ukphone": "læk",
+    "trans": [
+      "v.&n.缺乏，缺少"
+    ]
+  },
+  {
+    "name": "lake",
+    "usphone": "lek",
+    "ukphone": "leɪk",
+    "trans": [
+      "n.湖"
+    ]
+  },
+  {
+    "name": "land",
+    "usphone": "lænd",
+    "ukphone": "lænd",
+    "trans": [
+      "n.土地 v.着陆，登陆"
+    ]
+  },
+  {
+    "name": "language",
+    "usphone": "'læŋɡwɪdʒ",
+    "ukphone": "'læŋgwɪdʒ",
+    "trans": [
+      "n.语言"
+    ]
+  },
+  {
+    "name": "large",
+    "usphone": "lɑrdʒ",
+    "ukphone": "lɑːdʒ",
+    "trans": [
+      "adj.大的，巨大的"
+    ]
+  },
+  {
+    "name": "last",
+    "usphone": "læst",
+    "ukphone": "lɑːst",
+    "trans": [
+      "adv.最后,上一次 adj.最后的"
+    ]
+  },
+  {
+    "name": "late",
+    "usphone": "let",
+    "ukphone": "leɪt",
+    "trans": [
+      "adj./adv.晚的(地)，迟到的(地)"
+    ]
+  },
+  {
+    "name": "later",
+    "usphone": "'letɚ",
+    "ukphone": "'leɪtə",
+    "trans": [
+      "adv.后来；过后"
+    ]
+  },
+  {
+    "name": "lately",
+    "usphone": "'leitli",
+    "ukphone": "'leitli",
+    "trans": [
+      "adv.近来，不久前，最近"
+    ]
+  },
+  {
+    "name": "laugh",
+    "usphone": "læf",
+    "ukphone": "lɑːf",
+    "trans": [
+      "v.笑，嘲笑"
+    ]
+  },
+  {
+    "name": "launch",
+    "usphone": "lɔntʃ",
+    "ukphone": "lɔːntʃ",
+    "trans": [
+      "v.发射；使(船)下水；发动，开展 n.发射"
+    ]
+  },
+  {
+    "name": "law",
+    "usphone": "lɔ",
+    "ukphone": "lɔː",
+    "trans": [
+      "n.法律"
+    ]
+  },
+  {
+    "name": "lawyer",
+    "usphone": "'lɔjɚ",
+    "ukphone": "'lɔːjə; 'lɒɪə",
+    "trans": [
+      "n.律师，法学家"
+    ]
+  },
+  {
+    "name": "lead",
+    "usphone": "lid",
+    "ukphone": "liːd",
+    "trans": [
+      "v.引导，领导，率领"
+    ]
+  },
+  {
+    "name": "leader",
+    "usphone": "'lidɚ",
+    "ukphone": "'liːdə",
+    "trans": [
+      "n.领导者，领袖，首领"
+    ]
+  },
+  {
+    "name": "league",
+    "usphone": "lig",
+    "ukphone": "liːg",
+    "trans": [
+      "n.同盟，联盟"
+    ]
+  },
+  {
+    "name": "learn",
+    "usphone": "lɝn",
+    "ukphone": "lɜːn",
+    "trans": [
+      "v.学，学习"
+    ]
+  },
+  {
+    "name": "least",
+    "usphone": "list",
+    "ukphone": "liːst",
+    "trans": [
+      "adj.最少的，最小的 adv.最小，最少"
+    ]
+  },
+  {
+    "name": "leave",
+    "usphone": "liv",
+    "ukphone": "liːv",
+    "trans": [
+      "v.离开，留下"
+    ]
+  },
+  {
+    "name": "lecture",
+    "usphone": "'lɛktʃɚ",
+    "ukphone": "'lektʃə",
+    "trans": [
+      "v.&n.演讲，讲课"
+    ]
+  },
+  {
+    "name": "left",
+    "usphone": "lɛft",
+    "ukphone": "left",
+    "trans": [
+      "n.左面，左方 adj.左边的，左面的"
+    ]
+  },
+  {
+    "name": "legal",
+    "usphone": "'ligl",
+    "ukphone": "'liːg(ə)l",
+    "trans": [
+      "adj.法律的，法定的；合法的"
+    ]
+  },
+  {
+    "name": "leisure",
+    "usphone": "'liʒɚ",
+    "ukphone": "'leʒə",
+    "trans": [
+      "n.空闲，悠闲 adj.空闲的"
+    ]
+  },
+  {
+    "name": "less",
+    "usphone": "lɛs",
+    "ukphone": "les",
+    "trans": [
+      "adj.&adv.较少，更少"
+    ]
+  },
+  {
+    "name": "lesson",
+    "usphone": "'lɛsn",
+    "ukphone": "'les(ə)n",
+    "trans": [
+      "n.课程，教训"
+    ]
+  },
+  {
+    "name": "let",
+    "usphone": "lɛt",
+    "ukphone": "let",
+    "trans": [
+      "v.让"
+    ]
+  },
+  {
+    "name": "letter",
+    "usphone": "'lɛtɚ",
+    "ukphone": "'letə",
+    "trans": [
+      "n.信"
+    ]
+  },
+  {
+    "name": "level",
+    "usphone": "'lɛvl",
+    "ukphone": "'lev(ə)l",
+    "trans": [
+      "n.等级，水平"
+    ]
+  },
+  {
+    "name": "liberate",
+    "usphone": "'lɪbə'ret",
+    "ukphone": "'lɪbəreɪt",
+    "trans": [
+      "v.解放，使获自由"
+    ]
+  },
+  {
+    "name": "liberty",
+    "usphone": "'lɪbɚti",
+    "ukphone": "'lɪbətɪ",
+    "trans": [
+      "n.自由"
+    ]
+  },
+  {
+    "name": "library",
+    "usphone": "laɪˌbrɛrɪ",
+    "ukphone": "ˈlaɪbrərɪ",
+    "trans": [
+      "n.图书馆"
+    ]
+  },
+  {
+    "name": "lie",
+    "ukphone": "laɪ",
+    "trans": [
+      "v.躺，卧；平放"
+    ]
+  },
+  {
+    "name": "life",
+    "usphone": "laɪf",
+    "ukphone": "laɪf",
+    "trans": [
+      "n.生活，一生；生命"
+    ]
+  },
+  {
+    "name": "lifetime",
+    "usphone": "'laɪftaɪm",
+    "ukphone": "'laɪftaɪm",
+    "trans": [
+      "n.一生，终生"
+    ]
+  },
+  {
+    "name": "lift",
+    "usphone": "lɪft",
+    "ukphone": "lɪft",
+    "trans": [
+      "v.提起，举起，升起"
+    ]
+  },
+  {
+    "name": "light",
+    "usphone": "laɪt",
+    "ukphone": "laɪt",
+    "trans": [
+      "adj.明亮的；轻的；浅的"
+    ]
+  },
+  {
+    "name": "like",
+    "usphone": "laɪk",
+    "ukphone": "laɪk",
+    "trans": [
+      "v. 想要，喜欢 prep.像...，同...一样"
+    ]
+  },
+  {
+    "name": "likely",
+    "usphone": "'laɪkli",
+    "ukphone": "'laɪklɪ",
+    "trans": [
+      "adj.很可能的，几乎可以肯定的"
+    ]
+  },
+  {
+    "name": "likewise",
+    "usphone": "'laɪkwaɪz",
+    "ukphone": "'laɪkwaɪz",
+    "trans": [
+      "adv.同样地,照样地；又,也,而且"
+    ]
+  },
+  {
+    "name": "limit",
+    "usphone": "'lɪmɪt",
+    "ukphone": "'lɪmɪt",
+    "trans": [
+      "n.界限，限度，范围 v.限制"
+    ]
+  },
+  {
+    "name": "line",
+    "usphone": "laɪn",
+    "ukphone": "laɪn",
+    "trans": [
+      "n.线；线条；线路"
+    ]
+  },
+  {
+    "name": "link",
+    "usphone": "lɪŋk",
+    "ukphone": "lɪŋk",
+    "trans": [
+      "v.连接，联系 n. 联系，纽带"
+    ]
+  },
+  {
+    "name": "list",
+    "usphone": "lɪst",
+    "ukphone": "lɪst",
+    "trans": [
+      "n.表；目录；名单"
+    ]
+  },
+  {
+    "name": "listen",
+    "usphone": "'lɪsn",
+    "ukphone": "'lɪs(ə)n",
+    "trans": [
+      "v.听"
+    ]
+  },
+  {
+    "name": "literature",
+    "usphone": "lɪtərəˌtʃʊr",
+    "ukphone": "'lɪt(ə)rətʃə",
+    "trans": [
+      "n.文学，文学作品，文献"
+    ]
+  },
+  {
+    "name": "literary",
+    "usphone": "lɪtərɛri",
+    "ukphone": "'lɪt(ə)(rə)rɪ",
+    "trans": [
+      "adj.文学的"
+    ]
+  },
+  {
+    "name": "little",
+    "usphone": "'lɪtl",
+    "ukphone": "'lɪt(ə)l",
+    "trans": [
+      "adj.小的 adv. 完全不"
+    ]
+  },
+  {
+    "name": "live",
+    "usphone": "laɪv；lɪv",
+    "ukphone": "laɪv；lɪv",
+    "trans": [
+      "v.住,生活"
+    ]
+  },
+  {
+    "name": "lively",
+    "usphone": "'laɪvli",
+    "ukphone": "'laɪvlɪ",
+    "trans": [
+      "adj.活泼的，活跃的；栩栩如生的 adv.活泼地，轻快地"
+    ]
+  },
+  {
+    "name": "local",
+    "usphone": "ˈloʊkl",
+    "ukphone": "'ləʊk(ə)l",
+    "trans": [
+      "adj.地方的，当地的"
+    ]
+  },
+  {
+    "name": "location",
+    "usphone": "lo'keʃən",
+    "ukphone": "lə(ʊ)'keɪʃ(ə)n",
+    "trans": [
+      "n.位置，场所，定位"
+    ]
+  },
+  {
+    "name": "lonely",
+    "usphone": "'lonli",
+    "ukphone": "'ləʊnlɪ",
+    "trans": [
+      "adj.孤独的，寂寞的"
+    ]
+  },
+  {
+    "name": "long",
+    "usphone": "lɔŋ",
+    "ukphone": "lɒŋ",
+    "trans": [
+      "adj.长的"
+    ]
+  },
+  {
+    "name": "look",
+    "usphone": "lʊk",
+    "ukphone": "lʊk",
+    "trans": [
+      "v.看；看起来，看上去"
+    ]
+  },
+  {
+    "name": "loose",
+    "usphone": "lus",
+    "ukphone": "luːs",
+    "trans": [
+      "adj.松的；自由的,松散的"
+    ]
+  },
+  {
+    "name": "lose",
+    "usphone": "luz",
+    "ukphone": "luːz",
+    "trans": [
+      "v.失败；丢失"
+    ]
+  },
+  {
+    "name": "loss",
+    "usphone": "lɔs",
+    "ukphone": "lɒs",
+    "trans": [
+      "n.丧失，丢失，亏损，损失"
+    ]
+  },
+  {
+    "name": "low",
+    "ukphone": "ləʊ",
+    "trans": [
+      "adj.低的 .矮的"
+    ]
+  },
+  {
+    "name": "lower",
+    "usphone": "'loɚ",
+    "ukphone": "'ləʊə",
+    "trans": [
+      "adj.低的,下级的,下层的 v.(使)降下,放低"
+    ]
+  },
+  {
+    "name": "loyal",
+    "usphone": "'lɔɪəl",
+    "ukphone": "'lɒɪəl",
+    "trans": [
+      "adj.忠诚的，忠贞的"
+    ]
+  },
+  {
+    "name": "lucky",
+    "usphone": "'lʌki",
+    "ukphone": "'lʌkɪ",
+    "trans": [
+      "adj.幸运的，有幸的"
+    ]
+  },
+  {
+    "name": "lunch",
+    "usphone": "lʌntʃ",
+    "ukphone": "lʌn(t)ʃ",
+    "trans": [
+      "n.午餐"
+    ]
+  },
+  {
+    "name": "machine",
+    "usphone": "mə'ʃin",
+    "ukphone": "mə'ʃiːn",
+    "trans": [
+      "n.机器"
+    ]
+  },
+  {
+    "name": "mechanical",
+    "usphone": "mɪ'kænɪkəl",
+    "ukphone": "mɪ'kænɪk(ə)l",
+    "trans": [
+      "adj.机械的"
+    ]
+  },
+  {
+    "name": "magazine",
+    "usphone": "'mæɡəzin",
+    "ukphone": "mægə'ziːn",
+    "trans": [
+      "n.杂志"
+    ]
+  },
+  {
+    "name": "magic",
+    "usphone": "'mædʒɪk",
+    "ukphone": "'mædʒɪk",
+    "trans": [
+      "n.魔法,魔术,戏法 adj.有魔力的,魔术的"
+    ]
+  },
+  {
+    "name": "main",
+    "ukphone": "meɪn",
+    "trans": [
+      "adj.主要的"
+    ]
+  },
+  {
+    "name": "mainly",
+    "usphone": "'meinli",
+    "ukphone": "'meinli",
+    "trans": [
+      "adv.主要地"
+    ]
+  },
+  {
+    "name": "maintain",
+    "usphone": "men'ten",
+    "ukphone": "meɪn'teɪn; mən'teɪn",
+    "trans": [
+      "v.维修，保养；维持，坚持；主张"
+    ]
+  },
+  {
+    "name": "major",
+    "usphone": "'medʒɚ",
+    "ukphone": "'meɪdʒə",
+    "trans": [
+      "n.专业 adj.主要的，重大的"
+    ]
+  },
+  {
+    "name": "majority",
+    "usphone": "mə'dʒɔrəti",
+    "ukphone": "mə'dʒɒrɪtɪ",
+    "trans": [
+      "n.大多数"
+    ]
+  },
+  {
+    "name": "male",
+    "usphone": "mel",
+    "ukphone": "meɪl",
+    "trans": [
+      "n.男性"
+    ]
+  },
+  {
+    "name": "man",
+    "usphone": "mæn",
+    "ukphone": "mæn",
+    "trans": [
+      "n.男人"
+    ]
+  },
+  {
+    "name": "manage",
+    "usphone": "'mænɪdʒ",
+    "ukphone": "'mænɪdʒ",
+    "trans": [
+      "v.管理,经营,设法(做到)；对待，处理"
+    ]
+  },
+  {
+    "name": "management",
+    "usphone": "'mænɪdʒmənt",
+    "ukphone": "'mænɪdʒm(ə)nt",
+    "trans": [
+      "n.经营，管理"
+    ]
+  },
+  {
+    "name": "manager",
+    "usphone": "'mænɪdʒɚ",
+    "ukphone": "'mænɪdʒə",
+    "trans": [
+      "n.经理"
+    ]
+  },
+  {
+    "name": "manner",
+    "usphone": "'mænɚ",
+    "ukphone": "'mænə",
+    "trans": [
+      "n.方式，方法；举止，风度"
+    ]
+  },
+  {
+    "name": "manufacture",
+    "usphone": "'mænjə'fæktʃɚ",
+    "ukphone": "mænjʊ'fæktʃə",
+    "trans": [
+      "v.制造，加工 n.制造，制造业；产品"
+    ]
+  },
+  {
+    "name": "many",
+    "usphone": "'mɛni",
+    "ukphone": "'menɪ",
+    "trans": [
+      "adj.很多，许多"
+    ]
+  },
+  {
+    "name": "march",
+    "usphone": "mɑrtʃ",
+    "ukphone": "mɑːtʃ",
+    "trans": [
+      "v.行进，行军 n.行进，行军；进行曲"
+    ]
+  },
+  {
+    "name": "March",
+    "usphone": "mɑrtʃ",
+    "ukphone": "mɑːtʃ",
+    "trans": [
+      "n. 三 月"
+    ]
+  },
+  {
+    "name": "mark",
+    "ukphone": "mɑːk",
+    "trans": [
+      "n.标记，记号；分数 v.记分，打分"
+    ]
+  },
+  {
+    "name": "market",
+    "usphone": "'mɑrkɪt",
+    "ukphone": "'mɑːkɪt",
+    "trans": [
+      "n.集市；市场"
+    ]
+  },
+  {
+    "name": "marriage",
+    "usphone": "'mærɪdʒ",
+    "ukphone": "'mærɪdʒ",
+    "trans": [
+      "n.结婚，婚姻"
+    ]
+  },
+  {
+    "name": "match",
+    "usphone": "mætʃ",
+    "ukphone": "mætʃ",
+    "trans": [
+      "n.比赛"
+    ]
+  },
+  {
+    "name": "material",
+    "usphone": "mə'tɪrɪəl",
+    "ukphone": "mə'tɪərɪəl",
+    "trans": [
+      "n.材料，原料，资料 adj.物质的，实物的，具体的"
+    ]
+  },
+  {
+    "name": "matter",
+    "usphone": "'mætɚ",
+    "ukphone": "'mætə",
+    "trans": [
+      "n.东西,事情 v.有关系,要紧，重要"
+    ]
+  },
+  {
+    "name": "may",
+    "usphone": "mei",
+    "ukphone": "mei",
+    "trans": [
+      "aux.v.也许，可能"
+    ]
+  },
+  {
+    "name": "maybe",
+    "usphone": "'mebi",
+    "ukphone": "'meɪbiː; -bɪ",
+    "trans": [
+      "adv.也许"
+    ]
+  },
+  {
+    "name": "mayor",
+    "usphone": "'meɚ",
+    "ukphone": "ˈmeɪə",
+    "trans": [
+      "n.市长"
+    ]
+  },
+  {
+    "name": "meal",
+    "usphone": "mil",
+    "ukphone": "miːl",
+    "trans": [
+      "n.饭"
+    ]
+  },
+  {
+    "name": "mean",
+    "usphone": "min",
+    "ukphone": "miːn",
+    "trans": [
+      "v.意思是；意味着"
+    ]
+  },
+  {
+    "name": "meaning",
+    "usphone": "'minɪŋ",
+    "ukphone": "'miːnɪŋ",
+    "trans": [
+      "n.意思"
+    ]
+  },
+  {
+    "name": "means",
+    "usphone": "minz",
+    "ukphone": "miːnz",
+    "trans": [
+      "n.方法，手段；途径"
+    ]
+  },
+  {
+    "name": "meanwhile",
+    "usphone": "'minwaɪl",
+    "ukphone": "'miːnwaɪl",
+    "trans": [
+      "n.期间 adv.同时"
+    ]
+  },
+  {
+    "name": "measure",
+    "usphone": "'mɛʒɚ",
+    "ukphone": "'meʒə",
+    "trans": [
+      "n.量度，测量；措施 v.量，测量"
+    ]
+  },
+  {
+    "name": "medal",
+    "usphone": "'mɛdl",
+    "ukphone": "'med(ə)l",
+    "trans": [
+      "n.奖章，勋章，纪念章"
+    ]
+  },
+  {
+    "name": "medicine",
+    "usphone": "'mɛdsn",
+    "ukphone": "'meds(ə)n; 'medɪsɪn",
+    "trans": [
+      "n.医学，药"
+    ]
+  },
+  {
+    "name": "medical",
+    "usphone": "'mɛdɪkl",
+    "ukphone": "'medɪk(ə)l",
+    "trans": [
+      "adj.医学的"
+    ]
+  },
+  {
+    "name": "meet",
+    "usphone": "mit",
+    "ukphone": "miːt",
+    "trans": [
+      "v.见面，相遇"
+    ]
+  },
+  {
+    "name": "meeting",
+    "usphone": "'mitɪŋ",
+    "ukphone": "'miːtɪŋ",
+    "trans": [
+      "n.会议，集合"
+    ]
+  },
+  {
+    "name": "member",
+    "usphone": "'mɛmbɚ",
+    "ukphone": "'membə",
+    "trans": [
+      "n.成员，会员"
+    ]
+  },
+  {
+    "name": "membership",
+    "usphone": "'mɛmbɚʃɪp",
+    "ukphone": "'membəʃɪp",
+    "trans": [
+      "n.会员资格，成员资格"
+    ]
+  },
+  {
+    "name": "memory",
+    "usphone": "'mɛməri",
+    "ukphone": "'mem(ə)rɪ",
+    "trans": [
+      "n.记忆"
+    ]
+  },
+  {
+    "name": "mental",
+    "usphone": "'mɛntl",
+    "ukphone": "'ment(ə)l",
+    "trans": [
+      "adj.精神的,思想的,内心的"
+    ]
+  },
+  {
+    "name": "mention",
+    "usphone": "'mɛnʃən",
+    "ukphone": "'menʃ(ə)n",
+    "trans": [
+      "v.&n.提及，淡到，说起"
+    ]
+  },
+  {
+    "name": "menu",
+    "usphone": "'mɛnju",
+    "ukphone": "'menjuː",
+    "trans": [
+      "n.莱单"
+    ]
+  },
+  {
+    "name": "merchant",
+    "usphone": "'mɝtʃənt",
+    "ukphone": "'mɜːtʃ(ə)nt",
+    "trans": [
+      "n.商人，零售商"
+    ]
+  },
+  {
+    "name": "mere",
+    "usphone": "mɪr",
+    "ukphone": "mɪə",
+    "trans": [
+      "adj.纯粹的；仅仅的"
+    ]
+  },
+  {
+    "name": "merely",
+    "usphone": "'mɪrli",
+    "ukphone": "'mɪəlɪ",
+    "trans": [
+      "adv.仅仅，只不过"
+    ]
+  },
+  {
+    "name": "merit",
+    "usphone": "'mɛrɪt",
+    "ukphone": "'merɪt",
+    "trans": [
+      "n.优点"
+    ]
+  },
+  {
+    "name": "message",
+    "usphone": "'mɛsɪdʒ",
+    "ukphone": "'mesɪdʒ",
+    "trans": [
+      "n.消息"
+    ]
+  },
+  {
+    "name": "metal",
+    "usphone": "'mɛtl",
+    "ukphone": "'met(ə)l",
+    "trans": [
+      "n.金属；金属制品"
+    ]
+  },
+  {
+    "name": "middle",
+    "usphone": "'mɪdl",
+    "ukphone": "'mɪd(ə)l",
+    "trans": [
+      "adj.中间的；中等的"
+    ]
+  },
+  {
+    "name": "midnight",
+    "usphone": "'mɪdnaɪt",
+    "ukphone": "'mɪdnaɪt",
+    "trans": [
+      "n.半夜"
+    ]
+  },
+  {
+    "name": "mile",
+    "usphone": "maɪl",
+    "ukphone": "maɪl",
+    "trans": [
+      "n.英里"
+    ]
+  },
+  {
+    "name": "military",
+    "usphone": "'mɪlətɛri",
+    "ukphone": "'mɪlɪt(ə)rɪ",
+    "trans": [
+      "adj.军事的"
+    ]
+  },
+  {
+    "name": "million",
+    "usphone": "'mɪljən",
+    "ukphone": "'mɪljən",
+    "trans": [
+      "n./adj. 百万"
+    ]
+  },
+  {
+    "name": "mind",
+    "usphone": "maɪnd",
+    "ukphone": "maɪnd",
+    "trans": [
+      "v.关心，介意 n.思想，想法"
+    ]
+  },
+  {
+    "name": "mine",
+    "usphone": "maɪn",
+    "ukphone": "maɪn",
+    "trans": [
+      "n.矿 pron.我的"
+    ]
+  },
+  {
+    "name": "minute",
+    "usphone": "'mɪnɪt",
+    "ukphone": "'mɪnɪt",
+    "trans": [
+      "n.分钟"
+    ]
+  },
+  {
+    "name": "miss",
+    "usphone": "mɪs",
+    "ukphone": "mɪs",
+    "trans": [
+      "v.错过；思念"
+    ]
+  },
+  {
+    "name": "mistake",
+    "usphone": "mɪ'stek",
+    "ukphone": "mɪ'steɪk",
+    "trans": [
+      "n.错误"
+    ]
+  },
+  {
+    "name": "model",
+    "usphone": "'mɑdl",
+    "ukphone": "'mɒdl",
+    "trans": [
+      "n.模特"
+    ]
+  },
+  {
+    "name": "moderate",
+    "usphone": "ˈmɑdərɪt; (for v.,) ˈmɑdərˌeɪt",
+    "ukphone": "'mɒd(ə)rət",
+    "trans": [
+      "adj.中等的；温和的"
+    ]
+  },
+  {
+    "name": "modern",
+    "usphone": "'mɑdɚn",
+    "ukphone": "'mɒd(ə)n",
+    "trans": [
+      "adj.现代的"
+    ]
+  },
+  {
+    "name": "moment",
+    "usphone": "'momənt",
+    "ukphone": "'məʊm(ə)nt",
+    "trans": [
+      "n.一会儿，片刻"
+    ]
+  },
+  {
+    "name": "Monday",
+    "usphone": "ˈmʌnde; ˈmʌndɪ",
+    "ukphone": "ˈmʌndeɪ; ˈmʌndi",
+    "trans": [
+      "n.星期一"
+    ]
+  },
+  {
+    "name": "money",
+    "usphone": "'mʌni",
+    "ukphone": "'mʌnɪ",
+    "trans": [
+      "n.钱"
+    ]
+  },
+  {
+    "name": "monkey",
+    "usphone": "'mʌŋki",
+    "ukphone": "'mʌŋkɪ",
+    "trans": [
+      "n.猴子"
+    ]
+  },
+  {
+    "name": "month",
+    "usphone": "mʌnθ",
+    "ukphone": "mʌnθ",
+    "trans": [
+      "n.月份，月"
+    ]
+  },
+  {
+    "name": "monthly",
+    "usphone": "'mʌnθli",
+    "ukphone": "'mʌnθlɪ",
+    "trans": [
+      "adj./adv.每月的/地"
+    ]
+  },
+  {
+    "name": "monument",
+    "usphone": "'mɑnjumənt",
+    "ukphone": "'mɒnjʊm(ə)nt",
+    "trans": [
+      "n.纪念碑，纪念馆"
+    ]
+  },
+  {
+    "name": "mood",
+    "usphone": "mud",
+    "ukphone": "muːd",
+    "trans": [
+      "n.心情，情绪；语气"
+    ]
+  },
+  {
+    "name": "moral",
+    "usphone": "'mɔrəl",
+    "ukphone": "'mɒr(ə)l",
+    "trans": [
+      "adj.道德的，道义的"
+    ]
+  },
+  {
+    "name": "most",
+    "usphone": "most",
+    "ukphone": "məʊst",
+    "trans": [
+      "adv.最；非常 n.大多数，大部分 adj.(many, much的最高级) 最多的"
+    ]
+  },
+  {
+    "name": "mostly",
+    "usphone": "'mostli",
+    "ukphone": "'məʊs(t)lɪ",
+    "trans": [
+      "adv.主要地，大半；基本上"
+    ]
+  },
+  {
+    "name": "motor",
+    "usphone": "'motɚ",
+    "ukphone": "'məʊtə",
+    "trans": [
+      "n.发动机，电动机 .马达"
+    ]
+  },
+  {
+    "name": "mount",
+    "usphone": "maʊnt",
+    "ukphone": "maʊnt",
+    "trans": [
+      "v.登上，爬上"
+    ]
+  },
+  {
+    "name": "mountain",
+    "usphone": "ˈmaʊntn",
+    "ukphone": "ˈmaʊntən",
+    "trans": [
+      "n.高山"
+    ]
+  },
+  {
+    "name": "move",
+    "usphone": "muv",
+    "ukphone": "muːv",
+    "trans": [
+      "v.感动，搬动，移动"
+    ]
+  },
+  {
+    "name": "movie",
+    "usphone": "'muvi",
+    "ukphone": "'muːvɪ",
+    "trans": [
+      "n.电梯"
+    ]
+  },
+  {
+    "name": "much",
+    "usphone": "mʌtʃ",
+    "ukphone": "mʌtʃ",
+    "trans": [
+      "n.＆adj.许多 .大量 adv.非常；更"
+    ]
+  },
+  {
+    "name": "multiply",
+    "usphone": "'mʌltɪplaɪ",
+    "ukphone": "'mʌltɪplaɪ",
+    "trans": [
+      "v.(by) 乘，倍增，增加"
+    ]
+  },
+  {
+    "name": "murder",
+    "usphone": "'mɝdɚ",
+    "ukphone": "'mɜːdə",
+    "trans": [
+      "v.&n.谋杀"
+    ]
+  },
+  {
+    "name": "muscle",
+    "usphone": "'mʌsl",
+    "ukphone": "'mʌs(ə)l",
+    "trans": [
+      "n.肌肉；体力"
+    ]
+  },
+  {
+    "name": "museum",
+    "usphone": "mju'ziəm",
+    "ukphone": "mjuː'zɪəm",
+    "trans": [
+      "n.博物馆"
+    ]
+  },
+  {
+    "name": "music",
+    "usphone": "'mjuzɪk",
+    "ukphone": "'mjuːzɪk",
+    "trans": [
+      "n.音乐"
+    ]
+  },
+  {
+    "name": "musician",
+    "usphone": "mjʊ'zɪʃən",
+    "ukphone": "mjuː'zɪʃ(ə)n",
+    "trans": [
+      "n.音乐家，乐师"
+    ]
+  },
+  {
+    "name": "mutual",
+    "usphone": "'mjutʃuəl",
+    "ukphone": "'mjuːtʃʊəl; -tjʊəl",
+    "trans": [
+      "adj.相互的，彼此的"
+    ]
+  },
+  {
+    "name": "must",
+    "usphone": "mʌst",
+    "ukphone": "mʌst",
+    "trans": [
+      "aux.v.必须"
+    ]
+  },
+  {
+    "name": "myself",
+    "usphone": "maɪ'sɛlf",
+    "ukphone": "maɪ'self",
+    "trans": [
+      "pron.我自己"
+    ]
+  },
+  {
+    "name": "mystery",
+    "usphone": "ˈmɪstri",
+    "ukphone": "ˈmɪstri",
+    "trans": [
+      "n.神秘的事物"
+    ]
+  },
+  {
+    "name": "name",
+    "usphone": "nem",
+    "ukphone": "neɪm",
+    "trans": [
+      "n.名字 v.命名"
+    ]
+  },
+  {
+    "name": "nation",
+    "usphone": "'neʃən",
+    "ukphone": "'neɪʃ(ə)n",
+    "trans": [
+      "n.国家，民族"
+    ]
+  },
+  {
+    "name": "national",
+    "usphone": "'næʃnəl",
+    "ukphone": "'næʃ(ə)n(ə)l",
+    "trans": [
+      "adj.国家的"
+    ]
+  },
+  {
+    "name": "nationality",
+    "usphone": ",næʃə'næləti",
+    "ukphone": "næʃə'nælɪtɪ",
+    "trans": [
+      "n.国籍，民族"
+    ]
+  },
+  {
+    "name": "native",
+    "usphone": "'netɪv",
+    "ukphone": "'neɪtɪv",
+    "trans": [
+      "n.本地人(of)adj.本国的,本地的"
+    ]
+  },
+  {
+    "name": "natural",
+    "usphone": "'nætʃrəl",
+    "ukphone": "'nætʃ(ə)r(ə)l",
+    "trans": [
+      "adj.自然界的,天然的;自然的,天生的"
+    ]
+  },
+  {
+    "name": "nature",
+    "usphone": "'netʃɚ",
+    "ukphone": "'neɪtʃə",
+    "trans": [
+      "n.自然，自然界；性质，本性"
+    ]
+  },
+  {
+    "name": "navigation",
+    "usphone": "'nævə'geʃən",
+    "ukphone": "nævɪ'geɪʃ(ə)n",
+    "trans": [
+      "n.航海，航空；导航"
+    ]
+  },
+  {
+    "name": "near",
+    "usphone": "nɪr",
+    "ukphone": "nɪə",
+    "trans": [
+      "adj.近的 prep.靠近 adv.邻近"
+    ]
+  },
+  {
+    "name": "nearly",
+    "usphone": "'nɪrli",
+    "ukphone": "'nɪəlɪ",
+    "trans": [
+      "adv.几乎"
+    ]
+  },
+  {
+    "name": "necessary",
+    "usphone": "ˈnɛsəˌsɛri",
+    "ukphone": "ˈnɛsɪsərɪ",
+    "trans": [
+      "adj.需要的，重要的"
+    ]
+  },
+  {
+    "name": "necessity",
+    "usphone": "nə'sɛsəti",
+    "ukphone": "nɪ'sesɪtɪ",
+    "trans": [
+      "n.必要性,需要;必然性;(pl)必需品"
+    ]
+  },
+  {
+    "name": "need",
+    "usphone": "nid",
+    "ukphone": "niːd",
+    "trans": [
+      "n.&v.需要，必要"
+    ]
+  },
+  {
+    "name": "negative",
+    "usphone": "'nɛɡətɪv",
+    "ukphone": "'negətɪv",
+    "trans": [
+      "adj.否定的，消极的"
+    ]
+  },
+  {
+    "name": "neglect",
+    "usphone": "nɪ'glɛkt",
+    "ukphone": "nɪ'glekt",
+    "trans": [
+      "v.&n.忽视；疏忽"
+    ]
+  },
+  {
+    "name": "negotiation",
+    "usphone": "nɪ,ɡoʃɪ'eʃən",
+    "ukphone": "nɪgəʊʃɪ'eɪʃ(ə)n",
+    "trans": [
+      "n.谈判，商议"
+    ]
+  },
+  {
+    "name": "negotiate",
+    "usphone": "nɪ'ɡoʃɪet",
+    "ukphone": "nɪ'gəʊʃɪeɪt",
+    "trans": [
+      "v.谈判"
+    ]
+  },
+  {
+    "name": "neighbor",
+    "usphone": "'neibə",
+    "ukphone": "'neibə",
+    "trans": [
+      "n.邻居"
+    ]
+  },
+  {
+    "name": "neighborhood",
+    "usphone": "'neibəhud",
+    "ukphone": "'neibəhud",
+    "trans": [
+      "n.邻居"
+    ]
+  },
+  {
+    "name": "neither",
+    "usphone": "ˈniðɚ; ˈnaɪðɚ",
+    "ukphone": "ˈnaɪðə; ˈniːðə",
+    "trans": [
+      "pron./adj.(两者)都不(的)"
+    ]
+  },
+  {
+    "name": "nervous",
+    "usphone": "'nɝvəs",
+    "ukphone": "'nɜːvəs",
+    "trans": [
+      "adj.神经的；紧张不安的"
+    ]
+  },
+  {
+    "name": "net",
+    "usphone": "nɛt",
+    "ukphone": "net",
+    "trans": [
+      "n.网，网状物 adj.净，纯净的"
+    ]
+  },
+  {
+    "name": "network",
+    "usphone": "'nɛtwɝk",
+    "ukphone": "'netwɜːk",
+    "trans": [
+      "n.网状物; 网络"
+    ]
+  },
+  {
+    "name": "neutral",
+    "usphone": "'nʊtrəl",
+    "ukphone": "'njuːtr(ə)l",
+    "trans": [
+      "adj.中立的；中性的"
+    ]
+  },
+  {
+    "name": "never",
+    "usphone": "'nɛvɚ",
+    "ukphone": "'nevə",
+    "trans": [
+      "adv.从来不，决不"
+    ]
+  },
+  {
+    "name": "new",
+    "usphone": "nu",
+    "ukphone": "njuː",
+    "trans": [
+      "adj.新的"
+    ]
+  },
+  {
+    "name": "news",
+    "usphone": "nuz",
+    "ukphone": "njuːz",
+    "trans": [
+      "n.新闻"
+    ]
+  },
+  {
+    "name": "newspaper",
+    "usphone": "'nuzpepɚ",
+    "ukphone": "'njuːzpeɪpə; 'njuːs-",
+    "trans": [
+      "n.报纸"
+    ]
+  },
+  {
+    "name": "next",
+    "usphone": "nɛkst",
+    "ukphone": "nekst",
+    "trans": [
+      "adj.接下来的 adv.随后"
+    ]
+  },
+  {
+    "name": "nice",
+    "usphone": "naɪs",
+    "ukphone": "naɪs",
+    "trans": [
+      "adj. 好的，美的"
+    ]
+  },
+  {
+    "name": "night",
+    "usphone": "naɪt",
+    "ukphone": "naɪt",
+    "trans": [
+      "n.夜晚"
+    ]
+  },
+  {
+    "name": "noble",
+    "usphone": "'nobl",
+    "ukphone": "'nəʊb(ə)l",
+    "trans": [
+      "adj.高尚的，宏伟的"
+    ]
+  },
+  {
+    "name": "noise",
+    "usphone": "nɔɪz",
+    "ukphone": "nɒɪz",
+    "trans": [
+      "n.噪声"
+    ]
+  },
+  {
+    "name": "normal",
+    "usphone": "'nɔrml",
+    "ukphone": "'nɔːm(ə)l",
+    "trans": [
+      "adj.正常的"
+    ]
+  },
+  {
+    "name": "north",
+    "usphone": "nɔrθ",
+    "ukphone": "nɔːθ",
+    "trans": [
+      "n.北；北方 adj.北的，北方的 adv.向北方"
+    ]
+  },
+  {
+    "name": "note",
+    "usphone": "not",
+    "ukphone": "nəʊt",
+    "trans": [
+      "n.笔记，记录，便条"
+    ]
+  },
+  {
+    "name": "notebook",
+    "usphone": "'notbʊk",
+    "ukphone": "'nəʊtbʊk",
+    "trans": [
+      "n.笔记本"
+    ]
+  },
+  {
+    "name": "nothing",
+    "usphone": "'nʌθɪŋ",
+    "ukphone": "'nʌθɪŋ",
+    "trans": [
+      "n.什么也没有"
+    ]
+  },
+  {
+    "name": "notice",
+    "usphone": "'notɪs",
+    "ukphone": "'nəʊtɪs",
+    "trans": [
+      "n.布告，通知；注意"
+    ]
+  },
+  {
+    "name": "novel",
+    "usphone": "ˈnɑːvl",
+    "ukphone": "'nɒv(ə)l",
+    "trans": [
+      "n.(长篇) 小说 adj.新奇的，新颖的"
+    ]
+  },
+  {
+    "name": "nowadays",
+    "usphone": "'naʊədez",
+    "ukphone": "'naʊədeɪz",
+    "trans": [
+      "adv.现今，现在"
+    ]
+  },
+  {
+    "name": "nowhere",
+    "usphone": "'no'wɛr",
+    "ukphone": "'nəʊhweə",
+    "trans": [
+      "adv.任何地方都不"
+    ]
+  },
+  {
+    "name": "number",
+    "usphone": "'nʌmbɚ",
+    "ukphone": "'nʌmbə",
+    "trans": [
+      "n.号码"
+    ]
+  },
+  {
+    "name": "nurse",
+    "usphone": "nɝs",
+    "ukphone": "nɜːs",
+    "trans": [
+      "n.护士"
+    ]
+  },
+  {
+    "name": "obey",
+    "usphone": "ə'be",
+    "ukphone": "ə(ʊ)'beɪ",
+    "trans": [
+      "v.服从 .听从"
+    ]
+  },
+  {
+    "name": "object",
+    "usphone": "'ɑbdʒɛkt",
+    "ukphone": "'ɒbdʒɪkt; -dʒekt",
+    "trans": [
+      "v.反对 n.物体；对象"
+    ]
+  },
+  {
+    "name": "objective",
+    "usphone": "əb'dʒɛktɪv",
+    "ukphone": "əb'dʒektɪv",
+    "trans": [
+      "n.目标，目的 adj.客观的"
+    ]
+  },
+  {
+    "name": "observe",
+    "usphone": "əb'zɝv",
+    "ukphone": "əb'zɜːv",
+    "trans": [
+      "v.遵守，观察"
+    ]
+  },
+  {
+    "name": "observation",
+    "usphone": ",ɑbzɚ'veʃən",
+    "ukphone": "ɒbzə'veɪʃ(ə)n",
+    "trans": [
+      "n.观察"
+    ]
+  },
+  {
+    "name": "obtain",
+    "usphone": "əb'ten",
+    "ukphone": "əb'teɪn",
+    "trans": [
+      "v.获得，得到"
+    ]
+  },
+  {
+    "name": "obvious",
+    "usphone": "'ɑbvɪəs",
+    "ukphone": "'ɒbvɪəs",
+    "trans": [
+      "adj.明显的，清楚的"
+    ]
+  },
+  {
+    "name": "occasion",
+    "usphone": "ə'keʒn",
+    "ukphone": "ə'keɪʒ(ə)n",
+    "trans": [
+      "n.场合，时刻"
+    ]
+  },
+  {
+    "name": "occupy",
+    "usphone": "'ɑkjupaɪ",
+    "ukphone": "'ɒkjʊpaɪ",
+    "trans": [
+      "v.占据，占领"
+    ]
+  },
+  {
+    "name": "occur",
+    "usphone": "ə'kɝ",
+    "ukphone": "ə'kɜː",
+    "trans": [
+      "v.发生"
+    ]
+  },
+  {
+    "name": "October",
+    "usphone": "ɑk'tobɚ",
+    "ukphone": "ɒk'təʊbə",
+    "trans": [
+      "n.十月"
+    ]
+  },
+  {
+    "name": "odd",
+    "usphone": "ɑd",
+    "ukphone": "ɒd",
+    "trans": [
+      "adj. 古怪的，零散的"
+    ]
+  },
+  {
+    "name": "offer",
+    "usphone": "'ɔfɚ",
+    "ukphone": "'ɒfə",
+    "trans": [
+      "v./n.提供；提出"
+    ]
+  },
+  {
+    "name": "office",
+    "usphone": "'ɔfɪs",
+    "ukphone": "'ɒfɪs",
+    "trans": [
+      "n.办公室"
+    ]
+  },
+  {
+    "name": "officer",
+    "usphone": "'ɔfɪsɚ",
+    "ukphone": "'ɒfɪsə",
+    "trans": [
+      "n.军官，警官"
+    ]
+  },
+  {
+    "name": "official",
+    "usphone": "əˈfɪʃəl; oʊˈfɪʃəl",
+    "ukphone": "ə'fɪʃ(ə)l",
+    "trans": [
+      "n.官员 adj.官方的,正式的"
+    ]
+  },
+  {
+    "name": "often",
+    "usphone": "'ɔf(tə)n; 'ɑf(tə)n",
+    "ukphone": "'ɒf(tə)n",
+    "trans": [
+      "adv.经常，常常"
+    ]
+  },
+  {
+    "name": "oil",
+    "usphone": "ɔɪl",
+    "ukphone": "ɒɪl",
+    "trans": [
+      "n.油；石油"
+    ]
+  },
+  {
+    "name": "old",
+    "usphone": "old",
+    "ukphone": "əʊld",
+    "trans": [
+      "adj.年老的；老的，旧的"
+    ]
+  },
+  {
+    "name": "once",
+    "usphone": "wʌns",
+    "ukphone": "wʌns",
+    "trans": [
+      "adv.曾经，一次"
+    ]
+  },
+  {
+    "name": "online",
+    "usphone": "'ɑn'laɪn",
+    "ukphone": "ɒn'laɪn",
+    "trans": [
+      "adj. 联机的；在线的 adv. 在线地"
+    ]
+  },
+  {
+    "name": "only",
+    "usphone": "'onli",
+    "ukphone": "'əʊnlɪ",
+    "trans": [
+      "adv.才，只，仅仅 adj.唯一的，仅有的"
+    ]
+  },
+  {
+    "name": "open",
+    "usphone": "'opən",
+    "ukphone": "'əʊp(ə)n",
+    "trans": [
+      "adj.开着的；张口的 vt.打开；张开"
+    ]
+  },
+  {
+    "name": "operation",
+    "usphone": ",ɑpə'reʃən",
+    "ukphone": "ɒpə'reɪʃ(ə)n",
+    "trans": [
+      "n.操作，工作，运转"
+    ]
+  },
+  {
+    "name": "opinion",
+    "usphone": "ə'pɪnjən",
+    "ukphone": "ə'pɪnjən",
+    "trans": [
+      "n.观点，看法"
+    ]
+  },
+  {
+    "name": "opponent",
+    "usphone": "ə'ponənt",
+    "ukphone": "ə'pəʊnənt",
+    "trans": [
+      "n.对手,反对者,敌手 adj.对立的,对抗的"
+    ]
+  },
+  {
+    "name": "opportunity",
+    "usphone": "ˌɑpɚˈtunɪti, -ˈtju-",
+    "ukphone": "ɒpə'tjuːnɪtɪ",
+    "trans": [
+      "n.机会；时机"
+    ]
+  },
+  {
+    "name": "opposite",
+    "usphone": "ˈɑpəzɪt; ˈɑpəsɪt",
+    "ukphone": "'ɒpəzɪt; -sɪt",
+    "trans": [
+      "adj.对面的，对立的"
+    ]
+  },
+  {
+    "name": "oppose",
+    "usphone": "ə'poz",
+    "ukphone": "ə'pəʊz",
+    "trans": [
+      "v.反对，反抗"
+    ]
+  },
+  {
+    "name": "order",
+    "usphone": "'ɔrdɚ",
+    "ukphone": "'ɔːdə",
+    "trans": [
+      "n.命令,订货单,菜单,秩序 v.命令,订货"
+    ]
+  },
+  {
+    "name": "ordinary",
+    "usphone": "'ɔrdnɛri",
+    "ukphone": "'ɔːdɪn(ə)rɪ; -d(ə)n-",
+    "trans": [
+      "adj.普通的，平常的"
+    ]
+  },
+  {
+    "name": "organize",
+    "usphone": "ɔrɡənˌaɪz",
+    "ukphone": "ˈɔ:gənaɪz",
+    "trans": [
+      "v.(=organise)组织"
+    ]
+  },
+  {
+    "name": "organization",
+    "usphone": ",ɔrɡənə'zeʃən",
+    "ukphone": "ˌɔːɡənaɪ'zeɪʃn",
+    "trans": [
+      "n.组织；团体，机构"
+    ]
+  },
+  {
+    "name": "origin",
+    "usphone": "'ɔrɪdʒɪn",
+    "ukphone": "'ɒrɪdʒɪn",
+    "trans": [
+      "n.起源；出身"
+    ]
+  },
+  {
+    "name": "original",
+    "usphone": "ə'rɪdʒənl",
+    "ukphone": "ə'rɪdʒɪn(ə)l; ɒ-",
+    "trans": [
+      "adj.最初的，原版的"
+    ]
+  },
+  {
+    "name": "other",
+    "usphone": "'ʌðɚ",
+    "ukphone": "'ʌðə",
+    "trans": [
+      "pron.另外一个 adj.别的，另外的"
+    ]
+  },
+  {
+    "name": "otherwise",
+    "usphone": "'ʌðɚwaɪz",
+    "ukphone": "'ʌðəwaɪz",
+    "trans": [
+      "adv.&conj.否则，要不然"
+    ]
+  },
+  {
+    "name": "ourselves",
+    "usphone": "ɑr'sɛlvz",
+    "ukphone": "aʊə'selvz",
+    "trans": [
+      "pron.我们自己"
+    ]
+  },
+  {
+    "name": "outcome",
+    "usphone": "'aʊt'kʌm",
+    "ukphone": "'aʊtkʌm",
+    "trans": [
+      "n.结果，成果"
+    ]
+  },
+  {
+    "name": "outdoor",
+    "usphone": "'aʊt'dɔr",
+    "ukphone": "'aʊtdɔː",
+    "trans": [
+      "adj./adv.户外的，野外的；户外，野外"
+    ]
+  },
+  {
+    "name": "outline",
+    "usphone": "'aʊtlaɪn",
+    "ukphone": "'aʊtlaɪn",
+    "trans": [
+      "n.大纲，概要"
+    ]
+  },
+  {
+    "name": "outside",
+    "usphone": ",aʊt'saɪd",
+    "ukphone": "aʊt'saɪd; 'aʊtsaɪd",
+    "trans": [
+      "n.外部,外面,外侧 adj.外部的 adv.向外面"
+    ]
+  },
+  {
+    "name": "outstanding",
+    "usphone": "'aʊt'stændɪŋ",
+    "ukphone": "aʊt'stændɪŋ",
+    "trans": [
+      "adj.突出的，显著的"
+    ]
+  },
+  {
+    "name": "overcome",
+    "usphone": ",ovɚ'kʌm",
+    "ukphone": "əʊvə'kʌm",
+    "trans": [
+      "v.克服，战胜"
+    ]
+  },
+  {
+    "name": "overtime",
+    "usphone": ",ovə'taɪm",
+    "ukphone": "'əʊvətaɪm",
+    "trans": [
+      "adj.超时的，加班的 adv.超时地"
+    ]
+  },
+  {
+    "name": "owe",
+    "usphone": "o",
+    "ukphone": "əʊ",
+    "trans": [
+      "v.欠，负债；感激"
+    ]
+  },
+  {
+    "name": "own",
+    "usphone": "on",
+    "ukphone": "əʊn",
+    "trans": [
+      "adj.自己的"
+    ]
+  },
+  {
+    "name": "owner",
+    "usphone": "'onɚ",
+    "ukphone": "'əʊnə",
+    "trans": [
+      "n.所有者"
+    ]
+  },
+  {
+    "name": "ownership",
+    "usphone": "'onɚʃɪp",
+    "ukphone": "'əʊnəʃɪp",
+    "trans": [
+      "n.所有(权)，所有制"
+    ]
+  },
+  {
+    "name": "oxygen",
+    "usphone": "'ɑksɪdʒən",
+    "ukphone": "'ɒksɪdʒ(ə)n",
+    "trans": [
+      "n.氧气"
+    ]
+  },
+  {
+    "name": "pace",
+    "usphone": "pes",
+    "ukphone": "peɪs",
+    "trans": [
+      "n.步，步伐"
+    ]
+  },
+  {
+    "name": "page",
+    "ukphone": "peɪdʒ",
+    "trans": [
+      "n.页，页面"
+    ]
+  },
+  {
+    "name": "pain",
+    "usphone": "pen",
+    "ukphone": "peɪn",
+    "trans": [
+      "n.疼痛，痛苦"
+    ]
+  },
+  {
+    "name": "painful",
+    "usphone": "'penfl",
+    "ukphone": "'peɪnfʊl; -f(ə)l",
+    "trans": [
+      "adj.疼(痛)的，使痛苦的"
+    ]
+  },
+  {
+    "name": "paint",
+    "ukphone": "peɪnt",
+    "trans": [
+      "v.粉刷；油漆 n.颜料，油漆"
+    ]
+  },
+  {
+    "name": "palace",
+    "usphone": "'pælis",
+    "ukphone": "'pælɪs",
+    "trans": [
+      "n.宫殿"
+    ]
+  },
+  {
+    "name": "paper",
+    "usphone": "'pepɚ",
+    "ukphone": "'peɪpə",
+    "trans": [
+      "n.报纸"
+    ]
+  },
+  {
+    "name": "paragraph",
+    "usphone": "'pærəɡræf",
+    "ukphone": "'pærəgrɑːf",
+    "trans": [
+      "n.段，节"
+    ]
+  },
+  {
+    "name": "parent",
+    "usphone": "'pɛrənt",
+    "ukphone": "'peər(ə)nt",
+    "trans": [
+      "n.父母"
+    ]
+  },
+  {
+    "name": "Paris",
+    "usphone": "'pæris",
+    "ukphone": "'pæris",
+    "trans": [
+      "n.巴黎(法国首都)"
+    ]
+  },
+  {
+    "name": "park",
+    "usphone": "pɑrk",
+    "ukphone": "pɑːk",
+    "trans": [
+      "n.公园 v.停放(汽车等)"
+    ]
+  },
+  {
+    "name": "parliament",
+    "usphone": "'pɑrləmənt",
+    "ukphone": "'pɑːləm(ə)nt",
+    "trans": [
+      "n.国会，议会"
+    ]
+  },
+  {
+    "name": "part",
+    "usphone": "pɑrt",
+    "ukphone": "pɑːt",
+    "trans": [
+      "n.部分"
+    ]
+  },
+  {
+    "name": "partly",
+    "usphone": "'pɑrtli",
+    "ukphone": "'pɑːtlɪ",
+    "trans": [
+      "adv.部分地；在一定程度上"
+    ]
+  },
+  {
+    "name": "participate",
+    "usphone": "pɑr'tɪsə'pet",
+    "ukphone": "pɑː'tɪsɪpeɪt",
+    "trans": [
+      "v.(in) 参与,参加"
+    ]
+  },
+  {
+    "name": "partner",
+    "usphone": "'pɑrtnɚ",
+    "ukphone": "'pɑːtnə",
+    "trans": [
+      "n.合作者，伙伴"
+    ]
+  },
+  {
+    "name": "party",
+    "usphone": "'pɑrti",
+    "ukphone": "'pɑːtɪ",
+    "trans": [
+      "n.聚会"
+    ]
+  },
+  {
+    "name": "pass",
+    "usphone": "pæs",
+    "ukphone": "pɑːs",
+    "trans": [
+      "v.经过,路过；度过;递给；通过考试"
+    ]
+  },
+  {
+    "name": "passport",
+    "usphone": "'pæspɔrt",
+    "ukphone": "'pɑːspɔːt",
+    "trans": [
+      "n.护照"
+    ]
+  },
+  {
+    "name": "passion",
+    "usphone": "'pæʃən",
+    "ukphone": "'pæʃ(ə)n",
+    "trans": [
+      "n.强烈情感；爱好；激怒"
+    ]
+  },
+  {
+    "name": "past",
+    "usphone": "pæst",
+    "ukphone": "pɑːst",
+    "trans": [
+      "adj.过去的,从前的；刚过去的 adv.过 n.过去"
+    ]
+  },
+  {
+    "name": "patient",
+    "usphone": "'peʃnt",
+    "ukphone": "'peɪʃ(ə)nt",
+    "trans": [
+      "adj.有耐心的；能忍耐的 n.病人，患者"
+    ]
+  },
+  {
+    "name": "pattern",
+    "usphone": "'pætɚn",
+    "ukphone": "'pæt(ə)n",
+    "trans": [
+      "n.型，模型；样式；花样，图案"
+    ]
+  },
+  {
+    "name": "pay",
+    "usphone": "pe",
+    "ukphone": "peɪ",
+    "trans": [
+      "v.支付 n.报酬"
+    ]
+  },
+  {
+    "name": "payment",
+    "usphone": "'pemənt",
+    "ukphone": "'peɪm(ə)nt",
+    "trans": [
+      "n.支付；付款额"
+    ]
+  },
+  {
+    "name": "peace",
+    "usphone": "pis",
+    "ukphone": "piːs",
+    "trans": [
+      "n.和平；平静"
+    ]
+  },
+  {
+    "name": "peaceful",
+    "usphone": "'pisfəl",
+    "ukphone": "'piːsfʊl; -f(ə)l",
+    "trans": [
+      "adj.平静的；爱好和平的"
+    ]
+  },
+  {
+    "name": "peach",
+    "usphone": "pitʃ",
+    "ukphone": "piːtʃ",
+    "trans": [
+      "n.桃"
+    ]
+  },
+  {
+    "name": "peak",
+    "usphone": "pik",
+    "ukphone": "piːk",
+    "trans": [
+      "n.山顶，最高点；山峰 adj.高峰的，最高的"
+    ]
+  },
+  {
+    "name": "pencil",
+    "usphone": "'pɛnsl",
+    "ukphone": "'pens(ə)l; -sɪl",
+    "trans": [
+      "n.铅笔"
+    ]
+  },
+  {
+    "name": "pension",
+    "usphone": "'pɛnʃən",
+    "ukphone": "'penʃ(ə)n",
+    "trans": [
+      "n.养老金"
+    ]
+  },
+  {
+    "name": "people",
+    "usphone": "'pipl",
+    "ukphone": "'piːp(ə)l",
+    "trans": [
+      "n.人们，人民"
+    ]
+  },
+  {
+    "name": "perceive",
+    "usphone": "pɚ'siv",
+    "ukphone": "pə'siːv",
+    "trans": [
+      "v.感知，察觉；理解，醒悟"
+    ]
+  },
+  {
+    "name": "percent",
+    "usphone": "pɚ'sɛnt",
+    "ukphone": "pə'sent",
+    "trans": [
+      "n.百分点"
+    ]
+  },
+  {
+    "name": "perfect",
+    "usphone": "ˈpɝfɪkt; (for v.) pɝˈfɛkt",
+    "ukphone": "ˈpəːfɪkt; (for v.) pəˈfekt",
+    "trans": [
+      "adj.完美的"
+    ]
+  },
+  {
+    "name": "perform",
+    "usphone": "pɚ'fɔrm",
+    "ukphone": "pə'fɔːm",
+    "trans": [
+      "v.做，实施，完成；表演，演出"
+    ]
+  },
+  {
+    "name": "performance",
+    "usphone": "pɚ'fɔrməns",
+    "ukphone": "pə'fɔːm(ə)ns",
+    "trans": [
+      "n.履行,执行,表演,性能"
+    ]
+  },
+  {
+    "name": "perfume",
+    "usphone": "pɚ'fjum",
+    "ukphone": "'pɜːfjuːm",
+    "trans": [
+      "n.香味,香水"
+    ]
+  },
+  {
+    "name": "perhaps",
+    "usphone": "pɚ'hæps",
+    "ukphone": "pə'hæps",
+    "trans": [
+      "adv.也许"
+    ]
+  },
+  {
+    "name": "period",
+    "usphone": "'pɪrɪəd",
+    "ukphone": "'pɪərɪəd",
+    "trans": [
+      "n.期间，一段时间"
+    ]
+  },
+  {
+    "name": "permanent",
+    "usphone": "'pɝmənənt",
+    "ukphone": "'pɜːm(ə)nənt",
+    "trans": [
+      "adj.永久的，持久的"
+    ]
+  },
+  {
+    "name": "permission",
+    "usphone": "pɚ'mɪʃən",
+    "ukphone": "pə'mɪʃ(ə)n",
+    "trans": [
+      "n.允许，同意"
+    ]
+  },
+  {
+    "name": "person",
+    "usphone": "'pɝsn",
+    "ukphone": "'pɜːs(ə)n",
+    "trans": [
+      "n.人"
+    ]
+  },
+  {
+    "name": "personal",
+    "usphone": "'pɝsənl",
+    "ukphone": "'pɜːs(ə)n(ə)l",
+    "trans": [
+      "adj.私人的，个人的"
+    ]
+  },
+  {
+    "name": "personality",
+    "usphone": ",pɝsə'næləti",
+    "ukphone": "pɜːsə'nælɪtɪ",
+    "trans": [
+      "n.人格，个性"
+    ]
+  },
+  {
+    "name": "persuade",
+    "usphone": "pɚ'swed",
+    "ukphone": "pə'sweɪd",
+    "trans": [
+      "v.劝服，说服"
+    ]
+  },
+  {
+    "name": "pet",
+    "usphone": "pɛt",
+    "ukphone": "pet",
+    "trans": [
+      "n.宠物"
+    ]
+  },
+  {
+    "name": "philosophy",
+    "usphone": "fə'lɑsəfi",
+    "ukphone": "fɪ'lɒsəfɪ",
+    "trans": [
+      "n.哲学"
+    ]
+  },
+  {
+    "name": "phrase",
+    "usphone": "frez",
+    "ukphone": "freɪz",
+    "trans": [
+      "n.短语"
+    ]
+  },
+  {
+    "name": "physical",
+    "usphone": "'fɪzɪkl",
+    "ukphone": "'fɪzɪk(ə)l",
+    "trans": [
+      "adj.物质的,身体的,体力的,物理的"
+    ]
+  },
+  {
+    "name": "physician",
+    "usphone": "fɪ'zɪʃən",
+    "ukphone": "fɪ'zɪʃ(ə)n",
+    "trans": [
+      "n.医师"
+    ]
+  },
+  {
+    "name": "pick",
+    "usphone": "pɪk",
+    "ukphone": "pɪk",
+    "trans": [
+      "v.挑，捡"
+    ]
+  },
+  {
+    "name": "picnic",
+    "usphone": "'pɪknɪk",
+    "ukphone": "'pɪknɪk",
+    "trans": [
+      "n.野餐"
+    ]
+  },
+  {
+    "name": "picture",
+    "usphone": "'pɪktʃɚ",
+    "ukphone": "'pɪktʃə",
+    "trans": [
+      "n.画像；照片"
+    ]
+  },
+  {
+    "name": "piece",
+    "usphone": "pis",
+    "ukphone": "piːs",
+    "trans": [
+      "n.(一)块；(一)片；(一)件；(一)张"
+    ]
+  },
+  {
+    "name": "place",
+    "usphone": "ples",
+    "ukphone": "pleɪs",
+    "trans": [
+      "n.住处，地方"
+    ]
+  },
+  {
+    "name": "plan",
+    "usphone": "plæn",
+    "ukphone": "plæn",
+    "trans": [
+      "v./n.计划，打算"
+    ]
+  },
+  {
+    "name": "plane",
+    "usphone": "plen",
+    "ukphone": "pleɪn",
+    "trans": [
+      "n.飞机"
+    ]
+  },
+  {
+    "name": "planet",
+    "usphone": "'plænɪt",
+    "ukphone": "'plænɪt",
+    "trans": [
+      "n.行星"
+    ]
+  },
+  {
+    "name": "plant",
+    "usphone": "plænt",
+    "ukphone": "plɑːnt",
+    "trans": [
+      "v.栽种，播种，栽培 n.植物"
+    ]
+  },
+  {
+    "name": "plastic",
+    "usphone": "'plæstɪk",
+    "ukphone": "'plæstɪk",
+    "trans": [
+      "adj. 塑料的"
+    ]
+  },
+  {
+    "name": "play",
+    "usphone": "ple",
+    "ukphone": "pleɪ",
+    "trans": [
+      "v.玩,做游戏 n.剧本"
+    ]
+  },
+  {
+    "name": "player",
+    "usphone": "'pleɚ",
+    "ukphone": "'pleɪə",
+    "trans": [
+      "n.运动员；演奏者"
+    ]
+  },
+  {
+    "name": "playground",
+    "usphone": "'ple'graʊnd",
+    "ukphone": "'pleɪgraʊnd",
+    "trans": [
+      "n.运动场"
+    ]
+  },
+  {
+    "name": "please",
+    "usphone": "pliz",
+    "ukphone": "pliːz",
+    "trans": [
+      "v.请"
+    ]
+  },
+  {
+    "name": "pleasant",
+    "usphone": "'plɛznt",
+    "ukphone": "'plez(ə)nt",
+    "trans": [
+      "adj.美好的；合意的"
+    ]
+  },
+  {
+    "name": "pleasure",
+    "usphone": "ˈplɛʒɚ",
+    "ukphone": "'pleʒə",
+    "trans": [
+      "n.愉快，欢乐，乐趣"
+    ]
+  },
+  {
+    "name": "plot",
+    "usphone": "plɑt",
+    "ukphone": "plɒt",
+    "trans": [
+      "n.秘密计划,情节 v.绘制；密谋"
+    ]
+  },
+  {
+    "name": "point",
+    "usphone": "pɔɪnt",
+    "ukphone": "pɒɪnt",
+    "trans": [
+      "v.指向 n. 要点"
+    ]
+  },
+  {
+    "name": "poison",
+    "usphone": "'pɔɪzn",
+    "ukphone": "'pɒɪz(ə)n",
+    "trans": [
+      "n.毒物；毒药 v.毒害；使中毒；放毒"
+    ]
+  },
+  {
+    "name": "poisonous",
+    "usphone": "'pɔɪzənəs",
+    "ukphone": "'pɒɪzənəs",
+    "trans": [
+      "n.有毒的；有害的"
+    ]
+  },
+  {
+    "name": "police",
+    "usphone": "pə'lis",
+    "ukphone": "pə'liːs",
+    "trans": [
+      "n.警察，警察局"
+    ]
+  },
+  {
+    "name": "policy",
+    "usphone": "'pɑləsi",
+    "ukphone": "'pɒləsɪ",
+    "trans": [
+      "n.方针；政策"
+    ]
+  },
+  {
+    "name": "polite",
+    "usphone": "pə'laɪt",
+    "ukphone": "pə'laɪt",
+    "trans": [
+      "adj.有礼貌的,客气的"
+    ]
+  },
+  {
+    "name": "political",
+    "usphone": "pə'lɪtɪkl",
+    "ukphone": "pə'lɪtɪk(ə)l",
+    "trans": [
+      "adj.政治的"
+    ]
+  },
+  {
+    "name": "politician",
+    "usphone": ",pɑlə'tɪʃən",
+    "ukphone": "pɒlɪ'tɪʃ(ə)n",
+    "trans": [
+      "n.政客；政治家"
+    ]
+  },
+  {
+    "name": "pollution",
+    "usphone": "pə'luʃən",
+    "ukphone": "pə'luːʃ(ə)n",
+    "trans": [
+      "n.污染"
+    ]
+  },
+  {
+    "name": "pollute",
+    "usphone": "pə'lut",
+    "ukphone": "pə'luːt",
+    "trans": [
+      "v.污染；玷污"
+    ]
+  },
+  {
+    "name": "poor",
+    "usphone": "pʊr",
+    "ukphone": "pɔː; pʊə",
+    "trans": [
+      "adj.贫困的，穷的"
+    ]
+  },
+  {
+    "name": "poverty",
+    "usphone": "'pɑvɚti",
+    "ukphone": "'pɒvətɪ",
+    "trans": [
+      "n.贫穷，贫困"
+    ]
+  },
+  {
+    "name": "popular",
+    "usphone": "'pɑpjəlɚ",
+    "ukphone": "'pɒpjʊlə",
+    "trans": [
+      "adj.流行的，通俗的，大众的"
+    ]
+  },
+  {
+    "name": "population",
+    "usphone": ",pɑpju'leʃən",
+    "ukphone": "pɒpjʊ'leɪʃ(ə)n",
+    "trans": [
+      "n.人口；人口总数"
+    ]
+  },
+  {
+    "name": "position",
+    "usphone": "pə'zɪʃən",
+    "ukphone": "pə'zɪʃ(ə)n",
+    "trans": [
+      "n.(可数)位置,职位,职务,姿势，姿态"
+    ]
+  },
+  {
+    "name": "positive",
+    "usphone": "'pɑzətɪv",
+    "ukphone": "'pɒzɪtɪv",
+    "trans": [
+      "adj. 积极的,肯定的"
+    ]
+  },
+  {
+    "name": "possess",
+    "usphone": "pə'zɛs",
+    "ukphone": "pə'zes",
+    "trans": [
+      "v.占有，拥有"
+    ]
+  },
+  {
+    "name": "possession",
+    "usphone": "pə'zɛʃən",
+    "ukphone": "pə'zeʃ(ə)n",
+    "trans": [
+      "n.所有物；拥有，占有"
+    ]
+  },
+  {
+    "name": "possible",
+    "usphone": "'pɑsəbl",
+    "ukphone": "'pɒsɪb(ə)l",
+    "trans": [
+      "adj.可能的"
+    ]
+  },
+  {
+    "name": "possibility",
+    "usphone": ",pɑsə'bɪləti",
+    "ukphone": ",pɒsɪ'bɪlɪtɪ",
+    "trans": [
+      "n.可能性"
+    ]
+  },
+  {
+    "name": "post",
+    "usphone": "post",
+    "ukphone": "pəʊst",
+    "trans": [
+      "n.岗位，职位 v.张贴，公布"
+    ]
+  },
+  {
+    "name": "postcard",
+    "usphone": "'post'kɑrd",
+    "ukphone": "'pəʊs(t)kɑːd",
+    "trans": [
+      "n.明信片"
+    ]
+  },
+  {
+    "name": "pour",
+    "usphone": "pɔr",
+    "ukphone": "pɔː",
+    "trans": [
+      "v.灌，倒"
+    ]
+  },
+  {
+    "name": "powder",
+    "usphone": "'paʊdɚ",
+    "ukphone": "'paʊdə",
+    "trans": [
+      "n.粉末，药粉"
+    ]
+  },
+  {
+    "name": "power",
+    "usphone": "'paʊɚ",
+    "ukphone": "'paʊə",
+    "trans": [
+      "n.力，能力，精力"
+    ]
+  },
+  {
+    "name": "powerful",
+    "usphone": "'paʊɚfl",
+    "ukphone": "'paʊəfʊl; -f(ə)l",
+    "trans": [
+      "adj.强有力的"
+    ]
+  },
+  {
+    "name": "practice",
+    "usphone": "'præktɪs",
+    "ukphone": "'præktɪs",
+    "trans": [
+      "n. 练习,实行,习惯 v. 练习,实践"
+    ]
+  },
+  {
+    "name": "practical",
+    "usphone": "'præktɪkl",
+    "ukphone": "'præktɪk(ə)l",
+    "trans": [
+      "adj.实际的；实用的"
+    ]
+  },
+  {
+    "name": "praise",
+    "usphone": "prez",
+    "ukphone": "preɪz",
+    "trans": [
+      "v.&n. 称赞，表扬"
+    ]
+  },
+  {
+    "name": "precious",
+    "usphone": "'prɛʃəs",
+    "ukphone": "'preʃəs",
+    "trans": [
+      "adj. 珍贵的，贵重的"
+    ]
+  },
+  {
+    "name": "prefer",
+    "usphone": "prɪ'fɝ",
+    "ukphone": "prɪ'fɜː",
+    "trans": [
+      "vt.更喜欢，宁愿"
+    ]
+  },
+  {
+    "name": "prepare",
+    "usphone": "prɪ'pɛr",
+    "ukphone": "prɪ'peə",
+    "trans": [
+      "v.准备"
+    ]
+  },
+  {
+    "name": "preparation",
+    "usphone": ",prɛpə'reʃən",
+    "ukphone": ",prepə'reɪʃ(ə)n",
+    "trans": [
+      "n.准备,预备"
+    ]
+  },
+  {
+    "name": "presence",
+    "usphone": "'prɛzns",
+    "ukphone": "'prez(ə)ns",
+    "trans": [
+      "n.出席，到场；存在，在"
+    ]
+  },
+  {
+    "name": "present",
+    "usphone": "'prɛznt",
+    "ukphone": "'prez(ə)nt",
+    "trans": [
+      "n.礼物；现在 adj.出席的，在场的；目前的 v.赠送，给予；提出，出示"
+    ]
+  },
+  {
+    "name": "preserve",
+    "usphone": "prɪ'zɝv",
+    "ukphone": "prɪ'zɜːv",
+    "trans": [
+      "v.保护；保存"
+    ]
+  },
+  {
+    "name": "president",
+    "usphone": "'prɛzɪdənt",
+    "ukphone": "'prezɪd(ə)nt",
+    "trans": [
+      "n.总统"
+    ]
+  },
+  {
+    "name": "pressure",
+    "usphone": "'prɛʃɚ",
+    "ukphone": "'preʃə",
+    "trans": [
+      "n.压力；强制"
+    ]
+  },
+  {
+    "name": "pretend",
+    "usphone": "prɪ'tɛnd",
+    "ukphone": "prɪ'tend",
+    "trans": [
+      "v.假装"
+    ]
+  },
+  {
+    "name": "pretty",
+    "usphone": "'prɪti",
+    "ukphone": "'prɪtɪ",
+    "trans": [
+      "adj.漂亮的；可爱的"
+    ]
+  },
+  {
+    "name": "price",
+    "usphone": "praɪs",
+    "ukphone": "praɪs",
+    "trans": [
+      "n.价格"
+    ]
+  },
+  {
+    "name": "primary",
+    "usphone": "'praɪmɛri",
+    "ukphone": "'praɪm(ə)rɪ",
+    "trans": [
+      "adj.最早的；首要的"
+    ]
+  },
+  {
+    "name": "principal",
+    "usphone": "'prɪnsəpl",
+    "ukphone": "'prɪnsəp(ə)l",
+    "trans": [
+      "adj.最重要的,主要的 n.负责人,资本"
+    ]
+  },
+  {
+    "name": "principle",
+    "usphone": "'prɪnsəpl",
+    "ukphone": "'prɪnsɪp(ə)l",
+    "trans": [
+      "n.原理，原则；信念"
+    ]
+  },
+  {
+    "name": "print",
+    "usphone": "prɪnt",
+    "ukphone": "prɪnt",
+    "trans": [
+      "v.印刷；出版 n.印刷(品)；字体"
+    ]
+  },
+  {
+    "name": "private",
+    "usphone": "'praɪvət",
+    "ukphone": "'praɪvət",
+    "trans": [
+      "adj.私有的，私人的；秘密的"
+    ]
+  },
+  {
+    "name": "privacy",
+    "usphone": "'praɪvəsi",
+    "ukphone": "'prɪvəsɪ; 'praɪ-",
+    "trans": [
+      "n.隐居；私事，隐私"
+    ]
+  },
+  {
+    "name": "probably",
+    "usphone": "'prɔbəb(ə)li",
+    "ukphone": "ˈprɑːbəbli",
+    "trans": [
+      "adv.很可能，大概"
+    ]
+  },
+  {
+    "name": "problem",
+    "usphone": "'prɑbləm",
+    "ukphone": "'prɒbləm",
+    "trans": [
+      "n.问题；难题"
+    ]
+  },
+  {
+    "name": "procedure",
+    "usphone": "prə'sidʒɚ",
+    "ukphone": "prə'siːdʒə",
+    "trans": [
+      "n.程序；手续；步骤"
+    ]
+  },
+  {
+    "name": "process",
+    "usphone": "'prɑsɛs",
+    "ukphone": "'prəʊses",
+    "trans": [
+      "n.过程；工序 v.加工，处理"
+    ]
+  },
+  {
+    "name": "produce",
+    "usphone": "prə'dus",
+    "ukphone": "prə'djuːs",
+    "trans": [
+      "v.生产，制造，产生"
+    ]
+  },
+  {
+    "name": "product",
+    "usphone": "'prɑdʌkt",
+    "ukphone": "'prɒdʌkt",
+    "trans": [
+      "n.产品"
+    ]
+  },
+  {
+    "name": "production",
+    "usphone": "prə'dʌkʃən",
+    "ukphone": "prə'dʌkʃ(ə)n",
+    "trans": [
+      "n.生产，产量；产品"
+    ]
+  },
+  {
+    "name": "professional",
+    "usphone": "prə'fɛʃənl",
+    "ukphone": "prə'feʃ(ə)n(ə)l",
+    "trans": [
+      "adj.职业的,专业的"
+    ]
+  },
+  {
+    "name": "professor",
+    "usphone": "prə'fesə(r)",
+    "ukphone": "prəˈfesər",
+    "trans": [
+      "n.教授"
+    ]
+  },
+  {
+    "name": "progress",
+    "usphone": "'prɑɡrɛs",
+    "ukphone": "'prəʊgres",
+    "trans": [
+      "v.&n.前进，进步，进展"
+    ]
+  },
+  {
+    "name": "project",
+    "usphone": "prəˈdʒɛkt; prɑdʒɛkt",
+    "ukphone": "prəˈdʒekt; ˈprɒdʒekt",
+    "trans": [
+      "n.方案，计划，项目"
+    ]
+  },
+  {
+    "name": "promise",
+    "usphone": "'prɑmɪs",
+    "ukphone": "'prɒmɪs",
+    "trans": [
+      "n.承诺,诺言 v.允诺,答应"
+    ]
+  },
+  {
+    "name": "promote",
+    "usphone": "prə'mot",
+    "ukphone": "prə'məʊt",
+    "trans": [
+      "v.促进；提升"
+    ]
+  },
+  {
+    "name": "proof",
+    "usphone": "pruf",
+    "ukphone": "pruːf",
+    "trans": [
+      "n.证据，证明"
+    ]
+  },
+  {
+    "name": "proper",
+    "usphone": "'prɑpɚ",
+    "ukphone": "'prɒpə",
+    "trans": [
+      "adj.适当的，恰当的"
+    ]
+  },
+  {
+    "name": "property",
+    "usphone": "'prɑpɚti",
+    "ukphone": "'prɒpətɪ",
+    "trans": [
+      "n.财产，所有物"
+    ]
+  },
+  {
+    "name": "propose",
+    "usphone": "prə'poz",
+    "ukphone": "prə'pəʊz",
+    "trans": [
+      "v.提议，建议"
+    ]
+  },
+  {
+    "name": "proposal",
+    "usphone": "prə'pozl",
+    "ukphone": "prə'pəʊz(ə)l",
+    "trans": [
+      "n.提议，建议；求婚"
+    ]
+  },
+  {
+    "name": "prospect",
+    "usphone": "'prɑspɛkt",
+    "ukphone": "'prɒspekt",
+    "trans": [
+      "n.景色；前景，前途"
+    ]
+  },
+  {
+    "name": "prosperity",
+    "usphone": "prɑ'spɛrəti",
+    "ukphone": "prɒ'sperɪtɪ",
+    "trans": [
+      "n.繁荣，兴旺"
+    ]
+  },
+  {
+    "name": "prosperous",
+    "usphone": "'prɑspərəs",
+    "ukphone": "'prɒsp(ə)rəs",
+    "trans": [
+      "adj.富裕的,繁荣的"
+    ]
+  },
+  {
+    "name": "protect",
+    "usphone": "prə'tɛkt",
+    "ukphone": "prə'tekt",
+    "trans": [
+      "v.保护"
+    ]
+  },
+  {
+    "name": "proud",
+    "usphone": "praʊd",
+    "ukphone": "praʊd",
+    "trans": [
+      "adj.骄傲的，自豪的"
+    ]
+  },
+  {
+    "name": "prove",
+    "usphone": "pruv",
+    "ukphone": "pruːv",
+    "trans": [
+      "v.证明，证实；结果是"
+    ]
+  },
+  {
+    "name": "provide",
+    "usphone": "prə'vaɪd",
+    "ukphone": "prə'vaɪd",
+    "trans": [
+      "v.提供，供给；规定"
+    ]
+  },
+  {
+    "name": "provided",
+    "usphone": "prə'vaɪdɪd",
+    "ukphone": "prə'vaɪdɪd",
+    "trans": [
+      "conj.只要，假如"
+    ]
+  },
+  {
+    "name": "province",
+    "usphone": "'prɑvɪns",
+    "ukphone": "'prɒvɪns",
+    "trans": [
+      "n.省"
+    ]
+  },
+  {
+    "name": "public",
+    "usphone": "'pʌblɪk",
+    "ukphone": "'pʌblɪk",
+    "trans": [
+      "adj.公共的"
+    ]
+  },
+  {
+    "name": "publish",
+    "usphone": "'pʌblɪʃ",
+    "ukphone": "'pʌblɪʃ",
+    "trans": [
+      "v.出版；公布"
+    ]
+  },
+  {
+    "name": "pull",
+    "usphone": "pʊl",
+    "ukphone": "pʊl",
+    "trans": [
+      "v.拖，拔，拉 n.拉，拖，扯"
+    ]
+  },
+  {
+    "name": "pump",
+    "usphone": "pʌmp",
+    "ukphone": "pʌmp",
+    "trans": [
+      "n.泵 v.打气，泵送"
+    ]
+  },
+  {
+    "name": "punishment",
+    "usphone": "'pʌnɪʃmənt",
+    "ukphone": "'pʌnɪʃm(ə)nt",
+    "trans": [
+      "n.惩罚，处罚"
+    ]
+  },
+  {
+    "name": "punish",
+    "usphone": "'pʌnɪʃ",
+    "ukphone": "'pʌnɪʃ",
+    "trans": [
+      "v.处罚，惩罚"
+    ]
+  },
+  {
+    "name": "purchase",
+    "usphone": "'pɝtʃəs",
+    "ukphone": "'pɜ:tʃəs",
+    "trans": [
+      "v.买，购买 n.购买的物品"
+    ]
+  },
+  {
+    "name": "purpose",
+    "usphone": "'pɝpəs",
+    "ukphone": "'pɜːpəs",
+    "trans": [
+      "n.目的；用途"
+    ]
+  },
+  {
+    "name": "pursue",
+    "usphone": "pə'sʊ",
+    "ukphone": "pə'sjuː",
+    "trans": [
+      "v. 继续；追赶"
+    ]
+  },
+  {
+    "name": "push",
+    "usphone": "pʊʃ",
+    "ukphone": "pʊʃ",
+    "trans": [
+      "v.&n.推进，推动"
+    ]
+  },
+  {
+    "name": "put",
+    "usphone": "pʊt",
+    "ukphone": "pʊt",
+    "trans": [
+      "v.放，置"
+    ]
+  },
+  {
+    "name": "quality",
+    "usphone": "'kwɑləti",
+    "ukphone": "'kwɒlɪtɪ",
+    "trans": [
+      "n.质量；品质，特性"
+    ]
+  },
+  {
+    "name": "quarrel",
+    "usphone": "'kwɔrəl",
+    "ukphone": "'kwɒr(ə)l",
+    "trans": [
+      "v.&n.争吵，吵架"
+    ]
+  },
+  {
+    "name": "quarter",
+    "usphone": "'kwɔrtɚ",
+    "ukphone": "'kwɔːtə",
+    "trans": [
+      "n.十五分钟,一刻钟,四分之一"
+    ]
+  },
+  {
+    "name": "question",
+    "usphone": "'kwɛstʃən",
+    "ukphone": "'kwestʃ(ə)n",
+    "trans": [
+      "n.问题"
+    ]
+  },
+  {
+    "name": "quick",
+    "usphone": "kwɪk",
+    "ukphone": "kwɪk",
+    "trans": [
+      "adj.快的，迅速的"
+    ]
+  },
+  {
+    "name": "quickly",
+    "usphone": "'kwɪkli",
+    "ukphone": "'kwɪklɪ",
+    "trans": [
+      "adv.迅速地"
+    ]
+  },
+  {
+    "name": "quit",
+    "usphone": "kwɪt",
+    "ukphone": "kwɪt",
+    "trans": [
+      "v.离开，退出"
+    ]
+  },
+  {
+    "name": "quite",
+    "usphone": "kwaɪt",
+    "ukphone": "kwaɪt",
+    "trans": [
+      "adv.很，非常"
+    ]
+  },
+  {
+    "name": "quote",
+    "usphone": "kwot",
+    "ukphone": "kwəʊt",
+    "trans": [
+      "v.引用，援引"
+    ]
+  },
+  {
+    "name": "race",
+    "usphone": "res",
+    "ukphone": "reɪs",
+    "trans": [
+      "v.&n.比赛；赛跑"
+    ]
+  },
+  {
+    "name": "racial",
+    "usphone": "'reʃl",
+    "ukphone": "'reɪʃ(ə)l",
+    "trans": [
+      "adj.种族的"
+    ]
+  },
+  {
+    "name": "radical",
+    "usphone": "'rædɪkl",
+    "ukphone": "'rædɪkl",
+    "trans": [
+      "adj.基本的，重要的"
+    ]
+  },
+  {
+    "name": "radio",
+    "usphone": "'redɪo",
+    "ukphone": "'reɪdɪəʊ",
+    "trans": [
+      "n.收音机"
+    ]
+  },
+  {
+    "name": "rain",
+    "usphone": "reɪn",
+    "ukphone": "reɪn",
+    "trans": [
+      "n.雨 v.下雨"
+    ]
+  },
+  {
+    "name": "raise",
+    "usphone": "rez",
+    "ukphone": "reɪz",
+    "trans": [
+      "v.举起，提升；抚养"
+    ]
+  },
+  {
+    "name": "range",
+    "usphone": "rendʒ",
+    "ukphone": "reɪn(d)ʒ",
+    "trans": [
+      "n.范围,距离,领域"
+    ]
+  },
+  {
+    "name": "rank",
+    "usphone": "ræŋk",
+    "ukphone": "ræŋk",
+    "trans": [
+      "n.军衔，社会阶层；排"
+    ]
+  },
+  {
+    "name": "rapid",
+    "usphone": "'ræpɪd",
+    "ukphone": "'ræpɪd",
+    "trans": [
+      "adj.快的，迅速的"
+    ]
+  },
+  {
+    "name": "rare",
+    "usphone": "rɛr",
+    "ukphone": "reə",
+    "trans": [
+      "adj.稀有的 .珍奇的"
+    ]
+  },
+  {
+    "name": "rarely",
+    "usphone": "'rɛrli",
+    "ukphone": "'reəlɪ",
+    "trans": [
+      "adv.很少；非凡地"
+    ]
+  },
+  {
+    "name": "rate",
+    "usphone": "ret",
+    "ukphone": "reɪt",
+    "trans": [
+      "n.比率"
+    ]
+  },
+  {
+    "name": "rather",
+    "usphone": "'ræðɚ",
+    "ukphone": "'rɑːðə",
+    "trans": [
+      "adv.相当，很"
+    ]
+  },
+  {
+    "name": "ray",
+    "usphone": "re",
+    "ukphone": "rei",
+    "trans": [
+      "n.线，光线"
+    ]
+  },
+  {
+    "name": "reach",
+    "usphone": "ritʃ",
+    "ukphone": "riːtʃ",
+    "trans": [
+      "v.抵达 .达到"
+    ]
+  },
+  {
+    "name": "react",
+    "usphone": "ri'ækt",
+    "ukphone": "rɪ'ækt",
+    "trans": [
+      "v.反应，起作用"
+    ]
+  },
+  {
+    "name": "read",
+    "usphone": "rid; (read, read) rɛd",
+    "ukphone": "riːd; (read, read) red",
+    "trans": [
+      "v.阅读，朗读"
+    ]
+  },
+  {
+    "name": "reader",
+    "usphone": "'ridɚ",
+    "ukphone": "'riːdə",
+    "trans": [
+      "n.读者；读物"
+    ]
+  },
+  {
+    "name": "ready",
+    "usphone": "'rɛdi",
+    "ukphone": "'redɪ",
+    "trans": [
+      "adj.准备好的"
+    ]
+  },
+  {
+    "name": "real",
+    "usphone": "'riəl",
+    "ukphone": "riːl",
+    "trans": [
+      "adj. 真实的；实际的，现实的"
+    ]
+  },
+  {
+    "name": "realistic",
+    "usphone": ",riə'lɪstɪk",
+    "ukphone": "rɪə'lɪstɪk",
+    "trans": [
+      "adj.现实(主义)的"
+    ]
+  },
+  {
+    "name": "reality",
+    "usphone": "rɪ'æləti",
+    "ukphone": "rɪ'ælɪtɪ",
+    "trans": [
+      "n.现实，实际；真实"
+    ]
+  },
+  {
+    "name": "really",
+    "usphone": "'riəli",
+    "ukphone": "'riəli",
+    "trans": [
+      "adv.真正地，确实"
+    ]
+  },
+  {
+    "name": "realize",
+    "usphone": "rɪəˌlaɪz",
+    "ukphone": "'riːəlaɪz",
+    "trans": [
+      "v.认识到，了解"
+    ]
+  },
+  {
+    "name": "reason",
+    "usphone": "ˈrizən",
+    "ukphone": "'riːz(ə)n",
+    "trans": [
+      "n.理由；原因"
+    ]
+  },
+  {
+    "name": "reasonable",
+    "usphone": "'riznəbl",
+    "ukphone": "'riːz(ə)nəb(ə)l",
+    "trans": [
+      "adj.合理的；通情达理的"
+    ]
+  },
+  {
+    "name": "rebel",
+    "usphone": "rɪ'bɛl",
+    "ukphone": "'reb(ə)l",
+    "trans": [
+      "v.反抗，起义 n.叛逆者，起义者"
+    ]
+  },
+  {
+    "name": "receive",
+    "usphone": "rɪ'siv",
+    "ukphone": "rɪ'siːv",
+    "trans": [
+      "v.接受；接待"
+    ]
+  },
+  {
+    "name": "recent",
+    "usphone": "'risnt",
+    "ukphone": "'riːs(ə)nt",
+    "trans": [
+      "adj.最近的，近来的"
+    ]
+  },
+  {
+    "name": "reception",
+    "usphone": "rɪ'sɛpʃən",
+    "ukphone": "rɪ'sepʃ(ə)n",
+    "trans": [
+      "n.接待，招待会；接收"
+    ]
+  },
+  {
+    "name": "record",
+    "usphone": "(for v.) rɪˈkɔrd; (for n. adj.) ˈrɛkɚd",
+    "ukphone": "(for v.)rɪˈkɔːd; (for n.) ˈrekɔːd",
+    "trans": [
+      "n.唱片 v. 记录"
+    ]
+  },
+  {
+    "name": "recover",
+    "usphone": "rɪ'kʌvɚ",
+    "ukphone": "rɪ'kʌvə",
+    "trans": [
+      "v.收回，挽回；恢复"
+    ]
+  },
+  {
+    "name": "recovery",
+    "usphone": "rɪ'kʌvəri",
+    "ukphone": "rɪ'kʌvəri",
+    "trans": [
+      "n.复原，痊愈"
+    ]
+  },
+  {
+    "name": "recruit",
+    "usphone": "rɪ'krut",
+    "ukphone": "rɪ'kruːt",
+    "trans": [
+      "v.招募，招收 n.新兵"
+    ]
+  },
+  {
+    "name": "reduce",
+    "usphone": "rɪ'dʊs",
+    "ukphone": "rɪ'djuːs",
+    "trans": [
+      "v.缩小,减小"
+    ]
+  },
+  {
+    "name": "reference",
+    "usphone": "'rɛfrəns",
+    "ukphone": "'ref(ə)r(ə)ns",
+    "trans": [
+      "n.参考文献；参考"
+    ]
+  },
+  {
+    "name": "refer",
+    "usphone": "rɪ'fɝ",
+    "ukphone": "rɪ'fɜː",
+    "trans": [
+      "v.(与to连用)提及，谈到，指"
+    ]
+  },
+  {
+    "name": "refuse",
+    "usphone": "ri'fjʊz",
+    "ukphone": "rɪ'fjuːz",
+    "trans": [
+      "v.拒绝，回绝"
+    ]
+  },
+  {
+    "name": "regard",
+    "usphone": "rɪ'ɡɑrd",
+    "ukphone": "rɪ'gɑːd",
+    "trans": [
+      "v.考虑，认为，看作"
+    ]
+  },
+  {
+    "name": "region",
+    "usphone": "'ridʒən",
+    "ukphone": "'riːdʒ(ə)n",
+    "trans": [
+      "n.地区，区域"
+    ]
+  },
+  {
+    "name": "regret",
+    "usphone": "rɪ'ɡrɛt",
+    "ukphone": "rɪ'gret",
+    "trans": [
+      "v.&n.遗憾，懊悔"
+    ]
+  },
+  {
+    "name": "regular",
+    "usphone": "'rɛgjəlɚ",
+    "ukphone": "'regjʊlə",
+    "trans": [
+      "adj.规则的，规矩的"
+    ]
+  },
+  {
+    "name": "reject",
+    "usphone": "rɪ'dʒɛkt",
+    "ukphone": "rɪ'dʒekt",
+    "trans": [
+      "v.拒绝，抵制"
+    ]
+  },
+  {
+    "name": "relate",
+    "usphone": "rɪ'let",
+    "ukphone": "rɪ'leɪt",
+    "trans": [
+      "v.使互相关联"
+    ]
+  },
+  {
+    "name": "relation",
+    "usphone": "rɪ'leʃən",
+    "ukphone": "rɪ'leɪʃ(ə)n",
+    "trans": [
+      "n.关系"
+    ]
+  },
+  {
+    "name": "relax",
+    "usphone": "rɪ'læks",
+    "ukphone": "rɪ'læks",
+    "trans": [
+      "v.放松"
+    ]
+  },
+  {
+    "name": "release",
+    "usphone": "rɪ'lis",
+    "ukphone": "rɪ'liːs",
+    "trans": [
+      "v.释放；发表"
+    ]
+  },
+  {
+    "name": "relevant",
+    "usphone": "'rɛləvənt",
+    "ukphone": "ˈreləvənt",
+    "trans": [
+      "adj.(to)有关的"
+    ]
+  },
+  {
+    "name": "relief",
+    "usphone": "rɪ'lif",
+    "ukphone": "rɪ'liːf",
+    "trans": [
+      "n.(痛苦等)减轻，解除"
+    ]
+  },
+  {
+    "name": "relieve",
+    "usphone": "rɪ'liv",
+    "ukphone": "rɪ'liːv",
+    "trans": [
+      "v.(of)减轻，解除"
+    ]
+  },
+  {
+    "name": "rely",
+    "usphone": "rɪ'laɪ",
+    "ukphone": "rɪ'laɪ",
+    "trans": [
+      "v.(on)依赖，依靠"
+    ]
+  },
+  {
+    "name": "remain",
+    "usphone": "rɪ'men",
+    "ukphone": "rɪ'meɪn",
+    "trans": [
+      "v.剩下；依旧是"
+    ]
+  },
+  {
+    "name": "remarkable",
+    "usphone": "rɪ'mɑrkəbl",
+    "ukphone": "rɪ'mɑːkəb(ə)l",
+    "trans": [
+      "adj.显著的"
+    ]
+  },
+  {
+    "name": "remember",
+    "usphone": "rɪ'mɛmbɚ",
+    "ukphone": "rɪ'membə",
+    "trans": [
+      "v.记得"
+    ]
+  },
+  {
+    "name": "remind",
+    "usphone": "rɪ'maɪnd",
+    "ukphone": "rɪ'maɪnd",
+    "trans": [
+      "v.(of)提醒，使想起"
+    ]
+  },
+  {
+    "name": "remove",
+    "usphone": "rɪ'muv",
+    "ukphone": "rɪ'muːv",
+    "trans": [
+      "v.排除，消除"
+    ]
+  },
+  {
+    "name": "render",
+    "usphone": "'rɛndɚ",
+    "ukphone": "'rendə",
+    "trans": [
+      "v.使得；提出"
+    ]
+  },
+  {
+    "name": "rent",
+    "usphone": "rɛnt",
+    "ukphone": "rent",
+    "trans": [
+      "v.租用；租赁"
+    ]
+  },
+  {
+    "name": "repair",
+    "usphone": "rɪ'pɛr",
+    "ukphone": "rɪ'peə",
+    "trans": [
+      "v.&n.补救，纠正；修理"
+    ]
+  },
+  {
+    "name": "repeat",
+    "usphone": "rɪ'pit",
+    "ukphone": "rɪ'piːt",
+    "trans": [
+      "v.重复"
+    ]
+  },
+  {
+    "name": "replace",
+    "usphone": "rɪ'ples",
+    "ukphone": "rɪ'pleɪs",
+    "trans": [
+      "v.放回，替换"
+    ]
+  },
+  {
+    "name": "reply",
+    "usphone": "rɪ'plai",
+    "ukphone": "rɪ'plaɪ",
+    "trans": [
+      "v.&n.答复，回答"
+    ]
+  },
+  {
+    "name": "report",
+    "usphone": "rɪ'pɔrt",
+    "ukphone": "rɪ'pɔːt",
+    "trans": [
+      "v./n.汇报，报告"
+    ]
+  },
+  {
+    "name": "reporter",
+    "usphone": "rɪ'pɔrtɚ",
+    "ukphone": "rɪ'pɔːtə",
+    "trans": [
+      "n.记者"
+    ]
+  },
+  {
+    "name": "represent",
+    "usphone": ",rɛprɪ'zɛnt",
+    "ukphone": "reprɪ'zent",
+    "trans": [
+      "v.表示；代表"
+    ]
+  },
+  {
+    "name": "republic",
+    "usphone": "rɪ'pʌblɪk",
+    "ukphone": "rɪ'pʌblɪk",
+    "trans": [
+      "n.共和国"
+    ]
+  },
+  {
+    "name": "reputation",
+    "usphone": ",rɛpju'teʃən",
+    "ukphone": "repjʊ'teɪʃ(ə)n",
+    "trans": [
+      "n.名声，声望"
+    ]
+  },
+  {
+    "name": "require",
+    "usphone": "rɪ'kwaɪr",
+    "ukphone": "rɪ'kwaɪə",
+    "trans": [
+      "v.需求，要求"
+    ]
+  },
+  {
+    "name": "request",
+    "usphone": "rɪ'kwɛst",
+    "ukphone": "rɪ'kwest",
+    "trans": [
+      "v.&n.请求，要求"
+    ]
+  },
+  {
+    "name": "research",
+    "usphone": "'risɝtʃ",
+    "ukphone": "rɪ'sɜːtʃ; 'riːsɜːtʃ",
+    "trans": [
+      "v.&n.研究，调查"
+    ]
+  },
+  {
+    "name": "reserve",
+    "usphone": "rɪ'zɝv",
+    "ukphone": "rɪ'zɜːv",
+    "trans": [
+      "v.预定"
+    ]
+  },
+  {
+    "name": "resist",
+    "usphone": "rɪ'zɪst",
+    "ukphone": "rɪ'zɪst",
+    "trans": [
+      "v.抵抗，反抗"
+    ]
+  },
+  {
+    "name": "resolve",
+    "usphone": "rɪ'zɑlv",
+    "ukphone": "rɪ'zɒlv",
+    "trans": [
+      "v. 解决，决定"
+    ]
+  },
+  {
+    "name": "respect",
+    "usphone": "rɪ'spɛkt",
+    "ukphone": "rɪ'spekt",
+    "trans": [
+      "v.尊敬，尊重 n.尊敬"
+    ]
+  },
+  {
+    "name": "respond",
+    "usphone": "rɪ'spɑnd",
+    "ukphone": "rɪ'spɒnd",
+    "trans": [
+      "v.回答；(to)响应"
+    ]
+  },
+  {
+    "name": "responsibility",
+    "usphone": "rɪˌspɑːnsəˈbɪləti",
+    "ukphone": "rɪˌspɒnsəˈbɪlətɪ",
+    "trans": [
+      "n.责任,责任心"
+    ]
+  },
+  {
+    "name": "responsible",
+    "usphone": "rɪ'spɑnsəbl",
+    "ukphone": "rɪ'spɒnsɪb(ə)l",
+    "trans": [
+      "adj.(for,to) 负责的"
+    ]
+  },
+  {
+    "name": "rest",
+    "usphone": "rɛst",
+    "ukphone": "rest",
+    "trans": [
+      "n./v.休息 adj.其余的"
+    ]
+  },
+  {
+    "name": "restaurant",
+    "usphone": "ˈrɛstəˌrɑnt; ˈrɛstərənt; ˈrɛsˌtrɑnt",
+    "ukphone": "ˈrɛstəˌrɒŋ; ˈrɛstrɒŋ; -rɒnt",
+    "trans": [
+      "n.餐馆，饭店"
+    ]
+  },
+  {
+    "name": "restrict",
+    "usphone": "rɪ'strɪkt",
+    "ukphone": "rɪ'strɪkt",
+    "trans": [
+      "v.限制，约束"
+    ]
+  },
+  {
+    "name": "result",
+    "usphone": "rɪ'zʌlt",
+    "ukphone": "rɪ'zʌlt",
+    "trans": [
+      "n.结果"
+    ]
+  },
+  {
+    "name": "retain",
+    "usphone": "rɪ'ten",
+    "ukphone": "rɪ'teɪn",
+    "trans": [
+      "v.保持，保留"
+    ]
+  },
+  {
+    "name": "retire",
+    "usphone": "rɪ'taɪɚ",
+    "ukphone": "rɪ'taɪə",
+    "trans": [
+      "v.退休，引退"
+    ]
+  },
+  {
+    "name": "reveal",
+    "usphone": "rɪ'vil",
+    "ukphone": "rɪ'viːl",
+    "trans": [
+      "v.展现，显示；揭露"
+    ]
+  },
+  {
+    "name": "revenue",
+    "usphone": "'rɛvənu",
+    "ukphone": "'revənjuː",
+    "trans": [
+      "n.财政收入；税收"
+    ]
+  },
+  {
+    "name": "review",
+    "usphone": "rɪ'vju",
+    "ukphone": "rɪ'vjuː",
+    "trans": [
+      "v.&n.评论；复习，回顾"
+    ]
+  },
+  {
+    "name": "reward",
+    "usphone": "rɪ'wɔrd",
+    "ukphone": "rɪ'wɔːd",
+    "trans": [
+      "n.(for)报酬，赏金 v.(for)酬劳，奖赏"
+    ]
+  },
+  {
+    "name": "rich",
+    "usphone": "rɪtʃ",
+    "ukphone": "rɪtʃ",
+    "trans": [
+      "adj.富有的，富饶的"
+    ]
+  },
+  {
+    "name": "ridge",
+    "usphone": "rɪdʒ",
+    "ukphone": "rɪdʒ",
+    "trans": [
+      "n.岭；屋脊；鼻梁"
+    ]
+  },
+  {
+    "name": "right",
+    "usphone": "raɪt",
+    "ukphone": "raɪt",
+    "trans": [
+      "n. 右 边 adj.右边的 adv.正好"
+    ]
+  },
+  {
+    "name": "rise",
+    "usphone": "raɪz",
+    "ukphone": "raɪz",
+    "trans": [
+      "v.起立,上升,增长 n.起源,发生,上升"
+    ]
+  },
+  {
+    "name": "risk",
+    "usphone": "rɪsk",
+    "ukphone": "rɪsk",
+    "trans": [
+      "v.冒险 n.冒险，风险"
+    ]
+  },
+  {
+    "name": "river",
+    "usphone": "'rɪvɚ",
+    "ukphone": "'rɪvə",
+    "trans": [
+      "n.河流"
+    ]
+  },
+  {
+    "name": "road",
+    "usphone": "rod",
+    "ukphone": "rəʊd",
+    "trans": [
+      "n.道路"
+    ]
+  },
+  {
+    "name": "robot",
+    "usphone": "'robɑt",
+    "ukphone": "'rəʊbɒt",
+    "trans": [
+      "n.机器人"
+    ]
+  },
+  {
+    "name": "role",
+    "usphone": "rol",
+    "ukphone": "rəʊl",
+    "trans": [
+      "n.角色，任务"
+    ]
+  },
+  {
+    "name": "roll",
+    "usphone": "rol",
+    "ukphone": "rəʊl",
+    "trans": [
+      "v.绕，卷"
+    ]
+  },
+  {
+    "name": "Roman",
+    "usphone": "'romən",
+    "ukphone": "'rəʊmən",
+    "trans": [
+      "adj.罗马的"
+    ]
+  },
+  {
+    "name": "romantic",
+    "usphone": "ro'mæntɪk",
+    "ukphone": "rə(ʊ)'mæntɪk",
+    "trans": [
+      "adj.浪漫的"
+    ]
+  },
+  {
+    "name": "room",
+    "usphone": "rum",
+    "ukphone": "ruːm; rʊm",
+    "trans": [
+      "n.房间"
+    ]
+  },
+  {
+    "name": "root",
+    "usphone": "rut",
+    "ukphone": "ruːt",
+    "trans": [
+      "n.根"
+    ]
+  },
+  {
+    "name": "rough",
+    "usphone": "rʌf",
+    "ukphone": "rʌf",
+    "trans": [
+      "adj.粗糙的；粗野的"
+    ]
+  },
+  {
+    "name": "routine",
+    "usphone": "rʊ'tin",
+    "ukphone": "ruː'tiːn",
+    "trans": [
+      "n.例行公事，常规 adj.常规的，例行的"
+    ]
+  },
+  {
+    "name": "route",
+    "usphone": "raʊt",
+    "ukphone": "ruːt",
+    "trans": [
+      "n.路线，路程"
+    ]
+  },
+  {
+    "name": "royal",
+    "usphone": "'rɔɪəl",
+    "ukphone": "'rɒɪəl",
+    "trans": [
+      "adj.王室的"
+    ]
+  },
+  {
+    "name": "rubbish",
+    "usphone": "'rʌbɪʃ",
+    "ukphone": "'rʌbɪʃ",
+    "trans": [
+      "n.废物，垃圾；废话"
+    ]
+  },
+  {
+    "name": "rude",
+    "usphone": "rud",
+    "ukphone": "ruːd",
+    "trans": [
+      "adj.粗鲁的；猛烈的"
+    ]
+  },
+  {
+    "name": "rug",
+    "usphone": "rʌɡ",
+    "ukphone": "rʌg",
+    "trans": [
+      "n.(小)地毯"
+    ]
+  },
+  {
+    "name": "ruin",
+    "usphone": "'ruɪn",
+    "ukphone": "'ruːɪn",
+    "trans": [
+      "v.毁坏，破坏 n.毁灭"
+    ]
+  },
+  {
+    "name": "rule",
+    "usphone": "rul",
+    "ukphone": "ruːl",
+    "trans": [
+      "n.惯例；规章，规则"
+    ]
+  },
+  {
+    "name": "run",
+    "usphone": "rʌn",
+    "ukphone": "rʌn",
+    "trans": [
+      "v.穿过，流过；跑"
+    ]
+  },
+  {
+    "name": "rural",
+    "usphone": "'rʊrəl",
+    "ukphone": "'rʊər(ə)l",
+    "trans": [
+      "adj.农村的，乡村的"
+    ]
+  },
+  {
+    "name": "rush",
+    "usphone": "rʌʃ",
+    "ukphone": "rʌʃ",
+    "trans": [
+      "n./v.冲，奔"
+    ]
+  },
+  {
+    "name": "sad",
+    "usphone": "sæd",
+    "ukphone": "sæd",
+    "trans": [
+      "adj.难过的，难受的"
+    ]
+  },
+  {
+    "name": "safe",
+    "usphone": "sef",
+    "ukphone": "seɪf",
+    "trans": [
+      "adj.安全的"
+    ]
+  },
+  {
+    "name": "safeguard",
+    "usphone": "'sefɡɑrd",
+    "ukphone": "'seɪfgɑːd",
+    "trans": [
+      "v.维护，保护"
+    ]
+  },
+  {
+    "name": "safety",
+    "usphone": "'sefti",
+    "ukphone": "'seɪftɪ",
+    "trans": [
+      "n.安全"
+    ]
+  },
+  {
+    "name": "sail",
+    "usphone": "sel",
+    "ukphone": "seɪl",
+    "trans": [
+      "v.航行，启航 n.帆；航行"
+    ]
+  },
+  {
+    "name": "salary",
+    "usphone": "'sæləri",
+    "ukphone": "'sælərɪ",
+    "trans": [
+      "n.酬金，薪水"
+    ]
+  },
+  {
+    "name": "sale",
+    "usphone": "sel",
+    "ukphone": "seɪl",
+    "trans": [
+      "n.销售"
+    ]
+  },
+  {
+    "name": "same",
+    "usphone": "sem",
+    "ukphone": "seɪm",
+    "trans": [
+      "adj.相同的；同一的"
+    ]
+  },
+  {
+    "name": "sample",
+    "usphone": "'sæmpl",
+    "ukphone": "'sɑːmp(ə)l",
+    "trans": [
+      "n.样品，标本"
+    ]
+  },
+  {
+    "name": "satellite",
+    "usphone": "'sætəlaɪt",
+    "ukphone": "'sætəlaɪt",
+    "trans": [
+      "n.卫星，人造卫星"
+    ]
+  },
+  {
+    "name": "satisfy",
+    "usphone": "'sætɪsfaɪ",
+    "ukphone": "'sætɪsfaɪ",
+    "trans": [
+      "v.满足，使满意，符合(要求)"
+    ]
+  },
+  {
+    "name": "satisfaction",
+    "usphone": ",sætɪs'fækʃən",
+    "ukphone": "sætɪs'fækʃ(ə)n",
+    "trans": [
+      "n.满足，满意"
+    ]
+  },
+  {
+    "name": "Saturday",
+    "usphone": "sætɚdɪ; -de",
+    "ukphone": "ˈsætədɪ; -deɪ",
+    "trans": [
+      "n.星期六"
+    ]
+  },
+  {
+    "name": "save",
+    "usphone": "sev",
+    "ukphone": "seɪv",
+    "trans": [
+      "v.救，拯救；储蓄，储存；节省"
+    ]
+  },
+  {
+    "name": "say",
+    "usphone": "se",
+    "ukphone": "seɪ",
+    "trans": [
+      "v.说"
+    ]
+  },
+  {
+    "name": "scale",
+    "usphone": "skel",
+    "ukphone": "skeɪl",
+    "trans": [
+      "n.刻度；天平"
+    ]
+  },
+  {
+    "name": "scare",
+    "usphone": "skɛr",
+    "ukphone": "skeə",
+    "trans": [
+      "v.&n.惊恐，恐慌"
+    ]
+  },
+  {
+    "name": "schedule",
+    "usphone": "'skɛdʒul; (canadian) ˈʃɛdʒʊl; ˈʃɛdjʊl",
+    "ukphone": "ˈʃɛdjuːl",
+    "trans": [
+      "n.时间表，进度表"
+    ]
+  },
+  {
+    "name": "scheme",
+    "usphone": "skim",
+    "ukphone": "skiːm",
+    "trans": [
+      "v.&n.计划；阴谋"
+    ]
+  },
+  {
+    "name": "scholarship",
+    "usphone": "'skɑlɚʃɪp",
+    "ukphone": "'skɒləʃɪp",
+    "trans": [
+      "n.奖学金"
+    ]
+  },
+  {
+    "name": "scholar",
+    "usphone": "'skɑlɚ",
+    "ukphone": "'skɒlə",
+    "trans": [
+      "n.学者"
+    ]
+  },
+  {
+    "name": "science",
+    "usphone": "'saɪəns",
+    "ukphone": "'saɪəns",
+    "trans": [
+      "n.科学"
+    ]
+  },
+  {
+    "name": "scientific",
+    "usphone": ",saɪən'tɪfɪk",
+    "ukphone": "saɪən'tɪfɪk",
+    "trans": [
+      "adj.科学的"
+    ]
+  },
+  {
+    "name": "scientist",
+    "usphone": "'saɪəntɪst",
+    "ukphone": "'saɪəntɪst",
+    "trans": [
+      "n.科学家"
+    ]
+  },
+  {
+    "name": "scold",
+    "usphone": "skold",
+    "ukphone": "skəʊld",
+    "trans": [
+      "v.训斥，责骂"
+    ]
+  },
+  {
+    "name": "scope",
+    "usphone": "skop",
+    "ukphone": "skəʊp",
+    "trans": [
+      "n.(活动)范围"
+    ]
+  },
+  {
+    "name": "scream",
+    "usphone": "skrim",
+    "ukphone": "skriːm",
+    "trans": [
+      "v.&n.尖叫，嚎叫"
+    ]
+  },
+  {
+    "name": "screen",
+    "usphone": "skrin",
+    "ukphone": "skriːn",
+    "trans": [
+      "n.(电视)屏幕"
+    ]
+  },
+  {
+    "name": "sea",
+    "usphone": "si",
+    "ukphone": "siː",
+    "trans": [
+      "n.海"
+    ]
+  },
+  {
+    "name": "search",
+    "usphone": "sɝtʃ",
+    "ukphone": "sɜːtʃ",
+    "trans": [
+      "v.&n.搜索，寻找"
+    ]
+  },
+  {
+    "name": "season",
+    "usphone": "'sizn",
+    "ukphone": "'siːz(ə)n",
+    "trans": [
+      "n.季节"
+    ]
+  },
+  {
+    "name": "seat",
+    "usphone": "sit",
+    "ukphone": "siːt",
+    "trans": [
+      "n.席位，座次"
+    ]
+  },
+  {
+    "name": "second",
+    "usphone": "'sɛkənd",
+    "ukphone": "'sek(ə)nd",
+    "trans": [
+      "adj./n.第二；秒"
+    ]
+  },
+  {
+    "name": "secretary",
+    "usphone": "'sɛkrətɛrɪ",
+    "ukphone": "'sekrɪt(ə)rɪ",
+    "trans": [
+      "n.秘书"
+    ]
+  },
+  {
+    "name": "secret",
+    "usphone": "'sikrɪt",
+    "ukphone": "'siːkrɪt",
+    "trans": [
+      "adj.秘密的，机密的 n.秘密"
+    ]
+  },
+  {
+    "name": "section",
+    "usphone": "'sɛkʃən",
+    "ukphone": "'sekʃ(ə)n",
+    "trans": [
+      "n.部分，章节"
+    ]
+  },
+  {
+    "name": "secure",
+    "usphone": "sə'kjʊr",
+    "ukphone": "sɪ'kjʊə; sɪ'kjɔː",
+    "trans": [
+      "adj.安全的,可靠的"
+    ]
+  },
+  {
+    "name": "security",
+    "usphone": "sə'kjʊrəti",
+    "ukphone": "sɪ'kjʊərətɪ",
+    "trans": [
+      "n.安全"
+    ]
+  },
+  {
+    "name": "see",
+    "usphone": "si",
+    "ukphone": "siː",
+    "trans": [
+      "v.看见"
+    ]
+  },
+  {
+    "name": "seek",
+    "usphone": "sik",
+    "ukphone": "siːk",
+    "trans": [
+      "v.寻找，探求"
+    ]
+  },
+  {
+    "name": "seem",
+    "usphone": "sim",
+    "ukphone": "siːm",
+    "trans": [
+      "v.看上去，似乎"
+    ]
+  },
+  {
+    "name": "select",
+    "usphone": "sə'lɛkt",
+    "ukphone": "sɪ'lekt",
+    "trans": [
+      "v.选择，挑选"
+    ]
+  },
+  {
+    "name": "selection",
+    "usphone": "sɪ'lɛkʃən",
+    "ukphone": "sɪ'lekʃ(ə)n",
+    "trans": [
+      "n.选择"
+    ]
+  },
+  {
+    "name": "selfish",
+    "usphone": "'sɛlfɪʃ",
+    "ukphone": "'selfɪʃ",
+    "trans": [
+      "adj.自私的"
+    ]
+  },
+  {
+    "name": "sell",
+    "usphone": "sɛl",
+    "ukphone": "sel",
+    "trans": [
+      "v.卖"
+    ]
+  },
+  {
+    "name": "send",
+    "usphone": "sɛnd",
+    "ukphone": "send",
+    "trans": [
+      "v.送，寄"
+    ]
+  },
+  {
+    "name": "senior",
+    "usphone": "'sinɪɚ",
+    "ukphone": "'siːnɪə; 'siːnjə",
+    "trans": [
+      "n.年长者；上级 adj.年长的；资格老的"
+    ]
+  },
+  {
+    "name": "sense",
+    "usphone": "sɛns",
+    "ukphone": "sens",
+    "trans": [
+      "v.感觉，意识到 n.感觉,感官,意识"
+    ]
+  },
+  {
+    "name": "sensible",
+    "usphone": "'sɛnsəbl",
+    "ukphone": "'sensɪb(ə)l",
+    "trans": [
+      "adj.明智的,可觉察的"
+    ]
+  },
+  {
+    "name": "sentence",
+    "usphone": "'sɛntəns",
+    "ukphone": "'sent(ə)ns",
+    "trans": [
+      "n.句子"
+    ]
+  },
+  {
+    "name": "September",
+    "usphone": "sɛp'tɛmbɚ",
+    "ukphone": "sep'tembə",
+    "trans": [
+      "n.九月"
+    ]
+  },
+  {
+    "name": "serious",
+    "usphone": "'sɪrɪəs",
+    "ukphone": "'sɪərɪəs",
+    "trans": [
+      "adj.严重的"
+    ]
+  },
+  {
+    "name": "service",
+    "usphone": "'sɝvɪs",
+    "ukphone": "'sɜːvɪs",
+    "trans": [
+      "n.服务"
+    ]
+  },
+  {
+    "name": "serve",
+    "usphone": "sɝv",
+    "ukphone": "sɜːv",
+    "trans": [
+      "v.侍侯，招待；服务"
+    ]
+  },
+  {
+    "name": "servant",
+    "usphone": "'sɝvənt",
+    "ukphone": "'sɜːv(ə)nt",
+    "trans": [
+      "n.仆人"
+    ]
+  },
+  {
+    "name": "session",
+    "usphone": "'sɛʃən",
+    "ukphone": "'seʃ(ə)n",
+    "trans": [
+      "n.会议"
+    ]
+  },
+  {
+    "name": "set",
+    "usphone": "sɛt",
+    "ukphone": "set",
+    "trans": [
+      "n.台，套；放置"
+    ]
+  },
+  {
+    "name": "settle",
+    "usphone": "'sɛtl",
+    "ukphone": "'set(ə)l",
+    "trans": [
+      "v.安定,定居,解决"
+    ]
+  },
+  {
+    "name": "several",
+    "usphone": "ˈsevrəl",
+    "ukphone": "ˈsevrəl",
+    "trans": [
+      "adj.几个"
+    ]
+  },
+  {
+    "name": "severe",
+    "usphone": "sɪ'vɪr",
+    "ukphone": "sɪ'vɪə",
+    "trans": [
+      "adj.严重的；严格的，严厉的"
+    ]
+  },
+  {
+    "name": "sex",
+    "usphone": "sɛks",
+    "ukphone": "seks",
+    "trans": [
+      "n.性，性别"
+    ]
+  },
+  {
+    "name": "shade",
+    "usphone": "ʃed",
+    "ukphone": "ʃeɪd",
+    "trans": [
+      "n.阴影；遮光物 v.遮蔽，遮光"
+    ]
+  },
+  {
+    "name": "shape",
+    "usphone": "ʃep",
+    "ukphone": "ʃeɪp",
+    "trans": [
+      "n.形状，外形 adj.成形的"
+    ]
+  },
+  {
+    "name": "share",
+    "usphone": "ʃɛr",
+    "ukphone": "ʃeə",
+    "trans": [
+      "v.共享，分担，分享"
+    ]
+  },
+  {
+    "name": "sharp",
+    "usphone": "ʃɑrp",
+    "ukphone": "ʃɑːp",
+    "trans": [
+      "adj.尖锐的，锋利的"
+    ]
+  },
+  {
+    "name": "shift",
+    "usphone": "ʃɪft",
+    "ukphone": "ʃɪft",
+    "trans": [
+      "v.替换；移动 n.转换"
+    ]
+  },
+  {
+    "name": "ship",
+    "usphone": "ʃɪp",
+    "ukphone": "ʃɪp",
+    "trans": [
+      "n.轮船，船"
+    ]
+  },
+  {
+    "name": "shirt",
+    "usphone": "ʃɝt",
+    "ukphone": "ʃɜːt",
+    "trans": [
+      "n.衬衫"
+    ]
+  },
+  {
+    "name": "shock",
+    "usphone": "ʃɑk",
+    "ukphone": "ʃɒk",
+    "trans": [
+      "n.冲击，震惊 v.使震惊"
+    ]
+  },
+  {
+    "name": "shoot",
+    "usphone": "ʃut",
+    "ukphone": "ʃuːt",
+    "trans": [
+      "v.摄影；开枪；(开枪或射箭)打死"
+    ]
+  },
+  {
+    "name": "shop",
+    "usphone": "ʃɑp",
+    "ukphone": "ʃɒp",
+    "trans": [
+      "n.商店 v.购物"
+    ]
+  },
+  {
+    "name": "short",
+    "usphone": "ʃɔrt",
+    "ukphone": "ʃɔːt",
+    "trans": [
+      "adj.矮的，短的"
+    ]
+  },
+  {
+    "name": "shortage",
+    "usphone": "'ʃɔrtɪdʒ",
+    "ukphone": "'ʃɔːtɪdʒ",
+    "trans": [
+      "n.不足，缺少；缺点"
+    ]
+  },
+  {
+    "name": "should",
+    "usphone": "ʃəd; strong form ʃʊd",
+    "ukphone": "ʃəd; strong form ʃʊd",
+    "trans": [
+      "aux.v.应该"
+    ]
+  },
+  {
+    "name": "shoulder",
+    "usphone": "'ʃoldɚ",
+    "ukphone": "'ʃəʊldə",
+    "trans": [
+      "n.肩膀"
+    ]
+  },
+  {
+    "name": "show",
+    "usphone": "ʃo",
+    "ukphone": "ʃəʊ",
+    "trans": [
+      "v.出示；显示  n.展览会；演出"
+    ]
+  },
+  {
+    "name": "shrink",
+    "usphone": "ʃrɪŋk",
+    "ukphone": "ʃrɪŋk",
+    "trans": [
+      "v.起皱；退缩"
+    ]
+  },
+  {
+    "name": "shut",
+    "usphone": "ʃʌt",
+    "ukphone": "ʃʌt",
+    "trans": [
+      "v.关，闭"
+    ]
+  },
+  {
+    "name": "sick",
+    "usphone": "sɪk",
+    "ukphone": "sɪk",
+    "trans": [
+      "adj.生病的，病的"
+    ]
+  },
+  {
+    "name": "side",
+    "usphone": "saɪd",
+    "ukphone": "saɪd",
+    "trans": [
+      "n.边，侧"
+    ]
+  },
+  {
+    "name": "sight",
+    "usphone": "saɪt",
+    "ukphone": "saɪt",
+    "trans": [
+      "n.视力，视觉"
+    ]
+  },
+  {
+    "name": "sign",
+    "usphone": "saɪn",
+    "ukphone": "saɪn",
+    "trans": [
+      "n.标记，符号"
+    ]
+  },
+  {
+    "name": "signal",
+    "usphone": "'sɪgnl",
+    "ukphone": "'sɪgn(ə)l",
+    "trans": [
+      "n.信号，暗号 v.用信号通知 adj.信号的"
+    ]
+  },
+  {
+    "name": "significant",
+    "usphone": "sɪɡ'nɪfɪkənt",
+    "ukphone": "sɪg'nɪfɪk(ə)nt",
+    "trans": [
+      "adj.有意义的；重大的"
+    ]
+  },
+  {
+    "name": "significance",
+    "usphone": "sɪɡ'nɪfɪkəns",
+    "ukphone": "sɪg'nɪfɪk(ə)ns",
+    "trans": [
+      "n.意义；重要性"
+    ]
+  },
+  {
+    "name": "silence",
+    "usphone": "'saɪləns",
+    "ukphone": "'saɪləns",
+    "trans": [
+      "n.寂静，沉默"
+    ]
+  },
+  {
+    "name": "silent",
+    "usphone": "'saɪlənt",
+    "ukphone": "'saɪlənt",
+    "trans": [
+      "adj.寂静的，沉默的"
+    ]
+  },
+  {
+    "name": "silly",
+    "usphone": "'sɪli",
+    "ukphone": "'sɪlɪ",
+    "trans": [
+      "adj.愚蠢的"
+    ]
+  },
+  {
+    "name": "silver",
+    "usphone": "'silvə",
+    "ukphone": "'silvə",
+    "trans": [
+      "n.银，银器"
+    ]
+  },
+  {
+    "name": "similar",
+    "usphone": "'sɪməlɚ",
+    "ukphone": "'sɪmɪlə",
+    "trans": [
+      "adj.类似的，相似的"
+    ]
+  },
+  {
+    "name": "simple",
+    "usphone": "'sɪmpl",
+    "ukphone": "'sɪmp(ə)l",
+    "trans": [
+      "adj.简单的"
+    ]
+  },
+  {
+    "name": "sincere",
+    "usphone": "sɪn'sɪr",
+    "ukphone": "sɪn'sɪə",
+    "trans": [
+      "adj.真诚的"
+    ]
+  },
+  {
+    "name": "since",
+    "usphone": "sɪns",
+    "ukphone": "sɪns",
+    "trans": [
+      "conj.自从"
+    ]
+  },
+  {
+    "name": "single",
+    "usphone": "'sɪŋɡl",
+    "ukphone": "'sɪŋg(ə)l",
+    "trans": [
+      "adj.单一的，单个的"
+    ]
+  },
+  {
+    "name": "sink",
+    "usphone": "sɪŋk",
+    "ukphone": "sɪŋk",
+    "trans": [
+      "v.下落，下沉"
+    ]
+  },
+  {
+    "name": "site",
+    "usphone": "saɪt",
+    "ukphone": "saɪt",
+    "trans": [
+      "n.位置，插所，地点"
+    ]
+  },
+  {
+    "name": "situation",
+    "usphone": ",sɪtʃu'eʃən",
+    "ukphone": "sɪtjʊ'eɪʃ(ə)n",
+    "trans": [
+      "n.形势，局面"
+    ]
+  },
+  {
+    "name": "size",
+    "usphone": "saɪz",
+    "ukphone": "saɪz",
+    "trans": [
+      "n.大小；尺寸"
+    ]
+  },
+  {
+    "name": "skill",
+    "usphone": "skɪl",
+    "ukphone": "skɪl",
+    "trans": [
+      "n.技能，手艺"
+    ]
+  },
+  {
+    "name": "skin",
+    "usphone": "skɪn",
+    "ukphone": "skɪn",
+    "trans": [
+      "n.皮，皮肤"
+    ]
+  },
+  {
+    "name": "skirt",
+    "usphone": "skɝt",
+    "ukphone": "skɜːt",
+    "trans": [
+      "n.裙子"
+    ]
+  },
+  {
+    "name": "sky",
+    "usphone": "skaɪ",
+    "ukphone": "skaɪ",
+    "trans": [
+      "n.天空"
+    ]
+  },
+  {
+    "name": "sleeve",
+    "usphone": "sliv",
+    "ukphone": "sliːv",
+    "trans": [
+      "n.袖子"
+    ]
+  },
+  {
+    "name": "slice",
+    "usphone": "slaɪs",
+    "ukphone": "slaɪs",
+    "trans": [
+      "n.薄片; 一份"
+    ]
+  },
+  {
+    "name": "slightly",
+    "usphone": "'slaɪtli",
+    "ukphone": "'slaɪtlɪ",
+    "trans": [
+      "adv.轻微地，稍微"
+    ]
+  },
+  {
+    "name": "slip",
+    "usphone": "slɪp",
+    "ukphone": "slɪp",
+    "trans": [
+      "v.滑倒；溜走 n.疏忽"
+    ]
+  },
+  {
+    "name": "slipper",
+    "usphone": "'slɪpɚ",
+    "ukphone": "'slɪpə",
+    "trans": [
+      "n.便鞋，拖鞋"
+    ]
+  },
+  {
+    "name": "slope",
+    "usphone": "slop",
+    "ukphone": "sləʊp",
+    "trans": [
+      "n.斜坡；倾斜；斜度 v.(使)倾斜"
+    ]
+  },
+  {
+    "name": "slow",
+    "usphone": "sloʊ",
+    "ukphone": "sləʊ",
+    "trans": [
+      "adj.慢的"
+    ]
+  },
+  {
+    "name": "small",
+    "usphone": "smɔl",
+    "ukphone": "smɔːl",
+    "trans": [
+      "adj.小的"
+    ]
+  },
+  {
+    "name": "smart",
+    "usphone": "smɑrt",
+    "ukphone": "smɑːt",
+    "trans": [
+      "adj.聪明的，伶俐的"
+    ]
+  },
+  {
+    "name": "smell",
+    "usphone": "smɛl",
+    "ukphone": "smel",
+    "trans": [
+      "n.气味；嗅觉 v.闻；闻起来"
+    ]
+  },
+  {
+    "name": "smile",
+    "usphone": "smaɪl",
+    "ukphone": "smaɪl",
+    "trans": [
+      "v.微笑"
+    ]
+  },
+  {
+    "name": "smoke",
+    "usphone": "smok",
+    "ukphone": "sməʊk",
+    "trans": [
+      "n.烟,吸烟 v.冒烟"
+    ]
+  },
+  {
+    "name": "snack",
+    "usphone": "snæk",
+    "ukphone": "snæk",
+    "trans": [
+      "n.快餐，点心"
+    ]
+  },
+  {
+    "name": "snow",
+    "usphone": "sno",
+    "ukphone": "snəʊ",
+    "trans": [
+      "n.雪 v.下雪"
+    ]
+  },
+  {
+    "name": "social",
+    "usphone": "'soʃl",
+    "ukphone": "'səʊʃ(ə)l",
+    "trans": [
+      "adj.社会的；交际的"
+    ]
+  },
+  {
+    "name": "society",
+    "usphone": "sə'saɪəti",
+    "ukphone": "sə'saɪətɪ",
+    "trans": [
+      "n.社会"
+    ]
+  },
+  {
+    "name": "soft",
+    "usphone": "sɔft",
+    "ukphone": "sɒft",
+    "trans": [
+      "adj.软的，柔软的"
+    ]
+  },
+  {
+    "name": "software",
+    "usphone": "'sɔftwɛr",
+    "ukphone": "'sɒf(t)weə",
+    "trans": [
+      "n.软件"
+    ]
+  },
+  {
+    "name": "soldier",
+    "usphone": "'soldʒɚ",
+    "ukphone": "'səʊldʒə",
+    "trans": [
+      "n.土兵，军人"
+    ]
+  },
+  {
+    "name": "solution",
+    "usphone": "sə'luʃən",
+    "ukphone": "sə'luːʃ(ə)n",
+    "trans": [
+      "n.解答，解决办法"
+    ]
+  },
+  {
+    "name": "solve",
+    "usphone": "sɔlv",
+    "ukphone": "sɒlv",
+    "trans": [
+      "v.解决，解答"
+    ]
+  },
+  {
+    "name": "some",
+    "usphone": "səm",
+    "ukphone": "sʌm; s(ə)m",
+    "trans": [
+      "adj.几个,一些"
+    ]
+  },
+  {
+    "name": "somebody",
+    "usphone": "'sʌmbədi",
+    "ukphone": "'sʌmbədɪ",
+    "trans": [
+      "pron.有人，某人"
+    ]
+  },
+  {
+    "name": "somehow",
+    "usphone": "'sʌmhaʊ",
+    "ukphone": "'sʌmhaʊ",
+    "trans": [
+      "adv.以某种方式，不知怎么地"
+    ]
+  },
+  {
+    "name": "someone",
+    "usphone": "'sʌmwʌn",
+    "ukphone": "'sʌmwʌn",
+    "trans": [
+      "pron.有人，某人"
+    ]
+  },
+  {
+    "name": "something",
+    "usphone": "'sʌmθɪŋ",
+    "ukphone": "'sʌmθɪŋ",
+    "trans": [
+      "n.某物；某事，某东西"
+    ]
+  },
+  {
+    "name": "sometimes",
+    "usphone": "'sʌmtaɪmz",
+    "ukphone": "'sʌmtaɪmz",
+    "trans": [
+      "adv.有时"
+    ]
+  },
+  {
+    "name": "son",
+    "usphone": "sʌn",
+    "ukphone": "sʌn",
+    "trans": [
+      "n.儿子"
+    ]
+  },
+  {
+    "name": "soon",
+    "usphone": "sun",
+    "ukphone": "suːn",
+    "trans": [
+      "adv.不久"
+    ]
+  },
+  {
+    "name": "sorrow",
+    "usphone": "sɑro",
+    "ukphone": "'sɒrəʊ",
+    "trans": [
+      "n.悲哀；悔憾"
+    ]
+  },
+  {
+    "name": "soul",
+    "usphone": "sol",
+    "ukphone": "səʊl",
+    "trans": [
+      "n.灵魂,心灵；精神"
+    ]
+  },
+  {
+    "name": "sound",
+    "usphone": "saʊnd",
+    "ukphone": "saʊnd",
+    "trans": [
+      "v.听起来 n.声音"
+    ]
+  },
+  {
+    "name": "source",
+    "usphone": "sɔrs",
+    "ukphone": "sɔːs",
+    "trans": [
+      "n.源；来源"
+    ]
+  },
+  {
+    "name": "south",
+    "usphone": "saʊθ",
+    "ukphone": "saʊθ",
+    "trans": [
+      "n.&adj.南，南部"
+    ]
+  },
+  {
+    "name": "space",
+    "usphone": "spes",
+    "ukphone": "speɪs",
+    "trans": [
+      "n.太空，宇宙；空间"
+    ]
+  },
+  {
+    "name": "speak",
+    "usphone": "spik",
+    "ukphone": "spiːk",
+    "trans": [
+      "v.讲话，说话"
+    ]
+  },
+  {
+    "name": "speaker",
+    "usphone": "'spikɚ",
+    "ukphone": "'spiːkə",
+    "trans": [
+      "n.讲话人"
+    ]
+  },
+  {
+    "name": "special",
+    "usphone": "'spɛʃl",
+    "ukphone": "'speʃ(ə)l",
+    "trans": [
+      "adj.特殊的"
+    ]
+  },
+  {
+    "name": "specific",
+    "usphone": "spɪ'sɪfɪk",
+    "ukphone": "spə'sɪfɪk",
+    "trans": [
+      "adj.明确的；特定的"
+    ]
+  },
+  {
+    "name": "speech",
+    "usphone": "spitʃ",
+    "ukphone": "spiːtʃ",
+    "trans": [
+      "n.讲话，演说；言语"
+    ]
+  },
+  {
+    "name": "speed",
+    "usphone": "spid",
+    "ukphone": "spiːd",
+    "trans": [
+      "n.速度，速率"
+    ]
+  },
+  {
+    "name": "spell",
+    "usphone": "spɛl",
+    "ukphone": "spel",
+    "trans": [
+      "v.拼写"
+    ]
+  },
+  {
+    "name": "spend",
+    "usphone": "spɛnd",
+    "ukphone": "spend",
+    "trans": [
+      "vt.花费(金钱、时间、精力等)"
+    ]
+  },
+  {
+    "name": "sphere",
+    "usphone": "sfɪr",
+    "ukphone": "sfɪə",
+    "trans": [
+      "n.球，球体；范围"
+    ]
+  },
+  {
+    "name": "spirit",
+    "usphone": "'spɪrɪt",
+    "ukphone": "'spɪrɪt",
+    "trans": [
+      "n.精神"
+    ]
+  },
+  {
+    "name": "spoil",
+    "usphone": "spɔɪl",
+    "ukphone": "spɒɪl",
+    "trans": [
+      "v.破坏；宠坏"
+    ]
+  },
+  {
+    "name": "sponsor",
+    "usphone": "'spɑnsɚ",
+    "ukphone": "'spɒnsə",
+    "trans": [
+      "n.发起人，主办者 v.发起，主办"
+    ]
+  },
+  {
+    "name": "sport",
+    "usphone": "spɔrt",
+    "ukphone": "spɔːt",
+    "trans": [
+      "n.体育"
+    ]
+  },
+  {
+    "name": "sportsman",
+    "usphone": "'spɔrtsmən",
+    "ukphone": "'spɔːtsmən",
+    "trans": [
+      "n.运动员"
+    ]
+  },
+  {
+    "name": "spot",
+    "usphone": "spɑt",
+    "ukphone": "spɒt",
+    "trans": [
+      "n.(斑)点；地点 v.认出；玷污"
+    ]
+  },
+  {
+    "name": "spread",
+    "usphone": "sprɛd",
+    "ukphone": "spred",
+    "trans": [
+      "v.传播"
+    ]
+  },
+  {
+    "name": "spring",
+    "usphone": "sprɪŋ",
+    "ukphone": "sprɪŋ",
+    "trans": [
+      "n.春季，春天"
+    ]
+  },
+  {
+    "name": "square",
+    "usphone": "skwɛr",
+    "ukphone": "skweə",
+    "trans": [
+      "n.广场"
+    ]
+  },
+  {
+    "name": "squeeze",
+    "usphone": "skwiz",
+    "ukphone": "skwiːz",
+    "trans": [
+      "v.压榨，挤压"
+    ]
+  },
+  {
+    "name": "stable",
+    "usphone": "'stebl",
+    "ukphone": "'steɪb(ə)l",
+    "trans": [
+      "adj.稳定的，安定的"
+    ]
+  },
+  {
+    "name": "staff",
+    "usphone": "stæf",
+    "ukphone": "stɑːf",
+    "trans": [
+      "n.全体职工"
+    ]
+  },
+  {
+    "name": "stage",
+    "usphone": "stedʒ",
+    "ukphone": "steɪdʒ",
+    "trans": [
+      "n.阶段，时期；舞台"
+    ]
+  },
+  {
+    "name": "stand",
+    "usphone": "stænd",
+    "ukphone": "stænd",
+    "trans": [
+      "v.站；立"
+    ]
+  },
+  {
+    "name": "standard",
+    "usphone": "'stændɚd",
+    "ukphone": "'stændəd",
+    "trans": [
+      "adj.标准的"
+    ]
+  },
+  {
+    "name": "star",
+    "usphone": "stɑː(r)",
+    "ukphone": "stɑ:",
+    "trans": [
+      "n.星星"
+    ]
+  },
+  {
+    "name": "start",
+    "usphone": "stɑrt",
+    "ukphone": "stɑːt",
+    "trans": [
+      "v.出发；开始"
+    ]
+  },
+  {
+    "name": "state",
+    "usphone": "stet",
+    "ukphone": "steɪt",
+    "trans": [
+      "n.国家，州；情况，状态 v.声明，陈述"
+    ]
+  },
+  {
+    "name": "statesman",
+    "usphone": "'stetsmən",
+    "ukphone": "'steɪtsmən",
+    "trans": [
+      "(pl.statsmen)n.政治家"
+    ]
+  },
+  {
+    "name": "statement",
+    "usphone": "'stetmənt",
+    "ukphone": "'steɪtm(ə)nt",
+    "trans": [
+      "n.声明，陈述"
+    ]
+  },
+  {
+    "name": "stay",
+    "usphone": "ste",
+    "ukphone": "steɪ",
+    "trans": [
+      "v./n.停留，逗留"
+    ]
+  },
+  {
+    "name": "steep",
+    "usphone": "stip",
+    "ukphone": "stiːp",
+    "trans": [
+      "adj.陡峭的，险峻的"
+    ]
+  },
+  {
+    "name": "stem",
+    "usphone": "stɛm",
+    "ukphone": "stem",
+    "trans": [
+      "n.茎，(树)干"
+    ]
+  },
+  {
+    "name": "step",
+    "usphone": "stɛp",
+    "ukphone": "step",
+    "trans": [
+      "n.脚步,台阶，步骤"
+    ]
+  },
+  {
+    "name": "stick",
+    "usphone": "stɪk",
+    "ukphone": "stɪk",
+    "trans": [
+      "v.刺，截，扎；粘贴"
+    ]
+  },
+  {
+    "name": "still",
+    "usphone": "stɪl",
+    "ukphone": "stɪl",
+    "trans": [
+      "adv.仍，仍然"
+    ]
+  },
+  {
+    "name": "stock",
+    "usphone": "stɑk",
+    "ukphone": "stɒk",
+    "trans": [
+      "n.备料,存货,股票 v.储存,储备"
+    ]
+  },
+  {
+    "name": "stone",
+    "usphone": "ston",
+    "ukphone": "stəʊn",
+    "trans": [
+      "n.石头"
+    ]
+  },
+  {
+    "name": "stop",
+    "usphone": "stɑp",
+    "ukphone": "stɒp",
+    "trans": [
+      "v.停止；阻止 n.停止；停车站"
+    ]
+  },
+  {
+    "name": "store",
+    "usphone": "stɔr",
+    "ukphone": "stɔː",
+    "trans": [
+      "v.储藏,储存 n.商店"
+    ]
+  },
+  {
+    "name": "story",
+    "usphone": "'stɔri",
+    "ukphone": "'stɔːrɪ",
+    "trans": [
+      "n.故事，小说"
+    ]
+  },
+  {
+    "name": "straight",
+    "usphone": "stret",
+    "ukphone": "streɪt",
+    "trans": [
+      "adj.直的；笔直的 adv.一直地"
+    ]
+  },
+  {
+    "name": "straightforward",
+    "usphone": ",stret'fɔrwɚd",
+    "ukphone": "streɪt'fɔːwəd",
+    "trans": [
+      "adj.正直的"
+    ]
+  },
+  {
+    "name": "strange",
+    "usphone": "strendʒ",
+    "ukphone": "streɪn(d)ʒ",
+    "trans": [
+      "adj.奇怪的,奇异的"
+    ]
+  },
+  {
+    "name": "stranger",
+    "usphone": "'strendʒɚ",
+    "ukphone": "'streɪn(d)ʒə",
+    "trans": [
+      "n.陌生人"
+    ]
+  },
+  {
+    "name": "strategy",
+    "usphone": "'strætədʒi",
+    "ukphone": "ˈstrætədʒɪ",
+    "trans": [
+      "n.战略，策略"
+    ]
+  },
+  {
+    "name": "stream",
+    "usphone": "strim",
+    "ukphone": "striːm",
+    "trans": [
+      "n.小河，川；一股 v.流出"
+    ]
+  },
+  {
+    "name": "street",
+    "usphone": "strit",
+    "ukphone": "striːt",
+    "trans": [
+      "n.街道"
+    ]
+  },
+  {
+    "name": "strength",
+    "usphone": "strɛŋθ",
+    "ukphone": "streŋθ; streŋkθ",
+    "trans": [
+      "n.力，力量，力气"
+    ]
+  },
+  {
+    "name": "strengthen",
+    "usphone": "'strɛŋθn",
+    "ukphone": "'streŋθ(ə)n; -ŋkθ(ə)n",
+    "trans": [
+      "v.加强，巩固"
+    ]
+  },
+  {
+    "name": "stress",
+    "usphone": "strɛs",
+    "ukphone": "stres",
+    "trans": [
+      "v.强调，着重 n.压力"
+    ]
+  },
+  {
+    "name": "stretch",
+    "usphone": "strɛtʃ",
+    "ukphone": "stretʃ",
+    "trans": [
+      "n.一段时间 v.拉长；铺开"
+    ]
+  },
+  {
+    "name": "strict",
+    "usphone": "strɪkt",
+    "ukphone": "strɪkt",
+    "trans": [
+      "adj.严格的；严谨的"
+    ]
+  },
+  {
+    "name": "strike",
+    "usphone": "straɪk",
+    "ukphone": "straɪk",
+    "trans": [
+      "n.罢工 v.打，击；罢工"
+    ]
+  },
+  {
+    "name": "striking",
+    "usphone": "'straɪkɪŋ",
+    "ukphone": "'straɪkɪŋ",
+    "trans": [
+      "adj.显著的；非凡的"
+    ]
+  },
+  {
+    "name": "stroke",
+    "usphone": "strok",
+    "ukphone": "strəʊk",
+    "trans": [
+      "n.击打,中风 v.击打"
+    ]
+  },
+  {
+    "name": "strong",
+    "usphone": "strɔŋ",
+    "ukphone": "strɒŋ",
+    "trans": [
+      "adj.强大的,强烈的,坚固的"
+    ]
+  },
+  {
+    "name": "structure",
+    "usphone": "'strʌktʃɚ",
+    "ukphone": "'strʌktʃə",
+    "trans": [
+      "n.结构；建筑物 v.构造，建造"
+    ]
+  },
+  {
+    "name": "struggle",
+    "usphone": "'strʌɡl",
+    "ukphone": "'strʌg(ə)l",
+    "trans": [
+      "v.&n.斗争，奋斗，努力；挣扎"
+    ]
+  },
+  {
+    "name": "stuff",
+    "usphone": "stʌf",
+    "ukphone": "stʌf",
+    "trans": [
+      "n.原料，材料 v.装，把...塞进"
+    ]
+  },
+  {
+    "name": "style",
+    "usphone": "staɪl",
+    "ukphone": "staɪl",
+    "trans": [
+      "n.形式，风格"
+    ]
+  },
+  {
+    "name": "subject",
+    "usphone": "ˈsʌbdʒekt",
+    "ukphone": "ˈsʌbdʒɪkt",
+    "trans": [
+      "n.科目，课程"
+    ]
+  },
+  {
+    "name": "substance",
+    "usphone": "'sʌbstəns",
+    "ukphone": "'sʌbst(ə)ns",
+    "trans": [
+      "n.物质"
+    ]
+  },
+  {
+    "name": "substitute",
+    "usphone": "'sʌbstɪtut",
+    "ukphone": "'sʌbstɪtjuːt",
+    "trans": [
+      "n.代用品,代理人 v.(for)代替,替换"
+    ]
+  },
+  {
+    "name": "suburb",
+    "usphone": "'sʌbɝb",
+    "ukphone": "'sʌbɜːb",
+    "trans": [
+      "n.市郊，郊区"
+    ]
+  },
+  {
+    "name": "success",
+    "usphone": "sək'sɛs",
+    "ukphone": "sək'ses",
+    "trans": [
+      "n.成功，成就"
+    ]
+  },
+  {
+    "name": "successful",
+    "usphone": "sək'sɛsfl",
+    "ukphone": "sək'sesfʊl; -f(ə)l",
+    "trans": [
+      "adj.成功的"
+    ]
+  },
+  {
+    "name": "succeed",
+    "usphone": "sək'sid",
+    "ukphone": "sək'siːd",
+    "trans": [
+      "v.成功；继承，接替"
+    ]
+  },
+  {
+    "name": "such",
+    "usphone": "sʌtʃ",
+    "ukphone": "sʌtʃ",
+    "trans": [
+      "adj.这样的，如此的 pron.这样的人或事"
+    ]
+  },
+  {
+    "name": "suddenly",
+    "usphone": "'sʌdənli",
+    "ukphone": "'sʌd(ə)nlɪ",
+    "trans": [
+      "adv.突然"
+    ]
+  },
+  {
+    "name": "suffer",
+    "usphone": "'sʌfɚ",
+    "ukphone": "'sʌfə",
+    "trans": [
+      "v.遭受，忍受"
+    ]
+  },
+  {
+    "name": "suggest",
+    "usphone": "sə'dʒɛst",
+    "ukphone": "sə'dʒest",
+    "trans": [
+      "v.建议，提出；暗示"
+    ]
+  },
+  {
+    "name": "suggestion",
+    "usphone": "sə'dʒɛstʃən",
+    "ukphone": "sə'dʒestʃ(ə)n",
+    "trans": [
+      "n.建议，提议"
+    ]
+  },
+  {
+    "name": "suit",
+    "usphone": "sut",
+    "ukphone": "sju:t; su:t",
+    "trans": [
+      "n.一套衣服 v.适合，中...的意"
+    ]
+  },
+  {
+    "name": "suitable",
+    "usphone": "'sutəbl",
+    "ukphone": "'suːtəb(ə)l",
+    "trans": [
+      "adj.合适的，适合的"
+    ]
+  },
+  {
+    "name": "summer",
+    "usphone": "ˈsʌmə(r)",
+    "ukphone": "'sʌmə",
+    "trans": [
+      "n.夏季，夏天"
+    ]
+  },
+  {
+    "name": "sun",
+    "usphone": "sʌn",
+    "ukphone": "sʌn",
+    "trans": [
+      "n.太阳"
+    ]
+  },
+  {
+    "name": "Sunday",
+    "usphone": "ˈsʌnde; ˈsʌndi",
+    "ukphone": "ˈsʌndeɪ; ˈsʌndi",
+    "trans": [
+      "n.星期日"
+    ]
+  },
+  {
+    "name": "sunny",
+    "usphone": "'sʌni",
+    "ukphone": "'sʌnɪ",
+    "trans": [
+      "adj.阳光充足的；晴朗的"
+    ]
+  },
+  {
+    "name": "sunrise",
+    "usphone": "'sʌnraɪz",
+    "ukphone": "'sʌnraɪz",
+    "trans": [
+      "n.日出；黎明"
+    ]
+  },
+  {
+    "name": "sunset",
+    "usphone": "'sʌnsɛt",
+    "ukphone": "'sʌnset",
+    "trans": [
+      "n.日落"
+    ]
+  },
+  {
+    "name": "sunshine",
+    "usphone": "'sʌnʃaɪn",
+    "ukphone": "'sʌnʃaɪn",
+    "trans": [
+      "n.日光，日照；欢乐"
+    ]
+  },
+  {
+    "name": "super",
+    "usphone": "'sʊpɚ",
+    "ukphone": "'suːpə; 'sjuː-",
+    "trans": [
+      "adj.超级的"
+    ]
+  },
+  {
+    "name": "superior",
+    "usphone": "səˈpɪriər",
+    "ukphone": "suːˈpɪərɪə",
+    "trans": [
+      "adj.优良的；上级的"
+    ]
+  },
+  {
+    "name": "supermarket",
+    "usphone": "'sʊpɚ'mɑrkɪt",
+    "ukphone": "'suːpəmɑːkɪt; 'sjuː-",
+    "trans": [
+      "n.超级市场"
+    ]
+  },
+  {
+    "name": "supply",
+    "usphone": "sə'plaɪ",
+    "ukphone": "sə'plaɪ",
+    "trans": [
+      "n./v.供给；供应；补给"
+    ]
+  },
+  {
+    "name": "supplement",
+    "usphone": "'sʌplɪmənt",
+    "ukphone": "'sʌplɪm(ə)nt",
+    "trans": [
+      "n.补遗,增刊,附录 v.增刊,补充"
+    ]
+  },
+  {
+    "name": "support",
+    "usphone": "sə'pɔrt",
+    "ukphone": "sə'pɔːt",
+    "trans": [
+      "v.&n.支持，拥护；供养"
+    ]
+  },
+  {
+    "name": "suppose",
+    "usphone": "sə'poz",
+    "ukphone": "sə'pəʊz",
+    "trans": [
+      "v.猜想，料想；假设；以为"
+    ]
+  },
+  {
+    "name": "suppress",
+    "usphone": "sə'prɛs",
+    "ukphone": "sə'pres",
+    "trans": [
+      "v.镇压，抑制"
+    ]
+  },
+  {
+    "name": "surprise",
+    "usphone": "sɚ'praɪz",
+    "ukphone": "sə'praɪz",
+    "trans": [
+      "vt.使诧异，使惊奇 n.诧异，惊奇"
+    ]
+  },
+  {
+    "name": "surround",
+    "usphone": "sə'raʊnd",
+    "ukphone": "sə'raʊnd",
+    "trans": [
+      "v.围绕，包围"
+    ]
+  },
+  {
+    "name": "survey",
+    "usphone": "ˈsɝˌve; (for v.) sɝˈve",
+    "ukphone": "ˈsəːveɪ; (for v.) səˈveɪ",
+    "trans": [
+      "v.调查；测量 n.调查，测量"
+    ]
+  },
+  {
+    "name": "survive",
+    "usphone": "sɚ'vaɪv",
+    "ukphone": "sə'vaɪv",
+    "trans": [
+      "v.幸存；残存"
+    ]
+  },
+  {
+    "name": "suspect",
+    "usphone": "sʌspɛkt; (for v.) səˈspɛkt",
+    "ukphone": "ˈsʌspekt; (for v.) səˈspekt",
+    "trans": [
+      "v.怀疑；猜想 n.嫌疑犯"
+    ]
+  },
+  {
+    "name": "suspicious",
+    "usphone": "sə'spɪʃəs",
+    "ukphone": "sə'spɪʃəs",
+    "trans": [
+      "adj.(of)可疑的；多疑的"
+    ]
+  },
+  {
+    "name": "sweat",
+    "usphone": "swɛt",
+    "ukphone": "swet",
+    "trans": [
+      "v.汗 v.(使)出汗"
+    ]
+  },
+  {
+    "name": "sweater",
+    "usphone": "'swɛtɚ",
+    "ukphone": "'swetə",
+    "trans": [
+      "n.羊毛衫"
+    ]
+  },
+  {
+    "name": "swift",
+    "usphone": "swɪft",
+    "ukphone": "swɪft",
+    "trans": [
+      "adj.快速的，敏捷的"
+    ]
+  },
+  {
+    "name": "swim",
+    "usphone": "swɪm",
+    "ukphone": "swɪm",
+    "trans": [
+      "v.游泳"
+    ]
+  },
+  {
+    "name": "sympathy",
+    "usphone": "'sɪmpəθi",
+    "ukphone": "'sɪmpəθɪ",
+    "trans": [
+      "n.同情，同情心；赞同"
+    ]
+  },
+  {
+    "name": "system",
+    "usphone": "'sɪstəm",
+    "ukphone": "'sɪstəm",
+    "trans": [
+      "n.系统，体系；制度"
+    ]
+  },
+  {
+    "name": "table",
+    "usphone": "'tebl",
+    "ukphone": "'teɪb(ə)l",
+    "trans": [
+      "n.桌子；饭桌"
+    ]
+  },
+  {
+    "name": "take",
+    "usphone": "tek",
+    "ukphone": "teɪk",
+    "trans": [
+      "vt.认为，当作，拿，取"
+    ]
+  },
+  {
+    "name": "talk",
+    "usphone": "tɔk",
+    "ukphone": "tɔːk",
+    "trans": [
+      "v.说话；交谈 n.聊天；谈话"
+    ]
+  },
+  {
+    "name": "tank",
+    "usphone": "tæŋk",
+    "ukphone": "tæŋk",
+    "trans": [
+      "n.罐，水箱；坦克"
+    ]
+  },
+  {
+    "name": "target",
+    "usphone": "'tɑrɡɪt",
+    "ukphone": "'tɑːgɪt",
+    "trans": [
+      "n.目标，对象；靶子"
+    ]
+  },
+  {
+    "name": "task",
+    "usphone": "tæsk",
+    "ukphone": "tɑːsk",
+    "trans": [
+      "n.任务；工作"
+    ]
+  },
+  {
+    "name": "taste",
+    "usphone": "test",
+    "ukphone": "teɪst",
+    "trans": [
+      "v.品尝 n.味，味道"
+    ]
+  },
+  {
+    "name": "tax",
+    "usphone": "tæks",
+    "ukphone": "tæks",
+    "trans": [
+      "v.征税：加负担 n.税"
+    ]
+  },
+  {
+    "name": "tea",
+    "usphone": "ti",
+    "ukphone": "tiː",
+    "trans": [
+      "n.茶，茶叶"
+    ]
+  },
+  {
+    "name": "teacher",
+    "usphone": "'titʃɚ",
+    "ukphone": "'tiːtʃə",
+    "trans": [
+      "n.教师"
+    ]
+  },
+  {
+    "name": "teach",
+    "usphone": "titʃ",
+    "ukphone": "tiːtʃ",
+    "trans": [
+      "v.教，教学"
+    ]
+  },
+  {
+    "name": "team",
+    "usphone": "tim",
+    "ukphone": "tiːm",
+    "trans": [
+      "n.队；组"
+    ]
+  },
+  {
+    "name": "tear",
+    "usphone": "tiə",
+    "ukphone": "tiə",
+    "trans": [
+      "v.撕，撕下 n.眼泪"
+    ]
+  },
+  {
+    "name": "technical",
+    "usphone": "'tɛknɪkl",
+    "ukphone": "'teknɪk(ə)l",
+    "trans": [
+      "adj.技术的；工艺的"
+    ]
+  },
+  {
+    "name": "technique",
+    "usphone": "tɛk'nik",
+    "ukphone": "tek'niːk",
+    "trans": [
+      "n.技术"
+    ]
+  },
+  {
+    "name": "telephone",
+    "usphone": "'tɛlə'fon",
+    "ukphone": "'telɪfəʊn",
+    "trans": [
+      "n. 电 话 v.打电话"
+    ]
+  },
+  {
+    "name": "television",
+    "usphone": "'tɛlɪvɪʒn",
+    "ukphone": "'telɪvɪʒ(ə)n; telɪ'vɪʒ(ə)n",
+    "trans": [
+      "(=TV)n.电视，电视机"
+    ]
+  },
+  {
+    "name": "tell",
+    "ukphone": "tel",
+    "trans": [
+      "vt.告诉；吩咐"
+    ]
+  },
+  {
+    "name": "temperature",
+    "usphone": "'tɛmprətʃɚ",
+    "ukphone": "temprətʃə(r)",
+    "trans": [
+      "n.温度"
+    ]
+  },
+  {
+    "name": "temporary",
+    "usphone": "'tɛmpə'rɛri",
+    "ukphone": "'temp(ə)rərɪ",
+    "trans": [
+      "adj.暂时的，临时的"
+    ]
+  },
+  {
+    "name": "tend",
+    "usphone": "tɛnd",
+    "ukphone": "tend",
+    "trans": [
+      "v.趋向；照料，看护"
+    ]
+  },
+  {
+    "name": "tendency",
+    "usphone": "'tɛndənsi",
+    "ukphone": "'tend(ə)nsɪ",
+    "trans": [
+      "n.趋向，趋势"
+    ]
+  },
+  {
+    "name": "tennis",
+    "usphone": "'tenis",
+    "ukphone": "'tenis",
+    "trans": [
+      "n.网球"
+    ]
+  },
+  {
+    "name": "tense",
+    "usphone": "tɛns",
+    "ukphone": "tens",
+    "trans": [
+      "adj.紧张的 n.时态"
+    ]
+  },
+  {
+    "name": "term",
+    "usphone": "tɝm",
+    "ukphone": "tɜːm",
+    "trans": [
+      "n.术语；学期"
+    ]
+  },
+  {
+    "name": "terminal",
+    "usphone": "ˈtɜːrmɪnl",
+    "ukphone": "'tɜːmɪn(ə)l",
+    "trans": [
+      "n.终点站；终端 adj.期末的；末端的"
+    ]
+  },
+  {
+    "name": "terrible",
+    "usphone": "'tɛrəbl",
+    "ukphone": "'terɪb(ə)l",
+    "trans": [
+      "adj.可怕的,令人生畏的,糟糕的"
+    ]
+  },
+  {
+    "name": "test",
+    "usphone": "tɛst",
+    "ukphone": "test",
+    "trans": [
+      "n.测试，考试"
+    ]
+  },
+  {
+    "name": "text",
+    "usphone": "tɛkst",
+    "ukphone": "tekst",
+    "trans": [
+      "n.课文；原文"
+    ]
+  },
+  {
+    "name": "textbook",
+    "usphone": "'tɛkstbʊk",
+    "ukphone": "'teks(t)bʊk",
+    "trans": [
+      "n.课本，教科书"
+    ]
+  },
+  {
+    "name": "than",
+    "usphone": "ðæn",
+    "ukphone": "ðæn; ð(ə)n",
+    "trans": [
+      "conj.比"
+    ]
+  },
+  {
+    "name": "theater",
+    "usphone": "'θiətə(r)",
+    "ukphone": "ˈθiːətər",
+    "trans": [
+      "n.剧院 (=theatre)"
+    ]
+  },
+  {
+    "name": "theme",
+    "usphone": "θim",
+    "ukphone": "θiːm",
+    "trans": [
+      "n.题目，主题"
+    ]
+  },
+  {
+    "name": "themselves",
+    "usphone": "ðɛm'sɛlvz",
+    "ukphone": "ð(ə)m'selvz",
+    "trans": [
+      "pron.他们自己"
+    ]
+  },
+  {
+    "name": "then",
+    "usphone": "ðɛn",
+    "ukphone": "ðen",
+    "trans": [
+      "adv.当时，那时；那么；然后"
+    ]
+  },
+  {
+    "name": "theory",
+    "usphone": "'θiəri",
+    "ukphone": "'θɪərɪ",
+    "trans": [
+      "n.理论；学说，见解"
+    ]
+  },
+  {
+    "name": "therefore",
+    "usphone": "'ðɛrfɔr",
+    "ukphone": "'ðeəfɔː",
+    "trans": [
+      "conj.因此，所以"
+    ]
+  },
+  {
+    "name": "thin",
+    "usphone": "θɪn",
+    "ukphone": "θɪn",
+    "trans": [
+      "adj.细的，瘦的"
+    ]
+  },
+  {
+    "name": "thing",
+    "usphone": "θɪŋ",
+    "ukphone": "θɪŋ",
+    "trans": [
+      "n.事情，东西"
+    ]
+  },
+  {
+    "name": "think",
+    "usphone": "θɪŋk",
+    "ukphone": "θɪŋk",
+    "trans": [
+      "v.思考，想"
+    ]
+  },
+  {
+    "name": "thirsty",
+    "usphone": "'θɝsti",
+    "ukphone": "'θɜːstɪ",
+    "trans": [
+      "adj.渴的"
+    ]
+  },
+  {
+    "name": "though",
+    "usphone": "ðo",
+    "ukphone": "ðəʊ",
+    "trans": [
+      "conj.虽然 adv.可是，然而"
+    ]
+  },
+  {
+    "name": "thought",
+    "usphone": "θɔt",
+    "ukphone": "θɔːt",
+    "trans": [
+      "n.思想，思维，思考；想法，观念"
+    ]
+  },
+  {
+    "name": "thoughtful",
+    "usphone": "'θɔtfl",
+    "ukphone": "'θɔːtfʊl; -f(ə)l",
+    "trans": [
+      "adj.认真思考的，体贴的"
+    ]
+  },
+  {
+    "name": "thousand",
+    "usphone": "'θaʊznd",
+    "ukphone": "'θaʊz(ə)nd",
+    "trans": [
+      "n./adj.千"
+    ]
+  },
+  {
+    "name": "threat",
+    "usphone": "θrɛt",
+    "ukphone": "θret",
+    "trans": [
+      "n.恐吓；威胁"
+    ]
+  },
+  {
+    "name": "threaten",
+    "usphone": "'θrɛtn",
+    "ukphone": "'θret(ə)n",
+    "trans": [
+      "v.恐吓；有...危险"
+    ]
+  },
+  {
+    "name": "through",
+    "usphone": "θru",
+    "ukphone": "θruː",
+    "trans": [
+      "prep.穿过，通过"
+    ]
+  },
+  {
+    "name": "throughout",
+    "usphone": "θrʊ'aʊt",
+    "ukphone": "θruː'aʊt",
+    "trans": [
+      "prep./adv.遍及,到处,贯穿,始终"
+    ]
+  },
+  {
+    "name": "throw",
+    "usphone": "θro",
+    "ukphone": "θrəʊ",
+    "trans": [
+      "v.投，扔"
+    ]
+  },
+  {
+    "name": "ticket",
+    "usphone": "'tɪkɪt",
+    "ukphone": "'tɪkɪt",
+    "trans": [
+      "n.票,券"
+    ]
+  },
+  {
+    "name": "tie",
+    "usphone": "taɪ",
+    "ukphone": "taɪ",
+    "trans": [
+      "n.领带；纽带，联系 v.系，捆"
+    ]
+  },
+  {
+    "name": "tight",
+    "usphone": "taɪt",
+    "ukphone": "taɪt",
+    "trans": [
+      "adj.紧的，牢固的"
+    ]
+  },
+  {
+    "name": "time",
+    "usphone": "taɪm",
+    "ukphone": "taɪm",
+    "trans": [
+      "n.时间；次"
+    ]
+  },
+  {
+    "name": "tip",
+    "usphone": "tɪp",
+    "ukphone": "tɪp",
+    "trans": [
+      "n.小费；尖，顶端"
+    ]
+  },
+  {
+    "name": "tire",
+    "usphone": "'taɪɚ",
+    "ukphone": "taɪə",
+    "trans": [
+      "vt.(使)感到疲劳；(使)厌倦"
+    ]
+  },
+  {
+    "name": "tired",
+    "usphone": "'taɪɚd",
+    "ukphone": "taɪəd",
+    "trans": [
+      "adj.疲劳的，累的"
+    ]
+  },
+  {
+    "name": "today",
+    "usphone": "tə'de",
+    "ukphone": "tə'deɪ",
+    "trans": [
+      "adv./n.今天；现在"
+    ]
+  },
+  {
+    "name": "together",
+    "usphone": "tə'ɡɛðɚ",
+    "ukphone": "tə'geðə",
+    "trans": [
+      "adv.一起，一同"
+    ]
+  },
+  {
+    "name": "tolerate",
+    "usphone": "'tɑləret",
+    "ukphone": "'tɒləreɪt",
+    "trans": [
+      "v.容忍，默许"
+    ]
+  },
+  {
+    "name": "tomorrow",
+    "usphone": "tə'mɔro",
+    "ukphone": "tə'mɒrəʊ",
+    "trans": [
+      "n./adv.明天"
+    ]
+  },
+  {
+    "name": "tool",
+    "usphone": "tul",
+    "ukphone": "tuːl",
+    "trans": [
+      "n.工具"
+    ]
+  },
+  {
+    "name": "tooth",
+    "usphone": "tuθ",
+    "ukphone": "tuːθ",
+    "trans": [
+      "n.牙(齿)"
+    ]
+  },
+  {
+    "name": "top",
+    "usphone": "tɑp",
+    "ukphone": "tɒp",
+    "trans": [
+      "n.顶，顶部 adj.最高的"
+    ]
+  },
+  {
+    "name": "topic",
+    "usphone": "'tɑpɪk",
+    "ukphone": "'tɒpɪk",
+    "trans": [
+      "n.话题，主题；题目"
+    ]
+  },
+  {
+    "name": "total",
+    "usphone": "'totl",
+    "ukphone": "'təʊt(ə)l",
+    "trans": [
+      "adj.总的,完全的 n.总数,合计 v.合计,总计"
+    ]
+  },
+  {
+    "name": "touch",
+    "usphone": "tʌtʃ",
+    "ukphone": "tʌtʃ",
+    "trans": [
+      "v.碰；触动，感动 n.接触；联系"
+    ]
+  },
+  {
+    "name": "tough",
+    "usphone": "tʌf",
+    "ukphone": "tʌf",
+    "trans": [
+      "adj.坚韧的；强健的"
+    ]
+  },
+  {
+    "name": "tour",
+    "usphone": "tʊr",
+    "ukphone": "tʊə",
+    "trans": [
+      "n./v.游览，旅行，观光"
+    ]
+  },
+  {
+    "name": "tourist",
+    "usphone": "'tʊrɪst",
+    "ukphone": "'tʊərɪst",
+    "trans": [
+      "n.旅行者，观光者"
+    ]
+  },
+  {
+    "name": "towards",
+    "usphone": "təˈwɔːdz",
+    "ukphone": "tə'wɔ:dz",
+    "trans": [
+      "prep.(=toward)朝,向,近"
+    ]
+  },
+  {
+    "name": "tower",
+    "usphone": "'taʊɚ",
+    "ukphone": "'taʊə",
+    "trans": [
+      "n.塔；高楼"
+    ]
+  },
+  {
+    "name": "town",
+    "usphone": "taʊn",
+    "ukphone": "taʊn",
+    "trans": [
+      "n.城镇，城市"
+    ]
+  },
+  {
+    "name": "track",
+    "usphone": "træk",
+    "ukphone": "træk",
+    "trans": [
+      "n.车轨；轨道"
+    ]
+  },
+  {
+    "name": "trace",
+    "usphone": "tres",
+    "ukphone": "treɪs",
+    "trans": [
+      "n.痕迹 v.描绘；跟踪"
+    ]
+  },
+  {
+    "name": "tradition",
+    "usphone": "trə'dɪʃən",
+    "ukphone": "trə'dɪʃ(ə)n",
+    "trans": [
+      "n.传统，惯例；传说"
+    ]
+  },
+  {
+    "name": "traffic",
+    "usphone": "'træfɪk",
+    "ukphone": "'træfɪk",
+    "trans": [
+      "n.交通"
+    ]
+  },
+  {
+    "name": "train",
+    "usphone": "tren",
+    "ukphone": "treɪn",
+    "trans": [
+      "v.火车  n.培训,训练"
+    ]
+  },
+  {
+    "name": "training",
+    "usphone": "'trenɪŋ",
+    "ukphone": "'treɪnɪŋ",
+    "trans": [
+      "n.训练"
+    ]
+  },
+  {
+    "name": "transfer",
+    "usphone": "træns'fɝ",
+    "ukphone": "træns'fɜː; trɑːns-; -nz-",
+    "trans": [
+      "v.转移，调动；转让"
+    ]
+  },
+  {
+    "name": "transport",
+    "usphone": "'trænspɔrt",
+    "ukphone": "træn'spɔːt; trɑːn-",
+    "trans": [
+      "n.运送，运输"
+    ]
+  },
+  {
+    "name": "trap",
+    "usphone": "træp",
+    "ukphone": "træp",
+    "trans": [
+      "n.陷阱，圈套 v.诱捕，使中圈套"
+    ]
+  },
+  {
+    "name": "travel",
+    "usphone": "'trævl",
+    "ukphone": "'trævl",
+    "trans": [
+      "v./n.旅行"
+    ]
+  },
+  {
+    "name": "treasure",
+    "usphone": "'trɛʒɚ",
+    "ukphone": "'treʒə",
+    "trans": [
+      "n.财富；珍宝 v.珍视，珍惜"
+    ]
+  },
+  {
+    "name": "treat",
+    "usphone": "trit",
+    "ukphone": "triːt",
+    "trans": [
+      "v.&n.对待，处理；治疗；款待"
+    ]
+  },
+  {
+    "name": "treatment",
+    "usphone": "'tritmənt",
+    "ukphone": "'triːtm(ə)nt",
+    "trans": [
+      "n.对待，待遇；治疗，疗法"
+    ]
+  },
+  {
+    "name": "tree",
+    "usphone": "tri",
+    "ukphone": "triː",
+    "trans": [
+      "n.树，树木"
+    ]
+  },
+  {
+    "name": "trend",
+    "usphone": "trɛnd",
+    "ukphone": "trend",
+    "trans": [
+      "n.倾向，趋势 v.伸向，倾向"
+    ]
+  },
+  {
+    "name": "trial",
+    "usphone": "'traɪəl",
+    "ukphone": "'traɪəl",
+    "trans": [
+      "n.审讯；试验 adj.试验(性)的"
+    ]
+  },
+  {
+    "name": "trip",
+    "usphone": "trɪp",
+    "ukphone": "trɪp",
+    "trans": [
+      "n.旅行；旅程"
+    ]
+  },
+  {
+    "name": "trouble",
+    "usphone": "'trʌbl",
+    "ukphone": "'trʌb(ə)l",
+    "trans": [
+      "n./v.麻烦"
+    ]
+  },
+  {
+    "name": "truck",
+    "usphone": "trʌk",
+    "ukphone": "trʌk",
+    "trans": [
+      "n.卡车，载重汽车"
+    ]
+  },
+  {
+    "name": "trust",
+    "usphone": "trʌst",
+    "ukphone": "trʌst",
+    "trans": [
+      "v.&n.信任；委托，信托"
+    ]
+  },
+  {
+    "name": "truth",
+    "usphone": "trʊθ",
+    "ukphone": "truːθ",
+    "trans": [
+      "n.真相"
+    ]
+  },
+  {
+    "name": "try",
+    "usphone": "traɪ",
+    "ukphone": "traɪ",
+    "trans": [
+      "v./n.试，尝试；努力"
+    ]
+  },
+  {
+    "name": "tube",
+    "usphone": "tub",
+    "ukphone": "tjuːb",
+    "trans": [
+      "n.管，软管；电子管"
+    ]
+  },
+  {
+    "name": "Tuesday",
+    "usphone": "ˈtuzdi, -ˌde, ˈtjuz-",
+    "ukphone": "'tjuːzdeɪ; -dɪ",
+    "trans": [
+      "n.星期二"
+    ]
+  },
+  {
+    "name": "tune",
+    "usphone": "tun",
+    "ukphone": "tjuːn",
+    "trans": [
+      "n.调子，曲调 v.调音"
+    ]
+  },
+  {
+    "name": "turn",
+    "usphone": "tɝn",
+    "ukphone": "tɜːn",
+    "trans": [
+      "v.转动，旋转"
+    ]
+  },
+  {
+    "name": "twelve",
+    "usphone": "twɛlv",
+    "ukphone": "twelv",
+    "trans": [
+      "num.十二   pron./adj.十二(个，只...)"
+    ]
+  },
+  {
+    "name": "type",
+    "usphone": "taɪp",
+    "ukphone": "taɪp",
+    "trans": [
+      "n.种类，类型  v. 打字"
+    ]
+  },
+  {
+    "name": "typewriter",
+    "usphone": "'taɪpraɪtɚ",
+    "ukphone": "'taɪpraɪtə",
+    "trans": [
+      "n.打字机"
+    ]
+  },
+  {
+    "name": "typical",
+    "usphone": "'tɪpɪkl",
+    "ukphone": "'tɪpɪk(ə)l",
+    "trans": [
+      "adj.(of)典型的"
+    ]
+  },
+  {
+    "name": "unable",
+    "usphone": "ʌn'ebl",
+    "ukphone": "ʌn'eɪb(ə)l",
+    "trans": [
+      "adj.不能的，不会的"
+    ]
+  },
+  {
+    "name": "under",
+    "usphone": "'ʌndɚ",
+    "ukphone": "'ʌndə",
+    "trans": [
+      "prep.在...之下   adv.在下面"
+    ]
+  },
+  {
+    "name": "understand",
+    "usphone": "'ʌndɚ'stænd",
+    "ukphone": "ʌndə'stænd",
+    "trans": [
+      "v.理解，懂得，明白"
+    ]
+  },
+  {
+    "name": "uniform",
+    "usphone": "'junɪfɔrm",
+    "ukphone": "'juːnɪfɔːm",
+    "trans": [
+      "n.制服，军服 adj.一致的"
+    ]
+  },
+  {
+    "name": "unit",
+    "usphone": "'junɪt",
+    "ukphone": "'juːnɪt",
+    "trans": [
+      "n.单元"
+    ]
+  },
+  {
+    "name": "unite",
+    "usphone": "ju'naɪt",
+    "ukphone": "juː'naɪt",
+    "trans": [
+      "v.统一，结合"
+    ]
+  },
+  {
+    "name": "universe",
+    "usphone": "'junɪvɝs",
+    "ukphone": "'juːnɪvɜːs",
+    "trans": [
+      "n.宇宙，万物"
+    ]
+  },
+  {
+    "name": "universal",
+    "usphone": "'jʊnə'vɝsl",
+    "ukphone": "juːnɪ'vɜːs(ə)l",
+    "trans": [
+      "adj.普遍的,全体的,通用的"
+    ]
+  },
+  {
+    "name": "university",
+    "usphone": ",junɪ'vɝsəti",
+    "ukphone": "juːnɪ'vɜːsɪtɪ",
+    "trans": [
+      "n.大学"
+    ]
+  },
+  {
+    "name": "until",
+    "usphone": "ən'tɪl",
+    "ukphone": "ən'tɪl",
+    "trans": [
+      "conj./prep.直到"
+    ]
+  },
+  {
+    "name": "upon",
+    "usphone": "ə'pɔn",
+    "ukphone": "əˈpɑːn",
+    "trans": [
+      "prep.在...上面"
+    ]
+  },
+  {
+    "name": "upset",
+    "usphone": "ʌp'sɛt",
+    "ukphone": "ʌp'set",
+    "trans": [
+      "v.扰乱,使难过"
+    ]
+  },
+  {
+    "name": "upstairs",
+    "usphone": ",ʌp'stɛrz",
+    "ukphone": "ʌp'steəz",
+    "trans": [
+      "adv.在楼上，往楼上"
+    ]
+  },
+  {
+    "name": "urban",
+    "usphone": "'ɝbən",
+    "ukphone": "'ɜːb(ə)n",
+    "trans": [
+      "adj.城市的"
+    ]
+  },
+  {
+    "name": "urgent",
+    "usphone": "'ɝdʒənt",
+    "ukphone": "ˈɜːdʒənt",
+    "trans": [
+      "adj.急迫的，紧迫的"
+    ]
+  },
+  {
+    "name": "urge",
+    "usphone": "ɝdʒ",
+    "ukphone": "'ɜːdʒ",
+    "trans": [
+      "v.催促,强烈希望,鼓励"
+    ]
+  },
+  {
+    "name": "use",
+    "usphone": "juz",
+    "ukphone": "juːz",
+    "trans": [
+      "v.使用，消耗 n.使用，用法，用途"
+    ]
+  },
+  {
+    "name": "useful",
+    "usphone": "'jusfl",
+    "ukphone": "'juːsfʊl; -f(ə)l",
+    "trans": [
+      "adj.有用的"
+    ]
+  },
+  {
+    "name": "usually",
+    "usphone": "ˈjuːʒʊəlɪ",
+    "ukphone": "ˈjuːʒʊəlɪ",
+    "trans": [
+      "adv.通常"
+    ]
+  },
+  {
+    "name": "usual",
+    "usphone": "'juʒuəl",
+    "ukphone": "'juːʒʊəl",
+    "trans": [
+      "adj.通常的"
+    ]
+  },
+  {
+    "name": "utility",
+    "usphone": "ju'tɪləti",
+    "ukphone": "juːˈtɪlɪtɪ",
+    "trans": [
+      "n.效用；实用"
+    ]
+  },
+  {
+    "name": "vacant",
+    "usphone": "'vekənt",
+    "ukphone": "'veɪk(ə)nt",
+    "trans": [
+      "adj.未占用的，空缺的"
+    ]
+  },
+  {
+    "name": "vacation",
+    "usphone": "vəˈkeɪʃn; veɪ-",
+    "ukphone": "vəˈkeɪʃn; veɪ-",
+    "trans": [
+      "n.假期"
+    ]
+  },
+  {
+    "name": "valid",
+    "usphone": "'vælɪd",
+    "ukphone": "'vælɪd",
+    "trans": [
+      "adj.有效的；合理的"
+    ]
+  },
+  {
+    "name": "value",
+    "usphone": "'vælju",
+    "ukphone": "'væljuː",
+    "trans": [
+      "n.价值"
+    ]
+  },
+  {
+    "name": "valuable",
+    "usphone": "ˈvæljuəbəl; ˈvæljə-",
+    "ukphone": "'væljʊəb(ə)l",
+    "trans": [
+      "adj.贵重的,值钱的,有价值的"
+    ]
+  },
+  {
+    "name": "variety",
+    "usphone": "və'raɪəti",
+    "ukphone": "və'raɪətɪ",
+    "trans": [
+      "n.多样性；种类"
+    ]
+  },
+  {
+    "name": "various",
+    "usphone": "'vɛrɪəs",
+    "ukphone": "'veərɪəs",
+    "trans": [
+      "adj.各种各样的,不同的"
+    ]
+  },
+  {
+    "name": "vast",
+    "usphone": "væst",
+    "ukphone": "vɑːst",
+    "trans": [
+      "adj.(面积，地域)巨大的，广阔的"
+    ]
+  },
+  {
+    "name": "vehicle",
+    "usphone": "'viːɪkl",
+    "ukphone": "ˈviːɪk(ə)l",
+    "trans": [
+      "n.车辆"
+    ]
+  },
+  {
+    "name": "victim",
+    "usphone": "'vɪktɪm",
+    "ukphone": "'vɪktɪm",
+    "trans": [
+      "n.牺牲；牺牲品"
+    ]
+  },
+  {
+    "name": "victory",
+    "usphone": "'vɪktəri",
+    "ukphone": "'vɪkt(ə)rɪ",
+    "trans": [
+      "n.胜利"
+    ]
+  },
+  {
+    "name": "view",
+    "usphone": "vju",
+    "ukphone": "vjuː",
+    "trans": [
+      "n.景色；眼界；观点"
+    ]
+  },
+  {
+    "name": "village",
+    "usphone": "'vɪlɪdʒ",
+    "ukphone": "'vɪlɪdʒ",
+    "trans": [
+      "n.村庄"
+    ]
+  },
+  {
+    "name": "visible",
+    "usphone": "'vɪzəbl",
+    "ukphone": "ˈvɪzəbl",
+    "trans": [
+      "adj.可见的"
+    ]
+  },
+  {
+    "name": "vision",
+    "usphone": "'vɪʒən",
+    "ukphone": "'vɪʒ(ə)n",
+    "trans": [
+      "n.视觉，视力；眼力"
+    ]
+  },
+  {
+    "name": "violence",
+    "usphone": "'vaɪələns",
+    "ukphone": "'vaɪəl(ə)ns",
+    "trans": [
+      "n.暴力"
+    ]
+  },
+  {
+    "name": "violent",
+    "usphone": "'vaɪələnt",
+    "ukphone": "'vaɪəl(ə)nt",
+    "trans": [
+      "adj.猛烈的"
+    ]
+  },
+  {
+    "name": "visit",
+    "usphone": "'vɪzɪt",
+    "ukphone": "'vɪzɪt",
+    "trans": [
+      "v./n.拜访，参观"
+    ]
+  },
+  {
+    "name": "visitor",
+    "usphone": "'vɪzɪtɚ",
+    "ukphone": "'vɪzɪtə",
+    "trans": [
+      "n.客人，来宾，参观者"
+    ]
+  },
+  {
+    "name": "vital",
+    "usphone": "'vaɪtl",
+    "ukphone": "'vaɪt(ə)l",
+    "trans": [
+      "adj.生死攸关的；重要的"
+    ]
+  },
+  {
+    "name": "vocabulary",
+    "usphone": "və'kæbjəlɛri",
+    "ukphone": "və(ʊ)'kæbjʊlərɪ",
+    "trans": [
+      "n.词汇，词汇量；词汇表"
+    ]
+  },
+  {
+    "name": "volunteer",
+    "usphone": ",vɑlən'tɪr",
+    "ukphone": ",vɒlən'tɪə",
+    "trans": [
+      "n.志愿者 v.自愿"
+    ]
+  },
+  {
+    "name": "vote",
+    "usphone": "vot; voʊt",
+    "ukphone": "vəʊt",
+    "trans": [
+      "n.投票"
+    ]
+  },
+  {
+    "name": "wage",
+    "usphone": "wedʒ",
+    "ukphone": "weɪdʒ",
+    "trans": [
+      "n. 工资，报酬"
+    ]
+  },
+  {
+    "name": "wait",
+    "usphone": "wet",
+    "ukphone": "weɪt",
+    "trans": [
+      "v.等待，等候"
+    ]
+  },
+  {
+    "name": "waiter",
+    "usphone": "'wetɚ",
+    "ukphone": "'weɪtə",
+    "trans": [
+      "n.男服务员"
+    ]
+  },
+  {
+    "name": "wake",
+    "usphone": "wek",
+    "ukphone": "weɪk",
+    "trans": [
+      "v.醒来；唤醒"
+    ]
+  },
+  {
+    "name": "walk",
+    "usphone": "wɔk",
+    "ukphone": "wɔːk",
+    "trans": [
+      "v./n.走，步行，散步"
+    ]
+  },
+  {
+    "name": "wall",
+    "usphone": "wɔl",
+    "ukphone": "wɔːl",
+    "trans": [
+      "n.墙，城墙"
+    ]
+  },
+  {
+    "name": "wander",
+    "usphone": "'wɑndɚ",
+    "ukphone": "'wɒndə",
+    "trans": [
+      "v.漫步；迷路"
+    ]
+  },
+  {
+    "name": "war",
+    "usphone": "wɔr",
+    "ukphone": "wɔː",
+    "trans": [
+      "n.战争"
+    ]
+  },
+  {
+    "name": "warm",
+    "usphone": "wɔrm",
+    "ukphone": "wɔːm",
+    "trans": [
+      "adj.暖和的，温暖的"
+    ]
+  },
+  {
+    "name": "warn",
+    "usphone": "wɔrn",
+    "ukphone": "wɔːn",
+    "trans": [
+      "v.警告，告诫"
+    ]
+  },
+  {
+    "name": "wash",
+    "usphone": "wɑːʃ",
+    "ukphone": "wɒʃ",
+    "trans": [
+      "v.洗"
+    ]
+  },
+  {
+    "name": "waste",
+    "usphone": "west",
+    "ukphone": "weɪst",
+    "trans": [
+      "v./n.浪费"
+    ]
+  },
+  {
+    "name": "watch",
+    "usphone": "wɑtʃ",
+    "ukphone": "wɒtʃ",
+    "trans": [
+      "v.看，观看"
+    ]
+  },
+  {
+    "name": "water",
+    "usphone": "ˈwɔtɚ; ˈwɑtɚ",
+    "ukphone": "'wɔːtə",
+    "trans": [
+      "n.水 v.浇水"
+    ]
+  },
+  {
+    "name": "way",
+    "usphone": "we",
+    "ukphone": "weɪ",
+    "trans": [
+      "n.道路；方式"
+    ]
+  },
+  {
+    "name": "weak",
+    "usphone": "wik",
+    "ukphone": "wiːk",
+    "trans": [
+      "adj.虚弱的，软弱的"
+    ]
+  },
+  {
+    "name": "weakness",
+    "usphone": "'wiknəs",
+    "ukphone": "ˈwiːknəs",
+    "trans": [
+      "n.衰弱，软弱；弱点，缺点"
+    ]
+  },
+  {
+    "name": "wear",
+    "usphone": "wɛr",
+    "ukphone": "weə",
+    "trans": [
+      "v.穿戴，佩带"
+    ]
+  },
+  {
+    "name": "weather",
+    "usphone": "'wɛðɚ",
+    "ukphone": "'weðə",
+    "trans": [
+      "n.天气，气象"
+    ]
+  },
+  {
+    "name": "wedding",
+    "usphone": "'wɛdɪŋ",
+    "ukphone": "'wedɪŋ",
+    "trans": [
+      "n.婚礼"
+    ]
+  },
+  {
+    "name": "Wednesday",
+    "usphone": "'wɛnzde",
+    "ukphone": "ˈwɛnzdeɪ",
+    "trans": [
+      "n.星期三"
+    ]
+  },
+  {
+    "name": "week",
+    "usphone": "wik",
+    "ukphone": "wiːk",
+    "trans": [
+      "n.星期，周"
+    ]
+  },
+  {
+    "name": "weekend",
+    "usphone": "ˈwikend",
+    "ukphone": "wiːkˈɛnd",
+    "trans": [
+      "n.周末"
+    ]
+  },
+  {
+    "name": "weekday",
+    "usphone": "'wikde",
+    "ukphone": "'wiːkdeɪ",
+    "trans": [
+      "n.平常日，工作日"
+    ]
+  },
+  {
+    "name": "weight",
+    "usphone": "wet",
+    "ukphone": "weɪt",
+    "trans": [
+      "n.重量，体重"
+    ]
+  },
+  {
+    "name": "welcome",
+    "usphone": "ˈwelkəm",
+    "ukphone": "ˈwɛlkəm",
+    "trans": [
+      "v.欢迎 adj.受欢迎的"
+    ]
+  },
+  {
+    "name": "well",
+    "usphone": "wɛl",
+    "ukphone": "wel",
+    "trans": [
+      "adv.好 adj.(身体)好"
+    ]
+  },
+  {
+    "name": "well-known",
+    "usphone": ",wel ˈnəʊn",
+    "ukphone": ",wel ˈnoʊn",
+    "trans": [
+      "adj.出名的，众所周知的"
+    ]
+  },
+  {
+    "name": "west",
+    "usphone": "wɛst",
+    "ukphone": "west",
+    "trans": [
+      "n.西；西方，西部 adj.西边的"
+    ]
+  },
+  {
+    "name": "western",
+    "usphone": "'wɛstɚn",
+    "ukphone": "'west(ə)n",
+    "trans": [
+      "adj.西方的"
+    ]
+  },
+  {
+    "name": "wet",
+    "usphone": "wɛt",
+    "ukphone": "wet",
+    "trans": [
+      "adj.湿的"
+    ]
+  },
+  {
+    "name": "whatever",
+    "usphone": "wət'ɛvɚ",
+    "ukphone": "wɒt'evə",
+    "trans": [
+      "adj.不管怎样的，无论什么样的 pron.(引出状语从句)无论 ..."
+    ]
+  },
+  {
+    "name": "whereas",
+    "usphone": "'wɛr'æz",
+    "ukphone": "weər'æz",
+    "trans": [
+      "conj.然而，但是，尽管"
+    ]
+  },
+  {
+    "name": "whether",
+    "usphone": "'wɛðɚ",
+    "ukphone": "'weðə",
+    "trans": [
+      "conj.是否，不管，无论"
+    ]
+  },
+  {
+    "name": "while",
+    "usphone": "waɪl",
+    "ukphone": "wʌɪl",
+    "trans": [
+      "conj.在(当)...时候，和...同时；而"
+    ]
+  },
+  {
+    "name": "whole",
+    "usphone": "hol",
+    "ukphone": "həʊl",
+    "trans": [
+      "n.&adj.全部(的)，全体(的)；完整(的)"
+    ]
+  },
+  {
+    "name": "wide",
+    "usphone": "waɪd",
+    "ukphone": "waɪd",
+    "trans": [
+      "adj.宽的；广阔的"
+    ]
+  },
+  {
+    "name": "width",
+    "usphone": "wɪdθ",
+    "ukphone": "wɪtθ; wɪdθ",
+    "trans": [
+      "n.宽度"
+    ]
+  },
+  {
+    "name": "wife",
+    "usphone": "wʌɪf",
+    "ukphone": "wʌɪf",
+    "trans": [
+      "n.妻子，夫人"
+    ]
+  },
+  {
+    "name": "wild",
+    "usphone": "waɪld",
+    "ukphone": "waɪld",
+    "trans": [
+      "adj.疯狂的；野生的"
+    ]
+  },
+  {
+    "name": "will",
+    "usphone": "wɪl",
+    "ukphone": "wɪl",
+    "trans": [
+      "v.aux.将要"
+    ]
+  },
+  {
+    "name": "willing",
+    "usphone": "'wɪlɪŋ",
+    "ukphone": "'wɪlɪŋ",
+    "trans": [
+      "adj.自愿的，心甘情愿的"
+    ]
+  },
+  {
+    "name": "win",
+    "usphone": "wɪn",
+    "ukphone": "wɪn",
+    "trans": [
+      "v.获得，赢得"
+    ]
+  },
+  {
+    "name": "wind",
+    "usphone": "wɪnd; (for v.) waɪnd",
+    "ukphone": "wɪnd; (for v.) waɪnd",
+    "trans": [
+      "n.风"
+    ]
+  },
+  {
+    "name": "window",
+    "usphone": "'wɪndo",
+    "ukphone": "'wɪndəʊ",
+    "trans": [
+      "n.窗户"
+    ]
+  },
+  {
+    "name": "winter",
+    "usphone": "'wɪntɚ",
+    "ukphone": "'wɪntə",
+    "trans": [
+      "n.冬天；冬季"
+    ]
+  },
+  {
+    "name": "wireless",
+    "usphone": "'waɪərləs",
+    "ukphone": "ˈwʌɪəlɪs",
+    "trans": [
+      "adj.无线的,无线电的"
+    ]
+  },
+  {
+    "name": "wisdom",
+    "usphone": "'wɪzdəm",
+    "ukphone": "'wɪzdəm",
+    "trans": [
+      "n.智慧，明智"
+    ]
+  },
+  {
+    "name": "wit",
+    "usphone": "wɪt",
+    "ukphone": "wɪt",
+    "trans": [
+      "n.才智"
+    ]
+  },
+  {
+    "name": "wish",
+    "usphone": "wɪʃ",
+    "ukphone": "wɪʃ",
+    "trans": [
+      "n./v.希望，愿望"
+    ]
+  },
+  {
+    "name": "withdraw",
+    "usphone": "wɪð'drɔ",
+    "ukphone": "wɪð'drɔː",
+    "trans": [
+      "v.提取"
+    ]
+  },
+  {
+    "name": "without",
+    "usphone": "wɪðˈaʊt",
+    "ukphone": "wɪˈðaʊt",
+    "trans": [
+      "prep.没有；毫无"
+    ]
+  },
+  {
+    "name": "within",
+    "usphone": "wɪ'ðɪn",
+    "ukphone": "wɪð'ɪn",
+    "trans": [
+      "prep.在...之内"
+    ]
+  },
+  {
+    "name": "witness",
+    "usphone": "ˈwɪtnɪs",
+    "ukphone": "ˈwɪtnɪs",
+    "trans": [
+      "n.目击者,证人 v.目击,作证"
+    ]
+  },
+  {
+    "name": "wonderful",
+    "usphone": "ˈwʌndərfl",
+    "ukphone": "'wʌndəfʊl; -f(ə)l",
+    "trans": [
+      "adj.极好的，奇妙的"
+    ]
+  },
+  {
+    "name": "wonder",
+    "usphone": "'wʌndɚ",
+    "ukphone": "'wʌndə",
+    "trans": [
+      "n.惊奇，惊异 v.诧异，奇怪"
+    ]
+  },
+  {
+    "name": "wood",
+    "usphone": "wʊd",
+    "ukphone": "wʊd",
+    "trans": [
+      "n.树林，木头"
+    ]
+  },
+  {
+    "name": "word",
+    "usphone": "wɝd",
+    "ukphone": "wɜːd",
+    "trans": [
+      "n.字，单词"
+    ]
+  },
+  {
+    "name": "work",
+    "usphone": "wɝk",
+    "ukphone": "wɜːk",
+    "trans": [
+      "v./n.工作，干，做事"
+    ]
+  },
+  {
+    "name": "worker",
+    "usphone": "'wɝkɚ",
+    "ukphone": "'wɜːkə",
+    "trans": [
+      "n.工人，工作者"
+    ]
+  },
+  {
+    "name": "world",
+    "usphone": "wɝld",
+    "ukphone": "wɜːld",
+    "trans": [
+      "n.世界"
+    ]
+  },
+  {
+    "name": "worry",
+    "usphone": "ˈwɜːri",
+    "ukphone": "'wʌrɪ",
+    "trans": [
+      "v.担心，担忧 n.担心，担忧"
+    ]
+  },
+  {
+    "name": "worse",
+    "usphone": "wɜrs",
+    "ukphone": "wəːs",
+    "trans": [
+      "adj.&adv.(bad的比较级)更坏，更差"
+    ]
+  },
+  {
+    "name": "worth",
+    "usphone": "wɝθ",
+    "ukphone": "wɜːθ",
+    "trans": [
+      "adj.值得的 n.价值"
+    ]
+  },
+  {
+    "name": "worthy",
+    "usphone": "wɜði",
+    "ukphone": "ˈwəːði",
+    "trans": [
+      "adj.(of) 值得的,配得上的"
+    ]
+  },
+  {
+    "name": "wrap",
+    "usphone": "ræp",
+    "ukphone": "ræp",
+    "trans": [
+      "v.裹，缠"
+    ]
+  },
+  {
+    "name": "write",
+    "usphone": "raɪt",
+    "ukphone": "raɪt",
+    "trans": [
+      "v.写；写信"
+    ]
+  },
+  {
+    "name": "writer",
+    "usphone": "'raɪtɚ",
+    "ukphone": "'raɪtə",
+    "trans": [
+      "n.作家，作者"
+    ]
+  },
+  {
+    "name": "year",
+    "usphone": "yir",
+    "ukphone": "jɪə; jɜː",
+    "trans": [
+      "n.年"
+    ]
+  },
+  {
+    "name": "yearly",
+    "usphone": "'jɪrli",
+    "ukphone": "'jɪəlɪ; 'jɜː-",
+    "trans": [
+      "adj.&adv.每年的"
+    ]
+  },
+  {
+    "name": "yesterday",
+    "usphone": "ˈjɛstədi",
+    "ukphone": "ˈjɛstədeɪ",
+    "trans": [
+      "n./adv.昨天"
+    ]
+  },
+  {
+    "name": "yet",
+    "usphone": "jɛt",
+    "ukphone": "jet",
+    "trans": [
+      "adv.到目前为止，还；仍然"
+    ]
+  },
+  {
+    "name": "yield",
+    "usphone": "jild",
+    "ukphone": "jiːld",
+    "trans": [
+      "v.生产；(to)屈服，服从 n.产量，收成"
+    ]
+  },
+  {
+    "name": "young",
+    "usphone": "jʌŋ",
+    "ukphone": "jʌŋ",
+    "trans": [
+      "adj.年轻的，年幼的"
+    ]
+  },
+  {
+    "name": "youth",
+    "usphone": "jʊθ",
+    "ukphone": "juːθ",
+    "trans": [
+      "n.青春，青年时期；青年，青年人"
+    ]
+  },
+  {
+    "name": "yourself",
+    "usphone": "jɔr'sɛlf",
+    "ukphone": "jɔː'self; jʊə-; jə-",
+    "trans": [
+      "pron.你自己"
+    ]
+  },
+  {
+    "name": "zero",
+    "usphone": "ˈzɪərəʊ",
+    "ukphone": "'zɪərəʊ",
+    "trans": [
+      "n.零；零点；零度"
+    ]
+  },
+  {
+    "name": "zone",
+    "usphone": "zon",
+    "ukphone": "zəʊn",
+    "trans": [
+      "n.地区，区域，地带 v.分区，划分地带"
+    ]
+  }
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -161,6 +161,15 @@ export const dictionaries: Dictionary[] = [
     language: 'en',
   },
   {
+    id: 'pets3',
+    name: 'PETS-3',
+    description: '全国英语等级考试常考词汇',
+    category: '英语学习',
+    url: './dicts/PETS_3.json',
+    length: 1942,
+    language: 'en',
+  },
+  {
     id: 'PTE_junior',
     name: 'PTE 基础词汇',
     description: '',


### PR DESCRIPTION
[全国英语等级考试(Public English Test System, 简称PETS)](https://pets.neea.edu.cn/)是教育部教育考试院（原教育部考试中心）负责设计并实施的全国性英语水平考试体系。PETS 主要面向自考、成考或已毕业的社会人员。

* dict: 支持 PETS-3 词汇
* dict: 补充词汇「美音」、「英音」音标