### PR TITLE
add --host option to yarn start and set port expose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN yarn install
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 5173
 
-CMD yarn start
+CMD yarn start --host=0.0.0.0
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: 'node:16'
     user: 'root'
     working_dir: '/app/qwerty-learner'
-    ports: [8990:3000]
+    ports: [8990:5173]
     volumes:
       - $PWD/:/app/qwerty-learner
     command:
@@ -19,7 +19,7 @@ services:
         cd /app/qwerty-learner
         yarn install
         yarn build
-        nohup yarn start &
+        nohup yarn start --host=0.0.0.0 &
         echo 'success.. start..'
         pwd
         echo '查看输出:...'


### PR DESCRIPTION
默认服务监听端口和镜像的expose端口不一致，导致启动容器后访问不了；