### PR TITLE
新增一本词典，1500个名词按着使用频次排列

### DIFF
--- a/public/dicts/Top1500NounWords.json
+++ b/public/dicts/Top1500NounWords.json
@@ -1,0 +1,9152 @@
+[
+    {
+        "name": "people",
+        "trans": [
+            "People are individuals who are part of a society."
+        ]
+    },
+    {
+        "name": "history",
+        "trans": [
+            "History is the study of past events."
+        ]
+    },
+    {
+        "name": "way",
+        "trans": [
+            "A way is a path or route to get from one place to another."
+        ]
+    },
+    {
+        "name": "art",
+        "trans": [
+            "Art is the expression of creativity and imagination through visual or performing means."
+        ]
+    },
+    {
+        "name": "world",
+        "trans": [
+            "The world is the planet Earth and everything on it."
+        ]
+    },
+    {
+        "name": "information",
+        "trans": [
+            "Information is knowledge or facts that are communicated or received."
+        ]
+    },
+    {
+        "name": "map",
+        "trans": [
+            "A map is a visual representation of an area or a place."
+        ]
+    },
+    {
+        "name": "two",
+        "trans": [
+            "Two is the number that comes after one and before three."
+        ]
+    },
+    {
+        "name": "family",
+        "trans": [
+            "A family is a group of people who are related to each other by blood or marriage."
+        ]
+    },
+    {
+        "name": "government",
+        "trans": [
+            "Government is the system or group of people governing an organized community or nation."
+        ]
+    },
+    {
+        "name": "health",
+        "trans": [
+            "Health is the state of being free from illness or injury."
+        ]
+    },
+    {
+        "name": "system",
+        "trans": [
+            "A system is a set of interacting or interdependent components forming an integrated whole."
+        ]
+    },
+    {
+        "name": "computer",
+        "trans": [
+            "A computer is an electronic device that can perform various tasks by executing instructions."
+        ]
+    },
+    {
+        "name": "meat",
+        "trans": [
+            "Meat is animal flesh that is consumed as food."
+        ]
+    },
+    {
+        "name": "year",
+        "trans": [
+            "A year is a period of time consisting of 365 or 366 days."
+        ]
+    },
+    {
+        "name": "thanks",
+        "trans": [
+            "Thanks is an expression of gratitude or appreciation."
+        ]
+    },
+    {
+        "name": "music",
+        "trans": [
+            "Music is the art of creating or arranging sounds, usually in a structured way."
+        ]
+    },
+    {
+        "name": "person",
+        "trans": [
+            "A person is an individual human being."
+        ]
+    },
+    {
+        "name": "reading",
+        "trans": [
+            "Reading is the act of interpreting written or printed material."
+        ]
+    },
+    {
+        "name": "method",
+        "trans": [
+            "A method is a particular way of doing something."
+        ]
+    },
+    {
+        "name": "data",
+        "trans": [
+            "Data is facts or information used to calculate, analyze, or plan something."
+        ]
+    },
+    {
+        "name": "food",
+        "trans": [
+            "Food is any substance consumed to provide nutritional support for the body."
+        ]
+    },
+    {
+        "name": "understanding",
+        "trans": [
+            "Understanding is the ability to comprehend or grasp something."
+        ]
+    },
+    {
+        "name": "theory",
+        "trans": [
+            "A theory is a well-supported explanation of observed phenomena."
+        ]
+    },
+    {
+        "name": "law",
+        "trans": [
+            "A law is a system of rules that a particular country or community recognizes as regulating the actions of its members."
+        ]
+    },
+    {
+        "name": "bird",
+        "trans": [
+            "A bird is a warm-blooded vertebrate with feathers, wings, and a beak."
+        ]
+    },
+    {
+        "name": "literature",
+        "trans": [
+            "Literature is written works, especially those considered to have artistic or intellectual value."
+        ]
+    },
+    {
+        "name": "problem",
+        "trans": [
+            "A problem is a situation that needs to be resolved or dealt with."
+        ]
+    },
+    {
+        "name": "software",
+        "trans": [
+            "Software is the programs and other operating information used by a computer."
+        ]
+    },
+    {
+        "name": "control",
+        "trans": [
+            "Control is the power to influence or direct someone or something."
+        ]
+    },
+    {
+        "name": "knowledge",
+        "trans": [
+            "Knowledge is information, skills, and understanding acquired through experience or education."
+        ]
+    },
+    {
+        "name": "power",
+        "trans": [
+            "Power is the ability to influence or control people or things."
+        ]
+    },
+    {
+        "name": "ability",
+        "trans": [
+            "Ability is the power or skill to do something."
+        ]
+    },
+    {
+        "name": "economics",
+        "trans": [
+            "Economics is the study of the production, consumption, and distribution of goods and services."
+        ]
+    },
+    {
+        "name": "love",
+        "trans": [
+            "Love is a strong feeling of affection or attachment towards someone or something."
+        ]
+    },
+    {
+        "name": "internet",
+        "trans": [
+            "The internet is a global computer network that allows communication and information sharing through websites and other digital media."
+        ]
+    },
+    {
+        "name": "television",
+        "trans": [
+            "Television is a device or system for receiving and broadcasting images and sound over a distance."
+        ]
+    },
+    {
+        "name": "science",
+        "trans": [
+            "Science is the systematic study of the natural world through observation and experimentation."
+        ]
+    },
+    {
+        "name": "library",
+        "trans": [
+            "A library is a collection of books and other resources made available for people to use or borrow."
+        ]
+    },
+    {
+        "name": "nature",
+        "trans": [
+            "Nature is the physical world and all the living things in it."
+        ]
+    },
+    {
+        "name": "fact",
+        "trans": [
+            "A fact is a piece of information that is known to be true."
+        ]
+    },
+    {
+        "name": "product",
+        "trans": [
+            "A product is something that is made or created to be sold or used."
+        ]
+    },
+    {
+        "name": "idea",
+        "trans": [
+            "An idea is a concept or thought that is formed in the mind."
+        ]
+    },
+    {
+        "name": "temperature",
+        "trans": [
+            "Temperature is the degree of heat or coldness of a body or environment."
+        ]
+    },
+    {
+        "name": "investment",
+        "trans": [
+            "Investment is the action or process of putting money into something with the expectation of making a profit or achieving a benefit."
+        ]
+    },
+    {
+        "name": "area",
+        "trans": [
+            "An area is a particular part or region of a place or object."
+        ]
+    },
+    {
+        "name": "society",
+        "trans": [
+            "Society is the community of people living in a particular country or region and having shared customs, laws, and organizations."
+        ]
+    },
+    {
+        "name": "activity",
+        "trans": [
+            "An activity is an action that someone does for a particular purpose or reason."
+        ]
+    },
+    {
+        "name": "story",
+        "trans": [
+            "A story is a narrative account of a sequence of events."
+        ]
+    },
+    {
+        "name": "industry",
+        "trans": [
+            "Industry is the economic activity concerned with the processing of raw materials and the manufacturing of goods."
+        ]
+    },
+    {
+        "name": "media",
+        "trans": [
+            "Media are the means of communication, such as television, newspapers, and the internet, that reach large numbers of people."
+        ]
+    },
+    {
+        "name": "thing",
+        "trans": [
+            "A thing is an object, item, or matter that is being considered or discussed."
+        ]
+    },
+    {
+        "name": "oven",
+        "trans": [
+            "An oven is a thermally insulated chamber used for baking or heating food."
+        ]
+    },
+    {
+        "name": "community",
+        "trans": [
+            "A community is a group of people living in the same place or having a particular characteristic in common."
+        ]
+    },
+    {
+        "name": "definition",
+        "trans": [
+            "A definition is a statement of the exact meaning of a word or phrase."
+        ]
+    },
+    {
+        "name": "safety",
+        "trans": [
+            "Safety is the state of being protected from harm, danger, or injury."
+        ]
+    },
+    {
+        "name": "quality",
+        "trans": [
+            "Quality is the standard or level of something as measured against other things of a similar kind; the degree of excellence of something."
+        ]
+    },
+    {
+        "name": "development",
+        "trans": [
+            "Development is the process of growth, progress, or change towards a more advanced or mature state."
+        ]
+    },
+    {
+        "name": "language",
+        "trans": [
+            "A language is a system of communication consisting of sounds, words, and grammar used by a particular community or nation."
+        ]
+    },
+    {
+        "name": "management",
+        "trans": [
+            "Management is the process of planning, organizing, directing, and controlling resources to achieve specific goals."
+        ]
+    },
+    {
+        "name": "player",
+        "trans": [
+            "A player is a person who takes part in a game or sport."
+        ]
+    },
+    {
+        "name": "variety",
+        "trans": [
+            "Variety is the quality or state of being different or diverse."
+        ]
+    },
+    {
+        "name": "video",
+        "trans": [
+            "A video is a recording or broadcast of moving visual images."
+        ]
+    },
+    {
+        "name": "week",
+        "trans": [
+            "A week is a period of seven days."
+        ]
+    },
+    {
+        "name": "security",
+        "trans": [
+            "Security is the state of being protected against harm, loss, or unauthorized access."
+        ]
+    },
+    {
+        "name": "country",
+        "trans": [
+            "A country is a nation with its own government, occupying a particular territory."
+        ]
+    },
+    {
+        "name": "exam",
+        "trans": [
+            "An exam is a test of a person's knowledge or proficiency in a particular subject or skill."
+        ]
+    },
+    {
+        "name": "movie",
+        "trans": [
+            "A movie is a form of entertainment that tells a story through moving pictures and sound."
+        ]
+    },
+    {
+        "name": "organization",
+        "trans": [
+            "An organization is a group of people with a particular purpose or function, such as a business or government department."
+        ]
+    },
+    {
+        "name": "equipment",
+        "trans": [
+            "Equipment is the necessary items for a particular purpose or activity."
+        ]
+    },
+    {
+        "name": "physics",
+        "trans": [
+            "Physics is the study of matter, energy, and the interaction between them."
+        ]
+    },
+    {
+        "name": "analysis",
+        "trans": [
+            "Analysis is the process of examining something in detail to understand or explain it."
+        ]
+    },
+    {
+        "name": "policy",
+        "trans": [
+            "A policy is a course of action adopted or proposed by a government, party, business, or individual."
+        ]
+    },
+    {
+        "name": "series",
+        "trans": [
+            "A series is a number of events or things of a similar kind that follow each other in sequence."
+        ]
+    },
+    {
+        "name": "thought",
+        "trans": [
+            "A thought is an idea or opinion produced by thinking or occurring suddenly in the mind."
+        ]
+    },
+    {
+        "name": "basis",
+        "trans": [
+            "A basis is the underlying support or foundation for something."
+        ]
+    },
+    {
+        "name": "boyfriend",
+        "trans": [
+            "A boyfriend is a male partner in a romantic relationship."
+        ]
+    },
+    {
+        "name": "direction",
+        "trans": [
+            "Direction is the course or path along which something moves, develops, or changes."
+        ]
+    },
+    {
+        "name": "strategy",
+        "trans": [
+            "A strategy is a plan of action designed to achieve a particular goal or objective."
+        ]
+    },
+    {
+        "name": "technology",
+        "trans": [
+            "Technology is the application of scientific knowledge for practical purposes, especially in industry."
+        ]
+    },
+    {
+        "name": "army",
+        "trans": [
+            "An army is a large organized body of people trained and equipped for war or military service."
+        ]
+    },
+    {
+        "name": "camera",
+        "trans": [
+            "A camera is a device used to capture visual images and videos."
+        ]
+    },
+    {
+        "name": "freedom",
+        "trans": [
+            "Freedom is the power or right to act, speak, or think as one wants without hindrance or restraint."
+        ]
+    },
+    {
+        "name": "paper",
+        "trans": [
+            "Paper is a thin material used for writing or printing on, made from wood pulp or other fibrous material."
+        ]
+    },
+    {
+        "name": "environment",
+        "trans": [
+            "The environment is the natural world, including all living and non-living things that exist within it."
+        ]
+    },
+    {
+        "name": "child",
+        "trans": [
+            "A child is a young human being below the age of puberty or below the legal age of majority."
+        ]
+    },
+    {
+        "name": "instance",
+        "trans": [
+            "An instance is an occurrence or example of something."
+        ]
+    },
+    {
+        "name": "month",
+        "trans": [
+            "A month is a period of time consisting of approximately four weeks."
+        ]
+    },
+    {
+        "name": "truth",
+        "trans": [
+            "Truth is the quality or state of being in accordance with fact or reality."
+        ]
+    },
+    {
+        "name": "marketing",
+        "trans": [
+            "Marketing is the process of promoting and selling products or services."
+        ]
+    },
+    {
+        "name": "university",
+        "trans": [
+            "A university is an institution of higher education that grants academic degrees in various fields."
+        ]
+    },
+    {
+        "name": "writing",
+        "trans": [
+            "Writing is the act of putting thoughts, ideas, or information into written form."
+        ]
+    },
+    {
+        "name": "article",
+        "trans": [
+            "An article is a written composition on a particular topic, often published in a newspaper, magazine, or website."
+        ]
+    },
+    {
+        "name": "department",
+        "trans": [
+            "A department is a division of a larger organization, typically dealing with a specific area of activity or function."
+        ]
+    },
+    {
+        "name": "difference",
+        "trans": [
+            "A difference is a point or way in which people or things are not the same."
+        ]
+    },
+    {
+        "name": "goal",
+        "trans": [
+            "A goal is an aim or objective that someone strives to achieve."
+        ]
+    },
+    {
+        "name": "news",
+        "trans": [
+            "News is newly received or noteworthy information, especially about recent or important events."
+        ]
+    },
+    {
+        "name": "audience",
+        "trans": [
+            "An audience is a group of people who gather to watch or listen to a performance, speech, or presentation."
+        ]
+    },
+    {
+        "name": "fishing",
+        "trans": [
+            "Fishing is the activity of catching fish, typically for food or sport."
+        ]
+    },
+    {
+        "name": "growth",
+        "trans": [
+            "Growth is the process of developing or increasing in size, quantity, or degree."
+        ]
+    },
+    {
+        "name": "income",
+        "trans": [
+            "Income is the money a person or organization earns through work or investments."
+        ]
+    },
+    {
+        "name": "marriage",
+        "trans": [
+            "Marriage is a legally recognized union between two people, typically involving commitment, companionship, and mutual support."
+        ]
+    },
+    {
+        "name": "user",
+        "trans": [
+            "A user is a person or entity that utilizes a particular product or service."
+        ]
+    },
+    {
+        "name": "combination",
+        "trans": [
+            "A combination is a mixture or blend of two or more things or people."
+        ]
+    },
+    {
+        "name": "failure",
+        "trans": [
+            "Failure is the lack of success in achieving a desired goal or objective."
+        ]
+    },
+    {
+        "name": "meaning",
+        "trans": [
+            "Meaning is the significance or purpose behind something or someone."
+        ]
+    },
+    {
+        "name": "medicine",
+        "trans": [
+            "Medicine is the science and practice of diagnosing, treating, and preventing illness or injury."
+        ]
+    },
+    {
+        "name": "philosophy",
+        "trans": [
+            "Philosophy is the study of fundamental questions about existence, reality, knowledge, values, reason, and ethics."
+        ]
+    },
+    {
+        "name": "teacher",
+        "trans": [
+            "A teacher is a person who instructs or educates others, typically in a school or academic setting."
+        ]
+    },
+    {
+        "name": "communication",
+        "trans": [
+            "Communication is the exchange of information or ideas between people or groups."
+        ]
+    },
+    {
+        "name": "night",
+        "trans": [
+            "Night is the period of darkness between sunset and sunrise."
+        ]
+    },
+    {
+        "name": "chemistry",
+        "trans": [
+            "Chemistry is the scientific study of the properties, composition, and behavior of matter."
+        ]
+    },
+    {
+        "name": "disease",
+        "trans": [
+            "A disease is a disorder of the body or mind that causes specific symptoms or affects certain organs or systems."
+        ]
+    },
+    {
+        "name": "disk",
+        "trans": [
+            "A disk is a flat, circular object or storage device that can store or read digital information."
+        ]
+    },
+    {
+        "name": "energy",
+        "trans": [
+            "Energy is the ability to do work, produce light or heat, or cause movement."
+        ]
+    },
+    {
+        "name": "nation",
+        "trans": [
+            "A nation is a large group of people who share a common language, culture, history, or government."
+        ]
+    },
+    {
+        "name": "road",
+        "trans": [
+            "A road is a paved or unpaved pathway used for transportation, typically by vehicles or pedestrians."
+        ]
+    },
+    {
+        "name": "role",
+        "trans": [
+            "A role is the function or position someone or something plays in a particular situation or setting."
+        ]
+    },
+    {
+        "name": "soup",
+        "trans": [
+            "Soup is a liquid dish typically made by boiling vegetables, meat, or fish in water or stock."
+        ]
+    },
+    {
+        "name": "advertising",
+        "trans": [
+            "Advertising is the practice of promoting or selling products or services through various media channels."
+        ]
+    },
+    {
+        "name": "location",
+        "trans": [
+            "A location is a specific place or position in space, typically with a physical address or geographical coordinates."
+        ]
+    },
+    {
+        "name": "success",
+        "trans": [
+            "Success is the achievement of a desired goal or objective."
+        ]
+    },
+    {
+        "name": "addition",
+        "trans": [
+            "Addition is the act or process of adding something to something else."
+        ]
+    },
+    {
+        "name": "apartment",
+        "trans": [
+            "An apartment is a self-contained living space within a larger building, typically rented out to tenants."
+        ]
+    },
+    {
+        "name": "education",
+        "trans": [
+            "Education is the process of acquiring knowledge, skills, values, and attitudes through various forms of learning."
+        ]
+    },
+    {
+        "name": "math",
+        "trans": [
+            "Income is the money a person or organization earns through work or investments."
+        ]
+    },
+    {
+        "name": "moment",
+        "trans": [
+            "Marriage is a legally recognized union between two people, typically involving commitment, companionship, and mutual support."
+        ]
+    },
+    {
+        "name": "painting",
+        "trans": [
+            "A user is a person or entity that utilizes a particular product or service."
+        ]
+    },
+    {
+        "name": "politics",
+        "trans": [
+            "A combination is a mixture or blend of two or more things or people."
+        ]
+    },
+    {
+        "name": "attention",
+        "trans": [
+            "Failure is the lack of success in achieving a desired goal or objective."
+        ]
+    },
+    {
+        "name": "decision",
+        "trans": [
+            "Meaning is the significance or purpose behind something or someone."
+        ]
+    },
+    {
+        "name": "event",
+        "trans": [
+            "Medicine is the science and practice of diagnosing, treating, and preventing illness or injury."
+        ]
+    },
+    {
+        "name": "property",
+        "trans": [
+            "Philosophy is the study of fundamental questions about existence, reality, knowledge, values, reason, and ethics."
+        ]
+    },
+    {
+        "name": "shopping",
+        "trans": [
+            "A teacher is a person who instructs or educates others, typically in a school or academic setting."
+        ]
+    },
+    {
+        "name": "student",
+        "trans": [
+            "Communication is the exchange of information or ideas between people or groups."
+        ]
+    },
+    {
+        "name": "wood",
+        "trans": [
+            "Night is the period of darkness between sunset and sunrise."
+        ]
+    },
+    {
+        "name": "competition",
+        "trans": [
+            "Chemistry is the scientific study of the properties, composition, and behavior of matter."
+        ]
+    },
+    {
+        "name": "distribution",
+        "trans": [
+            "A disease is a disorder of the body or mind that causes specific symptoms or affects certain organs or systems."
+        ]
+    },
+    {
+        "name": "entertainment",
+        "trans": [
+            "A disk is a flat, circular object or storage device that can store or read digital information."
+        ]
+    },
+    {
+        "name": "office",
+        "trans": [
+            "Energy is the ability to do work, produce light or heat, or cause movement."
+        ]
+    },
+    {
+        "name": "population",
+        "trans": [
+            "A nation is a large group of people who share a common language, culture, history, or government."
+        ]
+    },
+    {
+        "name": "president",
+        "trans": [
+            "A road is a paved or unpaved pathway used for transportation, typically by vehicles or pedestrians."
+        ]
+    },
+    {
+        "name": "unit",
+        "trans": [
+            "A role is the function or position someone or something plays in a particular situation or setting."
+        ]
+    },
+    {
+        "name": "category",
+        "trans": [
+            "Soup is a liquid dish typically made by boiling vegetables, meat, or fish in water or stock."
+        ]
+    },
+    {
+        "name": "cigarette",
+        "trans": [
+            "Advertising is the practice of promoting or selling products or services through various media channels."
+        ]
+    },
+    {
+        "name": "context",
+        "trans": [
+            "A location is a specific place or position in space, typically with a physical address or geographical coordinates."
+        ]
+    },
+    {
+        "name": "introduction",
+        "trans": [
+            "Success is the achievement of a desired goal or objective."
+        ]
+    },
+    {
+        "name": "opportunity",
+        "trans": [
+            "Addition is the act or process of adding something to something else."
+        ]
+    },
+    {
+        "name": "performance",
+        "trans": [
+            "An apartment is a self-contained living space within a larger building, typically rented out to tenants."
+        ]
+    },
+    {
+        "name": "driver",
+        "trans": [
+            "A driver is a person who operates a vehicle or transportation device, often for commercial or personal purposes."
+        ]
+    },
+    {
+        "name": "flight",
+        "trans": [
+            "A flight is a journey made by air, typically in an airplane or other aircraft."
+        ]
+    },
+    {
+        "name": "length",
+        "trans": [
+            "Length is the measurement of the extent or dimension of something, typically referring to its longest side or distance."
+        ]
+    },
+    {
+        "name": "magazine",
+        "trans": [
+            "A magazine is a periodical publication containing articles, stories, photographs, and other features, often targeted to a specific audience or interest group."
+        ]
+    },
+    {
+        "name": "newspaper",
+        "trans": [
+            "A newspaper is a daily or weekly publication containing news, articles, and advertisements, typically printed on large sheets of paper and distributed for public consumption."
+        ]
+    },
+    {
+        "name": "relationship",
+        "trans": [
+            "A relationship is the way in which two or more people or things are connected or interact with each other."
+        ]
+    },
+    {
+        "name": "teaching",
+        "trans": [
+            "Teaching is the act or process of imparting knowledge, skills, or information to others, often in an academic or instructional setting."
+        ]
+    },
+    {
+        "name": "cell",
+        "trans": [
+            "A cell is the basic unit of life and the building block of all living organisms, typically consisting of a membrane-bound nucleus and other organelles."
+        ]
+    },
+    {
+        "name": "dealer",
+        "trans": [
+            "A dealer is a person or business that buys and sells goods, often in a specific industry or market."
+        ]
+    },
+    {
+        "name": "finding",
+        "trans": [
+            "A finding is a discovery or conclusion reached after investigation or research, often referring to a particular fact or piece of information."
+        ]
+    },
+    {
+        "name": "lake",
+        "trans": [
+            "A lake is a large body of water surrounded by land, typically formed by natural processes or human intervention."
+        ]
+    },
+    {
+        "name": "member",
+        "trans": [
+            "A member is a person who belongs to a group or organization, often participating in its activities or sharing its goals and values."
+        ]
+    },
+    {
+        "name": "message",
+        "trans": [
+            "A message is a piece of information or communication sent from one person or entity to another, often using technology or other means of delivery."
+        ]
+    },
+    {
+        "name": "phone",
+        "trans": [
+            "A phone is an electronic device used for communication, typically allowing people to make calls, send messages, and access the internet."
+        ]
+    },
+    {
+        "name": "scene",
+        "trans": [
+            "A scene is a particular setting or location, often referring to a specific moment in time or event that is taking place or has already occurred."
+        ]
+    },
+    {
+        "name": "appearance",
+        "trans": [
+            "Appearance is the way in which someone or something looks or appears, often referring to physical features or qualities."
+        ]
+    },
+    {
+        "name": "association",
+        "trans": [
+            "An association is a group of people or organizations working together toward a common goal or purpose, often sharing resources or expertise."
+        ]
+    },
+    {
+        "name": "concept",
+        "trans": [
+            "A concept is an abstract or general idea or notion, often used to describe a particular theory or understanding of something."
+        ]
+    },
+    {
+        "name": "customer",
+        "trans": [
+            "A customer is a person who purchases goods or services from a business or organization, often paying money in exchange for the products or services provided."
+        ]
+    },
+    {
+        "name": "death",
+        "trans": [
+            "Death is the permanent cessation of all biological functions that sustain a living organism, often occurring at the end of a person or animal's natural life span or as the result of injury or disease."
+        ]
+    },
+    {
+        "name": "discussion",
+        "trans": [
+            "A discussion is a conversation or exchange of ideas or opinions, often involving multiple people and focused on a particular topic or subject."
+        ]
+    },
+    {
+        "name": "housing",
+        "trans": [
+            "Housing refers to the provision of shelter or accommodation for people, often provided by a government or other organization for those in need."
+        ]
+    },
+    {
+        "name": "inflation",
+        "trans": [
+            "Inflation is the increase in the price of goods and services over time, often resulting from an increase in the supply of money or a decrease in the supply of goods and services."
+        ]
+    },
+    {
+        "name": "insurance",
+        "trans": [
+            "Insurance is a system of protection against financial loss or damage, often provided by an insurance company in exchange for regular payments or premiums."
+        ]
+    },
+    {
+        "name": "mood",
+        "trans": [
+            "Mood is a temporary state of mind or feeling, often influenced by external factors such as environment or circumstances."
+        ]
+    },
+    {
+        "name": "woman",
+        "trans": [
+            "A woman is an adult female human, typically distinguished from a girl or a man by physical and biological characteristics."
+        ]
+    },
+    {
+        "name": "advice",
+        "trans": [
+            "Advice is suggestions or recommendations offered to someone about what they should do in a particular situation."
+        ]
+    },
+    {
+        "name": "blood",
+        "trans": [
+            "Blood is a red liquid that circulates in the veins and arteries of humans and other animals, carrying oxygen and nutrients to the cells and tissues of the body."
+        ]
+    },
+    {
+        "name": "effort",
+        "trans": [
+            "Effort is the physical or mental energy that is exerted to achieve something."
+        ]
+    },
+    {
+        "name": "expression",
+        "trans": [
+            "Expression is the act of conveying a thought or feeling through words, gestures, or other means of communication."
+        ]
+    },
+    {
+        "name": "importance",
+        "trans": [
+            "Importance is the quality of being significant or essential."
+        ]
+    },
+    {
+        "name": "opinion",
+        "trans": [
+            "An opinion is a belief or judgment about something, often based on personal experiences or feelings rather than facts."
+        ]
+    },
+    {
+        "name": "payment",
+        "trans": [
+            "Payment is the act of giving or receiving money for goods or services."
+        ]
+    },
+    {
+        "name": "reality",
+        "trans": [
+            "Reality is the state of things as they actually exist, rather than how they are imagined or perceived."
+        ]
+    },
+    {
+        "name": "responsibility",
+        "trans": [
+            "Responsibility is the state or fact of being accountable or answerable for something within one's control."
+        ]
+    },
+    {
+        "name": "situation",
+        "trans": [
+            "A situation is a set of circumstances or conditions in which something or someone exists or operates."
+        ]
+    },
+    {
+        "name": "skill",
+        "trans": [
+            "A skill is the ability to do something well, often as a result of training or practice."
+        ]
+    },
+    {
+        "name": "statement",
+        "trans": [
+            "A statement is a declaration or expression of a fact, idea, opinion, or thought."
+        ]
+    },
+    {
+        "name": "wealth",
+        "trans": [
+            "Wealth is the abundance of valuable resources or valuable material possessions."
+        ]
+    },
+    {
+        "name": "application",
+        "trans": [
+            "An application is a software program designed for a specific task or purpose."
+        ]
+    },
+    {
+        "name": "city",
+        "trans": [
+            "A city is a large and densely populated urban area with its own government and infrastructure."
+        ]
+    },
+    {
+        "name": "county",
+        "trans": [
+            "A county is a geographical and administrative region within a state or country, often consisting of several cities or towns."
+        ]
+    },
+    {
+        "name": "depth",
+        "trans": [
+            "Depth is the distance from the top or surface to the bottom of something, or the extent to which something is deep."
+        ]
+    },
+    {
+        "name": "estate",
+        "trans": [
+            "An estate refers to a large piece of property, often including a house or other buildings, and any associated land."
+        ]
+    },
+    {
+        "name": "foundation",
+        "trans": [
+            "A foundation is the base or support upon which something is built or established."
+        ]
+    },
+    {
+        "name": "grandmother",
+        "trans": [
+            "A grandmother is the mother of one's parent."
+        ]
+    },
+    {
+        "name": "heart",
+        "trans": [
+            "The heart is a muscular organ that pumps blood throughout the body, providing oxygen and nutrients to the tissues."
+        ]
+    },
+    {
+        "name": "perspective",
+        "trans": [
+            "Perspective is a particular point of view or way of looking at something."
+        ]
+    },
+    {
+        "name": "photo",
+        "trans": [
+            "A photo is a picture taken with a camera or other photographic device."
+        ]
+    },
+    {
+        "name": "recipe",
+        "trans": [
+            "A recipe is a set of instructions for preparing a particular dish or food item."
+        ]
+    },
+    {
+        "name": "studio",
+        "trans": [
+            "A studio is a space where an artist, musician, or other creative professional works or creates."
+        ]
+    },
+    {
+        "name": "topic",
+        "trans": [
+            "A topic is the subject or theme of a conversation, discussion, or written work."
+        ]
+    },
+    {
+        "name": "collection",
+        "trans": [
+            "A collection is a group of similar or related items that have been gathered together."
+        ]
+    },
+    {
+        "name": "depression",
+        "trans": [
+            "Depression is a mental illness characterized by persistent feelings of sadness, hopelessness, and despair."
+        ]
+    },
+    {
+        "name": "imagination",
+        "trans": [
+            "Imagination is the ability to form mental images or ideas of things that are not present or that do not exist."
+        ]
+    },
+    {
+        "name": "passion",
+        "trans": [
+            "Passion is a strong and intense emotion or feeling, often related to love, desire, or enthusiasm."
+        ]
+    },
+    {
+        "name": "percentage",
+        "trans": [
+            "A percentage is a fraction of a hundred, often used to represent a proportion or share of something."
+        ]
+    },
+    {
+        "name": "resource",
+        "trans": [
+            "A resource is something that can be used to achieve a particular purpose or goal."
+        ]
+    },
+    {
+        "name": "setting",
+        "trans": [
+            "A setting is the place, time, and conditions in which something happens or exists."
+        ]
+    },
+    {
+        "name": "ad",
+        "trans": [
+            "An ad, short for advertisement, is a public announcement or notice designed to promote or sell a product, service, or idea."
+        ]
+    },
+    {
+        "name": "agency",
+        "trans": [
+            "An agency is an organization or company that provides a particular service, often acting on behalf of others."
+        ]
+    },
+    {
+        "name": "college",
+        "trans": [
+            "A college is an institution of higher education where students can earn degrees and pursue academic studies."
+        ]
+    },
+    {
+        "name": "connection",
+        "trans": [
+            "A connection is a relationship or association between people, things, or ideas."
+        ]
+    },
+    {
+        "name": "criticism",
+        "trans": [
+            "Criticism is the act of making negative judgments or evaluations about something or someone."
+        ]
+    },
+    {
+        "name": "debt",
+        "trans": [
+            "Debt is the state of owing money or being in financial obligation to another party."
+        ]
+    },
+    {
+        "name": "description",
+        "trans": [
+            "A description is a statement or account that gives details about something, often used to help identify or distinguish it from others."
+        ]
+    },
+    {
+        "name": "memory",
+        "trans": [
+            "A memory is a recollection or mental representation of past experiences, events, or information."
+        ]
+    },
+    {
+        "name": "patience",
+        "trans": [
+            "Patience is the ability to remain calm and composed in the face of difficulties or delays."
+        ]
+    },
+    {
+        "name": "secretary",
+        "trans": [
+            "A secretary is a person who performs administrative or clerical tasks, often working for an individual or organization."
+        ]
+    },
+    {
+        "name": "solution",
+        "trans": [
+            "A solution is a means of solving a problem or addressing an issue."
+        ]
+    },
+    {
+        "name": "administration",
+        "trans": [
+            "Administration refers to the management and organization of a system, business, or government."
+        ]
+    },
+    {
+        "name": "aspect",
+        "trans": [
+            "An aspect is a particular feature or characteristic of something, often considered from a specific point of view."
+        ]
+    },
+    {
+        "name": "attitude",
+        "trans": [
+            "Attitude refers to a person's mental position or perspective, often influencing their behavior or actions."
+        ]
+    },
+    {
+        "name": "director",
+        "trans": [
+            "A director is a person who oversees or manages an organization, project, or production."
+        ]
+    },
+    {
+        "name": "personality",
+        "trans": [
+            "Personality refers to the unique and distinctive set of characteristics, qualities, and traits that define a person's individuality and identity."
+        ]
+    },
+    {
+        "name": "psychology",
+        "trans": [
+            "Psychology is the scientific study of behavior and mental processes, often focused on understanding individual and group behavior, personality, and emotions."
+        ]
+    },
+    {
+        "name": "recommendation",
+        "trans": [
+            "A recommendation is a suggestion or advice on what someone should do or use."
+        ]
+    },
+    {
+        "name": "response",
+        "trans": [
+            "A response is an answer or reaction to something that has been said or done."
+        ]
+    },
+    {
+        "name": "selection",
+        "trans": [
+            "A selection is a choice made from a group of options or possibilities."
+        ]
+    },
+    {
+        "name": "storage",
+        "trans": [
+            "Storage is the act of keeping something in a place for future use."
+        ]
+    },
+    {
+        "name": "version",
+        "trans": [
+            "A version is a particular form or edition of something."
+        ]
+    },
+    {
+        "name": "alcohol",
+        "trans": [
+            "Alcohol is a type of drink that can make people drunk."
+        ]
+    },
+    {
+        "name": "argument",
+        "trans": [
+            "An argument is a disagreement or a reason given in support of or against an idea, action or theory."
+        ]
+    },
+    {
+        "name": "complaint",
+        "trans": [
+            "A complaint is a statement expressing dissatisfaction or unhappiness about something."
+        ]
+    },
+    {
+        "name": "contract",
+        "trans": [
+            "A contract is a legal agreement between two or more parties that outlines the terms and conditions of their relationship."
+        ]
+    },
+    {
+        "name": "emphasis",
+        "trans": [
+            "Emphasis is special attention or importance given to something to make it stand out."
+        ]
+    },
+    {
+        "name": "highway",
+        "trans": [
+            "A highway is a main road that connects different cities and regions."
+        ]
+    },
+    {
+        "name": "loss",
+        "trans": [
+            "A loss is the act of losing something or the result of losing something."
+        ]
+    },
+    {
+        "name": "membership",
+        "trans": [
+            "Membership is the status of being a member of a group or organization."
+        ]
+    },
+    {
+        "name": "possession",
+        "trans": [
+            "A possession is something that is owned or held by a person or group."
+        ]
+    },
+    {
+        "name": "preparation",
+        "trans": [
+            "Preparation is the act of getting ready for something."
+        ]
+    },
+    {
+        "name": "steak",
+        "trans": [
+            "A steak is a cut of meat, usually beef, that is cooked by grilling or frying."
+        ]
+    },
+    {
+        "name": "union",
+        "trans": [
+            "A union is a group of workers who come together to protect their rights and interests."
+        ]
+    },
+    {
+        "name": "agreement",
+        "trans": [
+            "An agreement is a mutual understanding or arrangement reached by two or more parties."
+        ]
+    },
+    {
+        "name": "cancer",
+        "trans": [
+            "Cancer is a disease characterized by the uncontrolled growth and spread of abnormal cells in the body."
+        ]
+    },
+    {
+        "name": "currency",
+        "trans": [
+            "Currency is a system of money used in a particular country or region."
+        ]
+    },
+    {
+        "name": "employment",
+        "trans": [
+            "Employment is the state of having a paid job or work."
+        ]
+    },
+    {
+        "name": "engineering",
+        "trans": [
+            "Engineering is the application of scientific and mathematical principles to design and develop structures, machines, and systems."
+        ]
+    },
+    {
+        "name": "entry",
+        "trans": [
+            "An entry is the act of entering or a place where someone enters."
+        ]
+    },
+    {
+        "name": "interaction",
+        "trans": [
+            "Interaction is the exchange of information or ideas between people or things."
+        ]
+    },
+    {
+        "name": "mixture",
+        "trans": [
+            "A mixture is a combination of different substances or things."
+        ]
+    },
+    {
+        "name": "preference",
+        "trans": [
+            "Preference refers to a liking or desire for one thing over another."
+        ]
+    },
+    {
+        "name": "region",
+        "trans": [
+            "A region is a geographical area or a part of a larger area that is identified by certain characteristics or boundaries."
+        ]
+    },
+    {
+        "name": "republic",
+        "trans": [
+            "A republic is a type of government in which the power is held by the people and their elected representatives."
+        ]
+    },
+    {
+        "name": "tradition",
+        "trans": [
+            "Tradition refers to beliefs, customs, or practices that are passed down from one generation to another."
+        ]
+    },
+    {
+        "name": "virus",
+        "trans": [
+            "A virus is a microscopic infectious agent that can replicate only inside the living cells of an organism."
+        ]
+    },
+    {
+        "name": "actor",
+        "trans": [
+            "An actor is a person who performs in plays, movies, or TV shows."
+        ]
+    },
+    {
+        "name": "classroom",
+        "trans": [
+            "A classroom is a room in a school or college where students receive instruction from a teacher."
+        ]
+    },
+    {
+        "name": "delivery",
+        "trans": [
+            "Delivery refers to the act of bringing or transporting something to a particular destination or recipient."
+        ]
+    },
+    {
+        "name": "device",
+        "trans": [
+            "A device is a tool, machine, or piece of equipment that is designed to perform a specific function."
+        ]
+    },
+    {
+        "name": "difficulty",
+        "trans": [
+            "Difficulty refers to the state or quality of being hard to do, understand, or deal with."
+        ]
+    },
+    {
+        "name": "drama",
+        "trans": [
+            "Drama refers to a genre of literature, film, or TV that deals with serious or emotional themes and has a dramatic plot."
+        ]
+    },
+    {
+        "name": "election",
+        "trans": [
+            "An election is a formal process by which people choose someone for a political office or a particular position."
+        ]
+    },
+    {
+        "name": "engine",
+        "trans": [
+            "An engine is a machine that uses energy to do work, such as powering a vehicle or generating electricity."
+        ]
+    },
+    {
+        "name": "football",
+        "trans": [
+            "Football is a popular team sport that involves kicking a ball to score goals."
+        ]
+    },
+    {
+        "name": "guidance",
+        "trans": [
+            "Guidance refers to the act of giving advice or direction to someone to help them make decisions or solve problems."
+        ]
+    },
+    {
+        "name": "hotel",
+        "trans": [
+            "A hotel is a place where people can pay to stay for a short period, usually while they are traveling."
+        ]
+    },
+    {
+        "name": "owner",
+        "trans": [
+            "An owner is a person who has legal possession or control of something, such as a property or a business."
+        ]
+    },
+    {
+        "name": "priority",
+        "trans": [
+            "Priority refers to the state or condition of being more important or urgent than something else."
+        ]
+    },
+    {
+        "name": "protection",
+        "trans": [
+            "Protection refers to the act of keeping something or someone safe from harm or danger."
+        ]
+    },
+    {
+        "name": "suggestion",
+        "trans": [
+            "A suggestion is an idea or proposal that is put forward for consideration or action."
+        ]
+    },
+    {
+        "name": "tension",
+        "trans": [
+            "Tension refers to the state of being stretched or strained, both physically and emotionally."
+        ]
+    },
+    {
+        "name": "variation",
+        "trans": [
+            "Variation refers to a difference or deviation from a standard or expected form, condition, or behavior."
+        ]
+    },
+    {
+        "name": "anxiety",
+        "trans": [
+            "Anxiety refers to a feeling of worry, nervousness, or unease about something with an uncertain outcome or situation."
+        ]
+    },
+    {
+        "name": "atmosphere",
+        "trans": [
+            "Atmosphere refers to the overall feeling or mood of a place or situation."
+        ]
+    },
+    {
+        "name": "awareness",
+        "trans": [
+            "Awareness refers to having knowledge or perception of something."
+        ]
+    },
+    {
+        "name": "bath",
+        "trans": [
+            "A bath is a container filled with water in which people bathe to wash their bodies."
+        ]
+    },
+    {
+        "name": "bread",
+        "trans": [
+            "Bread is a type of food made from flour, water, and yeast, which is baked and usually sliced before being eaten."
+        ]
+    },
+    {
+        "name": "candidate",
+        "trans": [
+            "A candidate is a person who applies or is nominated for a job, position, or award."
+        ]
+    },
+    {
+        "name": "climate",
+        "trans": [
+            "Climate refers to the long-term weather patterns of a specific area or region."
+        ]
+    },
+    {
+        "name": "comparison",
+        "trans": [
+            "Comparison is the act of examining the similarities and differences between two or more things."
+        ]
+    },
+    {
+        "name": "confusion",
+        "trans": [
+            "Confusion is a state of being uncertain or unclear about something."
+        ]
+    },
+    {
+        "name": "construction",
+        "trans": [
+            "Construction refers to the process of building or creating something, often a physical structure."
+        ]
+    },
+    {
+        "name": "elevator",
+        "trans": [
+            "An elevator is a machine used to move people or objects between different floors or levels of a building."
+        ]
+    },
+    {
+        "name": "emotion",
+        "trans": [
+            "An emotion is a feeling, such as happiness, sadness, anger, or fear, that is experienced by a person."
+        ]
+    },
+    {
+        "name": "employee",
+        "trans": [
+            "An employee is a person who works for a company or organization and is paid a salary or wages."
+        ]
+    },
+    {
+        "name": "employer",
+        "trans": [
+            "An employer is a person or company that hires and pays employees to work for them."
+        ]
+    },
+    {
+        "name": "guest",
+        "trans": [
+            "A guest is a person who is invited to visit or stay in someone else's home, hotel, or other accommodation."
+        ]
+    },
+    {
+        "name": "height",
+        "trans": [
+            "Height is the measurement of how tall something or someone is, usually from the bottom to the top."
+        ]
+    },
+    {
+        "name": "leadership",
+        "trans": [
+            "Leadership is the ability to inspire and guide others towards a common goal or vision."
+        ]
+    },
+    {
+        "name": "mall",
+        "trans": [
+            "A mall is a large shopping center with many stores and businesses."
+        ]
+    },
+    {
+        "name": "manager",
+        "trans": [
+            "A manager is a person who is responsible for overseeing a team or group of people and making sure they complete their work effectively and efficiently."
+        ]
+    },
+    {
+        "name": "operation",
+        "trans": [
+            "An operation is a planned activity or process designed to achieve a specific goal or outcome."
+        ]
+    },
+    {
+        "name": "recording",
+        "trans": [
+            "A recording is a reproduction of sound or video that is stored and played back at a later time."
+        ]
+    },
+    {
+        "name": "sample",
+        "trans": [
+            "A sample is a small portion or piece of something that is taken as a representation of the whole."
+        ]
+    },
+    {
+        "name": "transportation",
+        "trans": [
+            "Transportation refers to the movement of people or goods from one place to another, often by means of vehicles such as cars, buses, or trains."
+        ]
+    },
+    {
+        "name": "charity",
+        "trans": [
+            "A charity is an organization that collects donations or funds from people and uses them to help people in need or to support a particular cause."
+        ]
+    },
+    {
+        "name": "cousin",
+        "trans": [
+            "A cousin is a relative who shares a common ancestor, but who is not a sibling or direct descendant."
+        ]
+    },
+    {
+        "name": "disaster",
+        "trans": [
+            "A disaster is a catastrophic event or situation that causes widespread damage, destruction, or loss of life."
+        ]
+    },
+    {
+        "name": "editor",
+        "trans": [
+            "An editor is a person who is responsible for selecting, revising, and preparing written material for publication or broadcasting."
+        ]
+    },
+    {
+        "name": "efficiency",
+        "trans": [
+            "Efficiency is the ability to achieve maximum productivity with minimum wasted effort or resources."
+        ]
+    },
+    {
+        "name": "excitement",
+        "trans": [
+            "Excitement is a feeling of great enthusiasm or eagerness."
+        ]
+    },
+    {
+        "name": "extent",
+        "trans": [
+            "Extent refers to the degree or scope to which something exists or is true."
+        ]
+    },
+    {
+        "name": "feedback",
+        "trans": [
+            "Feedback is information or comments about something that is given to someone in order to help them improve or make changes."
+        ]
+    },
+    {
+        "name": "guitar",
+        "trans": [
+            "A guitar is a musical instrument with strings that is played by plucking or strumming."
+        ]
+    },
+    {
+        "name": "homework",
+        "trans": [
+            "Homework is schoolwork that is assigned to be completed outside of class."
+        ]
+    },
+    {
+        "name": "leader",
+        "trans": [
+            "A leader is a person who guides, directs, or commands a group or organization."
+        ]
+    },
+    {
+        "name": "mom",
+        "trans": [
+            "Mom is an informal term used to refer to one's mother."
+        ]
+    },
+    {
+        "name": "outcome",
+        "trans": [
+            "An outcome is the final result or consequence of a particular action or situation."
+        ]
+    },
+    {
+        "name": "permission",
+        "trans": [
+            "Permission is the act of allowing someone to do something or the right to do something."
+        ]
+    },
+    {
+        "name": "presentation",
+        "trans": [
+            "A presentation is a formal talk or speech given to an audience, often accompanied by visual aids."
+        ]
+    },
+    {
+        "name": "promotion",
+        "trans": [
+            "Promotion refers to the act of advancing someone to a higher position or rank in a company or organization."
+        ]
+    },
+    {
+        "name": "reflection",
+        "trans": [
+            "Reflection is the act of thinking deeply about something or contemplating an experience or event."
+        ]
+    },
+    {
+        "name": "refrigerator",
+        "trans": [
+            "A refrigerator is an appliance used for storing food and drinks at a low temperature."
+        ]
+    },
+    {
+        "name": "resolution",
+        "trans": [
+            "A resolution is a firm decision to do or not to do something, or the act of resolving a problem or issue."
+        ]
+    },
+    {
+        "name": "revenue",
+        "trans": [
+            "Revenue is the income that a company or organization earns from its business activities."
+        ]
+    },
+    {
+        "name": "session",
+        "trans": [
+            "A session is a period of time during which a particular activity or event takes place."
+        ]
+    },
+    {
+        "name": "singer",
+        "trans": [
+            "A singer is a person who sings, typically as a profession or as a form of artistic expression."
+        ]
+    },
+    {
+        "name": "tennis",
+        "trans": [
+            "Tennis is a sport played by two or four players who hit a ball over a net using rackets."
+        ]
+    },
+    {
+        "name": "basket",
+        "trans": [
+            "A basket is a container made of woven material, such as straw or wire, used for carrying or storing items."
+        ]
+    },
+    {
+        "name": "bonus",
+        "trans": [
+            "A bonus is an additional payment or reward given to someone as a result of their performance or work."
+        ]
+    },
+    {
+        "name": "cabinet",
+        "trans": [
+            "A cabinet is a piece of furniture with shelves or drawers used for storage, often found in kitchens or offices."
+        ]
+    },
+    {
+        "name": "childhood",
+        "trans": [
+            "Childhood is the period of life between infancy and adolescence."
+        ]
+    },
+    {
+        "name": "church",
+        "trans": [
+            "A church is a building used for Christian religious worship and ceremonies."
+        ]
+    },
+    {
+        "name": "clothes",
+        "trans": [
+            "Clothes are items of clothing that people wear to cover their bodies, such as shirts, pants, and dresses."
+        ]
+    },
+    {
+        "name": "coffee",
+        "trans": [
+            "Coffee is a drink made from roasted coffee beans."
+        ]
+    },
+    {
+        "name": "dinner",
+        "trans": [
+            "Dinner is a meal eaten in the evening, typically the main meal of the day."
+        ]
+    },
+    {
+        "name": "drawing",
+        "trans": [
+            "Drawing is the act of creating a picture, image or diagram by making marks on paper or another surface."
+        ]
+    },
+    {
+        "name": "hair",
+        "trans": [
+            "Hair is the protein filament that grows from follicles in the skin and covers much of the human body."
+        ]
+    },
+    {
+        "name": "hearing",
+        "trans": [
+            "Hearing is the ability to perceive sound by detecting vibrations through the ear."
+        ]
+    },
+    {
+        "name": "initiative",
+        "trans": [
+            "Initiative is the ability to take charge and begin something new or make changes."
+        ]
+    },
+    {
+        "name": "judgment",
+        "trans": [
+            "Judgment is the ability to make considered decisions based on careful thought and analysis."
+        ]
+    },
+    {
+        "name": "lab",
+        "trans": [
+            "Lab is an abbreviation of laboratory, a place equipped for scientific research and experiments."
+        ]
+    },
+    {
+        "name": "measurement",
+        "trans": [
+            "Measurement is the process of quantifying and determining the size, amount, or degree of something."
+        ]
+    },
+    {
+        "name": "mode",
+        "trans": [
+            "Mode is the most frequently occurring value in a set of data."
+        ]
+    },
+    {
+        "name": "mud",
+        "trans": [
+            "Mud is a mixture of water and soil or fine-grained sediment that can be soft and sticky when wet."
+        ]
+    },
+    {
+        "name": "orange",
+        "trans": [
+            "Orange is a fruit with a tough reddish-yellow rind and a juicy, sweet pulp."
+        ]
+    },
+    {
+        "name": "poetry",
+        "trans": [
+            "Poetry is a form of literature that uses aesthetic and rhythmic qualities of language, such as meter and rhyme, to evoke emotion and convey meaning."
+        ]
+    },
+    {
+        "name": "police",
+        "trans": [
+            "Police are a group of people responsible for maintaining law and order, preventing crime and protecting people and property."
+        ]
+    },
+    {
+        "name": "possibility",
+        "trans": [
+            "Possibility is the condition or fact of being possible; something that may or may not occur or be true."
+        ]
+    },
+    {
+        "name": "procedure",
+        "trans": [
+            "Procedure is a series of actions taken in a particular order to accomplish a specific task or goal."
+        ]
+    },
+    {
+        "name": "queen",
+        "trans": [
+            "Queen is a female ruler of an independent state, or the wife or widow of a king."
+        ]
+    },
+    {
+        "name": "ratio",
+        "trans": [
+            "Ratio is the quantitative relation between two amounts showing the number of times one value contains or is contained within the other."
+        ]
+    },
+    {
+        "name": "relation",
+        "trans": [
+            "Relation is the way in which two or more things are connected or the way in which one thing is dependent on another."
+        ]
+    },
+    {
+        "name": "restaurant",
+        "trans": [
+            "Restaurant is a place where people can order and eat meals prepared by professional chefs."
+        ]
+    },
+    {
+        "name": "satisfaction",
+        "trans": [
+            "Satisfaction is the feeling of pleasure or contentment that comes from fulfilling a desire or need."
+        ]
+    },
+    {
+        "name": "sector",
+        "trans": [
+            "Sector is a part or division of an area or sphere, especially of business, society, or the economy."
+        ]
+    },
+    {
+        "name": "signature",
+        "trans": [
+            "Signature is a person's name written in a distinctive way as a form of identification, authorization, or approval."
+        ]
+    },
+    {
+        "name": "significance",
+        "trans": [
+            "Significance is the quality of being worthy of attention; importance."
+        ]
+    },
+    {
+        "name": "song",
+        "trans": [
+            "Song is a musical composition consisting of lyrics and a melody typically for voice with accompaniment."
+        ]
+    },
+    {
+        "name": "tooth",
+        "trans": [
+            "Tooth is a hard bony structure in the jaws of most vertebrates used for biting and chewing food."
+        ]
+    },
+    {
+        "name": "town",
+        "trans": [
+            "A town is a place where people live and work, which is smaller than a city."
+        ]
+    },
+    {
+        "name": "vehicle",
+        "trans": [
+            "A vehicle is a machine designed to transport people or goods."
+        ]
+    },
+    {
+        "name": "volume",
+        "trans": [
+            "Volume is the amount of space that a substance or object occupies, or the degree of loudness of a sound."
+        ]
+    },
+    {
+        "name": "wife",
+        "trans": [
+            "A wife is a married woman considered in relation to her spouse."
+        ]
+    },
+    {
+        "name": "accident",
+        "trans": [
+            "An accident is an unexpected and unintentional event, often resulting in damage or injury."
+        ]
+    },
+    {
+        "name": "airport",
+        "trans": [
+            "An airport is a place where airplanes take off and land, and where passengers can board and leave planes."
+        ]
+    },
+    {
+        "name": "appointment",
+        "trans": [
+            "An appointment is a prearranged meeting or arrangement to see someone or be somewhere at a particular time."
+        ]
+    },
+    {
+        "name": "arrival",
+        "trans": [
+            "Arrival is the act of reaching a destination or the time at which someone or something arrives."
+        ]
+    },
+    {
+        "name": "assumption",
+        "trans": [
+            "An assumption is a belief or something taken for granted, often without proof or evidence."
+        ]
+    },
+    {
+        "name": "baseball",
+        "trans": [
+            "Baseball is a sport played with a ball and bat between two teams of nine players each, in which the players score points by hitting the ball and running around four bases in a diamond-shaped field."
+        ]
+    },
+    {
+        "name": "chapter",
+        "trans": [
+            "A chapter is a part or section of a book, typically with a number or title."
+        ]
+    },
+    {
+        "name": "committee",
+        "trans": [
+            "A committee is a group of people appointed or elected to consider or take action on a particular issue or matter."
+        ]
+    },
+    {
+        "name": "conversation",
+        "trans": [
+            "A conversation is a talk between two or more people, typically an informal one."
+        ]
+    },
+    {
+        "name": "database",
+        "trans": [
+            "A database is a collection of data that is organized and stored in a way that allows easy access, retrieval, and manipulation."
+        ]
+    },
+    {
+        "name": "enthusiasm",
+        "trans": [
+            "Enthusiasm is intense and eager enjoyment, interest, or approval."
+        ]
+    },
+    {
+        "name": "error",
+        "trans": [
+            "An error is a mistake or fault that is made, often resulting in incorrect or unexpected results."
+        ]
+    },
+    {
+        "name": "explanation",
+        "trans": [
+            "An explanation is a statement or account that makes something clear or easy to understand."
+        ]
+    },
+    {
+        "name": "farmer",
+        "trans": [
+            "A farmer is a person who cultivates crops and/or raises animals for food production."
+        ]
+    },
+    {
+        "name": "gate",
+        "trans": [
+            "A gate is a movable barrier used to control access to a particular area, such as a field, yard, or garden."
+        ]
+    },
+    {
+        "name": "girl",
+        "trans": [
+            "A girl is a female child or young woman."
+        ]
+    },
+    {
+        "name": "hall",
+        "trans": [
+            "A hall is a large room used for public gatherings or events."
+        ]
+    },
+    {
+        "name": "historian",
+        "trans": [
+            "A historian is a person who studies and writes about history, especially one who is an authority on it."
+        ]
+    },
+    {
+        "name": "hospital",
+        "trans": [
+            "A hospital is a place where sick or injured people are given medical treatment and care."
+        ]
+    },
+    {
+        "name": "injury",
+        "trans": [
+            "An injury is damage or harm caused to a person's body, often resulting from an accident or physical activity."
+        ]
+    },
+    {
+        "name": "instruction",
+        "trans": [
+            "Instruction is the act of teaching or providing information, guidance, or directions."
+        ]
+    },
+    {
+        "name": "maintenance",
+        "trans": [
+            "Maintenance is the act of keeping something in good condition."
+        ]
+    },
+    {
+        "name": "manufacturer",
+        "trans": [
+            "A manufacturer is a company or person that makes products."
+        ]
+    },
+    {
+        "name": "meal",
+        "trans": [
+            "A meal is an occasion when you eat food, especially breakfast, lunch or dinner."
+        ]
+    },
+    {
+        "name": "perception",
+        "trans": [
+            "Perception is the way you think about or understand something."
+        ]
+    },
+    {
+        "name": "pie",
+        "trans": [
+            "A pie is a baked dish with a pastry crust that usually contains sweet or savory filling."
+        ]
+    },
+    {
+        "name": "poem",
+        "trans": [
+            "A poem is a piece of writing in which the words are chosen for their beauty and sound and are often arranged in short lines."
+        ]
+    },
+    {
+        "name": "presence",
+        "trans": [
+            "Presence refers to the fact of being in a particular place."
+        ]
+    },
+    {
+        "name": "proposal",
+        "trans": [
+            "A proposal is a suggestion or plan that is put forward for consideration or discussion."
+        ]
+    },
+    {
+        "name": "reception",
+        "trans": [
+            "Reception is the act of receiving or the place where guests or visitors are received."
+        ]
+    },
+    {
+        "name": "replacement",
+        "trans": [
+            "A replacement is something that is used to replace something else that is broken or lost."
+        ]
+    },
+    {
+        "name": "revolution",
+        "trans": [
+            "Revolution is a sudden and often violent change in the political system or the way of doing things."
+        ]
+    },
+    {
+        "name": "river",
+        "trans": [
+            "A river is a large natural flow of water that runs through the land."
+        ]
+    },
+    {
+        "name": "son",
+        "trans": [
+            "A son is a male child of a parent or parents."
+        ]
+    },
+    {
+        "name": "speech",
+        "trans": [
+            "A speech is a formal talk given to an audience, especially one given by someone in a position of authority."
+        ]
+    },
+    {
+        "name": "tea",
+        "trans": [
+            "Tea is a hot drink made by pouring boiling water over dried leaves from the tea plant."
+        ]
+    },
+    {
+        "name": "village",
+        "trans": [
+            "A village is a small community in a rural area."
+        ]
+    },
+    {
+        "name": "warning",
+        "trans": [
+            "A warning is something that makes you aware of a danger or problem."
+        ]
+    },
+    {
+        "name": "winner",
+        "trans": [
+            "A winner is a person or thing that wins a competition or game."
+        ]
+    },
+    {
+        "name": "worker",
+        "trans": [
+            "A worker is a person who does a job to earn money."
+        ]
+    },
+    {
+        "name": "writer",
+        "trans": [
+            "A writer is a person who writes books, stories or articles as a job or hobby."
+        ]
+    },
+    {
+        "name": "assistance",
+        "trans": [
+            "Assistance is help or support that is given to someone who needs it."
+        ]
+    },
+    {
+        "name": "breath",
+        "trans": [
+            "Breath is the air that you take into your lungs and then let out again through your mouth or nose."
+        ]
+    },
+    {
+        "name": "buyer",
+        "trans": [
+            "A buyer is a person who buys something."
+        ]
+    },
+    {
+        "name": "chest",
+        "trans": [
+            "A chest is a large box with a lid that is used for storing things."
+        ]
+    },
+    {
+        "name": "chocolate",
+        "trans": [
+            "Chocolate is a sweet food made from roasted and ground cacao seeds, often combined with sugar and milk."
+        ]
+    },
+    {
+        "name": "conclusion",
+        "trans": [
+            "Conclusion is a decision or opinion reached after considering something."
+        ]
+    },
+    {
+        "name": "contribution",
+        "trans": [
+            "Contribution is the act of giving or doing something, especially to a common fund or for a particular purpose."
+        ]
+    },
+    {
+        "name": "cookie",
+        "trans": [
+            "A cookie is a small, sweet baked treat that is usually round or flat and often contains chocolate chips, nuts or other ingredients."
+        ]
+    },
+    {
+        "name": "courage",
+        "trans": [
+            "Courage is the ability to do something difficult or dangerous, even in the face of fear or uncertainty."
+        ]
+    },
+    {
+        "name": "dad",
+        "trans": [
+            "Dad is a term of affectionate address for one's father."
+        ]
+    },
+    {
+        "name": "desk",
+        "trans": [
+            "A desk is a piece of furniture with a flat surface for writing, reading or working at, often with drawers or compartments for storage."
+        ]
+    },
+    {
+        "name": "drawer",
+        "trans": [
+            "A drawer is a sliding compartment in a piece of furniture, used for storing items."
+        ]
+    },
+    {
+        "name": "establishment",
+        "trans": [
+            "Establishment refers to a place of business or organization that has been established for a certain period of time."
+        ]
+    },
+    {
+        "name": "examination",
+        "trans": [
+            "Examination is the act of inspecting or analyzing something closely, especially in order to determine its quality or condition."
+        ]
+    },
+    {
+        "name": "garbage",
+        "trans": [
+            "Garbage refers to waste materials that are no longer wanted and are usually thrown away."
+        ]
+    },
+    {
+        "name": "grocery",
+        "trans": [
+            "A grocery is a store that sells food and household items."
+        ]
+    },
+    {
+        "name": "honey",
+        "trans": [
+            "Honey is a sweet, sticky substance made by bees from nectar collected from flowers."
+        ]
+    },
+    {
+        "name": "impression",
+        "trans": [
+            "Impression is the way that someone or something is perceived or understood by others."
+        ]
+    },
+    {
+        "name": "improvement",
+        "trans": [
+            "Improvement is the act of making something better or improving its quality or condition."
+        ]
+    },
+    {
+        "name": "independence",
+        "trans": [
+            "Independence is the state of being free from the control or influence of others."
+        ]
+    },
+    {
+        "name": "insect",
+        "trans": [
+            "An insect is a small creature with six legs and sometimes wings, such as a bee, fly or ant."
+        ]
+    },
+    {
+        "name": "inspection",
+        "trans": [
+            "Inspection is the act of examining or checking something carefully."
+        ]
+    },
+    {
+        "name": "inspector",
+        "trans": [
+            "An inspector is a person who inspects or examines something, especially for quality or safety."
+        ]
+    },
+    {
+        "name": "king",
+        "trans": [
+            "A king is a male ruler of a country or territory."
+        ]
+    },
+    {
+        "name": "ladder",
+        "trans": [
+            "A ladder is a device consisting of a series of rungs or steps used for climbing up or down something."
+        ]
+    },
+    {
+        "name": "menu",
+        "trans": [
+            "A menu is a list of food and drink items available at a restaurant or other establishment."
+        ]
+    },
+    {
+        "name": "penalty",
+        "trans": [
+            "A penalty is a punishment imposed for breaking a law or rule."
+        ]
+    },
+    {
+        "name": "piano",
+        "trans": [
+            "A piano is a musical instrument with a keyboard and strings that are struck by hammers when the keys are played."
+        ]
+    },
+    {
+        "name": "potato",
+        "trans": [
+            "A potato is a starchy root vegetable that is commonly used in cooking."
+        ]
+    },
+    {
+        "name": "profession",
+        "trans": [
+            "A profession is a type of job or occupation that requires special training or education."
+        ]
+    },
+    {
+        "name": "professor",
+        "trans": [
+            "A professor is a senior teacher in a college or university who is an expert in their field of study."
+        ]
+    },
+    {
+        "name": "quantity",
+        "trans": [
+            "Quantity refers to the amount or number of something, often measured or expressed in numerical terms."
+        ]
+    },
+    {
+        "name": "reaction",
+        "trans": [
+            "A reaction is a response to something that happens, often involving emotions or physical changes."
+        ]
+    },
+    {
+        "name": "requirement",
+        "trans": [
+            "A requirement is something that is necessary or mandatory in order to achieve a certain goal or meet a certain standard."
+        ]
+    },
+    {
+        "name": "salad",
+        "trans": [
+            "A salad is a mixture of vegetables, fruits, and sometimes meat or other ingredients, usually served cold with a dressing."
+        ]
+    },
+    {
+        "name": "sister",
+        "trans": [
+            "A sister is a female sibling, either younger or older."
+        ]
+    },
+    {
+        "name": "supermarket",
+        "trans": [
+            "A supermarket is a large store that sells a wide variety of food, household items, and other consumer goods."
+        ]
+    },
+    {
+        "name": "tongue",
+        "trans": [
+            "The tongue is the muscular organ inside the mouth that is used for tasting, speaking, and swallowing."
+        ]
+    },
+    {
+        "name": "weakness",
+        "trans": [
+            "Weakness refers to a lack of strength or ability, often physical or emotional in nature."
+        ]
+    },
+    {
+        "name": "wedding",
+        "trans": [
+            "A wedding is a ceremony where two people get married and exchange vows to become life partners."
+        ]
+    },
+    {
+        "name": "affair",
+        "trans": [
+            "An affair refers to a romantic or sexual relationship between two people who are not married to each other."
+        ]
+    },
+    {
+        "name": "ambition",
+        "trans": [
+            "Ambition is a strong desire or goal to achieve something, often involving personal or career advancement."
+        ]
+    },
+    {
+        "name": "analyst",
+        "trans": [
+            "An analyst is a person who examines and interprets data, often for business or financial purposes."
+        ]
+    },
+    {
+        "name": "apple",
+        "trans": [
+            "An apple is a round fruit with a red, green, or yellow skin and a white inside, often eaten raw or used in cooking or baking."
+        ]
+    },
+    {
+        "name": "assignment",
+        "trans": [
+            "An assignment is a task or project that is given to someone to complete, often as part of a course of study or job."
+        ]
+    },
+    {
+        "name": "assistant",
+        "trans": [
+            "An assistant is a person who helps or supports someone in their work or duties."
+        ]
+    },
+    {
+        "name": "bathroom",
+        "trans": [
+            "A bathroom is a room in a house or building that is used for personal hygiene activities such as bathing and using the toilet."
+        ]
+    },
+    {
+        "name": "bedroom",
+        "trans": [
+            "A bedroom is a room in a house or apartment where people sleep and keep their personal belongings."
+        ]
+    },
+    {
+        "name": "beer",
+        "trans": [
+            "Beer is an alcoholic beverage made from fermented grains, often served cold in a glass or bottle."
+        ]
+    },
+    {
+        "name": "birthday",
+        "trans": [
+            "A birthday is the anniversary of the day on which a person was born, often celebrated with a party or other festivities."
+        ]
+    },
+    {
+        "name": "celebration",
+        "trans": [
+            "A celebration is an event or occasion to mark a special or significant moment, often involving festivities or ceremonies."
+        ]
+    },
+    {
+        "name": "championship",
+        "trans": [
+            "A championship is a competition or series of competitions to determine the best team or individual in a particular sport or activity."
+        ]
+    },
+    {
+        "name": "cheek",
+        "trans": [
+            "A cheek is one of the two fleshy parts of the face that form the lower edge of the eye socket and the upper edge of the jaw."
+        ]
+    },
+    {
+        "name": "client",
+        "trans": [
+            "A client is a person or organization that receives services or advice from a professional or business."
+        ]
+    },
+    {
+        "name": "consequence",
+        "trans": [
+            "A consequence is a result or effect of an action or decision, often with implications or repercussions."
+        ]
+    },
+    {
+        "name": "departure",
+        "trans": [
+            "Departure is the act of leaving or starting a journey, often from a specific place such as a airport or train station."
+        ]
+    },
+    {
+        "name": "diamond",
+        "trans": [
+            "A diamond is a precious stone that is used in jewelry and is known for its exceptional hardness and sparkle."
+        ]
+    },
+    {
+        "name": "dirt",
+        "trans": [
+            "Dirt is loose soil or earth, often found on the ground or under plants, and can also refer to grime or stains on surfaces."
+        ]
+    },
+    {
+        "name": "ear",
+        "trans": [
+            "The ear is the organ in the human body that is used for hearing and balance, consisting of the outer, middle, and inner ear."
+        ]
+    },
+    {
+        "name": "fortune",
+        "trans": [
+            "Fortune refers to luck or chance, often with respect to wealth or success."
+        ]
+    },
+    {
+        "name": "friendship",
+        "trans": [
+            "Friendship is a close and loyal relationship between two people who share mutual trust, support, and affection."
+        ]
+    },
+    {
+        "name": "funeral",
+        "trans": [
+            "A funeral is a ceremony or service that is held to honor and remember a person who has died, often involving rituals and traditions specific to the culture or religion of the deceased."
+        ]
+    },
+    {
+        "name": "gene",
+        "trans": [
+            "A gene is a unit of hereditary information that is passed down from parents to offspring, determining certain traits or characteristics."
+        ]
+    },
+    {
+        "name": "girlfriend",
+        "trans": [
+            "A girlfriend is a female romantic partner or companion, often in a committed relationship."
+        ]
+    },
+    {
+        "name": "hat",
+        "trans": [
+            "A hat is a type of headwear that is worn on top of the head, often for protection from the sun or for fashion purposes."
+        ]
+    },
+    {
+        "name": "indication",
+        "trans": [
+            "An indication is a sign or signal that suggests something, often used to convey information or point to a certain direction or meaning."
+        ]
+    },
+    {
+        "name": "intention",
+        "trans": [
+            "Intention refers to a plan or purpose that someone has, often with respect to their actions or behavior."
+        ]
+    },
+    {
+        "name": "lady",
+        "trans": [
+            "A lady is a polite and respectful term for a woman, often used to show admiration or respect."
+        ]
+    },
+    {
+        "name": "midnight",
+        "trans": [
+            "Midnight is the point in time that marks the start of a new day, exactly twelve o'clock at night."
+        ]
+    },
+    {
+        "name": "negotiation",
+        "trans": [
+            "Negotiation is the process of discussing and reaching an agreement or compromise between two or more parties, often with conflicting interests or goals."
+        ]
+    },
+    {
+        "name": "obligation",
+        "trans": [
+            "An obligation is a duty or responsibility that someone has, often based on a moral, legal, or social contract."
+        ]
+    },
+    {
+        "name": "passenger",
+        "trans": [
+            "A passenger is a person who is traveling in a vehicle or on a mode of transportation, often for a journey or trip."
+        ]
+    },
+    {
+        "name": "pizza",
+        "trans": [
+            "Pizza is a dish that consists of a flat bread base topped with tomato sauce, cheese, and various ingredients such as vegetables and meats."
+        ]
+    },
+    {
+        "name": "platform",
+        "trans": [
+            "A platform is a raised surface or area, often used for standing or as a base for something such as a stage or a structure."
+        ]
+    },
+    {
+        "name": "poet",
+        "trans": [
+            "A poet is a writer who specializes in creating poetry, often using language and rhythm to express emotions, ideas, or experiences."
+        ]
+    },
+    {
+        "name": "pollution",
+        "trans": [
+            "Pollution is the presence or introduction into the environment of harmful substances or contaminants that can damage ecosystems, health, or quality of life."
+        ]
+    },
+    {
+        "name": "recognition",
+        "trans": [
+            "Recognition is the act of acknowledging or identifying someone or something, often with respect to achievements, contributions, or qualities."
+        ]
+    },
+    {
+        "name": "reputation",
+        "trans": [
+            "Reputation is the overall perception or evaluation of someone or something, often based on their behavior, performance, or image."
+        ]
+    },
+    {
+        "name": "shirt",
+        "trans": [
+            "A shirt is a garment worn on the upper body, often with a collar, buttons, and sleeves, and typically made of cotton or other fabrics."
+        ]
+    },
+    {
+        "name": "sir",
+        "trans": [
+            "Sir is a polite and respectful term of address for a man, often used to show respect or courtesy."
+        ]
+    },
+    {
+        "name": "speaker",
+        "trans": [
+            "A speaker is someone who talks to an audience."
+        ]
+    },
+    {
+        "name": "stranger",
+        "trans": [
+            "A stranger is someone who you do not know."
+        ]
+    },
+    {
+        "name": "surgery",
+        "trans": [
+            "Surgery is a medical operation performed by a doctor to treat an injury or disease."
+        ]
+    },
+    {
+        "name": "sympathy",
+        "trans": [
+            "Sympathy is a feeling of sadness or pity for someone who is suffering."
+        ]
+    },
+    {
+        "name": "tale",
+        "trans": [
+            "A tale is a story, often fictional or imaginary."
+        ]
+    },
+    {
+        "name": "throat",
+        "trans": [
+            "The throat is the part of the body that connects the mouth and the stomach."
+        ]
+    },
+    {
+        "name": "trainer",
+        "trans": [
+            "A trainer is a person who helps someone to learn a particular skill or activity."
+        ]
+    },
+    {
+        "name": "uncle",
+        "trans": [
+            "An uncle is the brother of someone's parent."
+        ]
+    },
+    {
+        "name": "youth",
+        "trans": [
+            "Youth is the time of life when a person is young, usually referring to the teenage years."
+        ]
+    },
+    {
+        "name": "time",
+        "trans": [
+            "Time is the ongoing sequence of events that occur in the past, present, and future."
+        ]
+    },
+    {
+        "name": "work",
+        "trans": [
+            "Work is the activity of doing something to earn money or achieve a particular result."
+        ]
+    },
+    {
+        "name": "film",
+        "trans": [
+            "A film is a story that is shown on a screen, usually in a movie theater or on television."
+        ]
+    },
+    {
+        "name": "water",
+        "trans": [
+            "Water is a clear liquid that is essential for life and used for drinking, washing, and other purposes."
+        ]
+    },
+    {
+        "name": "money",
+        "trans": [
+            "Money is a medium of exchange used to buy goods and services."
+        ]
+    },
+    {
+        "name": "example",
+        "trans": [
+            "An example is something that is used to show what something else is like."
+        ]
+    },
+    {
+        "name": "while",
+        "trans": [
+            "While is a period of time during which something else is happening."
+        ]
+    },
+    {
+        "name": "business",
+        "trans": [
+            "Business is the activity of buying and selling goods and services to make a profit."
+        ]
+    },
+    {
+        "name": "study",
+        "trans": [
+            "Study is the act of learning about a subject through reading, research, and practice."
+        ]
+    },
+    {
+        "name": "game",
+        "trans": [
+            "A game is an activity or sport that is played for fun, competition, or entertainment."
+        ]
+    },
+    {
+        "name": "life",
+        "trans": [
+            "Life is the quality that distinguishes living things from non-living things, characterized by growth, reproduction, and adaptation."
+        ]
+    },
+    {
+        "name": "form",
+        "trans": [
+            "A form is a document or template used to collect information or data."
+        ]
+    },
+    {
+        "name": "air",
+        "trans": [
+            "Air is the invisible mixture of gases that surrounds the Earth and is necessary for breathing."
+        ]
+    },
+    {
+        "name": "day",
+        "trans": [
+            "A day is a unit of time equal to 24 hours, during which the Earth completes one rotation on its axis."
+        ]
+    },
+    {
+        "name": "place",
+        "trans": [
+            "A place is a location or position in space."
+        ]
+    },
+    {
+        "name": "number",
+        "trans": [
+            "A number is a mathematical value used to represent a quantity or amount."
+        ]
+    },
+    {
+        "name": "part",
+        "trans": [
+            "A part is a piece or segment of a larger object or system."
+        ]
+    },
+    {
+        "name": "field",
+        "trans": [
+            "A field is an area of land used for a specific purpose, such as farming or sports."
+        ]
+    },
+    {
+        "name": "fish",
+        "trans": [
+            "Fish are aquatic animals with scales that breathe through gills."
+        ]
+    },
+    {
+        "name": "back",
+        "trans": [
+            "The back is the part of the body that is opposite to the front and includes the spine."
+        ]
+    },
+    {
+        "name": "process",
+        "trans": [
+            "A process is a series of steps or actions taken to achieve a particular goal or outcome."
+        ]
+    },
+    {
+        "name": "heat",
+        "trans": [
+            "Heat is a form of energy that causes objects to become warmer."
+        ]
+    },
+    {
+        "name": "hand",
+        "trans": [
+            "A hand is the part of the body at the end of the arm, used for grasping and manipulating objects."
+        ]
+    },
+    {
+        "name": "experience",
+        "trans": [
+            "An experience is something that happens to a person, which they learn from and remember."
+        ]
+    },
+    {
+        "name": "job",
+        "trans": [
+            "A job is a regular activity that a person performs in order to earn money or gain experience."
+        ]
+    },
+    {
+        "name": "book",
+        "trans": [
+            "A book is a collection of written or printed pages bound together, containing information, stories, or other content."
+        ]
+    },
+    {
+        "name": "end",
+        "trans": [
+            "The end is the final part of something, or the point at which it finishes."
+        ]
+    },
+    {
+        "name": "point",
+        "trans": [
+            "A point is a specific location or position in space or time, often used to indicate direction or to emphasize something."
+        ]
+    },
+    {
+        "name": "type",
+        "trans": [
+            "A type is a category or classification of something based on its characteristics or qualities."
+        ]
+    },
+    {
+        "name": "home",
+        "trans": [
+            "A home is a place where someone lives and feels comfortable and safe."
+        ]
+    },
+    {
+        "name": "economy",
+        "trans": [
+            "The economy is the system of production, distribution, and consumption of goods and services in a region or country."
+        ]
+    },
+    {
+        "name": "value",
+        "trans": [
+            "Value refers to the worth or usefulness of something, often expressed in monetary terms."
+        ]
+    },
+    {
+        "name": "body",
+        "trans": [
+            "The body is the physical structure of a person or animal, including all the organs, tissues, and bones."
+        ]
+    },
+    {
+        "name": "market",
+        "trans": [
+            "A market is a place where goods or services are bought and sold."
+        ]
+    },
+    {
+        "name": "guide",
+        "trans": [
+            "A guide is a person or thing that provides direction or advice to help others achieve a particular goal or outcome."
+        ]
+    },
+    {
+        "name": "interest",
+        "trans": [
+            "Interest is the amount of money charged for borrowing money or the degree of attention or curiosity shown in something."
+        ]
+    },
+    {
+        "name": "state",
+        "trans": [
+            "A state is a defined area of a country or region that has its own government and laws."
+        ]
+    },
+    {
+        "name": "radio",
+        "trans": [
+            "A radio is an electronic device that receives and broadcasts sound using radio waves."
+        ]
+    },
+    {
+        "name": "course",
+        "trans": [
+            "A course is a series of lessons or lectures on a particular subject or topic."
+        ]
+    },
+    {
+        "name": "company",
+        "trans": [
+            "A company is a business organization that produces goods or services for sale."
+        ]
+    },
+    {
+        "name": "price",
+        "trans": [
+            "Price is the amount of money that must be paid in order to purchase a particular item or service."
+        ]
+    },
+    {
+        "name": "size",
+        "trans": [
+            "Size refers to the physical dimensions or extent of something."
+        ]
+    },
+    {
+        "name": "card",
+        "trans": [
+            "A card is a small rectangular piece of paper or plastic used for various purposes, such as identification or payment."
+        ]
+    },
+    {
+        "name": "list",
+        "trans": [
+            "A list is a group of items or information that are arranged in a particular order."
+        ]
+    },
+    {
+        "name": "mind",
+        "trans": [
+            "The mind refers to the part of a person that thinks, feels, and perceives."
+        ]
+    },
+    {
+        "name": "trade",
+        "trans": [
+            "Trade refers to the exchange of goods or services between individuals or groups."
+        ]
+    },
+    {
+        "name": "line",
+        "trans": [
+            "A line is a continuous path or mark that is long and narrow."
+        ]
+    },
+    {
+        "name": "care",
+        "trans": [
+            "Care refers to the effort and attention given to something or someone in order to keep them safe and healthy."
+        ]
+    },
+    {
+        "name": "group",
+        "trans": [
+            "A group is a collection of individuals who share common interests or characteristics."
+        ]
+    },
+    {
+        "name": "risk",
+        "trans": [
+            "Risk refers to the potential for harm or loss that may result from a particular action or decision."
+        ]
+    },
+    {
+        "name": "word",
+        "trans": [
+            "A word is a unit of language that has a meaning and can be used to communicate."
+        ]
+    },
+    {
+        "name": "fat",
+        "trans": [
+            "Fat refers to a type of nutrient that the body uses for energy storage and insulation."
+        ]
+    },
+    {
+        "name": "force",
+        "trans": [
+            "Force refers to the power or strength that is exerted on an object to make it move or change direction."
+        ]
+    },
+    {
+        "name": "key",
+        "trans": [
+            "A key is a small piece of metal or plastic used to open locks or start machines."
+        ]
+    },
+    {
+        "name": "light",
+        "trans": [
+            "Light refers to the electromagnetic radiation that enables us to see objects."
+        ]
+    },
+    {
+        "name": "training",
+        "trans": [
+            "Training refers to the process of learning and developing skills for a particular task or profession."
+        ]
+    },
+    {
+        "name": "name",
+        "trans": [
+            "A name is a word or phrase used to identify a particular person, place, or thing."
+        ]
+    },
+    {
+        "name": "school",
+        "trans": [
+            "A school is an educational institution where students are taught and trained."
+        ]
+    },
+    {
+        "name": "top",
+        "trans": [
+            "Top refers to the highest point or part of something."
+        ]
+    },
+    {
+        "name": "amount",
+        "trans": [
+            "Amount refers to the quantity or volume of something."
+        ]
+    },
+    {
+        "name": "level",
+        "trans": [
+            "Level refers to the height or position of something relative to a given point."
+        ]
+    },
+    {
+        "name": "order",
+        "trans": [
+            "Order refers to the arrangement or sequence of things or events."
+        ]
+    },
+    {
+        "name": "practice",
+        "trans": [
+            "Practice refers to the act of doing something repeatedly in order to improve or master it."
+        ]
+    },
+    {
+        "name": "research",
+        "trans": [
+            "Research refers to the systematic investigation of a particular topic or subject."
+        ]
+    },
+    {
+        "name": "sense",
+        "trans": [
+            "Sense refers to the ability to perceive and understand the world around us through our senses."
+        ]
+    },
+    {
+        "name": "service",
+        "trans": [
+            "Service refers to the work or assistance provided to others, often in exchange for payment."
+        ]
+    },
+    {
+        "name": "piece",
+        "trans": [
+            "A piece is a part or portion of something."
+        ]
+    },
+    {
+        "name": "web",
+        "trans": [
+            "A web is a network of interconnected things, often used to refer to the internet."
+        ]
+    },
+    {
+        "name": "boss",
+        "trans": [
+            "A boss is a person who has authority over others in a workplace."
+        ]
+    },
+    {
+        "name": "sport",
+        "trans": [
+            "Sport is an activity or game that requires physical skill and is usually competitive."
+        ]
+    },
+    {
+        "name": "fun",
+        "trans": [
+            "Fun is an enjoyable or amusing experience."
+        ]
+    },
+    {
+        "name": "house",
+        "trans": [
+            "A house is a building where people live."
+        ]
+    },
+    {
+        "name": "page",
+        "trans": [
+            "A page is a single side of a sheet of paper in a book or document."
+        ]
+    },
+    {
+        "name": "term",
+        "trans": [
+            "A term is a period of time or a word or phrase used in a specific context."
+        ]
+    },
+    {
+        "name": "test",
+        "trans": [
+            "A test is an assessment of knowledge or ability."
+        ]
+    },
+    {
+        "name": "answer",
+        "trans": [
+            "An answer is a response to a question or problem."
+        ]
+    },
+    {
+        "name": "sound",
+        "trans": [
+            "Sound is the vibrations that travel through the air and can be heard by the ear."
+        ]
+    },
+    {
+        "name": "focus",
+        "trans": [
+            "To focus is to pay attention or concentrate on a specific thing."
+        ]
+    },
+    {
+        "name": "matter",
+        "trans": [
+            "Matter is anything that has mass and occupies space."
+        ]
+    },
+    {
+        "name": "kind",
+        "trans": [
+            "Kind refers to a type or category of something."
+        ]
+    },
+    {
+        "name": "soil",
+        "trans": [
+            "Soil is the natural material that makes up the surface layer of the Earth's crust."
+        ]
+    },
+    {
+        "name": "board",
+        "trans": [
+            "A board is a flat piece of wood, plastic, or other material used for a variety of purposes."
+        ]
+    },
+    {
+        "name": "oil",
+        "trans": [
+            "Oil is a viscous liquid that is used as fuel and in the production of various materials."
+        ]
+    },
+    {
+        "name": "picture",
+        "trans": [
+            "A picture is a representation of a person, object, or scene created by art, photography, or other visual media."
+        ]
+    },
+    {
+        "name": "access",
+        "trans": [
+            "Access refers to the ability to enter or use something."
+        ]
+    },
+    {
+        "name": "garden",
+        "trans": [
+            "A garden is a space used for cultivating plants, often for decorative or culinary purposes."
+        ]
+    },
+    {
+        "name": "range",
+        "trans": [
+            "Range refers to the area or extent of something, often used to describe a series of values or a variety of options."
+        ]
+    },
+    {
+        "name": "rate",
+        "trans": [
+            "Rate is the speed at which something happens or the price charged for a service or product."
+        ]
+    },
+    {
+        "name": "reason",
+        "trans": [
+            "Reason refers to the cause or explanation for something."
+        ]
+    },
+    {
+        "name": "future",
+        "trans": [
+            "Future refers to the time that is yet to come."
+        ]
+    },
+    {
+        "name": "site",
+        "trans": [
+            "A site is a location or place where something is or will be located."
+        ]
+    },
+    {
+        "name": "demand",
+        "trans": [
+            "Demand is a request or requirement for something to be done or given."
+        ]
+    },
+    {
+        "name": "exercise",
+        "trans": [
+            "Exercise is physical activity done to improve health or strength."
+        ]
+    },
+    {
+        "name": "image",
+        "trans": [
+            "An image is a visual representation or picture of something."
+        ]
+    },
+    {
+        "name": "case",
+        "trans": [
+            "A case is a specific example or instance of something."
+        ]
+    },
+    {
+        "name": "cause",
+        "trans": [
+            "A cause is something that produces an effect or result."
+        ]
+    },
+    {
+        "name": "coast",
+        "trans": [
+            "A coast is the land that meets the sea or ocean."
+        ]
+    },
+    {
+        "name": "action",
+        "trans": [
+            "An action is something done or performed."
+        ]
+    },
+    {
+        "name": "age",
+        "trans": [
+            "Age is the amount of time that someone has lived or something has existed."
+        ]
+    },
+    {
+        "name": "bad",
+        "trans": [
+            "Bad is used to describe something that is not good or is of poor quality."
+        ]
+    },
+    {
+        "name": "boat",
+        "trans": [
+            "A boat is a watercraft used for transportation on water."
+        ]
+    },
+    {
+        "name": "record",
+        "trans": [
+            "A record is a collection of information or data that is kept for reference or evidence."
+        ]
+    },
+    {
+        "name": "result",
+        "trans": [
+            "A result is the outcome or consequence of an action or event."
+        ]
+    },
+    {
+        "name": "section",
+        "trans": [
+            "A section is a distinct part or subdivision of something larger."
+        ]
+    },
+    {
+        "name": "building",
+        "trans": [
+            "A building is a structure used for shelter, such as a house, office, or store."
+        ]
+    },
+    {
+        "name": "mouse",
+        "trans": [
+            "A mouse is a small, rodent-like animal with a pointed snout and long, curved tail."
+        ]
+    },
+    {
+        "name": "cash",
+        "trans": [
+            "Cash is money in the form of bills or coins."
+        ]
+    },
+    {
+        "name": "class",
+        "trans": [
+            "A class is a group of students who are taught together, or a category or level of something."
+        ]
+    },
+    {
+        "name": "nothing",
+        "trans": [
+            "Nothing is the absence of anything or something that has no significance or importance."
+        ]
+    },
+    {
+        "name": "period",
+        "trans": [
+            "A period is a length of time or a punctuation mark used to end a sentence."
+        ]
+    },
+    {
+        "name": "plan",
+        "trans": [
+            "A plan is a course of action or strategy designed to achieve a goal."
+        ]
+    },
+    {
+        "name": "store",
+        "trans": [
+            "A store is a retail establishment where goods are sold to customers."
+        ]
+    },
+    {
+        "name": "tax",
+        "trans": [
+            "A tax is a fee charged by a government on income, goods, or services."
+        ]
+    },
+    {
+        "name": "side",
+        "trans": [
+            "A side is one of the two surfaces of something flat or the left or right of a person or object."
+        ]
+    },
+    {
+        "name": "subject",
+        "trans": [
+            "A subject is a person or thing that is being discussed, studied, or talked about."
+        ]
+    },
+    {
+        "name": "space",
+        "trans": [
+            "Space is the area or expanse that exists beyond the Earth's atmosphere, or a place or area that is unoccupied."
+        ]
+    },
+    {
+        "name": "rule",
+        "trans": [
+            "A rule is a statement that tells you what you can or cannot do."
+        ]
+    },
+    {
+        "name": "stock",
+        "trans": [
+            "Stock refers to a supply of goods or materials that a company keeps to sell or trade."
+        ]
+    },
+    {
+        "name": "weather",
+        "trans": [
+            "Weather is the condition of the atmosphere, such as temperature, wind, and precipitation, at a particular time and place."
+        ]
+    },
+    {
+        "name": "chance",
+        "trans": [
+            "Chance is the possibility of something happening or not happening."
+        ]
+    },
+    {
+        "name": "figure",
+        "trans": [
+            "A figure is a shape, number, or picture."
+        ]
+    },
+    {
+        "name": "man",
+        "trans": [
+            "A man is an adult human male."
+        ]
+    },
+    {
+        "name": "model",
+        "trans": [
+            "A model is a representation or example of something, often used to help explain or demonstrate it."
+        ]
+    },
+    {
+        "name": "source",
+        "trans": [
+            "A source is the place or thing that something comes from or is obtained from."
+        ]
+    },
+    {
+        "name": "beginning",
+        "trans": [
+            "The beginning is the start or first part of something."
+        ]
+    },
+    {
+        "name": "earth",
+        "trans": [
+            "Earth is the planet we live on, the third from the sun."
+        ]
+    },
+    {
+        "name": "program",
+        "trans": [
+            "A program is a set of instructions or software designed to perform a specific task or function."
+        ]
+    },
+    {
+        "name": "chicken",
+        "trans": [
+            "Chicken is a type of bird that is commonly raised for meat and eggs."
+        ]
+    },
+    {
+        "name": "design",
+        "trans": [
+            "Design refers to the creation or planning of something, such as a building, product, or system."
+        ]
+    },
+    {
+        "name": "feature",
+        "trans": [
+            "A feature is a distinctive attribute or aspect of something."
+        ]
+    },
+    {
+        "name": "head",
+        "trans": [
+            "The head is the part of the body at the top, containing the brain, eyes, ears, mouth, and nose."
+        ]
+    },
+    {
+        "name": "material",
+        "trans": [
+            "Material refers to the physical substance or matter that something is made of."
+        ]
+    },
+    {
+        "name": "purpose",
+        "trans": [
+            "Purpose refers to the reason why something is done or created."
+        ]
+    },
+    {
+        "name": "question",
+        "trans": [
+            "A question is a sentence or phrase that is used to ask for information or to test someone's knowledge."
+        ]
+    },
+    {
+        "name": "rock",
+        "trans": [
+            "A rock is a natural substance made up of minerals or other materials."
+        ]
+    },
+    {
+        "name": "salt",
+        "trans": [
+            "Salt is a mineral substance that is commonly used to season or preserve food."
+        ]
+    },
+    {
+        "name": "act",
+        "trans": [
+            "An act is a behavior or action that is done by someone."
+        ]
+    },
+    {
+        "name": "birth",
+        "trans": [
+            "Birth is the process of being born, or the beginning of life for a human or animal."
+        ]
+    },
+    {
+        "name": "car",
+        "trans": [
+            "A car is a vehicle with four wheels that is powered by an engine and is used for transportation."
+        ]
+    },
+    {
+        "name": "dog",
+        "trans": [
+            "A dog is a type of domesticated mammal that is often kept as a pet."
+        ]
+    },
+    {
+        "name": "object",
+        "trans": [
+            "An object is a thing that can be seen or touched and is not alive."
+        ]
+    },
+    {
+        "name": "scale",
+        "trans": [
+            "A scale is a tool used to measure the weight or size of something."
+        ]
+    },
+    {
+        "name": "sun",
+        "trans": [
+            "The sun is a star that is the center of our solar system and provides light and heat to the earth."
+        ]
+    },
+    {
+        "name": "note",
+        "trans": [
+            "A note is a brief message or a written or printed symbol representing a musical tone."
+        ]
+    },
+    {
+        "name": "profit",
+        "trans": [
+            "Profit is the amount of money gained from a business or investment after expenses have been deducted."
+        ]
+    },
+    {
+        "name": "rent",
+        "trans": [
+            "Rent is the money paid to live in a house, apartment, or other property that belongs to someone else."
+        ]
+    },
+    {
+        "name": "speed",
+        "trans": [
+            "Speed is how fast something is moving."
+        ]
+    },
+    {
+        "name": "style",
+        "trans": [
+            "Style refers to a particular way of doing or presenting something."
+        ]
+    },
+    {
+        "name": "war",
+        "trans": [
+            "War is a state of armed conflict between two or more nations, groups, or societies."
+        ]
+    },
+    {
+        "name": "bank",
+        "trans": [
+            "A bank is a financial institution that accepts deposits from the public and makes loans or investments with those funds."
+        ]
+    },
+    {
+        "name": "craft",
+        "trans": [
+            "A craft is a skill or activity that requires manual dexterity and artistic ability, such as woodworking or pottery."
+        ]
+    },
+    {
+        "name": "half",
+        "trans": [
+            "Half is one of two equal parts of something."
+        ]
+    },
+    {
+        "name": "inside",
+        "trans": [
+            "Inside refers to the inner part or surface of something."
+        ]
+    },
+    {
+        "name": "outside",
+        "trans": [
+            "Outside refers to the outer part or surface of something."
+        ]
+    },
+    {
+        "name": "standard",
+        "trans": [
+            "A standard is a level of quality or performance that is generally accepted as normal or acceptable."
+        ]
+    },
+    {
+        "name": "bus",
+        "trans": [
+            "A bus is a large vehicle used for transporting passengers, typically along a regular route."
+        ]
+    },
+    {
+        "name": "exchange",
+        "trans": [
+            "An exchange is a place where people buy and sell goods, services, or currencies."
+        ]
+    },
+    {
+        "name": "eye",
+        "trans": [
+            "An eye is the organ of sight in humans and animals."
+        ]
+    },
+    {
+        "name": "fire",
+        "trans": [
+            "Fire is a combustion process that produces heat and light."
+        ]
+    },
+    {
+        "name": "position",
+        "trans": [
+            "Position refers to the location or placement of something."
+        ]
+    },
+    {
+        "name": "pressure",
+        "trans": [
+            "Pressure is the force exerted on an object per unit area."
+        ]
+    },
+    {
+        "name": "stress",
+        "trans": [
+            "Stress is a state of mental or emotional strain or tension caused by adverse circumstances."
+        ]
+    },
+    {
+        "name": "advantage",
+        "trans": [
+            "An advantage is a favorable or beneficial circumstance or condition that gives a competitive edge."
+        ]
+    },
+    {
+        "name": "benefit",
+        "trans": [
+            "A benefit is an advantage or profit gained from something."
+        ]
+    },
+    {
+        "name": "box",
+        "trans": [
+            "A box is a container with a flat bottom and sides, typically square or rectangular in shape."
+        ]
+    },
+    {
+        "name": "frame",
+        "trans": [
+            "A frame is a rigid structure that surrounds or encloses something, often used to hold or support other objects."
+        ]
+    },
+    {
+        "name": "issue",
+        "trans": [
+            "An issue is a problem or topic that people discuss or debate."
+        ]
+    },
+    {
+        "name": "step",
+        "trans": [
+            "A step is one movement of the foot when walking or running."
+        ]
+    },
+    {
+        "name": "cycle",
+        "trans": [
+            "A cycle is a series of events that repeat in a particular order."
+        ]
+    },
+    {
+        "name": "face",
+        "trans": [
+            "A face is the front part of a person's head, where their eyes, nose, and mouth are."
+        ]
+    },
+    {
+        "name": "item",
+        "trans": [
+            "An item is a thing or object."
+        ]
+    },
+    {
+        "name": "metal",
+        "trans": [
+            "Metal is a hard and shiny material that is used to make many things, such as cars and buildings."
+        ]
+    },
+    {
+        "name": "paint",
+        "trans": [
+            "Paint is a liquid that is used to color or decorate things."
+        ]
+    },
+    {
+        "name": "review",
+        "trans": [
+            "A review is an evaluation or assessment of something, such as a product or service."
+        ]
+    },
+    {
+        "name": "room",
+        "trans": [
+            "A room is a space within a building that is enclosed by walls and used for a particular purpose."
+        ]
+    },
+    {
+        "name": "screen",
+        "trans": [
+            "A screen is a flat surface that displays images or text, such as on a computer or television."
+        ]
+    },
+    {
+        "name": "structure",
+        "trans": [
+            "A structure is something that is built, such as a building or bridge."
+        ]
+    },
+    {
+        "name": "view",
+        "trans": [
+            "A view is what can be seen from a particular place or position."
+        ]
+    },
+    {
+        "name": "account",
+        "trans": [
+            "An account is a record or report of financial transactions or other events."
+        ]
+    },
+    {
+        "name": "ball",
+        "trans": [
+            "A ball is a round object that can be thrown, kicked, or hit in a game or sport."
+        ]
+    },
+    {
+        "name": "discipline",
+        "trans": [
+            "Discipline is a set of rules or a way of behaving that is expected and enforced."
+        ]
+    },
+    {
+        "name": "medium",
+        "trans": [
+            "A medium is a substance or material through which something is transmitted or communicated."
+        ]
+    },
+    {
+        "name": "share",
+        "trans": [
+            "A share is a portion or part of something that is divided among a group or individuals."
+        ]
+    },
+    {
+        "name": "balance",
+        "trans": [
+            "Balance is a state of equilibrium or stability, where things are equal and in the right proportion."
+        ]
+    },
+    {
+        "name": "bit",
+        "trans": [
+            "A bit is a small amount or a piece of something."
+        ]
+    },
+    {
+        "name": "black",
+        "trans": [
+            "Black is a color that is the darkest possible shade, the opposite of white."
+        ]
+    },
+    {
+        "name": "bottom",
+        "trans": [
+            "Bottom is the lowest or deepest part of something."
+        ]
+    },
+    {
+        "name": "choice",
+        "trans": [
+            "A choice is a decision or selection between two or more options."
+        ]
+    },
+    {
+        "name": "gift",
+        "trans": [
+            "A gift is something given to someone as a present or gesture of goodwill."
+        ]
+    },
+    {
+        "name": "impact",
+        "trans": [
+            "Impact is the effect or influence that something has on a situation or person."
+        ]
+    },
+    {
+        "name": "machine",
+        "trans": [
+            "A machine is a mechanical device that is used to perform tasks, such as lifting or cutting."
+        ]
+    },
+    {
+        "name": "shape",
+        "trans": [
+            "Shape refers to the physical form or appearance of an object."
+        ]
+    },
+    {
+        "name": "tool",
+        "trans": [
+            "A tool is a device or implement used to perform a specific task."
+        ]
+    },
+    {
+        "name": "wind",
+        "trans": [
+            "Wind is the natural movement of air in the atmosphere."
+        ]
+    },
+    {
+        "name": "address",
+        "trans": [
+            "Address can refer to the location of a person or place, or the way in which a person speaks to an audience."
+        ]
+    },
+    {
+        "name": "average",
+        "trans": [
+            "Average is a measure of central tendency, calculated by adding a group of numbers and dividing by the total number of values."
+        ]
+    },
+    {
+        "name": "career",
+        "trans": [
+            "Career refers to a person's profession or occupation, often including a series of jobs or positions within a particular field."
+        ]
+    },
+    {
+        "name": "culture",
+        "trans": [
+            "Culture encompasses the beliefs, customs, practices, and social behavior of a particular group or society."
+        ]
+    },
+    {
+        "name": "morning",
+        "trans": [
+            "Morning refers to the early part of the day, from sunrise until noon."
+        ]
+    },
+    {
+        "name": "pot",
+        "trans": [
+            "A pot is a container, typically made of clay or metal, used for cooking or storing food or liquids."
+        ]
+    },
+    {
+        "name": "sign",
+        "trans": [
+            "A sign is a visual indication or signal, often used to convey information or instructions."
+        ]
+    },
+    {
+        "name": "table",
+        "trans": [
+            "A table is a piece of furniture with a flat top and one or more legs, used as a surface for working at, eating from, or on which to place things."
+        ]
+    },
+    {
+        "name": "task",
+        "trans": [
+            "A task is a specific job or assignment that needs to be completed."
+        ]
+    },
+    {
+        "name": "condition",
+        "trans": [
+            "A condition is the state of something, often referring to its physical, mental, or emotional state."
+        ]
+    },
+    {
+        "name": "contact",
+        "trans": [
+            "Contact refers to communication or interaction between two or more people or things."
+        ]
+    },
+    {
+        "name": "credit",
+        "trans": [
+            "Credit refers to the ability to borrow money or receive goods or services with the promise of future payment."
+        ]
+    },
+    {
+        "name": "egg",
+        "trans": [
+            "An egg is a reproductive cell produced by female animals, typically containing nutrients to support the growth of a developing embryo."
+        ]
+    },
+    {
+        "name": "hope",
+        "trans": [
+            "Hope is a feeling of optimism or expectation for a positive outcome in the future."
+        ]
+    },
+    {
+        "name": "ice",
+        "trans": [
+            "Ice is a solid form of water, typically formed by freezing."
+        ]
+    },
+    {
+        "name": "network",
+        "trans": [
+            "A network is a system of interconnected elements, such as computers, people, or organizations."
+        ]
+    },
+    {
+        "name": "north",
+        "trans": [
+            "North is the direction that points toward the Earth's North Pole."
+        ]
+    },
+    {
+        "name": "square",
+        "trans": [
+            "Square refers to a shape with four equal sides and four 90-degree angles."
+        ]
+    },
+    {
+        "name": "attempt",
+        "trans": [
+            "An attempt is an effort to do something, often with the intention of succeeding."
+        ]
+    },
+    {
+        "name": "date",
+        "trans": [
+            "A date is a specific day or time period, often used to indicate when an event occurred or when something is scheduled to happen."
+        ]
+    },
+    {
+        "name": "effect",
+        "trans": [
+            "An effect is the result or consequence of a particular action or event."
+        ]
+    },
+    {
+        "name": "link",
+        "trans": [
+            "A link is a connection between two or more things, often used in reference to a hyperlink on a website that directs the user to another web page."
+        ]
+    },
+    {
+        "name": "post",
+        "trans": [
+            "A post is a message or piece of information that is published online or on a notice board."
+        ]
+    },
+    {
+        "name": "star",
+        "trans": [
+            "A star is a luminous celestial body visible in the sky at night, which is made up of hot gases and emits its own light."
+        ]
+    },
+    {
+        "name": "voice",
+        "trans": [
+            "A voice is the sound made by a person when they speak or sing."
+        ]
+    },
+    {
+        "name": "capital",
+        "trans": [
+            "Capital is a city that serves as the seat of government for a country or state, or it can refer to wealth and resources that can be used to create more wealth."
+        ]
+    },
+    {
+        "name": "challenge",
+        "trans": [
+            "A challenge is a task or problem that requires effort, skill, or courage to overcome."
+        ]
+    },
+    {
+        "name": "friend",
+        "trans": [
+            "A friend is a person with whom one has a bond of mutual affection and trust."
+        ]
+    },
+    {
+        "name": "self",
+        "trans": [
+            "The self refers to an individual's consciousness or identity, or it can refer to the totality of a person's being."
+        ]
+    },
+    {
+        "name": "shot",
+        "trans": [
+            "A shot is a small amount of a liquid substance, such as a medication or alcoholic beverage, or it can refer to a single discharge of a gun or firearm."
+        ]
+    },
+    {
+        "name": "brush",
+        "trans": [
+            "A brush is a tool with bristles or fibers used for cleaning, grooming, or painting."
+        ]
+    },
+    {
+        "name": "couple",
+        "trans": [
+            "A couple is a pair of people or things that are joined or associated with each other in some way."
+        ]
+    },
+    {
+        "name": "debate",
+        "trans": [
+            "A debate is a formal discussion or argument between people with different opinions or beliefs on a particular topic."
+        ]
+    },
+    {
+        "name": "exit",
+        "trans": [
+            "An exit is a way out of a place, such as a building or vehicle."
+        ]
+    },
+    {
+        "name": "front",
+        "trans": [
+            "The front is the part of something that faces forward or is the most visible, or it can refer to the area or position directly ahead of someone or something."
+        ]
+    },
+    {
+        "name": "function",
+        "trans": [
+            "A function is a purpose or task that something is designed or intended to perform, or it can refer to a mathematical relationship between two variables."
+        ]
+    },
+    {
+        "name": "lack",
+        "trans": [
+            "Lack is the absence or shortage of something that is needed or desired."
+        ]
+    },
+    {
+        "name": "living",
+        "trans": [
+            "Living refers to the condition or state of being alive or in existence, or it can refer to the means of sustaining life, such as food and shelter."
+        ]
+    },
+    {
+        "name": "plant",
+        "trans": [
+            "A plant is a living organism that is typically photosynthetic, has roots, stems, and leaves, and is able to reproduce."
+        ]
+    },
+    {
+        "name": "plastic",
+        "trans": [
+            "Plastic is a synthetic material made from polymers that can be molded into various shapes and used for a wide range of applications."
+        ]
+    },
+    {
+        "name": "spot",
+        "trans": [
+            "A spot is a small area or place, or it can refer to a stain or blemish on a surface."
+        ]
+    },
+    {
+        "name": "summer",
+        "trans": [
+            "Summer is the warmest season of the year, typically occurring between spring and autumn, characterized by longer days and shorter nights."
+        ]
+    },
+    {
+        "name": "taste",
+        "trans": [
+            "Taste is the sensation of flavor perceived in the mouth when eating or drinking something, or it can refer to a person's preference or liking for something."
+        ]
+    },
+    {
+        "name": "theme",
+        "trans": [
+            "A theme is a subject or topic that is repeated or developed throughout a piece of literature, art, or music, or it can refer to the overall style or tone of something."
+        ]
+    },
+    {
+        "name": "track",
+        "trans": [
+            "A track is a path or route for vehicles, or it can refer to a recorded sequence of sound or music."
+        ]
+    },
+    {
+        "name": "wing",
+        "trans": [
+            "A wing is a flat or curved surface on an aircraft that produces lift and enables it to fly, or it can refer to the side of a building or other structure that protrudes outward."
+        ]
+    },
+    {
+        "name": "brain",
+        "trans": [
+            "The brain is the organ in the head that controls the body's functions and enables conscious thought, perception, and emotion."
+        ]
+    },
+    {
+        "name": "button",
+        "trans": [
+            "A button is a small object that you press to make something happen."
+        ]
+    },
+    {
+        "name": "click",
+        "trans": [
+            "To click is to press a button on a computer mouse or other device."
+        ]
+    },
+    {
+        "name": "desire",
+        "trans": [
+            "To desire is to want something strongly."
+        ]
+    },
+    {
+        "name": "foot",
+        "trans": [
+            "A foot is a body part at the bottom of your leg that you use to walk or run."
+        ]
+    },
+    {
+        "name": "gas",
+        "trans": [
+            "Gas is a type of fuel that is used to power vehicles and machines."
+        ]
+    },
+    {
+        "name": "influence",
+        "trans": [
+            "To influence is to have an effect on someone or something."
+        ]
+    },
+    {
+        "name": "notice",
+        "trans": [
+            "To notice is to become aware of something with your senses or your mind."
+        ]
+    },
+    {
+        "name": "rain",
+        "trans": [
+            "Rain is water that falls from the sky when it is cloudy and wet outside."
+        ]
+    },
+    {
+        "name": "wall",
+        "trans": [
+            "A wall is a vertical structure that divides or surrounds an area."
+        ]
+    },
+    {
+        "name": "base",
+        "trans": [
+            "A base is the bottom or foundation of something."
+        ]
+    },
+    {
+        "name": "damage",
+        "trans": [
+            "Damage is harm or injury to something or someone."
+        ]
+    },
+    {
+        "name": "distance",
+        "trans": [
+            "Distance is the amount of space between two objects or places."
+        ]
+    },
+    {
+        "name": "feeling",
+        "trans": [
+            "A feeling is an emotion or sensation that you experience."
+        ]
+    },
+    {
+        "name": "pair",
+        "trans": [
+            "A pair is two objects of the same kind that are meant to be used together."
+        ]
+    },
+    {
+        "name": "savings",
+        "trans": [
+            "Savings are money that you set aside and don't spend."
+        ]
+    },
+    {
+        "name": "staff",
+        "trans": [
+            "Staff are people who work for an organization or business."
+        ]
+    },
+    {
+        "name": "sugar",
+        "trans": [
+            "Sugar is a sweet substance that is used to sweeten food and drinks."
+        ]
+    },
+    {
+        "name": "target",
+        "trans": [
+            "A target is a goal or objective that someone wants to achieve."
+        ]
+    },
+    {
+        "name": "text",
+        "trans": [
+            "A text is a written or printed piece of language that communicates information or ideas."
+        ]
+    },
+    {
+        "name": "animal",
+        "trans": [
+            "An animal is a living organism that is not a plant and has the ability to move around and respond to its environment."
+        ]
+    },
+    {
+        "name": "author",
+        "trans": [
+            "An author is a person who writes books, articles, or other written works."
+        ]
+    },
+    {
+        "name": "budget",
+        "trans": [
+            "A budget is a plan for how to spend money over a certain period of time."
+        ]
+    },
+    {
+        "name": "discount",
+        "trans": [
+            "A discount is a reduction in the price of something."
+        ]
+    },
+    {
+        "name": "file",
+        "trans": [
+            "A file is a collection of information or data that is stored on a computer or other electronic device."
+        ]
+    },
+    {
+        "name": "ground",
+        "trans": [
+            "The ground is the solid surface of the earth that people and things stand on."
+        ]
+    },
+    {
+        "name": "lesson",
+        "trans": [
+            "A lesson is a period of teaching or learning about a particular subject or activity."
+        ]
+    },
+    {
+        "name": "minute",
+        "trans": [
+            "A minute is a unit of time that equals 60 seconds."
+        ]
+    },
+    {
+        "name": "officer",
+        "trans": [
+            "An officer is a person who has a position of authority in a government, military, or other organization."
+        ]
+    },
+    {
+        "name": "phase",
+        "trans": [
+            "A phase is a distinct stage in a process of change or development."
+        ]
+    },
+    {
+        "name": "reference",
+        "trans": [
+            "A reference is a source of information or a mention of someone or something."
+        ]
+    },
+    {
+        "name": "register",
+        "trans": [
+            "To register is to officially sign up for something or to record information."
+        ]
+    },
+    {
+        "name": "sky",
+        "trans": [
+            "The sky is the space above the earth that is filled with clouds, stars, and the sun."
+        ]
+    },
+    {
+        "name": "stage",
+        "trans": [
+            "A stage is a raised platform or area on which actors or performers present a play, concert, or other form of entertainment."
+        ]
+    },
+    {
+        "name": "stick",
+        "trans": [
+            "A stick is a long, thin piece of wood or other material that is used for various purposes."
+        ]
+    },
+    {
+        "name": "title",
+        "trans": [
+            "A title is a name given to a book, movie, or other work of art."
+        ]
+    },
+    {
+        "name": "trouble",
+        "trans": [
+            "Trouble is a problem or difficulty that causes inconvenience or distress."
+        ]
+    },
+    {
+        "name": "bowl",
+        "trans": [
+            "A bowl is a round, deep dish used for holding food or liquid."
+        ]
+    },
+    {
+        "name": "bridge",
+        "trans": [
+            "A bridge is a structure that is built over a river, road, or other obstacle to allow people or vehicles to cross."
+        ]
+    },
+    {
+        "name": "campaign",
+        "trans": [
+            "A campaign is a series of planned actions that are intended to achieve a particular goal."
+        ]
+    },
+    {
+        "name": "character",
+        "trans": [
+            "A character is a person or animal in a book, movie, or other work of fiction."
+        ]
+    },
+    {
+        "name": "club",
+        "trans": [
+            "A club is a group of people who share a common interest or activity."
+        ]
+    },
+    {
+        "name": "edge",
+        "trans": [
+            "An edge is the outer or furthest point of something."
+        ]
+    },
+    {
+        "name": "evidence",
+        "trans": [
+            "Evidence is something that provides proof or support for a claim or theory."
+        ]
+    },
+    {
+        "name": "fan",
+        "trans": [
+            "A fan is a person who is enthusiastic about a particular sport, hobby, or celebrity."
+        ]
+    },
+    {
+        "name": "letter",
+        "trans": [
+            "A letter is a written or printed message that is usually sent by mail."
+        ]
+    },
+    {
+        "name": "lock",
+        "trans": [
+            "A lock is a device used to secure a door, gate, or other opening."
+        ]
+    },
+    {
+        "name": "maximum",
+        "trans": [
+            "Maximum is the highest amount or quantity that is allowed or possible."
+        ]
+    },
+    {
+        "name": "novel",
+        "trans": [
+            "A novel is a long work of fiction that tells a story."
+        ]
+    },
+    {
+        "name": "option",
+        "trans": [
+            "An option is a choice or possibility that is available."
+        ]
+    },
+    {
+        "name": "pack",
+        "trans": [
+            "To pack is to put things into a bag, box, or other container for storage or transport."
+        ]
+    },
+    {
+        "name": "park",
+        "trans": [
+            "A park is a public place with grass, trees, and often playgrounds or sports fields for people to enjoy."
+        ]
+    },
+    {
+        "name": "plenty",
+        "trans": [
+            "Plenty means having enough or more than enough of something."
+        ]
+    },
+    {
+        "name": "quarter",
+        "trans": [
+            "A quarter is a unit of measurement equal to one-fourth or 25% of something."
+        ]
+    },
+    {
+        "name": "skin",
+        "trans": [
+            "Skin is the outer layer that covers the body of a person or animal."
+        ]
+    },
+    {
+        "name": "sort",
+        "trans": [
+            "Sort means to categorize or put things in order based on their similarities or differences."
+        ]
+    },
+    {
+        "name": "weight",
+        "trans": [
+            "Weight is the measure of how heavy an object is."
+        ]
+    },
+    {
+        "name": "baby",
+        "trans": [
+            "A baby is a young human being who has not yet learned to walk or talk."
+        ]
+    },
+    {
+        "name": "background",
+        "trans": [
+            "Background refers to the part of a scene or picture that is furthest from the viewer, or the circumstances or events that lead up to a particular situation."
+        ]
+    },
+    {
+        "name": "carry",
+        "trans": [
+            "To carry means to hold or support the weight of something and transport it from one place to another."
+        ]
+    },
+    {
+        "name": "dish",
+        "trans": [
+            "A dish is a container, usually with a flat bottom and curved sides, used for serving or cooking food."
+        ]
+    },
+    {
+        "name": "factor",
+        "trans": [
+            "A factor is a circumstance or influence that contributes to a result or outcome."
+        ]
+    },
+    {
+        "name": "fruit",
+        "trans": [
+            "A fruit is the sweet and fleshy product of a tree or other plant that contains seeds."
+        ]
+    },
+    {
+        "name": "glass",
+        "trans": [
+            "Glass is a hard, transparent material used for windows, mirrors, and other purposes."
+        ]
+    },
+    {
+        "name": "joint",
+        "trans": [
+            "A joint is the place where two or more bones meet in the body, or a place where two or more things are joined together."
+        ]
+    },
+    {
+        "name": "master",
+        "trans": [
+            "A master is a person who has complete control or authority over something, or who has achieved a high level of skill or proficiency in a particular field."
+        ]
+    },
+    {
+        "name": "muscle",
+        "trans": [
+            "A muscle is a tissue in the body that can contract and produce movement."
+        ]
+    },
+    {
+        "name": "red",
+        "trans": [
+            "Red is a color that is the hue of blood, or a shade resembling it."
+        ]
+    },
+    {
+        "name": "strength",
+        "trans": [
+            "Strength is the measure of how much force or power a person or thing has."
+        ]
+    },
+    {
+        "name": "traffic",
+        "trans": [
+            "Traffic refers to the movement of vehicles on a road, or the volume of people or goods moving through a particular place or system."
+        ]
+    },
+    {
+        "name": "trip",
+        "trans": [
+            "A trip is a journey or excursion, usually for pleasure or vacation."
+        ]
+    },
+    {
+        "name": "vegetable",
+        "trans": [
+            "A vegetable is a plant or part of a plant that is eaten as food, such as broccoli, carrots, or potatoes."
+        ]
+    },
+    {
+        "name": "appeal",
+        "trans": [
+            "Appeal is the quality of being attractive or interesting, or the act of asking for a decision to be changed."
+        ]
+    },
+    {
+        "name": "chart",
+        "trans": [
+            "A chart is a visual representation of data or information, often in the form of a graph or table."
+        ]
+    },
+    {
+        "name": "gear",
+        "trans": [
+            "Gear refers to the machinery or equipment used for a particular purpose, or the clothing and equipment worn for a particular activity."
+        ]
+    },
+    {
+        "name": "ideal",
+        "trans": [
+            "Ideal refers to a standard of perfection or excellence that is considered to be the best or most desirable."
+        ]
+    },
+    {
+        "name": "kitchen",
+        "trans": [
+            "A kitchen is a room or area in a house where food is prepared and cooked."
+        ]
+    },
+    {
+        "name": "land",
+        "trans": [
+            "Land is the solid part of the Earth's surface that is not covered by water."
+        ]
+    },
+    {
+        "name": "log",
+        "trans": [
+            "A log is a thick piece of wood from a tree that has been cut down."
+        ]
+    },
+    {
+        "name": "mother",
+        "trans": [
+            "A mother is a female parent who gives birth to or raises a child."
+        ]
+    },
+    {
+        "name": "net",
+        "trans": [
+            "A net is a type of fabric or material that is woven or knotted together with small holes in it, used for catching or trapping things."
+        ]
+    },
+    {
+        "name": "party",
+        "trans": [
+            "A party is a social gathering or event where people come together to celebrate, socialize or have fun."
+        ]
+    },
+    {
+        "name": "principle",
+        "trans": [
+            "A principle is a fundamental truth, law, or belief that serves as the foundation for a system of thought or behavior."
+        ]
+    },
+    {
+        "name": "relative",
+        "trans": [
+            "A relative is a person who is connected to you by blood or marriage, such as a parent, sibling, cousin, or grandparent."
+        ]
+    },
+    {
+        "name": "sale",
+        "trans": [
+            "A sale is an event or process of selling goods or services in exchange for money or other forms of payment."
+        ]
+    },
+    {
+        "name": "season",
+        "trans": [
+            "A season is a division of the year marked by changes in weather, ecology, and hours of daylight."
+        ]
+    },
+    {
+        "name": "signal",
+        "trans": [
+            "A signal is a sound, gesture, or object used to convey information or instructions."
+        ]
+    },
+    {
+        "name": "spirit",
+        "trans": [
+            "A spirit is a non-physical entity that is believed to inhabit or influence a person, place, or thing."
+        ]
+    },
+    {
+        "name": "street",
+        "trans": [
+            "A street is a public road in a city or town, usually lined with buildings and used for vehicular and pedestrian traffic."
+        ]
+    },
+    {
+        "name": "tree",
+        "trans": [
+            "A tree is a tall plant with a trunk and branches made of wood that grows in the ground."
+        ]
+    },
+    {
+        "name": "wave",
+        "trans": [
+            "A wave is a disturbance that travels through a medium, such as water or air, and can be seen as a pattern of up-and-down or back-and-forth motion."
+        ]
+    },
+    {
+        "name": "belt",
+        "trans": [
+            "A belt is a flexible strip of material, such as leather or cloth, that is worn around the waist to hold clothing or carry tools."
+        ]
+    },
+    {
+        "name": "bench",
+        "trans": [
+            "A bench is a long, usually wooden, seat for two or more people, typically with a back and sometimes with arms."
+        ]
+    },
+    {
+        "name": "commission",
+        "trans": [
+            "A commission is a group of people authorized to perform a specific task or oversee a particular area of activity."
+        ]
+    },
+    {
+        "name": "copy",
+        "trans": [
+            "A copy is a reproduction or duplicate of an original document, book, or other object."
+        ]
+    },
+    {
+        "name": "drop",
+        "trans": [
+            "A drop is a small amount of liquid that falls or is released from a higher position to a lower one."
+        ]
+    },
+    {
+        "name": "minimum",
+        "trans": [
+            "The minimum is the smallest or lowest amount, level, or value that is acceptable or allowed."
+        ]
+    },
+    {
+        "name": "path",
+        "trans": [
+            "A path is a route or way that is taken or followed to get from one place to another."
+        ]
+    },
+    {
+        "name": "progress",
+        "trans": [
+            "Progress is the gradual improvement or advancement toward a goal or better state."
+        ]
+    },
+    {
+        "name": "project",
+        "trans": [
+            "A project is a planned and organized effort to achieve a specific goal or objective."
+        ]
+    },
+    {
+        "name": "sea",
+        "trans": [
+            "The sea is a large body of saltwater that covers most of the Earth's surface and is home to a diverse range of marine life."
+        ]
+    },
+    {
+        "name": "south",
+        "trans": [
+            "South refers to the direction opposite to north, towards the Earth's southern pole."
+        ]
+    },
+    {
+        "name": "status",
+        "trans": [
+            "Status refers to someone's social or professional position or standing."
+        ]
+    },
+    {
+        "name": "stuff",
+        "trans": [
+            "Stuff refers to a group of things, usually without specifying what those things are."
+        ]
+    },
+    {
+        "name": "ticket",
+        "trans": [
+            "A ticket is a piece of paper or electronic record that gives someone the right to enter an event or use a service."
+        ]
+    },
+    {
+        "name": "tour",
+        "trans": [
+            "A tour is a trip or journey, often with a specific purpose or destination."
+        ]
+    },
+    {
+        "name": "angle",
+        "trans": [
+            "An angle is the measurement of the space between two intersecting lines or surfaces."
+        ]
+    },
+    {
+        "name": "blue",
+        "trans": [
+            "Blue is a color that is often associated with the sky or water."
+        ]
+    },
+    {
+        "name": "breakfast",
+        "trans": [
+            "Breakfast is the first meal of the day, usually eaten in the morning."
+        ]
+    },
+    {
+        "name": "confidence",
+        "trans": [
+            "Confidence refers to a belief in one's abilities or qualities."
+        ]
+    },
+    {
+        "name": "daughter",
+        "trans": [
+            "A daughter is a female child of a parent or parents."
+        ]
+    },
+    {
+        "name": "degree",
+        "trans": [
+            "A degree is an academic title awarded by a college or university for completing a program of study."
+        ]
+    },
+    {
+        "name": "doctor",
+        "trans": [
+            "A doctor is a person who practices medicine and treats patients."
+        ]
+    },
+    {
+        "name": "dot",
+        "trans": [
+            "A dot is a small round mark or spot."
+        ]
+    },
+    {
+        "name": "dream",
+        "trans": [
+            "A dream is a series of thoughts, images, and sensations that occur in a person's mind during sleep."
+        ]
+    },
+    {
+        "name": "duty",
+        "trans": [
+            "Duty refers to something that someone is required or obligated to do."
+        ]
+    },
+    {
+        "name": "essay",
+        "trans": [
+            "An essay is a piece of writing that presents and supports an argument or idea."
+        ]
+    },
+    {
+        "name": "father",
+        "trans": [
+            "A father is a male parent or someone who fulfills the role of a male parent."
+        ]
+    },
+    {
+        "name": "fee",
+        "trans": [
+            "A fee is a payment that is required for a service or to participate in an event."
+        ]
+    },
+    {
+        "name": "finance",
+        "trans": [
+            "Finance refers to the management of money and investments."
+        ]
+    },
+    {
+        "name": "hour",
+        "trans": [
+            "An hour is a unit of time that equals 60 minutes."
+        ]
+    },
+    {
+        "name": "juice",
+        "trans": [
+            "Juice refers to a drink that is made by squeezing or extracting liquid from fruits or vegetables."
+        ]
+    },
+    {
+        "name": "limit",
+        "trans": [
+            "A limit is a point beyond which something cannot or should not go."
+        ]
+    },
+    {
+        "name": "luck",
+        "trans": [
+            "Luck refers to success or good fortune, often attributed to chance."
+        ]
+    },
+    {
+        "name": "milk",
+        "trans": [
+            "Milk is a white liquid produced by female mammals to feed their young."
+        ]
+    },
+    {
+        "name": "mouth",
+        "trans": [
+            "Mouth refers to the opening in a person's face through which they eat, breathe, and speak."
+        ]
+    },
+    {
+        "name": "peace",
+        "trans": [
+            "Peace is a state of calmness and absence of conflict or war."
+        ]
+    },
+    {
+        "name": "pipe",
+        "trans": [
+            "A pipe is a tube-like structure that is used to transport fluids or gases."
+        ]
+    },
+    {
+        "name": "seat",
+        "trans": [
+            "A seat is a piece of furniture designed for one person to sit on."
+        ]
+    },
+    {
+        "name": "stable",
+        "trans": [
+            "A stable is a building where horses are kept and cared for."
+        ]
+    },
+    {
+        "name": "storm",
+        "trans": [
+            "A storm is a violent disturbance of the atmosphere with strong winds, thunder, and lightning."
+        ]
+    },
+    {
+        "name": "substance",
+        "trans": [
+            "A substance is a material that has a particular chemical composition and physical properties."
+        ]
+    },
+    {
+        "name": "team",
+        "trans": [
+            "A team is a group of people who work together to achieve a common goal."
+        ]
+    },
+    {
+        "name": "trick",
+        "trans": [
+            "A trick is a clever or deceptive act that is intended to fool or deceive someone."
+        ]
+    },
+    {
+        "name": "afternoon",
+        "trans": [
+            "Afternoon is the time of day between noon and evening."
+        ]
+    },
+    {
+        "name": "bat",
+        "trans": [
+            "A bat is a flying mammal with leathery wings that can navigate and catch prey using echolocation."
+        ]
+    },
+    {
+        "name": "beach",
+        "trans": [
+            "A beach is a sandy or rocky area next to a body of water, usually the ocean."
+        ]
+    },
+    {
+        "name": "blank",
+        "trans": [
+            "Blank is a term used to describe something that has no writing or printing on it."
+        ]
+    },
+    {
+        "name": "catch",
+        "trans": [
+            "To catch is to intercept and grasp an object that is thrown or falling."
+        ]
+    },
+    {
+        "name": "chain",
+        "trans": [
+            "A chain is a series of links or rings that are connected to each other."
+        ]
+    },
+    {
+        "name": "consideration",
+        "trans": [
+            "Consideration is careful thought or attention given to a matter or decision."
+        ]
+    },
+    {
+        "name": "cream",
+        "trans": [
+            "Cream is a thick, smooth, and fatty substance that is used in cooking or as a topping for desserts."
+        ]
+    },
+    {
+        "name": "crew",
+        "trans": [
+            "A crew is a group of people who work together on a ship, plane, or other type of vehicle."
+        ]
+    },
+    {
+        "name": "detail",
+        "trans": [
+            "A detail is a small and specific aspect or feature of something."
+        ]
+    },
+    {
+        "name": "gold",
+        "trans": [
+            "Gold is a precious metal that is yellow in color and is often used to make jewelry and coins."
+        ]
+    },
+    {
+        "name": "interview",
+        "trans": [
+            "An interview is a formal meeting in which one person asks questions to another person in order to gather information."
+        ]
+    },
+    {
+        "name": "kid",
+        "trans": [
+            "A kid is a young goat or a slang term for a child or young person."
+        ]
+    },
+    {
+        "name": "mark",
+        "trans": [
+            "A mark is a visible trace or impression left by something."
+        ]
+    },
+    {
+        "name": "match",
+        "trans": [
+            "A match is a small stick made of wood or cardboard that is used to start a fire, or a competition or game in which two or more people or teams compete against each other."
+        ]
+    },
+    {
+        "name": "mission",
+        "trans": [
+            "A mission is a specific task or assignment that is given to someone or a group of people to accomplish."
+        ]
+    },
+    {
+        "name": "pain",
+        "trans": [
+            "Pain is an unpleasant physical sensation or discomfort in the body."
+        ]
+    },
+    {
+        "name": "pleasure",
+        "trans": [
+            "Pleasure is a feeling of enjoyment or satisfaction."
+        ]
+    },
+    {
+        "name": "score",
+        "trans": [
+            "Score refers to the number of points earned in a game or test."
+        ]
+    },
+    {
+        "name": "screw",
+        "trans": [
+            "To screw means to twist or turn a threaded object to fasten it or unfasten it."
+        ]
+    },
+    {
+        "name": "sex",
+        "trans": [
+            "Sex refers to the physical act of sexual intercourse between two individuals."
+        ]
+    },
+    {
+        "name": "shop",
+        "trans": [
+            "A shop is a place where goods or services are sold."
+        ]
+    },
+    {
+        "name": "shower",
+        "trans": [
+            "A shower is a device used to wash oneself with water that is sprayed from above."
+        ]
+    },
+    {
+        "name": "suit",
+        "trans": [
+            "A suit is a set of clothes consisting of a jacket and pants or skirt that match."
+        ]
+    },
+    {
+        "name": "tone",
+        "trans": [
+            "Tone refers to the pitch or quality of someone's voice or the atmosphere of something."
+        ]
+    },
+    {
+        "name": "window",
+        "trans": [
+            "A window is an opening in a wall or door that allows light and air to enter."
+        ]
+    },
+    {
+        "name": "agent",
+        "trans": [
+            "An agent is a person or organization that represents another person or organization in a business or legal transaction."
+        ]
+    },
+    {
+        "name": "band",
+        "trans": [
+            "A band is a group of musicians who play instruments and perform music together."
+        ]
+    },
+    {
+        "name": "block",
+        "trans": [
+            "A block is a solid piece of material, such as wood or stone, that has flat sides and is often used for building."
+        ]
+    },
+    {
+        "name": "bone",
+        "trans": [
+            "A bone is a hard, rigid part of the body that forms the skeleton and provides support."
+        ]
+    },
+    {
+        "name": "calendar",
+        "trans": [
+            "A calendar is a system used for organizing days, weeks, and months of the year."
+        ]
+    },
+    {
+        "name": "cap",
+        "trans": [
+            "A cap is a type of hat that fits closely to the head and has a visor or brim to protect the eyes from the sun."
+        ]
+    },
+    {
+        "name": "coat",
+        "trans": [
+            "A coat is a piece of clothing worn over other clothes to keep warm or dry."
+        ]
+    },
+    {
+        "name": "contest",
+        "trans": [
+            "A contest is a competition between individuals or teams to see who is the best at something."
+        ]
+    },
+    {
+        "name": "corner",
+        "trans": [
+            "A corner is the point where two lines or surfaces meet, often forming an angle."
+        ]
+    },
+    {
+        "name": "court",
+        "trans": [
+            "A court is a place where legal proceedings take place or a place where a game, such as basketball or tennis, is played."
+        ]
+    },
+    {
+        "name": "cup",
+        "trans": [
+            "A cup is a small, bowl-shaped container used for drinking liquids."
+        ]
+    },
+    {
+        "name": "district",
+        "trans": [
+            "A district is a specific area or region, often with its own unique characteristics or boundaries."
+        ]
+    },
+    {
+        "name": "door",
+        "trans": [
+            "A door is a movable panel that covers an opening in a wall or other partition and provides access to a room or building."
+        ]
+    },
+    {
+        "name": "east",
+        "trans": [
+            "East is one of the four main cardinal directions and refers to the direction toward the sunrise."
+        ]
+    },
+    {
+        "name": "finger",
+        "trans": [
+            "A finger is one of the five digits on the hand, used for grasping and touching."
+        ]
+    },
+    {
+        "name": "garage",
+        "trans": [
+            "A garage is a building or structure designed for storing vehicles, often attached to a house."
+        ]
+    },
+    {
+        "name": "guarantee",
+        "trans": [
+            "To guarantee is to promise or assure that something will happen or be true."
+        ]
+    },
+    {
+        "name": "hole",
+        "trans": [
+            "A hole is an opening or gap in something."
+        ]
+    },
+    {
+        "name": "hook",
+        "trans": [
+            "A hook is a curved piece of metal or other material used for catching, holding, or hanging things."
+        ]
+    },
+    {
+        "name": "implement",
+        "trans": [
+            "To implement is to put a plan or decision into action."
+        ]
+    },
+    {
+        "name": "layer",
+        "trans": [
+            "A layer is a sheet, film, or thickness of material lying over a surface or body."
+        ]
+    },
+    {
+        "name": "lecture",
+        "trans": [
+            "A lecture is a talk or speech given to an audience, often as part of a teaching or informative session."
+        ]
+    },
+    {
+        "name": "lie",
+        "trans": [
+            "To lie is to intentionally make a false statement or statement that is not true."
+        ]
+    },
+    {
+        "name": "manner",
+        "trans": [
+            "Manner refers to the way in which something is done or the way someone behaves."
+        ]
+    },
+    {
+        "name": "meeting",
+        "trans": [
+            "A meeting is a gathering of people for a particular purpose, usually to discuss or decide on something."
+        ]
+    },
+    {
+        "name": "nose",
+        "trans": [
+            "The nose is the part of the face or head that protrudes above the mouth, used for smelling and breathing."
+        ]
+    },
+    {
+        "name": "parking",
+        "trans": [
+            "Parking refers to the act of stopping and leaving a vehicle in a designated area for a period of time."
+        ]
+    },
+    {
+        "name": "partner",
+        "trans": [
+            "A partner is a person who shares in an activity or business with another person."
+        ]
+    },
+    {
+        "name": "profile",
+        "trans": [
+            "A profile is a description or summary of someone or something, often focusing on their characteristics or features."
+        ]
+    },
+    {
+        "name": "respect",
+        "trans": [
+            "Respect is a feeling of admiration or appreciation for someone or something."
+        ]
+    },
+    {
+        "name": "rice",
+        "trans": [
+            "Rice is a type of grain that is a staple food in many cultures around the world."
+        ]
+    },
+    {
+        "name": "routine",
+        "trans": [
+            "A routine is a sequence of actions that are regularly followed."
+        ]
+    },
+    {
+        "name": "schedule",
+        "trans": [
+            "A schedule is a plan that shows what will happen at a specific time or during a specific period."
+        ]
+    },
+    {
+        "name": "swimming",
+        "trans": [
+            "Swimming is the act of moving through water by using one's body, usually for exercise or recreation."
+        ]
+    },
+    {
+        "name": "telephone",
+        "trans": [
+            "A telephone is a device used for communicating with others over a distance, usually by voice."
+        ]
+    },
+    {
+        "name": "tip",
+        "trans": [
+            "A tip is a small piece of advice or a suggestion for how to do something."
+        ]
+    },
+    {
+        "name": "winter",
+        "trans": [
+            "Winter is the coldest season of the year, characterized by low temperatures, short days, and long nights."
+        ]
+    },
+    {
+        "name": "airline",
+        "trans": [
+            "An airline is a company that provides air transport services for passengers and/or cargo."
+        ]
+    },
+    {
+        "name": "bag",
+        "trans": [
+            "A bag is a flexible container used for carrying or storing items."
+        ]
+    },
+    {
+        "name": "battle",
+        "trans": [
+            "A battle is a violent confrontation between two or more groups, typically involving armed combat."
+        ]
+    },
+    {
+        "name": "bed",
+        "trans": [
+            "A bed is a piece of furniture used for sleeping or resting."
+        ]
+    },
+    {
+        "name": "bill",
+        "trans": [
+            "A bill is a statement that shows the amount of money owed for goods or services."
+        ]
+    },
+    {
+        "name": "bother",
+        "trans": [
+            "To bother someone is to annoy or disturb them."
+        ]
+    },
+    {
+        "name": "cake",
+        "trans": [
+            "A cake is a sweet dessert made from flour, sugar, eggs, and other ingredients, often baked in an oven."
+        ]
+    },
+    {
+        "name": "code",
+        "trans": [
+            "A code is a set of rules or instructions that are used to program or operate a computer, or to communicate information in a secret way."
+        ]
+    },
+    {
+        "name": "curve",
+        "trans": [
+            "A curve is a line or shape that is not straight but instead has a smooth, rounded shape."
+        ]
+    },
+    {
+        "name": "designer",
+        "trans": [
+            "A designer is a person who creates or plans the look, form, and function of something, such as clothing or buildings."
+        ]
+    },
+    {
+        "name": "dimension",
+        "trans": [
+            "A dimension is a measurement of the size or extent of something, such as length, width, or height."
+        ]
+    },
+    {
+        "name": "dress",
+        "trans": [
+            "A dress is a piece of clothing that is worn by women or girls and that covers the body and extends down to the legs."
+        ]
+    },
+    {
+        "name": "ease",
+        "trans": [
+            "Ease refers to a state of comfort, relaxation, or lack of difficulty."
+        ]
+    },
+    {
+        "name": "emergency",
+        "trans": [
+            "An emergency is a serious or dangerous situation that requires immediate action to be taken in order to prevent harm or damage."
+        ]
+    },
+    {
+        "name": "evening",
+        "trans": [
+            "Evening refers to the period of time between the end of the day and bedtime, typically from late afternoon to early night."
+        ]
+    },
+    {
+        "name": "extension",
+        "trans": [
+            "An extension is a part that is added to something in order to make it longer, larger, or more capable."
+        ]
+    },
+    {
+        "name": "farm",
+        "trans": [
+            "A farm is a piece of land used for growing crops or raising animals for food."
+        ]
+    },
+    {
+        "name": "fight",
+        "trans": [
+            "To fight is to engage in a physical or verbal conflict with someone or something."
+        ]
+    },
+    {
+        "name": "gap",
+        "trans": [
+            "A gap is a space or opening between two things or in a structure that is missing a piece."
+        ]
+    },
+    {
+        "name": "grade",
+        "trans": [
+            "A grade is a level of quality or performance that is assigned to something, such as a student's work or a product's materials."
+        ]
+    },
+    {
+        "name": "holiday",
+        "trans": [
+            "A holiday is a day or period of time set aside for celebration, relaxation, or recreation, typically observed by not working or attending school."
+        ]
+    },
+    {
+        "name": "horror",
+        "trans": [
+            "Horror refers to a feeling of intense fear, dread, or revulsion."
+        ]
+    },
+    {
+        "name": "horse",
+        "trans": [
+            "A horse is a large, four-legged animal with a mane, tail, and hooves, often used for riding or working on a farm."
+        ]
+    },
+    {
+        "name": "host",
+        "trans": [
+            "A host is a person or organization that provides lodging or entertainment for guests."
+        ]
+    },
+    {
+        "name": "husband",
+        "trans": [
+            "A husband is a man who is married to a woman."
+        ]
+    },
+    {
+        "name": "loan",
+        "trans": [
+            "A loan is an amount of money that is borrowed with the expectation of being paid back, typically with interest."
+        ]
+    },
+    {
+        "name": "mistake",
+        "trans": [
+            "A mistake is an error or fault in action, judgment, or thought."
+        ]
+    },
+    {
+        "name": "mountain",
+        "trans": [
+            "A mountain is a large, natural elevation of the earth's surface, often with steep sides and a peak."
+        ]
+    },
+    {
+        "name": "nail",
+        "trans": [
+            "A nail is a thin piece of metal with a pointed end that is used to fasten things together, typically hammered into wood or other materials."
+        ]
+    },
+    {
+        "name": "noise",
+        "trans": [
+            "Noise is a loud or unpleasant sound."
+        ]
+    },
+    {
+        "name": "occasion",
+        "trans": [
+            "An occasion is a particular time when something happens or an event is celebrated."
+        ]
+    },
+    {
+        "name": "package",
+        "trans": [
+            "A package is a box or container used for transporting or storing items."
+        ]
+    },
+    {
+        "name": "patient",
+        "trans": [
+            "A patient is a person receiving medical treatment or care."
+        ]
+    },
+    {
+        "name": "pause",
+        "trans": [
+            "To pause is to stop briefly before continuing."
+        ]
+    },
+    {
+        "name": "phrase",
+        "trans": [
+            "A phrase is a group of words used together in a sentence to convey a specific meaning."
+        ]
+    },
+    {
+        "name": "proof",
+        "trans": [
+            "Proof is evidence or confirmation that something is true or accurate."
+        ]
+    },
+    {
+        "name": "race",
+        "trans": [
+            "A race is a competition between people, animals, or vehicles to determine who is the fastest."
+        ]
+    },
+    {
+        "name": "relief",
+        "trans": [
+            "Relief is a feeling of comfort or happiness that comes from being free of pain, anxiety, or stress."
+        ]
+    },
+    {
+        "name": "sand",
+        "trans": [
+            "Sand is a substance made of small grains of rock or minerals, often found on beaches or in deserts."
+        ]
+    },
+    {
+        "name": "sentence",
+        "trans": [
+            "A sentence is a group of words that expresses a complete thought or idea."
+        ]
+    },
+    {
+        "name": "shoulder",
+        "trans": [
+            "A shoulder is the part of the body that connects the arm to the torso."
+        ]
+    },
+    {
+        "name": "smoke",
+        "trans": [
+            "Smoke is a visible suspension of particles in the air, typically created by burning something."
+        ]
+    },
+    {
+        "name": "stomach",
+        "trans": [
+            "The stomach is an organ in the body that breaks down food for digestion."
+        ]
+    },
+    {
+        "name": "string",
+        "trans": [
+            "A string is a thin piece of cord or material used for tying or holding things together."
+        ]
+    },
+    {
+        "name": "tourist",
+        "trans": [
+            "A tourist is a person who travels to a place for pleasure or culture."
+        ]
+    },
+    {
+        "name": "towel",
+        "trans": [
+            "A towel is a piece of absorbent fabric used for drying things, such as the body or dishes."
+        ]
+    },
+    {
+        "name": "vacation",
+        "trans": [
+            "A vacation is a period of time when a person takes a break from work or daily routine to relax or travel."
+        ]
+    },
+    {
+        "name": "west",
+        "trans": [
+            "The west is a cardinal direction that is opposite of east, often used to refer to a region or location."
+        ]
+    },
+    {
+        "name": "wheel",
+        "trans": [
+            "A wheel is a circular object that rotates around an axis and is used to facilitate movement or transportation."
+        ]
+    },
+    {
+        "name": "wine",
+        "trans": [
+            "Wine is an alcoholic beverage made from fermented grapes or other fruits."
+        ]
+    },
+    {
+        "name": "arm",
+        "trans": [
+            "An arm is a limb on the body that extends from the shoulder to the hand."
+        ]
+    },
+    {
+        "name": "aside",
+        "trans": [
+            "Aside is a word that means to move something to the side or out of the way, or to mention something in addition to the main point."
+        ]
+    },
+    {
+        "name": "associate",
+        "trans": [
+            "To associate is to connect or link things or people together in some way."
+        ]
+    },
+    {
+        "name": "bet",
+        "trans": [
+            "A bet is a wager or agreement in which a person risks something of value on the outcome of an event or contest."
+        ]
+    },
+    {
+        "name": "blow",
+        "trans": [
+            "To blow is to move air forcefully through your mouth or other means, often causing movement or sound."
+        ]
+    },
+    {
+        "name": "border",
+        "trans": [
+            "A border is the line or area separating two countries, regions, or places."
+        ]
+    },
+    {
+        "name": "branch",
+        "trans": [
+            "A branch is a part of a tree that grows out from the trunk or another branch, or a division of a company or organization."
+        ]
+    },
+    {
+        "name": "breast",
+        "trans": [
+            "A breast is the front part of a person's chest, usually referring to a female's mammary gland used for breastfeeding."
+        ]
+    },
+    {
+        "name": "brother",
+        "trans": [
+            "A brother is a male sibling, sharing at least one parent."
+        ]
+    },
+    {
+        "name": "buddy",
+        "trans": [
+            "A buddy is a friend or companion."
+        ]
+    },
+    {
+        "name": "bunch",
+        "trans": [
+            "A bunch is a group of objects or people that are together in a cluster or tightly packed."
+        ]
+    },
+    {
+        "name": "chip",
+        "trans": [
+            "A chip is a small piece or fragment that has been broken or cut off from a larger object or material, often referring to a small piece of semiconductor material used in electronic devices."
+        ]
+    },
+    {
+        "name": "coach",
+        "trans": [
+            "A coach is a person who trains or instructs someone in a particular sport or activity, or a vehicle for carrying passengers, typically with multiple seats."
+        ]
+    },
+    {
+        "name": "cross",
+        "trans": [
+            "To cross is to move from one side of something to the other, often referring to walking or traveling."
+        ]
+    },
+    {
+        "name": "document",
+        "trans": [
+            "A document is a written or printed record of information, often referring to an official or legal paper."
+        ]
+    },
+    {
+        "name": "draft",
+        "trans": [
+            "A draft is a preliminary or rough version of a written document or plan."
+        ]
+    },
+    {
+        "name": "dust",
+        "trans": [
+            "Dust is tiny, dry particles of earth, dirt, or other matter that can float in the air and settle on surfaces."
+        ]
+    },
+    {
+        "name": "expert",
+        "trans": [
+            "An expert is a person who has extensive knowledge or skills in a particular field or subject."
+        ]
+    },
+    {
+        "name": "floor",
+        "trans": [
+            "A floor is the level surface of a room on which people walk and furniture is placed."
+        ]
+    },
+    {
+        "name": "god",
+        "trans": [
+            "A god is a supernatural being or spirit worshipped by people, often considered to have power and control over the world and its inhabitants."
+        ]
+    },
+    {
+        "name": "golf",
+        "trans": [
+            "Golf is a sport played on a large open-air course, in which players use clubs to hit a small ball into a series of holes."
+        ]
+    },
+    {
+        "name": "habit",
+        "trans": [
+            "A habit is a regular tendency or practice, often referring to a behavior that is difficult to change."
+        ]
+    },
+    {
+        "name": "iron",
+        "trans": [
+            "Iron is a chemical element with the symbol Fe, commonly used to make metal objects or tools."
+        ]
+    },
+    {
+        "name": "judge",
+        "trans": [
+            "A judge is a person appointed or elected to decide on legal matters in a court of law."
+        ]
+    },
+    {
+        "name": "knife",
+        "trans": [
+            "A knife is a tool or weapon with a sharp blade used for cutting or slicing."
+        ]
+    },
+    {
+        "name": "landscape",
+        "trans": [
+            "A landscape is a large area of land with a particular type of scenery or natural features."
+        ]
+    },
+    {
+        "name": "league",
+        "trans": [
+            "A league is a group of sports teams or organizations that compete against each other."
+        ]
+    },
+    {
+        "name": "mail",
+        "trans": [
+            "Mail is the system used for sending letters, packages, and other postal items through a postal service."
+        ]
+    },
+    {
+        "name": "mess",
+        "trans": [
+            "A mess is a state of disorder or confusion, or a dirty or untidy place."
+        ]
+    },
+    {
+        "name": "native",
+        "trans": [
+            "Native refers to something or someone that is from a particular place by birth or origin."
+        ]
+    },
+    {
+        "name": "opening",
+        "trans": [
+            "An opening is a hole, gap or space that allows entry or access."
+        ]
+    },
+    {
+        "name": "parent",
+        "trans": [
+            "A parent is a person who has a child or children."
+        ]
+    },
+    {
+        "name": "pattern",
+        "trans": [
+            "A pattern is a repeated design or shape."
+        ]
+    },
+    {
+        "name": "pin",
+        "trans": [
+            "A pin is a small, pointed object used to fasten things together."
+        ]
+    },
+    {
+        "name": "pool",
+        "trans": [
+            "A pool is a small body of still water, often for swimming or as a reservoir."
+        ]
+    },
+    {
+        "name": "pound",
+        "trans": [
+            "A pound is a unit of weight measurement equal to 16 ounces."
+        ]
+    },
+    {
+        "name": "request",
+        "trans": [
+            "A request is an act of asking for something."
+        ]
+    },
+    {
+        "name": "salary",
+        "trans": [
+            "A salary is a fixed amount of money paid regularly for work done."
+        ]
+    },
+    {
+        "name": "shame",
+        "trans": [
+            "Shame is a feeling of guilt or embarrassment caused by doing something wrong or inappropriate."
+        ]
+    },
+    {
+        "name": "shelter",
+        "trans": [
+            "A shelter is a place that provides protection from bad weather or danger."
+        ]
+    },
+    {
+        "name": "shoe",
+        "trans": [
+            "A shoe is a covering for the foot, typically made of leather or rubber."
+        ]
+    },
+    {
+        "name": "silver",
+        "trans": [
+            "Silver is a precious metal that has a shiny, white-grey color."
+        ]
+    },
+    {
+        "name": "tackle",
+        "trans": [
+            "To tackle is to confront or deal with a difficult problem or task."
+        ]
+    },
+    {
+        "name": "tank",
+        "trans": [
+            "A tank is a large container for storing liquids or gases."
+        ]
+    },
+    {
+        "name": "trust",
+        "trans": [
+            "Trust is a belief or confidence in the reliability, truth, or ability of someone or something."
+        ]
+    },
+    {
+        "name": "assist",
+        "trans": [
+            "To assist is to help or support someone in doing something."
+        ]
+    },
+    {
+        "name": "bake",
+        "trans": [
+            "To bake is to cook food in an oven using dry heat."
+        ]
+    },
+    {
+        "name": "bar",
+        "trans": [
+            "A bar is a place where alcoholic beverages are sold and consumed."
+        ]
+    },
+    {
+        "name": "bell",
+        "trans": [
+            "A bell is a hollow, usually metal, cup-shaped object that produces a ringing sound when struck."
+        ]
+    },
+    {
+        "name": "bike",
+        "trans": [
+            "A bike is a short form of bicycle, which is a vehicle with two wheels that is powered by pedals."
+        ]
+    },
+    {
+        "name": "blame",
+        "trans": [
+            "Blame is to hold someone responsible for a fault or mistake."
+        ]
+    },
+    {
+        "name": "boy",
+        "trans": [
+            "A boy is a young male person."
+        ]
+    },
+    {
+        "name": "brick",
+        "trans": [
+            "A brick is a rectangular block made of clay or other materials used for building walls."
+        ]
+    },
+    {
+        "name": "chair",
+        "trans": [
+            "A chair is a piece of furniture designed for one person to sit on, typically with a back and four legs."
+        ]
+    },
+    {
+        "name": "closet",
+        "trans": [
+            "A closet is a small room or space used for storing clothes or other personal items."
+        ]
+    },
+    {
+        "name": "clue",
+        "trans": [
+            "A clue is a piece of information that helps solve a problem or mystery."
+        ]
+    },
+    {
+        "name": "collar",
+        "trans": [
+            "A collar is a band of material worn around the neck, often on a shirt or jacket."
+        ]
+    },
+    {
+        "name": "comment",
+        "trans": [
+            "A comment is a statement or opinion expressing thoughts or feelings about something."
+        ]
+    },
+    {
+        "name": "conference",
+        "trans": [
+            "A conference is a meeting of people to discuss or exchange ideas on a particular topic."
+        ]
+    },
+    {
+        "name": "devil",
+        "trans": [
+            "The devil is a supernatural being often associated with evil or mischief."
+        ]
+    },
+    {
+        "name": "diet",
+        "trans": [
+            "A diet is the kinds of food that a person, animal, or community habitually eats."
+        ]
+    },
+    {
+        "name": "fear",
+        "trans": [
+            "Fear is a feeling of being afraid or scared of something."
+        ]
+    },
+    {
+        "name": "fuel",
+        "trans": [
+            "Fuel is a substance that is burned to produce energy, such as gasoline or coal."
+        ]
+    },
+    {
+        "name": "glove",
+        "trans": [
+            "A glove is a piece of clothing worn on the hand for warmth or protection."
+        ]
+    },
+    {
+        "name": "jacket",
+        "trans": [
+            "A jacket is a piece of clothing worn over the upper body, often for warmth or style."
+        ]
+    },
+    {
+        "name": "lunch",
+        "trans": [
+            "Lunch is a meal eaten in the middle of the day."
+        ]
+    },
+    {
+        "name": "monitor",
+        "trans": [
+            "A monitor is a device used to display or measure information, such as a computer monitor or a heart monitor."
+        ]
+    },
+    {
+        "name": "mortgage",
+        "trans": [
+            "A mortgage is a loan taken out to buy property or real estate, with the property serving as collateral."
+        ]
+    },
+    {
+        "name": "nurse",
+        "trans": [
+            "A nurse is a healthcare professional who provides medical care and support to patients."
+        ]
+    },
+    {
+        "name": "pace",
+        "trans": [
+            "Pace is the speed or rate at which something moves or progresses."
+        ]
+    },
+    {
+        "name": "panic",
+        "trans": [
+            "Panic is a sudden feeling of fear or anxiety that causes people to act in a frantic or irrational way."
+        ]
+    },
+    {
+        "name": "peak",
+        "trans": [
+            "A peak is the highest point of something, such as a mountain or a wave."
+        ]
+    },
+    {
+        "name": "plane",
+        "trans": [
+            "A plane is a vehicle that is designed for air travel and has wings and one or more engines."
+        ]
+    },
+    {
+        "name": "reward",
+        "trans": [
+            "A reward is something given in return for good behavior or work, often as a form of incentive or recognition."
+        ]
+    },
+    {
+        "name": "row",
+        "trans": [
+            "A row is a line of things arranged side by side, often in a straight line or sequence."
+        ]
+    },
+    {
+        "name": "sandwich",
+        "trans": [
+            "A sandwich is a food item made by placing filling (such as meat or vegetables) between two slices of bread."
+        ]
+    },
+    {
+        "name": "shock",
+        "trans": [
+            "Shock is a sudden, intense feeling of surprise or disbelief, often caused by something unexpected."
+        ]
+    },
+    {
+        "name": "spite",
+        "trans": [
+            "Spite is a feeling of resentment or ill-will towards someone, often leading to harmful or negative actions."
+        ]
+    },
+    {
+        "name": "spray",
+        "trans": [
+            "Spray is a liquid or mist that is dispersed in the air in small droplets, often used for cleaning or applying chemicals."
+        ]
+    },
+    {
+        "name": "surprise",
+        "trans": [
+            "A surprise is something unexpected or sudden that happens to someone."
+        ]
+    },
+    {
+        "name": "till",
+        "trans": [
+            "A till is a cash register or a box used to store money."
+        ]
+    },
+    {
+        "name": "transition",
+        "trans": [
+            "A transition is the process of changing from one state or condition to another."
+        ]
+    },
+    {
+        "name": "weekend",
+        "trans": [
+            "The weekend is the period of time between the end of the work or school week and the beginning of the next one, usually Saturday and Sunday."
+        ]
+    },
+    {
+        "name": "welcome",
+        "trans": [
+            "To welcome someone is to greet them in a friendly way and make them feel comfortable."
+        ]
+    },
+    {
+        "name": "yard",
+        "trans": [
+            "A yard is an area of land next to a building, usually used for outdoor activities."
+        ]
+    },
+    {
+        "name": "alarm",
+        "trans": [
+            "An alarm is a device that makes a loud noise to warn people of danger or to wake them up."
+        ]
+    },
+    {
+        "name": "bend",
+        "trans": [
+            "To bend is to curve or to change the shape of something by applying pressure."
+        ]
+    },
+    {
+        "name": "bicycle",
+        "trans": [
+            "A bicycle is a two-wheeled vehicle that is powered by pedaling."
+        ]
+    },
+    {
+        "name": "bite",
+        "trans": [
+            "To bite is to use your teeth to break, cut, or grip something."
+        ]
+    },
+    {
+        "name": "blind",
+        "trans": [
+            "Blind means unable to see, or without vision."
+        ]
+    },
+    {
+        "name": "bottle",
+        "trans": [
+            "A bottle is a container with a narrow neck used for storing liquids."
+        ]
+    },
+    {
+        "name": "cable",
+        "trans": [
+            "A cable is a thick, strong wire used for transmitting electricity, data, or audio and video signals."
+        ]
+    },
+    {
+        "name": "candle",
+        "trans": [
+            "A candle is a stick of wax with a wick that can be lit and used for illumination or decoration."
+        ]
+    },
+    {
+        "name": "clerk",
+        "trans": [
+            "A clerk is a person who works in an office or a store and is responsible for keeping records or serving customers."
+        ]
+    },
+    {
+        "name": "cloud",
+        "trans": [
+            "A cloud is a visible mass of water droplets or ice crystals suspended in the atmosphere."
+        ]
+    },
+    {
+        "name": "concert",
+        "trans": [
+            "A concert is a musical performance in front of an audience."
+        ]
+    },
+    {
+        "name": "counter",
+        "trans": [
+            "A counter is a flat surface used for conducting business or for preparing food."
+        ]
+    },
+    {
+        "name": "flower",
+        "trans": [
+            "A flower is the reproductive structure of a plant, usually colorful and fragrant."
+        ]
+    },
+    {
+        "name": "grandfather",
+        "trans": [
+            "A grandfather is the father of a person's parent."
+        ]
+    },
+    {
+        "name": "harm",
+        "trans": [
+            "Harm is physical or emotional damage that is caused to someone or something."
+        ]
+    },
+    {
+        "name": "knee",
+        "trans": [
+            "A knee is the joint that connects the upper and lower parts of the leg."
+        ]
+    },
+    {
+        "name": "lawyer",
+        "trans": [
+            "A lawyer is a person who practices law, as an advocate, barrister, attorney, counselor, solicitor, notary, or civil law notary."
+        ]
+    },
+    {
+        "name": "leather",
+        "trans": [
+            "Leather is a material made from the skin of an animal, usually a cow, used to make shoes, belts, and other products."
+        ]
+    },
+    {
+        "name": "load",
+        "trans": [
+            "Load is the weight or burden carried by a person, animal, or vehicle."
+        ]
+    },
+    {
+        "name": "mirror",
+        "trans": [
+            "A mirror is a reflective surface that shows a person's reflection."
+        ]
+    },
+    {
+        "name": "neck",
+        "trans": [
+            "The neck is the part of the body that connects the head to the shoulders."
+        ]
+    },
+    {
+        "name": "pension",
+        "trans": [
+            "A pension is a regular payment made to a person who has retired from work."
+        ]
+    },
+    {
+        "name": "plate",
+        "trans": [
+            "A plate is a flat dish used for serving or eating food."
+        ]
+    },
+    {
+        "name": "purple",
+        "trans": [
+            "Purple is a color that is a mixture of blue and red."
+        ]
+    },
+    {
+        "name": "ruin",
+        "trans": [
+            "Ruin is the state of being destroyed or in disrepair."
+        ]
+    },
+    {
+        "name": "ship",
+        "trans": [
+            "A ship is a large vessel used for transporting goods or people across water."
+        ]
+    },
+    {
+        "name": "skirt",
+        "trans": [
+            "A skirt is a garment worn by women that hangs from the waist and covers the legs."
+        ]
+    },
+    {
+        "name": "slice",
+        "trans": [
+            "A slice is a thin, flat piece of something that has been cut."
+        ]
+    },
+    {
+        "name": "snow",
+        "trans": [
+            "Snow is a type of precipitation that falls from the sky in cold weather and covers the ground in white."
+        ]
+    },
+    {
+        "name": "specialist",
+        "trans": [
+            "A specialist is a person who has expertise in a particular field or subject."
+        ]
+    },
+    {
+        "name": "stroke",
+        "trans": [
+            "A stroke is a medical condition that occurs when the blood supply to the brain is interrupted."
+        ]
+    },
+    {
+        "name": "switch",
+        "trans": [
+            "A switch is a device used to turn something on or off or to change its direction or mode of operation."
+        ]
+    },
+    {
+        "name": "trash",
+        "trans": [
+            "Trash is waste material that is no longer useful and is thrown away."
+        ]
+    },
+    {
+        "name": "tune",
+        "trans": [
+            "A tune is a melody or musical composition."
+        ]
+    },
+    {
+        "name": "zone",
+        "trans": [
+            "A zone is an area or region that has specific characteristics or is designated for a particular purpose."
+        ]
+    },
+    {
+        "name": "anger",
+        "trans": [
+            "Anger is a strong feeling of displeasure or hostility."
+        ]
+    },
+    {
+        "name": "award",
+        "trans": [
+            "An award is a prize or recognition given to a person or group for their achievements."
+        ]
+    },
+    {
+        "name": "bid",
+        "trans": [
+            "A bid is an offer or proposal to buy or do something."
+        ]
+    },
+    {
+        "name": "bitter",
+        "trans": [
+            "Bitter is a taste that is sharp, harsh, and unpleasant."
+        ]
+    },
+    {
+        "name": "boot",
+        "trans": [
+            "A boot is a type of footwear that covers the foot and ankle and sometimes extends up the leg."
+        ]
+    },
+    {
+        "name": "bug",
+        "trans": [
+            "A bug is an insect or a small creature that can cause harm or annoyance."
+        ]
+    },
+    {
+        "name": "camp",
+        "trans": [
+            "A camp is a temporary shelter or dwelling used for camping or outdoor activities."
+        ]
+    },
+    {
+        "name": "candy",
+        "trans": [
+            "Candy is a sweet treat made from sugar or chocolate."
+        ]
+    },
+    {
+        "name": "carpet",
+        "trans": [
+            "A carpet is a type of flooring made of fabric or woven material."
+        ]
+    },
+    {
+        "name": "cat",
+        "trans": [
+            "A cat is a small, furry animal that is often kept as a pet."
+        ]
+    },
+    {
+        "name": "champion",
+        "trans": [
+            "A champion is a person or team that has won a competition or tournament."
+        ]
+    },
+    {
+        "name": "channel",
+        "trans": [
+            "A channel is a way for something to flow, such as a river or a TV station."
+        ]
+    },
+    {
+        "name": "clock",
+        "trans": [
+            "A clock is a device that tells time, usually with a face and hands."
+        ]
+    },
+    {
+        "name": "comfort",
+        "trans": [
+            "Comfort is a feeling of being relaxed and at ease, often from being in a comfortable place or situation."
+        ]
+    },
+    {
+        "name": "cow",
+        "trans": [
+            "A cow is a large domesticated mammal that is raised for meat, milk, or leather."
+        ]
+    },
+    {
+        "name": "crack",
+        "trans": [
+            "A crack is a narrow opening or fissure, often in a hard surface like a wall or pavement."
+        ]
+    },
+    {
+        "name": "engineer",
+        "trans": [
+            "An engineer is a person who designs and builds things, such as machines, bridges, or software."
+        ]
+    },
+    {
+        "name": "entrance",
+        "trans": [
+            "An entrance is a way to get into a place, such as a door or a gate."
+        ]
+    },
+    {
+        "name": "fault",
+        "trans": [
+            "A fault is a mistake or flaw, often in a machine or system."
+        ]
+    },
+    {
+        "name": "grass",
+        "trans": [
+            "Grass is a type of plant with long, thin leaves that is often used for lawns and pastures."
+        ]
+    },
+    {
+        "name": "guy",
+        "trans": [
+            "A guy is a slang term for a man or boy."
+        ]
+    },
+    {
+        "name": "hell",
+        "trans": [
+            "Hell is a place of punishment or suffering in some religions and belief systems."
+        ]
+    },
+    {
+        "name": "highlight",
+        "trans": [
+            "A highlight is the most important or interesting part of something."
+        ]
+    },
+    {
+        "name": "incident",
+        "trans": [
+            "An incident is an event or occurrence, often one that is unexpected or unplanned."
+        ]
+    },
+    {
+        "name": "island",
+        "trans": [
+            "An island is a piece of land surrounded by water, often smaller than a continent."
+        ]
+    },
+    {
+        "name": "joke",
+        "trans": [
+            "A joke is something said or done to make people laugh or feel amused."
+        ]
+    },
+    {
+        "name": "jury",
+        "trans": [
+            "A jury is a group of people who listen to evidence in a court case and decide on a verdict."
+        ]
+    },
+    {
+        "name": "leg",
+        "trans": [
+            "A leg is a part of the body that connects the foot to the hip."
+        ]
+    },
+    {
+        "name": "lip",
+        "trans": [
+            "A lip is the fleshy part of the mouth that helps with speaking, eating, and drinking."
+        ]
+    },
+    {
+        "name": "mate",
+        "trans": [
+            "A mate is a friend or companion, often a romantic partner."
+        ]
+    },
+    {
+        "name": "motor",
+        "trans": [
+            "A motor is a machine that converts energy into motion, often used to power vehicles or machinery."
+        ]
+    },
+    {
+        "name": "nerve",
+        "trans": [
+            "A nerve is a bundle of fibers that transmit signals between the brain and other parts of the body."
+        ]
+    },
+    {
+        "name": "passage",
+        "trans": [
+            "A passage is a way through something, often a narrow or restricted path."
+        ]
+    },
+    {
+        "name": "pen",
+        "trans": [
+            "A pen is a writing instrument, often with ink or a ballpoint tip."
+        ]
+    },
+    {
+        "name": "pride",
+        "trans": [
+            "Pride is a feeling of satisfaction or happiness about something that you have done or something you possess."
+        ]
+    },
+    {
+        "name": "priest",
+        "trans": [
+            "A priest is a person who performs religious ceremonies and provides spiritual guidance to others."
+        ]
+    },
+    {
+        "name": "prize",
+        "trans": [
+            "A prize is an award or reward given to someone who has achieved something great or who has won a competition."
+        ]
+    },
+    {
+        "name": "promise",
+        "trans": [
+            "A promise is a commitment or assurance made by one person to another, that they will do something or act in a certain way."
+        ]
+    },
+    {
+        "name": "resident",
+        "trans": [
+            "A resident is a person who lives in a particular place, especially for a long period of time."
+        ]
+    },
+    {
+        "name": "resort",
+        "trans": [
+            "A resort is a place where people go for relaxation or recreation, usually located in a scenic or tourist destination."
+        ]
+    },
+    {
+        "name": "ring",
+        "trans": [
+            "A ring is a circular band worn on the finger, typically as an ornament or a symbol of marriage or commitment."
+        ]
+    },
+    {
+        "name": "roof",
+        "trans": [
+            "A roof is the uppermost part of a building that covers and protects the inside from the elements."
+        ]
+    },
+    {
+        "name": "rope",
+        "trans": [
+            "Rope is a strong cord made of twisted fibers, used for tying or pulling objects."
+        ]
+    },
+    {
+        "name": "sail",
+        "trans": [
+            "To sail is to travel on water using wind power, usually on a boat or ship."
+        ]
+    },
+    {
+        "name": "scheme",
+        "trans": [
+            "A scheme is a plan or proposal for achieving a particular goal or outcome."
+        ]
+    },
+    {
+        "name": "script",
+        "trans": [
+            "A script is a written text or document used in theater, film, or television productions, often containing dialogue and stage directions."
+        ]
+    },
+    {
+        "name": "sock",
+        "trans": [
+            "A sock is a piece of clothing worn on the foot and ankle, usually made of cotton or wool."
+        ]
+    },
+    {
+        "name": "station",
+        "trans": [
+            "A station is a place where vehicles stop to pick up or drop off passengers or goods, such as a train station or gas station."
+        ]
+    },
+    {
+        "name": "toe",
+        "trans": [
+            "A toe is one of the digits on the foot, usually five in number."
+        ]
+    },
+    {
+        "name": "tower",
+        "trans": [
+            "A tower is a tall, narrow building or structure, often used for observation or communication purposes."
+        ]
+    },
+    {
+        "name": "truck",
+        "trans": [
+            "A truck is a large motor vehicle used for transporting goods or materials."
+        ]
+    },
+    {
+        "name": "witness",
+        "trans": [
+            "A witness is a person who sees or hears something and can provide evidence or testimony about it."
+        ]
+    },
+    {
+        "name": "a",
+        "trans": [
+            "A is the first letter of the English alphabet and is used as an indefinite article before a singular noun."
+        ]
+    },
+    {
+        "name": "you",
+        "trans": [
+            "You is a pronoun used to refer to the person or people being addressed."
+        ]
+    },
+    {
+        "name": "it",
+        "trans": [
+            "It is a pronoun used to refer to a thing or animal previously mentioned or easily identifiable from the context."
+        ]
+    },
+    {
+        "name": "can",
+        "trans": [
+            "Can is a modal verb used to express ability or possibility."
+        ]
+    },
+    {
+        "name": "will",
+        "trans": [
+            "Will is a modal verb used to express future actions or intentions."
+        ]
+    },
+    {
+        "name": "if",
+        "trans": [
+            "If is a conjunction used to introduce a condition or hypothetical situation."
+        ]
+    },
+    {
+        "name": "one",
+        "trans": [
+            "One is a number that comes after zero and before two, or a pronoun used to refer to a person or thing in general."
+        ]
+    },
+    {
+        "name": "many",
+        "trans": [
+            "Many means a large number of something."
+        ]
+    },
+    {
+        "name": "most",
+        "trans": [
+            "Most means the majority or the greatest amount of something."
+        ]
+    },
+    {
+        "name": "other",
+        "trans": [
+            "Other refers to a different thing or things from the one already mentioned or known."
+        ]
+    },
+    {
+        "name": "use",
+        "trans": [
+            "To use means to employ or utilize something for a particular purpose."
+        ]
+    },
+    {
+        "name": "make",
+        "trans": [
+            "To make means to create or construct something."
+        ]
+    },
+    {
+        "name": "good",
+        "trans": [
+            "Good means of high quality or satisfactory standard."
+        ]
+    },
+    {
+        "name": "look",
+        "trans": [
+            "To look means to direct your eyes towards something to see or observe it."
+        ]
+    },
+    {
+        "name": "help",
+        "trans": [
+            "To help means to assist or give support to someone."
+        ]
+    },
+    {
+        "name": "go",
+        "trans": [
+            "To go means to move from one place to another."
+        ]
+    },
+    {
+        "name": "great",
+        "trans": [
+            "Great means very good or excellent."
+        ]
+    },
+    {
+        "name": "being",
+        "trans": [
+            "Being refers to the existence or presence of something or someone."
+        ]
+    },
+    {
+        "name": "few",
+        "trans": [
+            "Few means a small number of something."
+        ]
+    },
+    {
+        "name": "might",
+        "trans": [
+            "Might means to express possibility or permission."
+        ]
+    },
+    {
+        "name": "still",
+        "trans": [
+            "Still means to remain in the same position or state without changing."
+        ]
+    },
+    {
+        "name": "public",
+        "trans": [
+            "Public refers to something that is open and accessible to everyone."
+        ]
+    },
+    {
+        "name": "read",
+        "trans": [
+            "To read means to look at and comprehend the meaning of written or printed matter by interpreting the characters or symbols."
+        ]
+    },
+    {
+        "name": "keep",
+        "trans": [
+            "To keep means to hold or retain something in one's possession or control."
+        ]
+    },
+    {
+        "name": "start",
+        "trans": [
+            "To start means to begin or initiate something."
+        ]
+    },
+    {
+        "name": "give",
+        "trans": [
+            "To give means to transfer the possession of something to someone else as a gift or payment."
+        ]
+    },
+    {
+        "name": "human",
+        "trans": [
+            "Human refers to a person or a member of the Homo sapiens species."
+        ]
+    },
+    {
+        "name": "local",
+        "trans": [
+            "Local refers to something that is nearby or from a particular place or region."
+        ]
+    },
+    {
+        "name": "general",
+        "trans": [
+            "General refers to something that is widespread or applicable to a wide range of people or situations."
+        ]
+    },
+    {
+        "name": "she",
+        "trans": [
+            "She refers to a female person or animal."
+        ]
+    },
+    {
+        "name": "specific",
+        "trans": [
+            "Specific refers to something that is precise, clear, and well-defined."
+        ]
+    },
+    {
+        "name": "long",
+        "trans": [
+            "Long refers to something that is of a great distance or duration in time."
+        ]
+    },
+    {
+        "name": "play",
+        "trans": [
+            "To play is to engage in an activity for enjoyment or competition."
+        ]
+    },
+    {
+        "name": "feel",
+        "trans": [
+            "To feel is to have a perception of something through touch or emotions."
+        ]
+    },
+    {
+        "name": "high",
+        "trans": [
+            "High refers to being far up or having an intense feeling, often related to drugs."
+        ]
+    },
+    {
+        "name": "tonight",
+        "trans": [
+            "Tonight refers to the present or coming evening."
+        ]
+    },
+    {
+        "name": "put",
+        "trans": [
+            "To put is to place something in a particular position or location."
+        ]
+    },
+    {
+        "name": "common",
+        "trans": [
+            "Common means something that is frequent or shared by many."
+        ]
+    },
+    {
+        "name": "set",
+        "trans": [
+            "Set refers to a collection of objects or things that belong together."
+        ]
+    },
+    {
+        "name": "change",
+        "trans": [
+            "Change refers to the act of making something different."
+        ]
+    },
+    {
+        "name": "simple",
+        "trans": [
+            "Simple means something that is easy to understand or do."
+        ]
+    },
+    {
+        "name": "past",
+        "trans": [
+            "Past refers to a time that has already happened."
+        ]
+    },
+    {
+        "name": "big",
+        "trans": [
+            "Big means something that is large in size or significant."
+        ]
+    },
+    {
+        "name": "possible",
+        "trans": [
+            "Possible means something that can be done or achieved."
+        ]
+    },
+    {
+        "name": "particular",
+        "trans": [
+            "Particular means something that is specific or unique."
+        ]
+    },
+    {
+        "name": "today",
+        "trans": [
+            "Today refers to the present day."
+        ]
+    },
+    {
+        "name": "major",
+        "trans": [
+            "Major means something that is significant or important."
+        ]
+    },
+    {
+        "name": "personal",
+        "trans": [
+            "Personal means something that is related to oneself or individual."
+        ]
+    },
+    {
+        "name": "current",
+        "trans": [
+            "Current means something that is happening or existing now."
+        ]
+    },
+    {
+        "name": "national",
+        "trans": [
+            "National means something that is related to a country or its people."
+        ]
+    },
+    {
+        "name": "cut",
+        "trans": [
+            "Cut refers to the act of separating or removing something using a sharp tool or object."
+        ]
+    },
+    {
+        "name": "natural",
+        "trans": [
+            "Natural means something that occurs in nature or is not man-made."
+        ]
+    },
+    {
+        "name": "physical",
+        "trans": [
+            "Physical means something that is related to the body or physical world."
+        ]
+    },
+    {
+        "name": "show",
+        "trans": [
+            "Show refers to an event or performance that is intended to be watched or seen."
+        ]
+    },
+    {
+        "name": "try",
+        "trans": [
+            "Try means to attempt to do or achieve something."
+        ]
+    },
+    {
+        "name": "check",
+        "trans": [
+            "Check means to inspect or examine something for accuracy or completeness."
+        ]
+    },
+    {
+        "name": "second",
+        "trans": [
+            "Second refers to the unit of time equal to one-sixtieth of a minute."
+        ]
+    },
+    {
+        "name": "call",
+        "trans": [
+            "To call is to use your voice to get someone's attention or to speak to someone over the phone."
+        ]
+    },
+    {
+        "name": "move",
+        "trans": [
+            "To move is to change the position or place of something or someone."
+        ]
+    },
+    {
+        "name": "pay",
+        "trans": [
+            "To pay is to give someone money in exchange for something."
+        ]
+    },
+    {
+        "name": "let",
+        "trans": [
+            "To let is to allow someone to do something or to rent a property to someone."
+        ]
+    },
+    {
+        "name": "increase",
+        "trans": [
+            "To increase is to make something bigger or more in amount."
+        ]
+    },
+    {
+        "name": "single",
+        "trans": [
+            "Single means one and not more than one."
+        ]
+    },
+    {
+        "name": "individual",
+        "trans": [
+            "Individual refers to a single person or thing."
+        ]
+    },
+    {
+        "name": "turn",
+        "trans": [
+            "To turn is to change the direction or position of something."
+        ]
+    },
+    {
+        "name": "ask",
+        "trans": [
+            "To ask is to request information or to invite someone to do something."
+        ]
+    },
+    {
+        "name": "buy",
+        "trans": [
+            "To buy is to exchange money for a product or service."
+        ]
+    },
+    {
+        "name": "guard",
+        "trans": [
+            "A guard is a person who protects someone or something."
+        ]
+    },
+    {
+        "name": "hold",
+        "trans": [
+            "To hold is to have or keep something in your hands or arms."
+        ]
+    },
+    {
+        "name": "main",
+        "trans": [
+            "Main refers to the most important or central part of something."
+        ]
+    },
+    {
+        "name": "offer",
+        "trans": [
+            "To offer is to give someone the opportunity to accept or take something."
+        ]
+    },
+    {
+        "name": "potential",
+        "trans": [
+            "Potential means having the ability to become something in the future."
+        ]
+    },
+    {
+        "name": "professional",
+        "trans": [
+            "Professional refers to someone who is skilled or trained in a particular job or activity."
+        ]
+    },
+    {
+        "name": "international",
+        "trans": [
+            "International refers to something that involves different countries or people from different countries."
+        ]
+    },
+    {
+        "name": "travel",
+        "trans": [
+            "To travel is to go from one place to another, usually over a distance."
+        ]
+    },
+    {
+        "name": "cook",
+        "trans": [
+            "To cook is to prepare food by heating it."
+        ]
+    },
+    {
+        "name": "alternative",
+        "trans": [
+            "Alternative refers to a choice or option that is different from the usual or mainstream."
+        ]
+    },
+    {
+        "name": "following",
+        "trans": [
+            "Following means happening or coming after something else."
+        ]
+    },
+    {
+        "name": "special",
+        "trans": [
+            "Special refers to something that is different or unique and is not like other things."
+        ]
+    },
+    {
+        "name": "working",
+        "trans": [
+            "Working refers to the act of doing a job or performing a task."
+        ]
+    },
+    {
+        "name": "whole",
+        "trans": [
+            "Whole means complete or not divided or broken."
+        ]
+    },
+    {
+        "name": "dance",
+        "trans": [
+            "To dance is to move your body rhythmically to music."
+        ]
+    },
+    {
+        "name": "excuse",
+        "trans": [
+            "To excuse is to forgive someone for doing something wrong or to offer a reason for why something happened."
+        ]
+    },
+    {
+        "name": "cold",
+        "trans": [
+            "Cold is a low temperature, often felt as uncomfortable or unpleasant."
+        ]
+    },
+    {
+        "name": "commercial",
+        "trans": [
+            "Commercial refers to something that is related to business or is done for profit."
+        ]
+    },
+    {
+        "name": "low",
+        "trans": [
+            "Low refers to something that is not high or tall, or something that is not expensive or important."
+        ]
+    },
+    {
+        "name": "purchase",
+        "trans": [
+            "To purchase is to buy something by paying money for it."
+        ]
+    },
+    {
+        "name": "deal",
+        "trans": [
+            "A deal is an agreement or a transaction between two or more parties."
+        ]
+    },
+    {
+        "name": "primary",
+        "trans": [
+            "Primary refers to something that is the most important or fundamental."
+        ]
+    },
+    {
+        "name": "worth",
+        "trans": [
+            "Worth refers to the value or usefulness of something, often measured in money."
+        ]
+    },
+    {
+        "name": "fall",
+        "trans": [
+            "Fall refers to the season between summer and winter, or the act of dropping or descending from a higher place."
+        ]
+    },
+    {
+        "name": "necessary",
+        "trans": [
+            "Necessary refers to something that is needed or required, or something that is essential."
+        ]
+    },
+    {
+        "name": "positive",
+        "trans": [
+            "Positive refers to something that is good or beneficial, or someone who has an optimistic outlook."
+        ]
+    },
+    {
+        "name": "produce",
+        "trans": [
+            "To produce is to create or make something, often in a manufacturing or agricultural context."
+        ]
+    },
+    {
+        "name": "search",
+        "trans": [
+            "To search is to look for something or someone, often with the intent of finding them."
+        ]
+    },
+    {
+        "name": "present",
+        "trans": [
+            "Present refers to the current time or the act of giving something to someone, often as a gift or award."
+        ]
+    },
+    {
+        "name": "spend",
+        "trans": [
+            "To spend is to use money to buy something or to use time doing something."
+        ]
+    },
+    {
+        "name": "talk",
+        "trans": [
+            "Talk refers to the act of speaking or conversing with someone."
+        ]
+    },
+    {
+        "name": "creative",
+        "trans": [
+            "Creative refers to something that is imaginative or original, or someone who is skilled at producing artistic work."
+        ]
+    },
+    {
+        "name": "tell",
+        "trans": [
+            "To tell is to communicate information or a story to someone."
+        ]
+    },
+    {
+        "name": "cost",
+        "trans": [
+            "Cost refers to the amount of money that is required to purchase or produce something."
+        ]
+    },
+    {
+        "name": "drive",
+        "trans": [
+            "To drive is to operate a vehicle or to motivate or push oneself or others to achieve a goal."
+        ]
+    },
+    {
+        "name": "green",
+        "trans": [
+            "Green refers to the color of grass or leaves, or something that is environmentally friendly."
+        ]
+    },
+    {
+        "name": "support",
+        "trans": [
+            "To support is to help or assist someone or something, often by providing resources or encouragement."
+        ]
+    },
+    {
+        "name": "glad",
+        "trans": [
+            "Glad refers to a feeling of happiness or satisfaction."
+        ]
+    },
+    {
+        "name": "remove",
+        "trans": [
+            "To remove is to take something away or to eliminate or get rid of something."
+        ]
+    },
+    {
+        "name": "return",
+        "trans": [
+            "To return is to go back to a previous place or condition, or to give something back to its original owner."
+        ]
+    },
+    {
+        "name": "run",
+        "trans": [
+            "To run is to move quickly on foot."
+        ]
+    },
+    {
+        "name": "complex",
+        "trans": [
+            "Complex means something that is made up of many interconnected parts or elements."
+        ]
+    },
+    {
+        "name": "due",
+        "trans": [
+            "Due means something that is expected to happen or owed to someone or something."
+        ]
+    },
+    {
+        "name": "effective",
+        "trans": [
+            "Effective means something that is successful in producing the desired result."
+        ]
+    },
+    {
+        "name": "middle",
+        "trans": [
+            "Middle refers to the central point or position between two things."
+        ]
+    },
+    {
+        "name": "regular",
+        "trans": [
+            "Regular means something that happens or occurs frequently or at the same intervals."
+        ]
+    },
+    {
+        "name": "reserve",
+        "trans": [
+            "Reserve means to set something aside or keep something for future use or purpose."
+        ]
+    },
+    {
+        "name": "independent",
+        "trans": [
+            "Independent means something that is free from the control or influence of others."
+        ]
+    },
+    {
+        "name": "leave",
+        "trans": [
+            "To leave is to go away from a place or to stop doing something."
+        ]
+    },
+    {
+        "name": "original",
+        "trans": [
+            "Original means something that is the first or earliest form of something."
+        ]
+    },
+    {
+        "name": "reach",
+        "trans": [
+            "To reach is to arrive at a particular place or to make contact with something."
+        ]
+    },
+    {
+        "name": "rest",
+        "trans": [
+            "Rest means to relax or take a break from activity."
+        ]
+    },
+    {
+        "name": "serve",
+        "trans": [
+            "To serve is to provide a service or perform a duty for someone or something."
+        ]
+    },
+    {
+        "name": "watch",
+        "trans": [
+            "To watch is to observe or pay attention to something."
+        ]
+    },
+    {
+        "name": "beautiful",
+        "trans": [
+            "Beautiful means something that is pleasing to the senses or aesthetically pleasing."
+        ]
+    },
+    {
+        "name": "charge",
+        "trans": [
+            "To charge means to demand payment or to entrust someone with a responsibility."
+        ]
+    },
+    {
+        "name": "active",
+        "trans": [
+            "Active means something that is involved in ongoing action or movement."
+        ]
+    },
+    {
+        "name": "break",
+        "trans": [
+            "To break is to separate something into pieces or to stop working properly."
+        ]
+    },
+    {
+        "name": "negative",
+        "trans": [
+            "Negative means something that is unfavorable or not constructive."
+        ]
+    },
+    {
+        "name": "safe",
+        "trans": [
+            "Safe means something that is free from danger or harm."
+        ]
+    },
+    {
+        "name": "stay",
+        "trans": [
+            "To stay is to remain in a particular place or to continue in a particular state or condition."
+        ]
+    },
+    {
+        "name": "visit",
+        "trans": [
+            "To visit is to go to a place to see someone or something."
+        ]
+    },
+    {
+        "name": "visual",
+        "trans": [
+            "Visual means something that is related to seeing or visual perception."
+        ]
+    },
+    {
+        "name": "affect",
+        "trans": [
+            "To affect means to have an influence on or to produce a change in something."
+        ]
+    },
+    {
+        "name": "cover",
+        "trans": [
+            "To cover is to place something over or around something else to conceal or protect it."
+        ]
+    },
+    {
+        "name": "report",
+        "trans": [
+            "A report is a written or spoken description of something, often giving information about an event or situation."
+        ]
+    },
+    {
+        "name": "rise",
+        "trans": [
+            "To rise is to move upward from a lower position or to increase in amount or number."
+        ]
+    },
+    {
+        "name": "walk",
+        "trans": [
+            "To walk is to move forward by putting one foot in front of the other."
+        ]
+    },
+    {
+        "name": "white",
+        "trans": [
+            "White is the color of snow, milk, or chalk, and is the opposite of black."
+        ]
+    },
+    {
+        "name": "beyond",
+        "trans": [
+            "Beyond means further away in distance or time, or in a more advanced state or stage."
+        ]
+    },
+    {
+        "name": "junior",
+        "trans": [
+            "Junior is used to describe someone who is younger or less experienced than someone else in the same profession or organization."
+        ]
+    },
+    {
+        "name": "pick",
+        "trans": [
+            "To pick is to choose something or someone from a group of options."
+        ]
+    },
+    {
+        "name": "unique",
+        "trans": [
+            "Unique means being the only one of its kind, unlike anything else."
+        ]
+    },
+    {
+        "name": "anything",
+        "trans": [
+            "Anything means any thing or object, no matter what it is."
+        ]
+    },
+    {
+        "name": "classic",
+        "trans": [
+            "Classic refers to something of lasting value or traditional style, often used to describe a piece of art or literature."
+        ]
+    },
+    {
+        "name": "final",
+        "trans": [
+            "Final means being the last in a series, or the concluding part of something."
+        ]
+    },
+    {
+        "name": "lift",
+        "trans": [
+            "To lift is to move something upward or to raise something to a higher position."
+        ]
+    },
+    {
+        "name": "mix",
+        "trans": [
+            "To mix is to combine two or more substances together to form a new mixture."
+        ]
+    },
+    {
+        "name": "private",
+        "trans": [
+            "Private means belonging to or for the use of one particular person or group, not for public or general use."
+        ]
+    },
+    {
+        "name": "stop",
+        "trans": [
+            "To stop is to cease movement or action."
+        ]
+    },
+    {
+        "name": "teach",
+        "trans": [
+            "To teach is to impart knowledge or skills to someone through instruction or example."
+        ]
+    },
+    {
+        "name": "western",
+        "trans": [
+            "Western refers to something related to the Western Hemisphere, or the customs and culture of the American West."
+        ]
+    },
+    {
+        "name": "concern",
+        "trans": [
+            "Concern means to be worried or anxious about something."
+        ]
+    },
+    {
+        "name": "familiar",
+        "trans": [
+            "Familiar means well-known or easily recognized, often because of being seen or experienced before."
+        ]
+    },
+    {
+        "name": "fly",
+        "trans": [
+            "To fly is to travel through the air by means of wings or an aircraft."
+        ]
+    },
+    {
+        "name": "official",
+        "trans": [
+            "Official means being authorized or approved by a person or organization in a position of authority."
+        ]
+    },
+    {
+        "name": "broad",
+        "trans": [
+            "Broad means wide in extent or scope, or including a wide variety of things."
+        ]
+    },
+    {
+        "name": "comfortable",
+        "trans": [
+            "Comfortable means providing physical or psychological ease and relaxation."
+        ]
+    },
+    {
+        "name": "gain",
+        "trans": [
+            "To gain is to obtain or acquire something, often through effort or hard work."
+        ]
+    },
+    {
+        "name": "maybe",
+        "trans": [
+            "Maybe means perhaps, possibly or it could be."
+        ]
+    },
+    {
+        "name": "rich",
+        "trans": [
+            "Rich means having a lot of money or valuable possessions."
+        ]
+    },
+    {
+        "name": "save",
+        "trans": [
+            "To save means to keep something for future use or to rescue someone or something from harm."
+        ]
+    },
+    {
+        "name": "stand",
+        "trans": [
+            "To stand means to be upright on your feet or to take a position or viewpoint."
+        ]
+    },
+    {
+        "name": "young",
+        "trans": [
+            "Young means being in the early stage of life or growth or having little experience."
+        ]
+    },
+    {
+        "name": "fail",
+        "trans": [
+            "To fail means to be unsuccessful in doing something or to not meet expectations."
+        ]
+    },
+    {
+        "name": "heavy",
+        "trans": [
+            "Heavy means having a lot of weight or being difficult to lift or move."
+        ]
+    },
+    {
+        "name": "hello",
+        "trans": [
+            "Hello is a greeting used when you meet or speak to someone."
+        ]
+    },
+    {
+        "name": "lead",
+        "trans": [
+            "To lead means to guide or direct a group of people or to be in charge of something."
+        ]
+    },
+    {
+        "name": "listen",
+        "trans": [
+            "To listen means to pay attention to someone or something that is speaking or making a sound."
+        ]
+    },
+    {
+        "name": "valuable",
+        "trans": [
+            "Valuable means having a high worth in money or being very useful or important."
+        ]
+    },
+    {
+        "name": "worry",
+        "trans": [
+            "To worry means to feel anxious or concerned about something or someone."
+        ]
+    },
+    {
+        "name": "handle",
+        "trans": [
+            "To handle means to manage or deal with something or to hold or touch something with your hands."
+        ]
+    },
+    {
+        "name": "leading",
+        "trans": [
+            "Leading means being in the front or having the most important position or influence."
+        ]
+    },
+    {
+        "name": "meet",
+        "trans": [
+            "To meet means to come together or be introduced to someone for the first time."
+        ]
+    },
+    {
+        "name": "release",
+        "trans": [
+            "To release means to set something free or to make something available to the public."
+        ]
+    },
+    {
+        "name": "sell",
+        "trans": [
+            "To sell means to exchange something for money or to convince someone to buy something."
+        ]
+    },
+    {
+        "name": "finish",
+        "trans": [
+            "To finish means to complete or bring something to an end."
+        ]
+    },
+    {
+        "name": "normal",
+        "trans": [
+            "Normal means being typical or expected or not having any significant deviations."
+        ]
+    },
+    {
+        "name": "press",
+        "trans": [
+            "To press means to apply force or pressure to something or to urge someone to do something."
+        ]
+    },
+    {
+        "name": "ride",
+        "trans": [
+            "To ride means to travel on something, such as a vehicle or animal, by sitting on it."
+        ]
+    },
+    {
+        "name": "secret",
+        "trans": [
+            "Secret means being kept hidden or not known by others or having confidential information."
+        ]
+    },
+    {
+        "name": "spread",
+        "trans": [
+            "To spread means to make something cover a larger area or to distribute something over a surface."
+        ]
+    },
+    {
+        "name": "spring",
+        "trans": [
+            "Spring means the season between winter and summer or a coil or elastic object that can be stretched and then returns to its original shape."
+        ]
+    },
+    {
+        "name": "tough",
+        "trans": [
+            "Tough means difficult or strong or able to withstand hardship or pain."
+        ]
+    },
+    {
+        "name": "wait",
+        "trans": [
+            "To wait means to stay in one place until something happens or someone arrives."
+        ]
+    },
+    {
+        "name": "brown",
+        "trans": [
+            "Brown is a color that is darker than yellow or beige."
+        ]
+    },
+    {
+        "name": "deep",
+        "trans": [
+            "Deep means going far down or being far from the surface."
+        ]
+    },
+    {
+        "name": "display",
+        "trans": [
+            "To display is to show something for others to see."
+        ]
+    },
+    {
+        "name": "flow",
+        "trans": [
+            "Flow is the movement of a liquid or gas."
+        ]
+    },
+    {
+        "name": "hit",
+        "trans": [
+            "To hit is to strike something with force."
+        ]
+    },
+    {
+        "name": "objective",
+        "trans": [
+            "An objective is a goal or purpose."
+        ]
+    },
+    {
+        "name": "shoot",
+        "trans": [
+            "To shoot is to fire a weapon or take a photograph."
+        ]
+    },
+    {
+        "name": "touch",
+        "trans": [
+            "To touch is to come into contact with something."
+        ]
+    },
+    {
+        "name": "cancel",
+        "trans": [
+            "To cancel is to stop or annul something."
+        ]
+    },
+    {
+        "name": "chemical",
+        "trans": [
+            "A chemical is a substance made up of different molecules."
+        ]
+    },
+    {
+        "name": "cry",
+        "trans": [
+            "To cry is to shed tears as an emotional response."
+        ]
+    },
+    {
+        "name": "dump",
+        "trans": [
+            "To dump is to get rid of something in a careless way."
+        ]
+    },
+    {
+        "name": "extreme",
+        "trans": [
+            "Extreme means being very far from the usual or ordinary."
+        ]
+    },
+    {
+        "name": "push",
+        "trans": [
+            "To push is to apply force to move something away."
+        ]
+    },
+    {
+        "name": "conflict",
+        "trans": [
+            "A conflict is a disagreement or struggle between people or groups."
+        ]
+    },
+    {
+        "name": "eat",
+        "trans": [
+            "To eat is to consume food."
+        ]
+    },
+    {
+        "name": "fill",
+        "trans": [
+            "To fill is to put something into a space until it is full."
+        ]
+    },
+    {
+        "name": "formal",
+        "trans": [
+            "Formal means following established rules or customs."
+        ]
+    },
+    {
+        "name": "jump",
+        "trans": [
+            "To jump is to propel oneself upward by pushing off the ground."
+        ]
+    },
+    {
+        "name": "kick",
+        "trans": [
+            "To kick is to strike with the foot."
+        ]
+    },
+    {
+        "name": "opposite",
+        "trans": [
+            "Opposite means being completely different or contrary."
+        ]
+    },
+    {
+        "name": "pass",
+        "trans": [
+            "To pass is to move past or go beyond something."
+        ]
+    },
+    {
+        "name": "pitch",
+        "trans": [
+            "A pitch is a throw or toss of an object."
+        ]
+    },
+    {
+        "name": "remote",
+        "trans": [
+            "Remote means being far away or distant."
+        ]
+    },
+    {
+        "name": "total",
+        "trans": [
+            "Total means being the complete amount or sum."
+        ]
+    },
+    {
+        "name": "treat",
+        "trans": [
+            "To treat means to act a certain way towards someone or something, often in a kind or generous manner."
+        ]
+    },
+    {
+        "name": "vast",
+        "trans": [
+            "Vast means something that is very large in size or extent."
+        ]
+    },
+    {
+        "name": "abuse",
+        "trans": [
+            "Abuse means to use something or someone in a harmful or cruel way."
+        ]
+    },
+    {
+        "name": "beat",
+        "trans": [
+            "To beat means to strike repeatedly, usually with the intention of causing harm or injury."
+        ]
+    },
+    {
+        "name": "burn",
+        "trans": [
+            "To burn means to use fire or heat to destroy something."
+        ]
+    },
+    {
+        "name": "deposit",
+        "trans": [
+            "To deposit means to put something in a specific place or location."
+        ]
+    },
+    {
+        "name": "print",
+        "trans": [
+            "To print means to create a copy of something on paper or another material."
+        ]
+    },
+    {
+        "name": "raise",
+        "trans": [
+            "To raise means to lift or elevate something to a higher position."
+        ]
+    },
+    {
+        "name": "sleep",
+        "trans": [
+            "To sleep means to rest and be in a state of unconsciousness for a period of time."
+        ]
+    },
+    {
+        "name": "somewhere",
+        "trans": [
+            "Somewhere refers to a place that is not specified or known."
+        ]
+    },
+    {
+        "name": "advance",
+        "trans": [
+            "To advance means to move forward or progress in some way."
+        ]
+    },
+    {
+        "name": "anywhere",
+        "trans": [
+            "Anywhere refers to any place at all, without being specific."
+        ]
+    },
+    {
+        "name": "consist",
+        "trans": [
+            "To consist means to be composed or made up of certain elements or parts."
+        ]
+    },
+    {
+        "name": "dark",
+        "trans": [
+            "Dark refers to the absence or very low level of light."
+        ]
+    },
+    {
+        "name": "double",
+        "trans": [
+            "Double means two times the amount or quantity of something."
+        ]
+    },
+    {
+        "name": "draw",
+        "trans": [
+            "To draw means to make a picture or image by using a pen, pencil, or other instrument."
+        ]
+    },
+    {
+        "name": "equal",
+        "trans": [
+            "Equal means to have the same value, amount, or worth as something else."
+        ]
+    },
+    {
+        "name": "fix",
+        "trans": [
+            "To fix means to repair or make something work properly again."
+        ]
+    },
+    {
+        "name": "hire",
+        "trans": [
+            "To hire means to employ or bring someone on to do a job or task."
+        ]
+    },
+    {
+        "name": "internal",
+        "trans": [
+            "Internal refers to something that is located or exists inside of something else."
+        ]
+    },
+    {
+        "name": "join",
+        "trans": [
+            "To join means to connect or link two or more things together."
+        ]
+    },
+    {
+        "name": "kill",
+        "trans": [
+            "To kill means to cause the death of something or someone."
+        ]
+    },
+    {
+        "name": "sensitive",
+        "trans": [
+            "Sensitive means easily affected or influenced by external factors."
+        ]
+    },
+    {
+        "name": "tap",
+        "trans": [
+            "To tap means to hit lightly or gently, often to make a sound or get someone's attention."
+        ]
+    },
+    {
+        "name": "win",
+        "trans": [
+            "To win means to achieve victory or success in a competition or contest."
+        ]
+    },
+    {
+        "name": "attack",
+        "trans": [
+            "To attack is to try to hurt or harm someone or something."
+        ]
+    },
+    {
+        "name": "claim",
+        "trans": [
+            "To claim is to say something is true or belongs to you."
+        ]
+    },
+    {
+        "name": "constant",
+        "trans": [
+            "Constant means something that doesn't change or stays the same."
+        ]
+    },
+    {
+        "name": "drag",
+        "trans": [
+            "To drag is to pull something along the ground."
+        ]
+    },
+    {
+        "name": "drink",
+        "trans": [
+            "A drink is something you consume that is liquid."
+        ]
+    },
+    {
+        "name": "guess",
+        "trans": [
+            "To guess is to try to figure out an answer or solution without knowing for sure."
+        ]
+    },
+    {
+        "name": "minor",
+        "trans": [
+            "Minor means something that is not important or not serious."
+        ]
+    },
+    {
+        "name": "pull",
+        "trans": [
+            "To pull is to use force to move something towards you."
+        ]
+    },
+    {
+        "name": "raw",
+        "trans": [
+            "Raw means something that is not cooked or processed."
+        ]
+    },
+    {
+        "name": "soft",
+        "trans": [
+            "Soft means something that is not hard or firm and can be easily pressed."
+        ]
+    },
+    {
+        "name": "solid",
+        "trans": [
+            "Solid means something that is not liquid or gas and has a fixed shape."
+        ]
+    },
+    {
+        "name": "wear",
+        "trans": [
+            "To wear is to have something on your body as clothing or accessory."
+        ]
+    },
+    {
+        "name": "weird",
+        "trans": [
+            "Weird means something that is strange or unusual."
+        ]
+    },
+    {
+        "name": "wonder",
+        "trans": [
+            "To wonder is to think about something or be curious about it."
+        ]
+    },
+    {
+        "name": "annual",
+        "trans": [
+            "Annual means something that happens once a year."
+        ]
+    },
+    {
+        "name": "count",
+        "trans": [
+            "To count is to find out how many of something there are."
+        ]
+    },
+    {
+        "name": "dead",
+        "trans": [
+            "Dead means something or someone that is no longer alive."
+        ]
+    },
+    {
+        "name": "doubt",
+        "trans": [
+            "Doubt means to be uncertain or not believe something."
+        ]
+    },
+    {
+        "name": "feed",
+        "trans": [
+            "To feed is to give food to someone or something."
+        ]
+    },
+    {
+        "name": "forever",
+        "trans": [
+            "Forever means something that never ends or lasts for all time."
+        ]
+    },
+    {
+        "name": "impress",
+        "trans": [
+            "To impress is to make someone feel admiration or respect."
+        ]
+    },
+    {
+        "name": "nobody",
+        "trans": [
+            "Nobody means no one or not anyone."
+        ]
+    },
+    {
+        "name": "repeat",
+        "trans": [
+            "To repeat is to do something again."
+        ]
+    },
+    {
+        "name": "round",
+        "trans": [
+            "Round means something that is circular or curved."
+        ]
+    },
+    {
+        "name": "sing",
+        "trans": [
+            "To sing is to make music with your voice."
+        ]
+    },
+    {
+        "name": "slide",
+        "trans": [
+            "A slide is a smooth, sloping surface or chute that is used for gliding or descending."
+        ]
+    },
+    {
+        "name": "strip",
+        "trans": [
+            "A strip is a long, narrow piece of material or land, often used for decoration or as a strip of film in a movie."
+        ]
+    },
+    {
+        "name": "whereas",
+        "trans": [
+            "Whereas is a conjunction used to introduce a contrasting or opposing clause or phrase."
+        ]
+    },
+    {
+        "name": "wish",
+        "trans": [
+            "A wish is a desire or hope for something to happen or be true."
+        ]
+    },
+    {
+        "name": "combine",
+        "trans": [
+            "To combine is to join or mix two or more things together to form a single entity."
+        ]
+    },
+    {
+        "name": "command",
+        "trans": [
+            "A command is an order given to someone or something to do something."
+        ]
+    },
+    {
+        "name": "dig",
+        "trans": [
+            "To dig is to break up and move earth, sand, or other material using a tool, or to search or investigate in a determined way."
+        ]
+    },
+    {
+        "name": "divide",
+        "trans": [
+            "To divide is to separate into two or more parts or groups."
+        ]
+    },
+    {
+        "name": "equivalent",
+        "trans": [
+            "An equivalent is something that has the same value, amount, or meaning as something else."
+        ]
+    },
+    {
+        "name": "hang",
+        "trans": [
+            "To hang is to suspend or attach something from above, or to be suspended from above."
+        ]
+    },
+    {
+        "name": "hunt",
+        "trans": [
+            "To hunt is to search for or pursue game or other wild animals for food, sport, or profit."
+        ]
+    },
+    {
+        "name": "initial",
+        "trans": [
+            "An initial is the first letter of a word or name, or the first stage of a process."
+        ]
+    },
+    {
+        "name": "march",
+        "trans": [
+            "To march is to walk steadily and rhythmically, especially in a group, typically as part of a military or protest demonstration."
+        ]
+    },
+    {
+        "name": "mention",
+        "trans": [
+            "To mention is to refer to or briefly speak about something or someone."
+        ]
+    },
+    {
+        "name": "smell",
+        "trans": [
+            "A smell is a distinctive odor or fragrance that can be perceived by the nose."
+        ]
+    },
+    {
+        "name": "spiritual",
+        "trans": [
+            "Spiritual refers to matters of the spirit or soul, rather than material or physical things."
+        ]
+    },
+    {
+        "name": "survey",
+        "trans": [
+            "A survey is an investigation or study of something in order to gather information or data."
+        ]
+    },
+    {
+        "name": "tie",
+        "trans": [
+            "A tie is a long, narrow piece of fabric that is worn around the neck and tied in a knot."
+        ]
+    },
+    {
+        "name": "adult",
+        "trans": [
+            "An adult is a fully grown person who has reached the age of maturity."
+        ]
+    },
+    {
+        "name": "brief",
+        "trans": [
+            "Brief means of short duration or duration or short in length, or a concise summary or statement."
+        ]
+    },
+    {
+        "name": "crazy",
+        "trans": [
+            "Crazy means mentally deranged or extremely foolish or bizarre."
+        ]
+    },
+    {
+        "name": "escape",
+        "trans": [
+            "An escape is an act of breaking free from confinement or danger."
+        ]
+    },
+    {
+        "name": "gather",
+        "trans": [
+            "To gather is to bring together, collect, or assemble in one place or group."
+        ]
+    },
+    {
+        "name": "hate",
+        "trans": [
+            "Hate is an intense feeling of dislike or animosity towards someone or something."
+        ]
+    },
+    {
+        "name": "prior",
+        "trans": [
+            "Prior means existing or occurring before in time, order, or importance."
+        ]
+    },
+    {
+        "name": "repair",
+        "trans": [
+            "Repair is the act of fixing something that is broken or damaged."
+        ]
+    },
+    {
+        "name": "rough",
+        "trans": [
+            "Rough refers to the surface or texture that is uneven, bumpy, or not smooth."
+        ]
+    },
+    {
+        "name": "sad",
+        "trans": [
+            "Sad is a feeling of unhappiness or sorrow."
+        ]
+    },
+    {
+        "name": "scratch",
+        "trans": [
+            "Scratch is a mark or wound on a surface caused by rubbing or scraping."
+        ]
+    },
+    {
+        "name": "sick",
+        "trans": [
+            "Sick is a state of physical or mental illness or discomfort."
+        ]
+    },
+    {
+        "name": "strike",
+        "trans": [
+            "Strike is a work stoppage caused by employees refusing to work until their demands are met."
+        ]
+    },
+    {
+        "name": "employ",
+        "trans": [
+            "Employ is to give someone a job or work."
+        ]
+    },
+    {
+        "name": "external",
+        "trans": [
+            "External refers to something that is outside or exterior to a particular thing or system."
+        ]
+    },
+    {
+        "name": "hurt",
+        "trans": [
+            "Hurt is the feeling of physical or emotional pain or discomfort."
+        ]
+    },
+    {
+        "name": "illegal",
+        "trans": [
+            "Illegal refers to something that is prohibited by law or rules."
+        ]
+    },
+    {
+        "name": "laugh",
+        "trans": [
+            "Laugh is a sound made by someone expressing amusement or joy."
+        ]
+    },
+    {
+        "name": "lay",
+        "trans": [
+            "Lay is to place something in a flat or horizontal position."
+        ]
+    },
+    {
+        "name": "mobile",
+        "trans": [
+            "Mobile is a device or vehicle that is capable of moving from one place to another."
+        ]
+    },
+    {
+        "name": "nasty",
+        "trans": [
+            "Nasty is something that is unpleasant or offensive."
+        ]
+    },
+    {
+        "name": "ordinary",
+        "trans": [
+            "Ordinary refers to something that is common or typical, without any special or distinctive features."
+        ]
+    },
+    {
+        "name": "respond",
+        "trans": [
+            "Respond is to reply or react to something."
+        ]
+    },
+    {
+        "name": "royal",
+        "trans": [
+            "Royal refers to something that is related to or associated with a king, queen, or royalty."
+        ]
+    },
+    {
+        "name": "senior",
+        "trans": [
+            "Senior is someone who is older or more experienced than others in a group or organization."
+        ]
+    },
+    {
+        "name": "split",
+        "trans": [
+            "Split is to divide something into two or more parts."
+        ]
+    },
+    {
+        "name": "strain",
+        "trans": [
+            "Strain is a physical or mental tension or pressure."
+        ]
+    },
+    {
+        "name": "struggle",
+        "trans": [
+            "Struggle is a difficult or challenging effort to achieve something."
+        ]
+    },
+    {
+        "name": "swim",
+        "trans": [
+            "Swim is the act of moving through water by using one's arms and legs."
+        ]
+    },
+    {
+        "name": "train",
+        "trans": [
+            "Train is a vehicle that runs on tracks and is used for transporting people or goods."
+        ]
+    },
+    {
+        "name": "upper",
+        "trans": [
+            "Upper refers to the higher part of something or the top half of the body."
+        ]
+    },
+    {
+        "name": "wash",
+        "trans": [
+            "Wash is the act of cleaning something with water and soap or detergent."
+        ]
+    },
+    {
+        "name": "yellow",
+        "trans": [
+            "Yellow is a bright color that is often associated with sunshine, happiness, and warmth."
+        ]
+    },
+    {
+        "name": "convert",
+        "trans": [
+            "Convert means to change or transform something into a different form or state."
+        ]
+    },
+    {
+        "name": "crash",
+        "trans": [
+            "A crash is a sudden and violent collision or impact between two objects, such as vehicles or airplanes."
+        ]
+    },
+    {
+        "name": "dependent",
+        "trans": [
+            "Dependent means relying on or being controlled by something or someone else."
+        ]
+    },
+    {
+        "name": "fold",
+        "trans": [
+            "Fold means to bend something, such as a piece of paper or fabric, so that one part covers another."
+        ]
+    },
+    {
+        "name": "funny",
+        "trans": [
+            "Funny means causing laughter or amusement; humorous."
+        ]
+    },
+    {
+        "name": "grab",
+        "trans": [
+            "Grab means to take hold of something quickly and forcefully."
+        ]
+    },
+    {
+        "name": "hide",
+        "trans": [
+            "Hide means to conceal or keep something out of sight."
+        ]
+    },
+    {
+        "name": "miss",
+        "trans": [
+            "Miss means to feel the absence or loss of someone or something that one has become accustomed to or fond of."
+        ]
+    },
+    {
+        "name": "permit",
+        "trans": [
+            "Permit means to allow or authorize someone to do something."
+        ]
+    },
+    {
+        "name": "quote",
+        "trans": [
+            "A quote is a statement or passage from a book, article, or speech that is used as evidence or support for an argument."
+        ]
+    },
+    {
+        "name": "recover",
+        "trans": [
+            "Recover means to regain something lost or taken away, such as health or possessions."
+        ]
+    },
+    {
+        "name": "resolve",
+        "trans": [
+            "Resolve means to settle or find a solution to a problem or dispute."
+        ]
+    },
+    {
+        "name": "roll",
+        "trans": [
+            "Roll means to move forward by turning over and over, such as a ball or a barrel."
+        ]
+    },
+    {
+        "name": "sink",
+        "trans": [
+            "Sink means to descend or fall downward, often into water or a hole."
+        ]
+    },
+    {
+        "name": "slip",
+        "trans": [
+            "Slip means to slide or lose one's footing on a surface, often accidentally."
+        ]
+    },
+    {
+        "name": "spare",
+        "trans": [
+            "Spare means to give or provide something extra or in addition to what is required."
+        ]
+    },
+    {
+        "name": "suspect",
+        "trans": [
+            "Suspect means to believe or have an idea that someone is involved in a crime or wrongdoing."
+        ]
+    },
+    {
+        "name": "sweet",
+        "trans": [
+            "Sweet means having a taste like sugar or honey, or having a pleasant or agreeable personality."
+        ]
+    },
+    {
+        "name": "swing",
+        "trans": [
+            "Swing means to move back and forth or from side to side in a rhythmic motion."
+        ]
+    },
+    {
+        "name": "twist",
+        "trans": [
+            "Twist means to turn or rotate something, often in a way that causes it to become distorted or spiral-shaped."
+        ]
+    },
+    {
+        "name": "upstairs",
+        "trans": [
+            "Upstairs refers to the upper level of a building or house."
+        ]
+    },
+    {
+        "name": "usual",
+        "trans": [
+            "Usual means normal or typical; what is expected or customary."
+        ]
+    },
+    {
+        "name": "abroad",
+        "trans": [
+            "Abroad means in or to a foreign country or countries."
+        ]
+    },
+    {
+        "name": "brave",
+        "trans": [
+            "Brave means showing courage or fearlessness in the face of danger or difficulty."
+        ]
+    },
+    {
+        "name": "calm",
+        "trans": [
+            "Calm refers to a state of peace and tranquility, free from agitation or disturbance."
+        ]
+    },
+    {
+        "name": "concentrate",
+        "trans": [
+            "Concentrate means to focus one's attention or effort on a particular task or objective."
+        ]
+    },
+    {
+        "name": "estimate",
+        "trans": [
+            "An estimate is a rough calculation or approximation of the value, quantity, or extent of something."
+        ]
+    },
+    {
+        "name": "grand",
+        "trans": [
+            "Grand refers to something of impressive size, extent, or importance, often associated with luxury and opulence."
+        ]
+    },
+    {
+        "name": "male",
+        "trans": [
+            "Male refers to a person or animal that is biologically characterized as having the reproductive organs typically associated with producing sperm."
+        ]
+    },
+    {
+        "name": "mine",
+        "trans": [
+            "Mine refers to a place where minerals or other valuable resources are extracted from the earth, or to something that belongs to the speaker."
+        ]
+    },
+    {
+        "name": "prompt",
+        "trans": [
+            "Prompt refers to a cue or stimulus that initiates an action or response, or to something that is done without delay or hesitation."
+        ]
+    },
+    {
+        "name": "quiet",
+        "trans": [
+            "Quiet refers to a state of low or minimal sound or noise, or to a peaceful and calm atmosphere."
+        ]
+    },
+    {
+        "name": "refuse",
+        "trans": [
+            "Refuse means to decline or reject something, often because it is not desirable or acceptable."
+        ]
+    },
+    {
+        "name": "regret",
+        "trans": [
+            "Regret refers to a feeling of sadness or disappointment about something that has happened or been done in the past."
+        ]
+    },
+    {
+        "name": "reveal",
+        "trans": [
+            "Reveal means to make something known or visible that was previously concealed or hidden."
+        ]
+    },
+    {
+        "name": "rush",
+        "trans": [
+            "Rush refers to a sudden, rapid movement or activity, often characterized by a sense of urgency or haste."
+        ]
+    },
+    {
+        "name": "shake",
+        "trans": [
+            "Shake refers to a rapid, back-and-forth movement, often involving the hands or body."
+        ]
+    },
+    {
+        "name": "shift",
+        "trans": [
+            "Shift refers to a change or adjustment in position, direction, or focus, often involving a movement or transfer from one thing to another."
+        ]
+    },
+    {
+        "name": "shine",
+        "trans": [
+            "Shine refers to a bright, glowing appearance or luster, often associated with the reflection of light."
+        ]
+    },
+    {
+        "name": "steal",
+        "trans": [
+            "Steal means to take something without permission or right, often in a surreptitious or illegal manner."
+        ]
+    },
+    {
+        "name": "suck",
+        "trans": [
+            "Suck means to draw in air or liquid through the mouth, often to consume or extract something."
+        ]
+    },
+    {
+        "name": "surround",
+        "trans": [
+            "Surround means to encircle or encompass something, often with the intention of confining or enclosing it."
+        ]
+    },
+    {
+        "name": "anybody",
+        "trans": [
+            "Anybody refers to any person, regardless of identity or specific characteristics."
+        ]
+    },
+    {
+        "name": "bear",
+        "trans": [
+            "Bear refers to a large, carnivorous mammal with shaggy fur and a distinctive hump on its back, or to endure or tolerate something difficult or unpleasant."
+        ]
+    },
+    {
+        "name": "brilliant",
+        "trans": [
+            "Brilliant refers to something that is exceptionally bright, vivid, or radiant, often associated with intelligence or talent."
+        ]
+    },
+    {
+        "name": "dare",
+        "trans": [
+            "Dare means to have the courage or audacity to do something, often in defiance of rules or social norms."
+        ]
+    },
+    {
+        "name": "dear",
+        "trans": [
+            "Dear refers to something that is loved or valued, often in an emotional or sentimental way."
+        ]
+    },
+    {
+        "name": "delay",
+        "trans": [
+            "Delay refers to a period of time during which something is postponed or held back, often due to circumstances beyond one's control."
+        ]
+    },
+    {
+        "name": "drunk",
+        "trans": [
+            "Drunk refers to a state of intoxication or inebriation resulting from the consumption of alcohol or other mind-altering substances."
+        ]
+    },
+    {
+        "name": "female",
+        "trans": [
+            "Female refers to the sex or gender associated with having the reproductive organs and characteristics typically associated with producing eggs, bearing offspring, and nurturing young in mammals and some other animals."
+        ]
+    },
+    {
+        "name": "hurry",
+        "trans": [
+            "Hurry means to move or act quickly, often due to a sense of urgency or time constraint."
+        ]
+    },
+    {
+        "name": "inevitable",
+        "trans": [
+            "Inevitable refers to something that is bound to happen or cannot be avoided, regardless of any efforts to prevent it."
+        ]
+    },
+    {
+        "name": "invite",
+        "trans": [
+            "Invite means to request or ask someone to come or join a particular event, gathering, or activity."
+        ]
+    },
+    {
+        "name": "kiss",
+        "trans": [
+            "Kiss refers to an act of touching or pressing one's lips against another person or object, often as a sign of affection, love, or respect."
+        ]
+    },
+    {
+        "name": "neat",
+        "trans": [
+            "Neat refers to something that is tidy, orderly, or well-organized, often with a sense of simplicity and elegance."
+        ]
+    },
+    {
+        "name": "pop",
+        "trans": [
+            "Pop refers to a short, sharp sound or burst, often produced by something bursting or exploding."
+        ]
+    },
+    {
+        "name": "punch",
+        "trans": [
+            "Punch refers to a forceful hit or strike, often delivered with a closed fist."
+        ]
+    },
+    {
+        "name": "quit",
+        "trans": [
+            "Quit means to stop doing or using something, often voluntarily and permanently."
+        ]
+    },
+    {
+        "name": "reply",
+        "trans": [
+            "Reply means to respond to a message, question, or request, often with a verbal or written answer or reaction."
+        ]
+    },
+    {
+        "name": "representative",
+        "trans": [
+            "Representative refers to a person or thing that stands for or represents someone or something else, often in a formal or official capacity."
+        ]
+    },
+    {
+        "name": "resist",
+        "trans": [
+            "Resist means to oppose or refuse to comply with something, often due to a sense of disagreement, discomfort, or moral objection."
+        ]
+    },
+    {
+        "name": "rip",
+        "trans": [
+            "Rip means to tear or separate something forcefully or quickly, often resulting in damage or destruction."
+        ]
+    },
+    {
+        "name": "rub",
+        "trans": [
+            "Rub means to apply pressure or friction to something with one's hands or another object, often to clean, polish, or soothe."
+        ]
+    },
+    {
+        "name": "silly",
+        "trans": [
+            "Silly refers to something that is foolish, absurd, or nonsensical, often with a sense of humor or playfulness."
+        ]
+    },
+    {
+        "name": "smile",
+        "trans": [
+            "Smile refers to the expression of happiness, joy, or amusement, often characterized by the lifting of the corners of the mouth and the showing of teeth."
+        ]
+    },
+    {
+        "name": "spell",
+        "trans": [
+            "Spell refers to a series of letters or words that form a word, phrase, or sentence, often used for communication or writing."
+        ]
+    },
+    {
+        "name": "stretch",
+        "trans": [
+            "Stretch means to extend or elongate something, often with a sense of flexibility, tension, or reach."
+        ]
+    },
+    {
+        "name": "stupid",
+        "trans": [
+            "Stupid refers to something that is unintelligent, foolish, or lacking in common sense, often with a sense of frustration or disbelief."
+        ]
+    },
+    {
+        "name": "tear",
+        "trans": [
+            "Tear refers to a drop of salty liquid that comes out of the eye, often as a sign of strong emotion, such as sadness, happiness, or pain."
+        ]
+    },
+    {
+        "name": "temporary",
+        "trans": [
+            "Temporary refers to something that is not permanent or lasting, often intended for a limited or short-term use."
+        ]
+    },
+    {
+        "name": "tomorrow",
+        "trans": [
+            "Tomorrow refers to the day after today, often used to indicate the near future."
+        ]
+    },
+    {
+        "name": "wake",
+        "trans": [
+            "Wake refers to the state of being awake or conscious, often after sleeping or being unconscious."
+        ]
+    },
+    {
+        "name": "wrap",
+        "trans": [
+            "Wrap means to cover or enclose something with a material, often for protection or insulation."
+        ]
+    },
+    {
+        "name": "yesterday",
+        "trans": [
+            "Yesterday refers to the day before today, often used to indicate the recent past."
+        ]
+    }
+]

--- a/public/dicts/top2000words.json
+++ b/public/dicts/top2000words.json
@@ -1,7470 +1,11204 @@
 [
   {
     "name": "the",
-    "trans": "definite article, adverb"
+    "trans": [
+      "definite article, adverb"
+    ]
   },
   {
     "name": "of",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "and",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "to",
-    "trans": "preposition, adverb"
+    "trans": [
+      "preposition, adverb"
+    ]
   },
   {
     "name": "a",
-    "trans": "indefinite article, noun, preposition"
+    "trans": [
+      "indefinite article, noun, preposition"
+    ]
   },
   {
     "name": "in",
-    "trans": "preposition, adverb"
+    "trans": [
+      "preposition, adverb"
+    ]
   },
   {
     "name": "you",
-    "trans": "pronoun, noun"
+    "trans": [
+      "pronoun, noun"
+    ]
   },
   {
     "name": "for",
-    "trans": "preposition, conjunction"
+    "trans": [
+      "preposition, conjunction"
+    ]
   },
   {
     "name": "or",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "it",
-    "trans": "pronoun, noun"
+    "trans": [
+      "pronoun, noun"
+    ]
   },
   {
     "name": "as",
-    "trans": "adverb, conjunction, pronoun, preposition"
+    "trans": [
+      "adverb, conjunction, pronoun, preposition"
+    ]
   },
   {
     "name": "be",
-    "trans": "verb, auxiliary verb"
+    "trans": [
+      "verb, auxiliary verb"
+    ]
   },
   {
     "name": "on",
-    "trans": "preposition, adverb, adjective"
+    "trans": [
+      "preposition, adverb, adjective"
+    ]
   },
   {
     "name": "with",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "can",
-    "trans": "auxiliary verb, noun"
+    "trans": [
+      "auxiliary verb, noun"
+    ]
   },
   {
     "name": "have",
-    "trans": "verb, auxiliary verb"
+    "trans": [
+      "verb, auxiliary verb"
+    ]
   },
   {
     "name": "this",
-    "trans": "pronoun, adjective, adverb"
+    "trans": [
+      "pronoun, adjective, adverb"
+    ]
   },
   {
     "name": "by",
-    "trans": "preposition, adverb"
+    "trans": [
+      "preposition, adverb"
+    ]
   },
   {
     "name": "not",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "but",
-    "trans": "conjunction, preposition, adverb, noun"
+    "trans": [
+      "conjunction, preposition, adverb, noun"
+    ]
   },
   {
     "name": "at",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "from",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "I",
-    "trans": "pronoun"
+    "trans": [
+      "pronoun"
+    ]
   },
   {
     "name": "they",
-    "trans": "pronoun"
+    "trans": [
+      "pronoun"
+    ]
   },
   {
     "name": "more",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "will",
-    "trans": "auxiliary verb, noun"
+    "trans": [
+      "auxiliary verb, noun"
+    ]
   },
   {
     "name": "if",
-    "trans": "conjunction, noun"
+    "trans": [
+      "conjunction, noun"
+    ]
   },
   {
     "name": "some",
-    "trans": "adjective, pronoun, adverb"
+    "trans": [
+      "adjective, pronoun, adverb"
+    ]
   },
   {
     "name": "there",
-    "trans": "adverb, pronoun, noun, adjective"
+    "trans": [
+      "adverb, pronoun, noun, adjective"
+    ]
   },
   {
     "name": "what",
-    "trans": "pronoun, adjective, adverb, interjection"
+    "trans": [
+      "pronoun, adjective, adverb, interjection"
+    ]
   },
   {
     "name": "about",
-    "trans": "preposition, adverb, adjective"
+    "trans": [
+      "preposition, adverb, adjective"
+    ]
   },
   {
     "name": "which",
-    "trans": "pronoun, adjective"
+    "trans": [
+      "pronoun, adjective"
+    ]
   },
   {
     "name": "when",
-    "trans": "adverb, conjunction"
+    "trans": [
+      "adverb, conjunction"
+    ]
   },
   {
     "name": "one",
-    "trans": "adjective, noun, pronoun"
+    "trans": [
+      "adjective, noun, pronoun"
+    ]
   },
   {
     "name": "all",
-    "trans": "adjective, pronoun, noun, adverb"
+    "trans": [
+      "adjective, pronoun, noun, adverb"
+    ]
   },
   {
     "name": "also",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "how",
-    "trans": "adverb, conjunction"
+    "trans": [
+      "adverb, conjunction"
+    ]
   },
   {
     "name": "many",
-    "trans": "adjective, noun, pronoun"
+    "trans": [
+      "adjective, noun, pronoun"
+    ]
   },
   {
     "name": "do",
-    "trans": "auxiliary verb"
+    "trans": [
+      "auxiliary verb"
+    ]
   },
   {
     "name": "most",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "people",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "other",
-    "trans": "adjective, noun, pronoun, adverb"
+    "trans": [
+      "adjective, noun, pronoun, adverb"
+    ]
   },
   {
     "name": "time",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "so",
-    "trans": "adverb, conjunction, pronoun, adjective"
+    "trans": [
+      "adverb, conjunction, pronoun, adjective"
+    ]
   },
   {
     "name": "we",
-    "trans": "pronoun"
+    "trans": [
+      "pronoun"
+    ]
   },
   {
     "name": "may",
-    "trans": "auxiliary verb"
+    "trans": [
+      "auxiliary verb"
+    ]
   },
   {
     "name": "like",
-    "trans": "preposition, verb, conjunction, adverb"
+    "trans": [
+      "preposition, verb, conjunction, adverb"
+    ]
   },
   {
     "name": "use",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "into",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "than",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "up",
-    "trans": "adverb, preposition, adjective, noun"
+    "trans": [
+      "adverb, preposition, adjective, noun"
+    ]
   },
   {
     "name": "out",
-    "trans": "adverb, preposition, adjective, interjection"
+    "trans": [
+      "adverb, preposition, adjective, interjection"
+    ]
   },
   {
     "name": "who",
-    "trans": "pronoun"
+    "trans": [
+      "pronoun"
+    ]
   },
   {
     "name": "make",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "because",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "such",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "through",
-    "trans": "preposition, adverb, adjective"
+    "trans": [
+      "preposition, adverb, adjective"
+    ]
   },
   {
     "name": "get",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "work",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "even",
-    "trans": "adjective, verb, adverb"
+    "trans": [
+      "adjective, verb, adverb"
+    ]
   },
   {
     "name": "no",
-    "trans": "adverb, adjective, noun"
+    "trans": [
+      "adverb, adjective, noun"
+    ]
   },
   {
     "name": "new",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "film",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "just",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "only",
-    "trans": "adverb, adjective, conjunction"
+    "trans": [
+      "adverb, adjective, conjunction"
+    ]
   },
   {
     "name": "see",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "good",
-    "trans": "adjective, noun, adverb, interjection"
+    "trans": [
+      "adjective, noun, adverb, interjection"
+    ]
   },
   {
     "name": "water",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "need",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "should",
-    "trans": "auxiliary verb"
+    "trans": [
+      "auxiliary verb"
+    ]
   },
   {
     "name": "very",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "any",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "history",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "often",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "way",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "well",
-    "trans": "adverb, verb, noun, interjection"
+    "trans": [
+      "adverb, verb, noun, interjection"
+    ]
   },
   {
     "name": "art",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "know",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "then",
-    "trans": "adverb, adjective"
+    "trans": [
+      "adverb, adjective"
+    ]
   },
   {
     "name": "first",
-    "trans": "adverb, adjective"
+    "trans": [
+      "adverb, adjective"
+    ]
   },
   {
     "name": "would",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "money",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "each",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "over",
-    "trans": "preposition, adjective, noun"
+    "trans": [
+      "preposition, adjective, noun"
+    ]
   },
   {
     "name": "world",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "map",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "find",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "where",
-    "trans": "adverb, pronoun, noun"
+    "trans": [
+      "adverb, pronoun, noun"
+    ]
   },
   {
     "name": "much",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "take",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "two",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "want",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "important",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "family",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "example",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "while",
-    "trans": "noun, conjunction, preposition, verb"
+    "trans": [
+      "noun, conjunction, preposition, verb"
+    ]
   },
   {
     "name": "he",
-    "trans": "pronoun"
+    "trans": [
+      "pronoun"
+    ]
   },
   {
     "name": "look",
-    "trans": "verb, noun, interjection"
+    "trans": [
+      "verb, noun, interjection"
+    ]
   },
   {
     "name": "before",
-    "trans": "preposition, adverb, conjunction"
+    "trans": [
+      "preposition, adverb, conjunction"
+    ]
   },
   {
     "name": "help",
-    "trans": "verb, noun, interjection"
+    "trans": [
+      "verb, noun, interjection"
+    ]
   },
   {
     "name": "between",
-    "trans": "preposition, adverb"
+    "trans": [
+      "preposition, adverb"
+    ]
   },
   {
     "name": "go",
-    "trans": "verb, noun, adjective, interjection"
+    "trans": [
+      "verb, noun, adjective, interjection"
+    ]
   },
   {
     "name": "own",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "however",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "business",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "great",
-    "trans": "adjective, noun, adverb, interjection"
+    "trans": [
+      "adjective, noun, adverb, interjection"
+    ]
   },
   {
     "name": "another",
-    "trans": "adjective, pronoun"
+    "trans": [
+      "adjective, pronoun"
+    ]
   },
   {
     "name": "health",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "same",
-    "trans": "adjective, pronoun, adverb"
+    "trans": [
+      "adjective, pronoun, adverb"
+    ]
   },
   {
     "name": "study",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "why",
-    "trans": "adverb, conjunction, noun, interjection"
+    "trans": [
+      "adverb, conjunction, noun, interjection"
+    ]
   },
   {
     "name": "few",
-    "trans": "adjective, noun, pronoun"
+    "trans": [
+      "adjective, noun, pronoun"
+    ]
   },
   {
     "name": "game",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "might",
-    "trans": "auxiliary verb, noun"
+    "trans": [
+      "auxiliary verb, noun"
+    ]
   },
   {
     "name": "think",
-    "trans": "verb, adjective, noun"
+    "trans": [
+      "verb, adjective, noun"
+    ]
   },
   {
     "name": "free",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "too",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "right",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "still",
-    "trans": "adjective, noun, adverb, verb"
+    "trans": [
+      "adjective, noun, adverb, verb"
+    ]
   },
   {
     "name": "system",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "after",
-    "trans": "preposition, adjective, adverb"
+    "trans": [
+      "preposition, adjective, adverb"
+    ]
   },
   {
     "name": "best",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "must",
-    "trans": "auxiliary verb, verb, adjective, noun"
+    "trans": [
+      "auxiliary verb, verb, adjective, noun"
+    ]
   },
   {
     "name": "life",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "since",
-    "trans": "preposition, adverb, conjunction"
+    "trans": [
+      "preposition, adverb, conjunction"
+    ]
   },
   {
     "name": "could",
-    "trans": "auxiliary verb"
+    "trans": [
+      "auxiliary verb"
+    ]
   },
   {
     "name": "now",
-    "trans": "adverb, conjunction, adjective"
+    "trans": [
+      "adverb, conjunction, adjective"
+    ]
   },
   {
     "name": "during",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "learn",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "around",
-    "trans": "adverb, preposition"
+    "trans": [
+      "adverb, preposition"
+    ]
   },
   {
     "name": "form",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "meat",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "air",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "day",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "place",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "become",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "number",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "public",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "read",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "keep",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "part",
-    "trans": "noun, verb, adverb"
+    "trans": [
+      "noun, verb, adverb"
+    ]
   },
   {
     "name": "start",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "year",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "every",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "field",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "large",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "once",
-    "trans": "adverb, conjunction"
+    "trans": [
+      "adverb, conjunction"
+    ]
   },
   {
     "name": "available",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "down",
-    "trans": "adverb, preposition, adjective, verb"
+    "trans": [
+      "adverb, preposition, adjective, verb"
+    ]
   },
   {
     "name": "give",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "fish",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "human",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "both",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "local",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "sure",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "without",
-    "trans": "preposition, adverb, conjunction"
+    "trans": [
+      "preposition, adverb, conjunction"
+    ]
   },
   {
     "name": "come",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "back",
-    "trans": "noun, adverb, verb, adjective"
+    "trans": [
+      "noun, adverb, verb, adjective"
+    ]
   },
   {
     "name": "general",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "process",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "she",
-    "trans": "pronoun, noun"
+    "trans": [
+      "pronoun, noun"
+    ]
   },
   {
     "name": "heat",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "specific",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "enough",
-    "trans": "adjective, adverb, interjection"
+    "trans": [
+      "adjective, adverb, interjection"
+    ]
   },
   {
     "name": "long",
-    "trans": "adjective, noun, adverb, verb"
+    "trans": [
+      "adjective, noun, adverb, verb"
+    ]
   },
   {
     "name": "lot",
-    "trans": "pronoun, adverb, noun, verb"
+    "trans": [
+      "pronoun, adverb, noun, verb"
+    ]
   },
   {
     "name": "hand",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "popular",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "small",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "though",
-    "trans": "conjunction, adverb"
+    "trans": [
+      "conjunction, adverb"
+    ]
   },
   {
     "name": "experience",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "include",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "job",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "music",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "person",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "really",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "although",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "thank",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "book",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "early",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "end",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "method",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "never",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "less",
-    "trans": "adjective, adverb, preposition"
+    "trans": [
+      "adjective, adverb, preposition"
+    ]
   },
   {
     "name": "play",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "able",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "data",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "feel",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "high",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "off",
-    "trans": "adverb, preposition, adjective, noun"
+    "trans": [
+      "adverb, preposition, adjective, noun"
+    ]
   },
   {
     "name": "point",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "type",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "whether",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "food",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "here",
-    "trans": "adverb, interjection"
+    "trans": [
+      "adverb, interjection"
+    ]
   },
   {
     "name": "home",
-    "trans": "noun, adjective, adverb, verb"
+    "trans": [
+      "noun, adjective, adverb, verb"
+    ]
   },
   {
     "name": "certain",
-    "trans": "adjective, pronoun"
+    "trans": [
+      "adjective, pronoun"
+    ]
   },
   {
     "name": "economy",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "little",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "theory",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "tonight",
-    "trans": "adverb, noun"
+    "trans": [
+      "adverb, noun"
+    ]
   },
   {
     "name": "law",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "put",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "under",
-    "trans": "preposition, adverb, adjective"
+    "trans": [
+      "preposition, adverb, adjective"
+    ]
   },
   {
     "name": "value",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "always",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "body",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "common",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "market",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "set",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "bird",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "guide",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "provide",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "change",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "interest",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "literature",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "problem",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "say",
-    "trans": "verb, interjection, noun"
+    "trans": [
+      "verb, interjection, noun"
+    ]
   },
   {
     "name": "next",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "create",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "simple",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "software",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "state",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "together",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "control",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "knowledge",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "power",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "radio",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "course",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "hard",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "add",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "company",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "love",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "past",
-    "trans": "adjective, noun, preposition, adverb"
+    "trans": [
+      "adjective, noun, preposition, adverb"
+    ]
   },
   {
     "name": "price",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "size",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "away",
-    "trans": "adverb, adjective"
+    "trans": [
+      "adverb, adjective"
+    ]
   },
   {
     "name": "big",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "internet",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "possible",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "television",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "three",
-    "trans": "number"
+    "trans": [
+      "number"
+    ]
   },
   {
     "name": "understand",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "various",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "card",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "difficult",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "list",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "mind",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "particular",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "real",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "science",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "trade",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "consider",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "either",
-    "trans": "conjunction, adjective"
+    "trans": [
+      "conjunction, adjective"
+    ]
   },
   {
     "name": "library",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "likely",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "nature",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "fact",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "line",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "product",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "care",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "group",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "idea",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "risk",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "several",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "temperature",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "word",
-    "trans": "noun, verb, interjection"
+    "trans": [
+      "noun, verb, interjection"
+    ]
   },
   {
     "name": "fat",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "force",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "key",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "light",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "today",
-    "trans": "adverb, noun"
+    "trans": [
+      "adverb, noun"
+    ]
   },
   {
     "name": "until",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "major",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "name",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "school",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "top",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "current",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "left",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "amount",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "level",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "order",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "practice",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "research",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sense",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "service",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "area",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cut",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "hot",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "instead",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "physical",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "piece",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "show",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "society",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "try",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "check",
-    "trans": "verb, noun, interjection"
+    "trans": [
+      "verb, noun, interjection"
+    ]
   },
   {
     "name": "choose",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "develop",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "second",
-    "trans": "number, noun"
+    "trans": [
+      "number, noun"
+    ]
   },
   {
     "name": "tense",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "web",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "boss",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "short",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "story",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "call",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "industry",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "last",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "media",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "mental",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "move",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "pay",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "sport",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "thing",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "against",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "far",
-    "trans": "adverb, adjective"
+    "trans": [
+      "adverb, adjective"
+    ]
   },
   {
     "name": "fun",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "house",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "let",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "page",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "remember",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "term",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "test",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "within",
-    "trans": "preposition, adverb"
+    "trans": [
+      "preposition, adverb"
+    ]
   },
   {
     "name": "along",
-    "trans": "preposition, adverb"
+    "trans": [
+      "preposition, adverb"
+    ]
   },
   {
     "name": "answer",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "increase",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "oven",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "quite",
-    "trans": "adverb, interjection"
+    "trans": [
+      "adverb, interjection"
+    ]
   },
   {
     "name": "single",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "sound",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "again",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "community",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "focus",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "individual",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "matter",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "percent",
-    "trans": "adverb, noun"
+    "trans": [
+      "adverb, noun"
+    ]
   },
   {
     "name": "turn",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "kind",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "quality",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "soil",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "ask",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "board",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "buy",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "guard",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "hold",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "language",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "main",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "offer",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "oil",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "picture",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "potential",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "professional",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "rather",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "access",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "almost",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "garden",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "international",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "open",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "range",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rate",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "reason",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "travel",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "variety",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "video",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "week",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "above",
-    "trans": "adverb, preposition, adjective, noun"
+    "trans": [
+      "adverb, preposition, adjective, noun"
+    ]
   },
   {
     "name": "according",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "cook",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "determine",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "future",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "site",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "alternative",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "demand",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "ever",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "exercise",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "image",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "special",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "case",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cause",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "coast",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "TRUE",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "whole",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "age",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "among",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "bad",
-    "trans": "noun, adverb, adjective"
+    "trans": [
+      "noun, adverb, adjective"
+    ]
   },
   {
     "name": "boat",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "country",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "dance",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "exam",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "excuse",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "grow",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "movie",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "record",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "result",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "section",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "across",
-    "trans": "preposition, adverb, adjective"
+    "trans": [
+      "preposition, adverb, adjective"
+    ]
   },
   {
     "name": "already",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "below",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "mouse",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "allow",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "cash",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "class",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "clear",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "dry",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "easy",
-    "trans": "adjective, adverb, interjection"
+    "trans": [
+      "adjective, adverb, interjection"
+    ]
   },
   {
     "name": "live",
-    "trans": "verb, adjective, adverb"
+    "trans": [
+      "verb, adjective, adverb"
+    ]
   },
   {
     "name": "period",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "physics",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "plan",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "store",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "tax",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cold",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "full",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "low",
-    "trans": "adjective, noun, adverb, verb"
+    "trans": [
+      "adjective, noun, adverb, verb"
+    ]
   },
   {
     "name": "old",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "policy",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "purchase",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "series",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "side",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "subject",
-    "trans": "noun, adjective, adverb, verb"
+    "trans": [
+      "noun, adjective, adverb, verb"
+    ]
   },
   {
     "name": "supply",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "therefore",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "basis",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "boyfriend",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "deal",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "direction",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "mean",
-    "trans": "verb, adjective, noun"
+    "trans": [
+      "verb, adjective, noun"
+    ]
   },
   {
     "name": "primary",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "space",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "strategy",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "technology",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "worth",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "army",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "camera",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "fall",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "paper",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "rule",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "similar",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "stock",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "weather",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "yet",
-    "trans": "adverb, conjunction"
+    "trans": [
+      "adverb, conjunction"
+    ]
   },
   {
     "name": "bring",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "chance",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "environment",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "figure",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "improve",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "man",
-    "trans": "noun, verb, interjection"
+    "trans": [
+      "noun, verb, interjection"
+    ]
   },
   {
     "name": "mathematics",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "model",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "necessary",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "positive",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "produce",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "search",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "source",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "child",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "earth",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "else",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "instance",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "maintain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "month",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "present",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "program",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "spend",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "talk",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "upset",
-    "trans": "verb, adjective"
+    "trans": [
+      "verb, adjective"
+    ]
   },
   {
     "name": "begin",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "chicken",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "close",
-    "trans": "adjective, adverb, verb, noun"
+    "trans": [
+      "adjective, adverb, verb, noun"
+    ]
   },
   {
     "name": "design",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "feature",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "head",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "material",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "medical",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "purpose",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "question",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rock",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "salt",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "tell",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "university",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "act",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "article",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "birth",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "car",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "cost",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "department",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "difference",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "dog",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "drive",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "essential",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "exist",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "federal",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "goal",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "green",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "intelligence",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "late",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "news",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "object",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "scale",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sun",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "support",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "tend",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "thus",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "audience",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "enjoy",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "entire",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "fit",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "glad",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "income",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "note",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "perform",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "profit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "proper",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "remove",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "rent",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "return",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "run",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "speed",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "strong",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "style",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "war",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "actual",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "appropriate",
-    "trans": "verb, adjective"
+    "trans": [
+      "verb, adjective"
+    ]
   },
   {
     "name": "bank",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "complex",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "content",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "craft",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "due",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "failure",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "half",
-    "trans": "noun, predeterminer, adverb"
+    "trans": [
+      "noun, predeterminer, adverb"
+    ]
   },
   {
     "name": "inside",
-    "trans": "noun, adjective, preposition"
+    "trans": [
+      "noun, adjective, preposition"
+    ]
   },
   {
     "name": "meaning",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "medicine",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "middle",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "philosophy",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "regular",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "reserve",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "standard",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "bus",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "decide",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "exchange",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "eye",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "fast",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "fire",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "identify",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "independent",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "leave",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "original",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "position",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "pressure",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "reach",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "rest",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "serve",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "stress",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "watch",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "wide",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "advantage",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "benefit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "box",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "charge",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "complete",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "continue",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "frame",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "issue",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "night",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "protect",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "require",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "significant",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "step",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "unless",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "active",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "break",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "chemistry",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cycle",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "disease",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "energy",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "face",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "item",
-    "trans": "noun, adverb"
+    "trans": [
+      "noun, adverb"
+    ]
   },
   {
     "name": "metal",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "nation",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "negative",
-    "trans": "adjective, noun, interjection, verb"
+    "trans": [
+      "adjective, noun, interjection, verb"
+    ]
   },
   {
     "name": "occur",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "paint",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "pregnant",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "review",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "road",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "role",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "room",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "safe",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "screen",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "soup",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "stay",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "structure",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "view",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "visit",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "visual",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "write",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "wrong",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "account",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "affect",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "ago",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "approach",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "avoid",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "ball",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "behind",
-    "trans": "preposition, adverb, adjective, noun"
+    "trans": [
+      "preposition, adverb, adjective, noun"
+    ]
   },
   {
     "name": "cover",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "discipline",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "medium",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "prepare",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "quick",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "ready",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "report",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "rise",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "share",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "apartment",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "balance",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "black",
-    "trans": "noun, verb, adjective, adverb"
+    "trans": [
+      "noun, verb, adjective, adverb"
+    ]
   },
   {
     "name": "bottom",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "build",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "choice",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "gift",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "impact",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "machine",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "moment",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "shape",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "straight",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "tool",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "walk",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "white",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "wind",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "achieve",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "address",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "average",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "believe",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "beyond",
-    "trans": "preposition, noun"
+    "trans": [
+      "preposition, noun"
+    ]
   },
   {
     "name": "career",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "culture",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "decision",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "direct",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "event",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "excellent",
-    "trans": "adjective, interjection"
+    "trans": [
+      "adjective, interjection"
+    ]
   },
   {
     "name": "extra",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "junior",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "morning",
-    "trans": "noun, adverb"
+    "trans": [
+      "noun, adverb"
+    ]
   },
   {
     "name": "pick",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "poor",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "pot",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "pretty",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "property",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "receive",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "seem",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "sign",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "student",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "table",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "task",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "unique",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "wood",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "classic",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "competition",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "condition",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "contact",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "credit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "discuss",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "egg",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "final",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "happy",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "hope",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "ice",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "lift",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "mix",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "network",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "north",
-    "trans": "noun, adjective, adverb"
+    "trans": [
+      "noun, adjective, adverb"
+    ]
   },
   {
     "name": "office",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "overall",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "population",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "president",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "private",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "realize",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "responsible",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "separate",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "square",
-    "trans": "noun, adjective, adverb"
+    "trans": [
+      "noun, adjective, adverb"
+    ]
   },
   {
     "name": "stop",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "teach",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "unit",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "western",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "yes",
-    "trans": "interjection"
+    "trans": [
+      "interjection"
+    ]
   },
   {
     "name": "alone",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "attempt",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "category",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cigarette",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "concern",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "contain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "context",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cute",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "date",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "effect",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "familiar",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "fly",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "follow",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "link",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "official",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "opportunity",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "perfect",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "post",
-    "trans": "noun, verb, adverb"
+    "trans": [
+      "noun, verb, adverb"
+    ]
   },
   {
     "name": "recent",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "refer",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "solve",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "star",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "toward",
-    "trans": "preposition, adjective"
+    "trans": [
+      "preposition, adjective"
+    ]
   },
   {
     "name": "voice",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bright",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "broad",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "capital",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "challenge",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "describe",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "despite",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "flat",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "flight",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "friend",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "gain",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "length",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "magazine",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "maybe",
-    "trans": "adverb, noun"
+    "trans": [
+      "adverb, noun"
+    ]
   },
   {
     "name": "newspaper",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "nice",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "prefer",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "prevent",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "rich",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "save",
-    "trans": "verb, noun, preposition"
+    "trans": [
+      "verb, noun, preposition"
+    ]
   },
   {
     "name": "self",
-    "trans": "noun, pronoun, adjective, verb"
+    "trans": [
+      "noun, pronoun, adjective, verb"
+    ]
   },
   {
     "name": "soon",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "stand",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "warm",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "young",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "ahead",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "beauty",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "brush",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cell",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "couple",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "debate",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "discover",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "ensure",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "exit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "expect",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "fail",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "front",
-    "trans": "noun, adjective, verb, interjection"
+    "trans": [
+      "noun, adjective, verb, interjection"
+    ]
   },
   {
     "name": "function",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "heavy",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "invest",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "lack",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "lake",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "lead",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "listen",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "member",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "message",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "plant",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "plastic",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "reduce",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "scene",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "serious",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "speak",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "spot",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "summer",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "taste",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "theme",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "track",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "wing",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "worry",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "appear",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "brain",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "button",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "click",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "concept",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "correct",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "customer",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "death",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "desire",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "explain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "explore",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "express",
-    "trans": "verb, adjective, adverb, noun"
+    "trans": [
+      "verb, adjective, adverb, noun"
+    ]
   },
   {
     "name": "foot",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "gas",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "handle",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "huge",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "influence",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "involve",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "lose",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "meet",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "mood",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "notice",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rain",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rare",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "release",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "sell",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "slow",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "technical",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "typical",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "upon",
-    "trans": "preposition"
+    "trans": [
+      "preposition"
+    ]
   },
   {
     "name": "wall",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "woman",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "advice",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "afford",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "agree",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "base",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "blood",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "clean",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "damage",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "distance",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "effort",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "electronic",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "finish",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "fresh",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "hear",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "immediate",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "importance",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "normal",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "opinion",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "otherwise",
-    "trans": "adverb, adjective"
+    "trans": [
+      "adverb, adjective"
+    ]
   },
   {
     "name": "pair",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "plus",
-    "trans": "preposition, adjective, noun, conjunction"
+    "trans": [
+      "preposition, adjective, noun, conjunction"
+    ]
   },
   {
     "name": "press",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "remain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "represent",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "ride",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "secret",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "skill",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "spread",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "spring",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "staff",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sugar",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "target",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "text",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "tough",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "wait",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "wealth",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "animal",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "apply",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "author",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "aware",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "brown",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "budget",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "cheap",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "city",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "county",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "deep",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "discount",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "display",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "estate",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "file",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "flow",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "forget",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "foundation",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "global",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "ground",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "heart",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "hit",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "legal",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "lesson",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "measure",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "minute",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "near",
-    "trans": "adverb, preposition, adjective, verb"
+    "trans": [
+      "adverb, preposition, adjective, verb"
+    ]
   },
   {
     "name": "objective",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "perspective",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "phase",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "promote",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "recipe",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "recommend",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "register",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "relevant",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "rely",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "secure",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "shoot",
-    "trans": "verb, noun, interjection"
+    "trans": [
+      "verb, noun, interjection"
+    ]
   },
   {
     "name": "sky",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "stage",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "stick",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "studio",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "thin",
-    "trans": "adjective, adverb, verb"
+    "trans": [
+      "adjective, adverb, verb"
+    ]
   },
   {
     "name": "title",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "topic",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "touch",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "trouble",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "vary",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "absolute",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "accurate",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "bowl",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bridge",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "campaign",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cancel",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "capable",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "character",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "chemical",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "club",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cool",
-    "trans": "adjective, adverb, noun, verb"
+    "trans": [
+      "adjective, adverb, noun, verb"
+    ]
   },
   {
     "name": "cry",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "dump",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "edge",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "evidence",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "extreme",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "fan",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "generate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "letter",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "lock",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "maximum",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "novel",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "obtain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "option",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "pack",
-    "trans": "noun, verb, adjective, idiom"
+    "trans": [
+      "noun, verb, adjective, idiom"
+    ]
   },
   {
     "name": "park",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "passion",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "plenty",
-    "trans": "noun, adjective, adverb"
+    "trans": [
+      "noun, adjective, adverb"
+    ]
   },
   {
     "name": "push",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "quarter",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "resource",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "select",
-    "trans": "verb, adjective"
+    "trans": [
+      "verb, adjective"
+    ]
   },
   {
     "name": "skin",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sort",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "accept",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "baby",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "background",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "carry",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "college",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "communicate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "complain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "conflict",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "criticism",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "debt",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "define",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "depend",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "die",
-    "trans": "verb, idiom"
+    "trans": [
+      "verb, idiom"
+    ]
   },
   {
     "name": "dish",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "eat",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "efficient",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "enter",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "exact",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "factor",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "fair",
-    "trans": "adjective, adverb, noun, idiom"
+    "trans": [
+      "adjective, adverb, noun, idiom"
+    ]
   },
   {
     "name": "fill",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "fine",
-    "trans": "adjective, adverb, verb, noun"
+    "trans": [
+      "adjective, adverb, verb, noun"
+    ]
   },
   {
     "name": "formal",
-    "trans": "adjective, noun, adverb"
+    "trans": [
+      "adjective, noun, adverb"
+    ]
   },
   {
     "name": "forward",
-    "trans": "adverb, adjective, noun, verb"
+    "trans": [
+      "adverb, adjective, noun, verb"
+    ]
   },
   {
     "name": "fruit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "glass",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "happen",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "indicate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "joint",
-    "trans": "noun, adjective, verb, idiom"
+    "trans": [
+      "noun, adjective, verb, idiom"
+    ]
   },
   {
     "name": "jump",
-    "trans": "verb, noun, adjective, adverb"
+    "trans": [
+      "verb, noun, adjective, adverb"
+    ]
   },
   {
     "name": "kick",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "master",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "memory",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "muscle",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "opposite",
-    "trans": "adjective, noun, preposition, adverb"
+    "trans": [
+      "adjective, noun, preposition, adverb"
+    ]
   },
   {
     "name": "pass",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "pitch",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "red",
-    "trans": "noun, adjective, idiom"
+    "trans": [
+      "noun, adjective, idiom"
+    ]
   },
   {
     "name": "remote",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "secretary",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "solution",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "somewhat",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "strength",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "suggest",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "survive",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "total",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "traffic",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "treat",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "trip",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "vast",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "vegetable",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "abuse",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "administration",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "appeal",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "appreciate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "aspect",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "attitude",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "beat",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "burn",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "chart",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "compare",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "deposit",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "foreign",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "gear",
-    "trans": "noun, verb, adjective, idiom"
+    "trans": [
+      "noun, verb, adjective, idiom"
+    ]
   },
   {
     "name": "ideal",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "imagine",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "kitchen",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "land",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "log",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "manage",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "mother",
-    "trans": "noun, adjective, verb, idiom"
+    "trans": [
+      "noun, adjective, verb, idiom"
+    ]
   },
   {
     "name": "net",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "party",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "personality",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "photograph",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "practical",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "principle",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "print",
-    "trans": "verb, noun, adjective, idiom"
+    "trans": [
+      "verb, noun, adjective, idiom"
+    ]
   },
   {
     "name": "psychology",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "raise",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "relative",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "response",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "sale",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "season",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "severe",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "signal",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "sleep",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "smooth",
-    "trans": "adjective, adverb, verb, noun"
+    "trans": [
+      "adjective, adverb, verb, noun"
+    ]
   },
   {
     "name": "spirit",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "street",
-    "trans": "noun, adjective, idiom"
+    "trans": [
+      "noun, adjective, idiom"
+    ]
   },
   {
     "name": "tree",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "version",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "wave",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "advance",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "alcohol",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "belt",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bench",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "commission",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "connect",
-    "trans": "verb, adjective"
+    "trans": [
+      "verb, adjective"
+    ]
   },
   {
     "name": "consist",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "contract",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "contribute",
-    "trans": "verb, idiom"
+    "trans": [
+      "verb, idiom"
+    ]
   },
   {
     "name": "copy",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "dark",
-    "trans": "adjective, noun, idiom"
+    "trans": [
+      "adjective, noun, idiom"
+    ]
   },
   {
     "name": "differ",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "double",
-    "trans": "adjective, noun, verb, adverb"
+    "trans": [
+      "adjective, noun, verb, adverb"
+    ]
   },
   {
     "name": "draw",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "drop",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "emphasis",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "encourage",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "equal",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "expand",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "firm",
-    "trans": "adjective, verb, adverb, noun"
+    "trans": [
+      "adjective, verb, adverb, noun"
+    ]
   },
   {
     "name": "fix",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "frequent",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "hire",
-    "trans": "verb, noun, adjective, idiom"
+    "trans": [
+      "verb, noun, adjective, idiom"
+    ]
   },
   {
     "name": "internal",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "join",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "kill",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "loss",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "mere",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "minimum",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "numerous",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "path",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "progress",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "project",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "prove",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "react",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "recognize",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "relax",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "replace",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "sea",
-    "trans": "noun, adjective, idiom"
+    "trans": [
+      "noun, adjective, idiom"
+    ]
   },
   {
     "name": "sensitive",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "sit",
-    "trans": "verb, idiom"
+    "trans": [
+      "verb, idiom"
+    ]
   },
   {
     "name": "south",
-    "trans": "noun, adjective, adverb, verb"
+    "trans": [
+      "noun, adjective, adverb, verb"
+    ]
   },
   {
     "name": "status",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "steak",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "stuff",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sufficient",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "tap",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "ticket",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "tour",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "union",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "win",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "angle",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "attack",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "blue",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "borrow",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "breakfast",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cancer",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "claim",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "confidence",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "consistent",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "constant",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "currency",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "daughter",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "degree",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "doctor",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "dot",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "drag",
-    "trans": "verb, noun, adjective, idiom"
+    "trans": [
+      "verb, noun, adjective, idiom"
+    ]
   },
   {
     "name": "dream",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "drink",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "duty",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "earn",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "enable",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "essay",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "famous",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "father",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "fee",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "finance",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "guess",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "hour",
-    "trans": "noun, adjective, idiom"
+    "trans": [
+      "noun, adjective, idiom"
+    ]
   },
   {
     "name": "juice",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "limit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "luck",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "milk",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "minor",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "mixture",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "mouth",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "nor",
-    "trans": "conjunction"
+    "trans": [
+      "conjunction"
+    ]
   },
   {
     "name": "operate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "peace",
-    "trans": "noun, interjection, verb, idiom"
+    "trans": [
+      "noun, interjection, verb, idiom"
+    ]
   },
   {
     "name": "pipe",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "please",
-    "trans": "adverb, verb, idiom"
+    "trans": [
+      "adverb, verb, idiom"
+    ]
   },
   {
     "name": "previous",
-    "trans": "adjective, idiom"
+    "trans": [
+      "adjective, idiom"
+    ]
   },
   {
     "name": "pull",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "pure",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "raw",
-    "trans": "adjective, noun, idiom"
+    "trans": [
+      "adjective, noun, idiom"
+    ]
   },
   {
     "name": "reflect",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "region",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "republic",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "seat",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "send",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "soft",
-    "trans": "adjective, noun, adverb, interjection"
+    "trans": [
+      "adjective, noun, adverb, interjection"
+    ]
   },
   {
     "name": "solid",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "stable",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "storm",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "substance",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "team",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "tradition",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "trick",
-    "trans": "noun, adjective, verb, idiom"
+    "trans": [
+      "noun, adjective, verb, idiom"
+    ]
   },
   {
     "name": "virus",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "wear",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "weird",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "wonder",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "afraid",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "afternoon",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "analyze",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "annual",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "anticipate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "assume",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "bat",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "beach",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "blank",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "busy",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "catch",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "chain",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "count",
-    "trans": "verb, noun, adjective, idiom"
+    "trans": [
+      "verb, noun, adjective, idiom"
+    ]
   },
   {
     "name": "cream",
-    "trans": "noun, verb, adjective, idiom"
+    "trans": [
+      "noun, verb, adjective, idiom"
+    ]
   },
   {
     "name": "crew",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "dead",
-    "trans": "adjective, noun, adverb, idiom"
+    "trans": [
+      "adjective, noun, adverb, idiom"
+    ]
   },
   {
     "name": "detail",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "device",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "doubt",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "drama",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "engage",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "engine",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "enhance",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "examine",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "expense",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "FALSE",
-    "trans": "adjective, adverb, idiom"
+    "trans": [
+      "adjective, adverb, idiom"
+    ]
   },
   {
     "name": "feed",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "forever",
-    "trans": "adverb, noun, idiom"
+    "trans": [
+      "adverb, noun, idiom"
+    ]
   },
   {
     "name": "gold",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "hotel",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "impress",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "install",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "interact",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "interview",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "kid",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "logic",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "mark",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "match",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "mission",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "obvious",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "pain",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "participate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "pleasure",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "priority",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "repeat",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "round",
-    "trans": "adjective, noun, adverb, verb"
+    "trans": [
+      "adjective, noun, adverb, verb"
+    ]
   },
   {
     "name": "score",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "screw",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "seek",
-    "trans": "verb, idiom"
+    "trans": [
+      "verb, idiom"
+    ]
   },
   {
     "name": "sex",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "sharp",
-    "trans": "adjective, verb, adverb, noun"
+    "trans": [
+      "adjective, verb, adverb, noun"
+    ]
   },
   {
     "name": "shop",
-    "trans": "noun, verb, interjection, idiom"
+    "trans": [
+      "noun, verb, interjection, idiom"
+    ]
   },
   {
     "name": "shower",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "sing",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "slide",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "strip",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "suit",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "thick",
-    "trans": "adjective, adverb, noun, idiom"
+    "trans": [
+      "adjective, adverb, noun, idiom"
+    ]
   },
   {
     "name": "tone",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "whereas",
-    "trans": "conjunction, noun"
+    "trans": [
+      "conjunction, noun"
+    ]
   },
   {
     "name": "window",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "wise",
-    "trans": "adjective, verb, idiom"
+    "trans": [
+      "adjective, verb, idiom"
+    ]
   },
   {
     "name": "wish",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "agent",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "anxiety",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "atmosphere",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "band",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bath",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "block",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bone",
-    "trans": "noun, verb, adverb"
+    "trans": [
+      "noun, verb, adverb"
+    ]
   },
   {
     "name": "bread",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "calendar",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "candidate",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cap",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "climate",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "coat",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "collect",
-    "trans": "verb, adverb, noun"
+    "trans": [
+      "verb, adverb, noun"
+    ]
   },
   {
     "name": "combine",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "command",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "contest",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "corner",
-    "trans": "noun, adjective, verb, idiom"
+    "trans": [
+      "noun, adjective, verb, idiom"
+    ]
   },
   {
     "name": "court",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "cup",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "dig",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "district",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "divide",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "door",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "east",
-    "trans": "noun, adjective, adverb"
+    "trans": [
+      "noun, adjective, adverb"
+    ]
   },
   {
     "name": "electric",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "emotion",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "equivalent",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "except",
-    "trans": "preposition, conjunction, idiom"
+    "trans": [
+      "preposition, conjunction, idiom"
+    ]
   },
   {
     "name": "finger",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "garage",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "guarantee",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "guest",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "hang",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "height",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "hole",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "hook",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "hunt",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "implement",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "initial",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "intend",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "introduce",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "latter",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "layer",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "lecture",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "lie",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "mall",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "manner",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "march",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "mention",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "narrow",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "neither",
-    "trans": "conjunction, adjective, pronoun"
+    "trans": [
+      "conjunction, adjective, pronoun"
+    ]
   },
   {
     "name": "nose",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "partner",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "profile",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "proud",
-    "trans": "adjective, idiom"
+    "trans": [
+      "adjective, idiom"
+    ]
   },
   {
     "name": "respect",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rice",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "routine",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "sample",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "schedule",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "settle",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "smell",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "survey",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "telephone",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "tie",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "tip",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "wild",
-    "trans": "adjective, adverb, noun, idiom"
+    "trans": [
+      "adjective, adverb, noun, idiom"
+    ]
   },
   {
     "name": "winter",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "adult",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "aggressive",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "airline",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "apart",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "assure",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "attract",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "bag",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "battle",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bed",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bill",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "boring",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "bother",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "brief",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "cake",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "charity",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "code",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "commerce",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cousin",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "crazy",
-    "trans": "adjective, noun, idiom"
+    "trans": [
+      "adjective, noun, idiom"
+    ]
   },
   {
     "name": "curve",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "dimension",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "disaster",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "distinct",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "distribute",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "dress",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "ease",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "eastern",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "emergency",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "escape",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "evening",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "expose",
-    "trans": "verb, idiom"
+    "trans": [
+      "verb, idiom"
+    ]
   },
   {
     "name": "extension",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "extent",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "farm",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "feedback",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "fight",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "gap",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "gather",
-    "trans": "verb, noun, idiom"
+    "trans": [
+      "verb, noun, idiom"
+    ]
   },
   {
     "name": "gentle",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "govern",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "grade",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "guitar",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "hate",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "holiday",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "homework",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "horror",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "horse",
-    "trans": "noun, verb, adjective, idiom"
+    "trans": [
+      "noun, verb, adjective, idiom"
+    ]
   },
   {
     "name": "host",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "husband",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "loan",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "mistake",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "mountain",
-    "trans": "noun, adjective, idiom"
+    "trans": [
+      "noun, adjective, idiom"
+    ]
   },
   {
     "name": "nail",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "noise",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "none",
-    "trans": "pronoun, adverb, adjective"
+    "trans": [
+      "pronoun, adverb, adjective"
+    ]
   },
   {
     "name": "occasion",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "outcome",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "overcome",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "owe",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "patient",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "pause",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "phrase",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "prior",
-    "trans": "adjective, noun, idiom"
+    "trans": [
+      "adjective, noun, idiom"
+    ]
   },
   {
     "name": "proof",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "race",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "relief",
-    "trans": "noun, idiom"
+    "trans": [
+      "noun, idiom"
+    ]
   },
   {
     "name": "repair",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "resolution",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "revenue",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "rough",
-    "trans": "adjective, noun, adverb, verb"
+    "trans": [
+      "adjective, noun, adverb, verb"
+    ]
   },
   {
     "name": "sad",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "sand",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "scratch",
-    "trans": "verb, noun, adjective, idiom"
+    "trans": [
+      "verb, noun, adjective, idiom"
+    ]
   },
   {
     "name": "sentence",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "session",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "shoulder",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "sick",
-    "trans": "adjective, noun, idiom"
+    "trans": [
+      "adjective, noun, idiom"
+    ]
   },
   {
     "name": "smoke",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "stomach",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "strange",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "strict",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "strike",
-    "trans": "verb, noun, adjective, idiom"
+    "trans": [
+      "verb, noun, adjective, idiom"
+    ]
   },
   {
     "name": "string",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "succeed",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "suffer",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "tennis",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "throw",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "towel",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "vacation",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "virtual",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "west",
-    "trans": "noun, adjective, adverb, idiom"
+    "trans": [
+      "noun, adjective, adverb, idiom"
+    ]
   },
   {
     "name": "wheel",
-    "trans": "noun, verb, idiom"
+    "trans": [
+      "noun, verb, idiom"
+    ]
   },
   {
     "name": "wine",
-    "trans": "noun, adjective, verb, idiom"
+    "trans": [
+      "noun, adjective, verb, idiom"
+    ]
   },
   {
     "name": "acquire",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "adapt",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "adjust",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "administrative",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "altogether",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "argue",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "arise",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "arm",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "aside",
-    "trans": "noun, adverb"
+    "trans": [
+      "noun, adverb"
+    ]
   },
   {
     "name": "assign",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "associate",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "automatic",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "basket",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "bet",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "blow",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bonus",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "border",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "branch",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "breast",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "brother",
-    "trans": "noun, interjection"
+    "trans": [
+      "noun, interjection"
+    ]
   },
   {
     "name": "buddy",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bunch",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cabinet",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "chip",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "church",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "civil",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "coach",
-    "trans": "noun, verb, adverb"
+    "trans": [
+      "noun, verb, adverb"
+    ]
   },
   {
     "name": "coffee",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "confirm",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "construct",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "cross",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "danger",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "definite",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "dinner",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "document",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "draft",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "dust",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "edit",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "employ",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "expert",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "external",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "floor",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "former",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "god",
-    "trans": "noun, interjection"
+    "trans": [
+      "noun, interjection"
+    ]
   },
   {
     "name": "golf",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "habit",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "hair",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "hardly",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "hurt",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "incorporate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "iron",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "judge",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "justify",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "knife",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "laboratory",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "landscape",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "laugh",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "lay",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "league",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "loud",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "mail",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "massive",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "mess",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "mobile",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "mode",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "mud",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "nasty",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "native",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "orange",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "ordinary",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "organize",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "ought",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "parent",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "pattern",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "pin",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "police",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "pool",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "possess",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "pound",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "queen",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "ratio",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "relation",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "relieve",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "request",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "respond",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "restaurant",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "retain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "royal",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "salary",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sector",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "senior",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "shame",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "shelter",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "shoe",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "shut",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "signature",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "silver",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "song",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "southern",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "split",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "strain",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "struggle",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "super",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "swim",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "tackle",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "tank",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "tight",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "tooth",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "town",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "train",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "trust",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "upper",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "vehicle",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "visible",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "volume",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "wash",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "waste",
-    "trans": "verb, adjective, noun"
+    "trans": [
+      "verb, adjective, noun"
+    ]
   },
   {
     "name": "wife",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "yellow",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "accident",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "advertise",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "airport",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "alive",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "angry",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "assist",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bake",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bar",
-    "trans": "noun, verb, preposition"
+    "trans": [
+      "noun, verb, preposition"
+    ]
   },
   {
     "name": "baseball",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "bell",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bike",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "blame",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "boy",
-    "trans": "noun, interjection"
+    "trans": [
+      "noun, interjection"
+    ]
   },
   {
     "name": "brick",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "calculate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "chair",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "chapter",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "closet",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "clue",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "collar",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "comment",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "committee",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "compete",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "confuse",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "consult",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "convert",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "crash",
-    "trans": "verb, noun, adjective, adverb"
+    "trans": [
+      "verb, noun, adjective, adverb"
+    ]
   },
   {
     "name": "database",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "deliver",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "desperate",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "devil",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "diet",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "disc",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "educate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "enthusiasm",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "error",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "extend",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "fear",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "fold",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "forth",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "fuel",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "gate",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "girl",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "glove",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "grab",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "gross",
-    "trans": "adjective, adverb, verb, noun"
+    "trans": [
+      "adjective, adverb, verb, noun"
+    ]
   },
   {
     "name": "hall",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "hide",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "hospital",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "ill",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "insure",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "investigate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "jacket",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "literal",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "lunch",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "meal",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "miss",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "monitor",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "mortgage",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "negotiate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "nurse",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "pace",
-    "trans": "noun, verb, preposition"
+    "trans": [
+      "noun, verb, preposition"
+    ]
   },
   {
     "name": "panic",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "peak",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "perception",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "permit",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "pie",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "plane",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "poem",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "presence",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "qualify",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "quote",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "reception",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "recover",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "resolve",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "retire",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "revolution",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "reward",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rid",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "river",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "roll",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "row",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sandwich",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "satisfy",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "scare",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "shock",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sink",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "slip",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "son",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "sorry",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "spare",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "speech",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "spite",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "spray",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "surprise",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "suspect",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "sweet",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "swing",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "tea",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "transition",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "transport",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "twist",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "ugly",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "ultimate",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "usual",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "village",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "weigh",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "welcome",
-    "trans": "noun, interjection, verb, adjective"
+    "trans": [
+      "noun, interjection, verb, adjective"
+    ]
   },
   {
     "name": "yard",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "abroad",
-    "trans": "adverb, noun"
+    "trans": [
+      "adverb, noun"
+    ]
   },
   {
     "name": "alarm",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "anxious",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "apology",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "arrive",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "attach",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "behave",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "bend",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bicycle",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bite",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "blind",
-    "trans": "noun, verb, adjective, adverb"
+    "trans": [
+      "noun, verb, adjective, adverb"
+    ]
   },
   {
     "name": "bottle",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "brave",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "breath",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cable",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "calm",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "candle",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "celebrate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "chest",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "chocolate",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "clerk",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cloud",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "comprehensive",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "concentrate",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "concert",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "conclusion",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "convince",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "cookie",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "counter",
-    "trans": "noun, verb, adverb, adjective"
+    "trans": [
+      "noun, verb, adverb, adjective"
+    ]
   },
   {
     "name": "courage",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "critic",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "curious",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "dad",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "desk",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "dirty",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "downtown",
-    "trans": "adjective, adverb, noun"
+    "trans": [
+      "adjective, adverb, noun"
+    ]
   },
   {
     "name": "drawer",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "elevate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "entertain",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "establish",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "estimate",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "excite",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "flower",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "garbage",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "grand",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "grocery",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "harm",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "honest",
-    "trans": "adjective, adverb"
+    "trans": [
+      "adjective, adverb"
+    ]
   },
   {
     "name": "honey",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "imply",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "informal",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "injure",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "insect",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "insist",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "inspect",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "king",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "knee",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "ladder",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "leather",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "load",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "loose",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "male",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "menu",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "mirror",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "moreover",
-    "trans": "adverb"
+    "trans": [
+      "adverb"
+    ]
   },
   {
     "name": "neck",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "okay",
-    "trans": "adjective, adverb, interjection"
+    "trans": [
+      "adjective, adverb, interjection"
+    ]
   },
   {
     "name": "penalty",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "pension",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "piano",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "plate",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "potato",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "proceed",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "profession",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "professor",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "prompt",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "purple",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "pursue",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "quantity",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "quiet",
-    "trans": "adjective, noun, verb"
+    "trans": [
+      "adjective, noun, verb"
+    ]
   },
   {
     "name": "refuse",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "regret",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "reveal",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "ruin",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rush",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "salad",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "shake",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "shift",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "shine",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "ship",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "sister",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "skirt",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "slice",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "snow",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "specify",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "stairs",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "steal",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "stroke",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "suck",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "sudden",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "supermarket",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "surround",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "switch",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "terrible",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "tire",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "tongue",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "trash",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "tune",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "warn",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "weak",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "zone",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "accuse",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "admire",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "admit",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "adopt",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "affair",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "amaze",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "ambition",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "anger",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "announce",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "apple",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "approve",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "asleep",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "attend",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "award",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bathroom",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "bear",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "beer",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "belong",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "bid",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "bitter",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "boot",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "brilliant",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "bug",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "camp",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "candy",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "carpet",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cat",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "champion",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "channel",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "cheek",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "client",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "clock",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "closes",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "comfort",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "commit",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "complaints",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "compute",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "conscious",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "consequence",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "cow",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "crack",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "criticize",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "dare",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "dear",
-    "trans": "adjective, noun, adverb, interjection"
+    "trans": [
+      "adjective, noun, adverb, interjection"
+    ]
   },
   {
     "name": "decent",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "delay",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "deliberate",
-    "trans": "adjective, verb"
+    "trans": [
+      "adjective, verb"
+    ]
   },
   {
     "name": "departure",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "deserve",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "destroy",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "diamond",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "ear",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "embarrass",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "empty",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "eventual",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "fault",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "female",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "fortune",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "funeral",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "gene",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "girlfriend",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "grass",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "guilty",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "guy",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "hat",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "hell",
-    "trans": "noun, interjection"
+    "trans": [
+      "noun, interjection"
+    ]
   },
   {
     "name": "hesitate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "highlight",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "hunger",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "hurry",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "illustrate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "incident",
-    "trans": "noun, adjective"
+    "trans": [
+      "noun, adjective"
+    ]
   },
   {
     "name": "inevitable",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "inform",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "initiate",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "intent",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "invite",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "island",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "joke",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "jury",
-    "trans": "noun, verb, adjective"
+    "trans": [
+      "noun, verb, adjective"
+    ]
   },
   {
     "name": "kiss",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "lady",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "leg",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "lip",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "locate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "lone",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "mad",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "manufacture",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "marry",
-    "trans": "verb, interjection"
+    "trans": [
+      "verb, interjection"
+    ]
   },
   {
     "name": "mate",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "motor",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "neat",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "nerve",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "nervous",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "odd",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "passage",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "passenger",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "pen",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "persuade",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "pizza",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "platform",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "poet",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "pop",
-    "trans": "verb, noun, adverb, adjective"
+    "trans": [
+      "verb, noun, adverb, adjective"
+    ]
   },
   {
     "name": "pour",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "pray",
-    "trans": "verb, adverb"
+    "trans": [
+      "verb, adverb"
+    ]
   },
   {
     "name": "pretend",
-    "trans": "verb, adjective"
+    "trans": [
+      "verb, adjective"
+    ]
   },
   {
     "name": "pride",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "priest",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "prize",
-    "trans": "noun, adjective, verb"
+    "trans": [
+      "noun, adjective, verb"
+    ]
   },
   {
     "name": "probable",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "promise",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "propose",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "punch",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "quit",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "remark",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "remind",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "reply",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "reputation",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "resist",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "resort",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "ring",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rip",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "roof",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rope",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "rub",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "sail",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "scheme",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "script",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "shall",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "shirt",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "silly",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "sir",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "slight",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "smart",
-    "trans": "adjective, verb, noun"
+    "trans": [
+      "adjective, verb, noun"
+    ]
   },
   {
     "name": "smile",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "sock",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "spell",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "station",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "stretch",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "stupid",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "submit",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "substantial",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "suppose",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "surgery",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "suspicious",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "sympathy",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "tale",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "tall",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "tear",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "temporary",
-    "trans": "adjective, noun"
+    "trans": [
+      "adjective, noun"
+    ]
   },
   {
     "name": "throat",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "tiny",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "toe",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "tomorrow",
-    "trans": "adverb, noun"
+    "trans": [
+      "adverb, noun"
+    ]
   },
   {
     "name": "tower",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "translate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "truck",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "uncle",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "wake",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "witness",
-    "trans": "noun, verb"
+    "trans": [
+      "noun, verb"
+    ]
   },
   {
     "name": "wrap",
-    "trans": "verb, noun"
+    "trans": [
+      "verb, noun"
+    ]
   },
   {
     "name": "yesterday",
-    "trans": "adverb, noun"
+    "trans": [
+      "adverb, noun"
+    ]
   },
   {
     "name": "youth",
-    "trans": "noun"
+    "trans": [
+      "noun"
+    ]
   },
   {
     "name": "appoint",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "clothe",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "complicate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "confer",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "converse",
-    "trans": "verb, noun, adjective"
+    "trans": [
+      "verb, noun, adjective"
+    ]
   },
   {
     "name": "depress",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "disappoint",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "elect",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "equip",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "ignorant",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "inflate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "instruct",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "oblige",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "politic",
-    "trans": "adjective"
+    "trans": [
+      "adjective"
+    ]
   },
   {
     "name": "pollute",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "refrigerate",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "reside",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   },
   {
     "name": "situate",
-    "trans": "verb, adjective"
+    "trans": [
+      "verb, adjective"
+    ]
   },
   {
     "name": "unite",
-    "trans": "verb"
+    "trans": [
+      "verb"
+    ]
   }
 ]

--- a/public/dicts/top2000words.json
+++ b/public/dicts/top2000words.json
@@ -1,0 +1,7470 @@
+[
+  {
+    "name": "the",
+    "trans": "definite article, adverb"
+  },
+  {
+    "name": "of",
+    "trans": "preposition"
+  },
+  {
+    "name": "and",
+    "trans": "conjunction"
+  },
+  {
+    "name": "to",
+    "trans": "preposition, adverb"
+  },
+  {
+    "name": "a",
+    "trans": "indefinite article, noun, preposition"
+  },
+  {
+    "name": "in",
+    "trans": "preposition, adverb"
+  },
+  {
+    "name": "you",
+    "trans": "pronoun, noun"
+  },
+  {
+    "name": "for",
+    "trans": "preposition, conjunction"
+  },
+  {
+    "name": "or",
+    "trans": "conjunction"
+  },
+  {
+    "name": "it",
+    "trans": "pronoun, noun"
+  },
+  {
+    "name": "as",
+    "trans": "adverb, conjunction, pronoun, preposition"
+  },
+  {
+    "name": "be",
+    "trans": "verb, auxiliary verb"
+  },
+  {
+    "name": "on",
+    "trans": "preposition, adverb, adjective"
+  },
+  {
+    "name": "with",
+    "trans": "preposition"
+  },
+  {
+    "name": "can",
+    "trans": "auxiliary verb, noun"
+  },
+  {
+    "name": "have",
+    "trans": "verb, auxiliary verb"
+  },
+  {
+    "name": "this",
+    "trans": "pronoun, adjective, adverb"
+  },
+  {
+    "name": "by",
+    "trans": "preposition, adverb"
+  },
+  {
+    "name": "not",
+    "trans": "adverb"
+  },
+  {
+    "name": "but",
+    "trans": "conjunction, preposition, adverb, noun"
+  },
+  {
+    "name": "at",
+    "trans": "preposition"
+  },
+  {
+    "name": "from",
+    "trans": "preposition"
+  },
+  {
+    "name": "I",
+    "trans": "pronoun"
+  },
+  {
+    "name": "they",
+    "trans": "pronoun"
+  },
+  {
+    "name": "more",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "will",
+    "trans": "auxiliary verb, noun"
+  },
+  {
+    "name": "if",
+    "trans": "conjunction, noun"
+  },
+  {
+    "name": "some",
+    "trans": "adjective, pronoun, adverb"
+  },
+  {
+    "name": "there",
+    "trans": "adverb, pronoun, noun, adjective"
+  },
+  {
+    "name": "what",
+    "trans": "pronoun, adjective, adverb, interjection"
+  },
+  {
+    "name": "about",
+    "trans": "preposition, adverb, adjective"
+  },
+  {
+    "name": "which",
+    "trans": "pronoun, adjective"
+  },
+  {
+    "name": "when",
+    "trans": "adverb, conjunction"
+  },
+  {
+    "name": "one",
+    "trans": "adjective, noun, pronoun"
+  },
+  {
+    "name": "all",
+    "trans": "adjective, pronoun, noun, adverb"
+  },
+  {
+    "name": "also",
+    "trans": "adverb"
+  },
+  {
+    "name": "how",
+    "trans": "adverb, conjunction"
+  },
+  {
+    "name": "many",
+    "trans": "adjective, noun, pronoun"
+  },
+  {
+    "name": "do",
+    "trans": "auxiliary verb"
+  },
+  {
+    "name": "most",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "people",
+    "trans": "noun"
+  },
+  {
+    "name": "other",
+    "trans": "adjective, noun, pronoun, adverb"
+  },
+  {
+    "name": "time",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "so",
+    "trans": "adverb, conjunction, pronoun, adjective"
+  },
+  {
+    "name": "we",
+    "trans": "pronoun"
+  },
+  {
+    "name": "may",
+    "trans": "auxiliary verb"
+  },
+  {
+    "name": "like",
+    "trans": "preposition, verb, conjunction, adverb"
+  },
+  {
+    "name": "use",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "into",
+    "trans": "preposition"
+  },
+  {
+    "name": "than",
+    "trans": "conjunction"
+  },
+  {
+    "name": "up",
+    "trans": "adverb, preposition, adjective, noun"
+  },
+  {
+    "name": "out",
+    "trans": "adverb, preposition, adjective, interjection"
+  },
+  {
+    "name": "who",
+    "trans": "pronoun"
+  },
+  {
+    "name": "make",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "because",
+    "trans": "conjunction"
+  },
+  {
+    "name": "such",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "through",
+    "trans": "preposition, adverb, adjective"
+  },
+  {
+    "name": "get",
+    "trans": "verb"
+  },
+  {
+    "name": "work",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "even",
+    "trans": "adjective, verb, adverb"
+  },
+  {
+    "name": "no",
+    "trans": "adverb, adjective, noun"
+  },
+  {
+    "name": "new",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "film",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "just",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "only",
+    "trans": "adverb, adjective, conjunction"
+  },
+  {
+    "name": "see",
+    "trans": "verb"
+  },
+  {
+    "name": "good",
+    "trans": "adjective, noun, adverb, interjection"
+  },
+  {
+    "name": "water",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "need",
+    "trans": "verb"
+  },
+  {
+    "name": "should",
+    "trans": "auxiliary verb"
+  },
+  {
+    "name": "very",
+    "trans": "adverb"
+  },
+  {
+    "name": "any",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "history",
+    "trans": "noun"
+  },
+  {
+    "name": "often",
+    "trans": "adverb"
+  },
+  {
+    "name": "way",
+    "trans": "noun"
+  },
+  {
+    "name": "well",
+    "trans": "adverb, verb, noun, interjection"
+  },
+  {
+    "name": "art",
+    "trans": "noun"
+  },
+  {
+    "name": "know",
+    "trans": "verb"
+  },
+  {
+    "name": "then",
+    "trans": "adverb, adjective"
+  },
+  {
+    "name": "first",
+    "trans": "adverb, adjective"
+  },
+  {
+    "name": "would",
+    "trans": "verb"
+  },
+  {
+    "name": "money",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "each",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "over",
+    "trans": "preposition, adjective, noun"
+  },
+  {
+    "name": "world",
+    "trans": "noun"
+  },
+  {
+    "name": "map",
+    "trans": "noun"
+  },
+  {
+    "name": "find",
+    "trans": "verb"
+  },
+  {
+    "name": "where",
+    "trans": "adverb, pronoun, noun"
+  },
+  {
+    "name": "much",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "take",
+    "trans": "verb"
+  },
+  {
+    "name": "two",
+    "trans": "noun"
+  },
+  {
+    "name": "want",
+    "trans": "verb"
+  },
+  {
+    "name": "important",
+    "trans": "adjective"
+  },
+  {
+    "name": "family",
+    "trans": "noun"
+  },
+  {
+    "name": "example",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "while",
+    "trans": "noun, conjunction, preposition, verb"
+  },
+  {
+    "name": "he",
+    "trans": "pronoun"
+  },
+  {
+    "name": "look",
+    "trans": "verb, noun, interjection"
+  },
+  {
+    "name": "before",
+    "trans": "preposition, adverb, conjunction"
+  },
+  {
+    "name": "help",
+    "trans": "verb, noun, interjection"
+  },
+  {
+    "name": "between",
+    "trans": "preposition, adverb"
+  },
+  {
+    "name": "go",
+    "trans": "verb, noun, adjective, interjection"
+  },
+  {
+    "name": "own",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "however",
+    "trans": "adverb"
+  },
+  {
+    "name": "business",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "great",
+    "trans": "adjective, noun, adverb, interjection"
+  },
+  {
+    "name": "another",
+    "trans": "adjective, pronoun"
+  },
+  {
+    "name": "health",
+    "trans": "noun"
+  },
+  {
+    "name": "same",
+    "trans": "adjective, pronoun, adverb"
+  },
+  {
+    "name": "study",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "why",
+    "trans": "adverb, conjunction, noun, interjection"
+  },
+  {
+    "name": "few",
+    "trans": "adjective, noun, pronoun"
+  },
+  {
+    "name": "game",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "might",
+    "trans": "auxiliary verb, noun"
+  },
+  {
+    "name": "think",
+    "trans": "verb, adjective, noun"
+  },
+  {
+    "name": "free",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "too",
+    "trans": "adverb"
+  },
+  {
+    "name": "right",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "still",
+    "trans": "adjective, noun, adverb, verb"
+  },
+  {
+    "name": "system",
+    "trans": "noun"
+  },
+  {
+    "name": "after",
+    "trans": "preposition, adjective, adverb"
+  },
+  {
+    "name": "best",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "must",
+    "trans": "auxiliary verb, verb, adjective, noun"
+  },
+  {
+    "name": "life",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "since",
+    "trans": "preposition, adverb, conjunction"
+  },
+  {
+    "name": "could",
+    "trans": "auxiliary verb"
+  },
+  {
+    "name": "now",
+    "trans": "adverb, conjunction, adjective"
+  },
+  {
+    "name": "during",
+    "trans": "preposition"
+  },
+  {
+    "name": "learn",
+    "trans": "verb"
+  },
+  {
+    "name": "around",
+    "trans": "adverb, preposition"
+  },
+  {
+    "name": "form",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "meat",
+    "trans": "noun"
+  },
+  {
+    "name": "air",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "day",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "place",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "become",
+    "trans": "verb"
+  },
+  {
+    "name": "number",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "public",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "read",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "keep",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "part",
+    "trans": "noun, verb, adverb"
+  },
+  {
+    "name": "start",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "year",
+    "trans": "noun"
+  },
+  {
+    "name": "every",
+    "trans": "adjective"
+  },
+  {
+    "name": "field",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "large",
+    "trans": "adjective"
+  },
+  {
+    "name": "once",
+    "trans": "adverb, conjunction"
+  },
+  {
+    "name": "available",
+    "trans": "adjective"
+  },
+  {
+    "name": "down",
+    "trans": "adverb, preposition, adjective, verb"
+  },
+  {
+    "name": "give",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "fish",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "human",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "both",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "local",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "sure",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "without",
+    "trans": "preposition, adverb, conjunction"
+  },
+  {
+    "name": "come",
+    "trans": "verb"
+  },
+  {
+    "name": "back",
+    "trans": "noun, adverb, verb, adjective"
+  },
+  {
+    "name": "general",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "process",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "she",
+    "trans": "pronoun, noun"
+  },
+  {
+    "name": "heat",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "specific",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "enough",
+    "trans": "adjective, adverb, interjection"
+  },
+  {
+    "name": "long",
+    "trans": "adjective, noun, adverb, verb"
+  },
+  {
+    "name": "lot",
+    "trans": "pronoun, adverb, noun, verb"
+  },
+  {
+    "name": "hand",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "popular",
+    "trans": "adjective"
+  },
+  {
+    "name": "small",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "though",
+    "trans": "conjunction, adverb"
+  },
+  {
+    "name": "experience",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "include",
+    "trans": "verb"
+  },
+  {
+    "name": "job",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "music",
+    "trans": "noun"
+  },
+  {
+    "name": "person",
+    "trans": "noun"
+  },
+  {
+    "name": "really",
+    "trans": "adverb"
+  },
+  {
+    "name": "although",
+    "trans": "conjunction"
+  },
+  {
+    "name": "thank",
+    "trans": "verb"
+  },
+  {
+    "name": "book",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "early",
+    "trans": "adverb"
+  },
+  {
+    "name": "end",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "method",
+    "trans": "noun"
+  },
+  {
+    "name": "never",
+    "trans": "adverb"
+  },
+  {
+    "name": "less",
+    "trans": "adjective, adverb, preposition"
+  },
+  {
+    "name": "play",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "able",
+    "trans": "adjective"
+  },
+  {
+    "name": "data",
+    "trans": "noun"
+  },
+  {
+    "name": "feel",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "high",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "off",
+    "trans": "adverb, preposition, adjective, noun"
+  },
+  {
+    "name": "point",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "type",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "whether",
+    "trans": "conjunction"
+  },
+  {
+    "name": "food",
+    "trans": "noun"
+  },
+  {
+    "name": "here",
+    "trans": "adverb, interjection"
+  },
+  {
+    "name": "home",
+    "trans": "noun, adjective, adverb, verb"
+  },
+  {
+    "name": "certain",
+    "trans": "adjective, pronoun"
+  },
+  {
+    "name": "economy",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "little",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "theory",
+    "trans": "noun"
+  },
+  {
+    "name": "tonight",
+    "trans": "adverb, noun"
+  },
+  {
+    "name": "law",
+    "trans": "noun"
+  },
+  {
+    "name": "put",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "under",
+    "trans": "preposition, adverb, adjective"
+  },
+  {
+    "name": "value",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "always",
+    "trans": "adverb"
+  },
+  {
+    "name": "body",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "common",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "market",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "set",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "bird",
+    "trans": "noun"
+  },
+  {
+    "name": "guide",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "provide",
+    "trans": "verb"
+  },
+  {
+    "name": "change",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "interest",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "literature",
+    "trans": "noun"
+  },
+  {
+    "name": "problem",
+    "trans": "noun"
+  },
+  {
+    "name": "say",
+    "trans": "verb, interjection, noun"
+  },
+  {
+    "name": "next",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "create",
+    "trans": "verb"
+  },
+  {
+    "name": "simple",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "software",
+    "trans": "noun"
+  },
+  {
+    "name": "state",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "together",
+    "trans": "adverb"
+  },
+  {
+    "name": "control",
+    "trans": "noun"
+  },
+  {
+    "name": "knowledge",
+    "trans": "noun"
+  },
+  {
+    "name": "power",
+    "trans": "noun"
+  },
+  {
+    "name": "radio",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "course",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "hard",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "add",
+    "trans": "verb"
+  },
+  {
+    "name": "company",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "love",
+    "trans": "noun"
+  },
+  {
+    "name": "past",
+    "trans": "adjective, noun, preposition, adverb"
+  },
+  {
+    "name": "price",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "size",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "away",
+    "trans": "adverb, adjective"
+  },
+  {
+    "name": "big",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "internet",
+    "trans": "noun"
+  },
+  {
+    "name": "possible",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "television",
+    "trans": "noun"
+  },
+  {
+    "name": "three",
+    "trans": "number"
+  },
+  {
+    "name": "understand",
+    "trans": "verb"
+  },
+  {
+    "name": "various",
+    "trans": "adjective"
+  },
+  {
+    "name": "card",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "difficult",
+    "trans": "adjective"
+  },
+  {
+    "name": "list",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "mind",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "particular",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "real",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "science",
+    "trans": "noun"
+  },
+  {
+    "name": "trade",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "consider",
+    "trans": "verb"
+  },
+  {
+    "name": "either",
+    "trans": "conjunction, adjective"
+  },
+  {
+    "name": "library",
+    "trans": "noun"
+  },
+  {
+    "name": "likely",
+    "trans": "adverb"
+  },
+  {
+    "name": "nature",
+    "trans": "noun"
+  },
+  {
+    "name": "fact",
+    "trans": "noun"
+  },
+  {
+    "name": "line",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "product",
+    "trans": "noun"
+  },
+  {
+    "name": "care",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "group",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "idea",
+    "trans": "noun"
+  },
+  {
+    "name": "risk",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "several",
+    "trans": "adjective"
+  },
+  {
+    "name": "temperature",
+    "trans": "noun"
+  },
+  {
+    "name": "word",
+    "trans": "noun, verb, interjection"
+  },
+  {
+    "name": "fat",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "force",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "key",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "light",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "today",
+    "trans": "adverb, noun"
+  },
+  {
+    "name": "until",
+    "trans": "preposition"
+  },
+  {
+    "name": "major",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "name",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "school",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "top",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "current",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "left",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "amount",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "level",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "order",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "practice",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "research",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sense",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "service",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "area",
+    "trans": "noun"
+  },
+  {
+    "name": "cut",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "hot",
+    "trans": "adjective"
+  },
+  {
+    "name": "instead",
+    "trans": "adverb"
+  },
+  {
+    "name": "physical",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "piece",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "show",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "society",
+    "trans": "noun"
+  },
+  {
+    "name": "try",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "check",
+    "trans": "verb, noun, interjection"
+  },
+  {
+    "name": "choose",
+    "trans": "verb"
+  },
+  {
+    "name": "develop",
+    "trans": "verb"
+  },
+  {
+    "name": "second",
+    "trans": "number, noun"
+  },
+  {
+    "name": "tense",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "web",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "boss",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "short",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "story",
+    "trans": "noun"
+  },
+  {
+    "name": "call",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "industry",
+    "trans": "noun"
+  },
+  {
+    "name": "last",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "media",
+    "trans": "noun"
+  },
+  {
+    "name": "mental",
+    "trans": "adjective"
+  },
+  {
+    "name": "move",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "pay",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "sport",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "thing",
+    "trans": "noun"
+  },
+  {
+    "name": "against",
+    "trans": "preposition"
+  },
+  {
+    "name": "far",
+    "trans": "adverb, adjective"
+  },
+  {
+    "name": "fun",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "house",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "let",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "page",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "remember",
+    "trans": "verb"
+  },
+  {
+    "name": "term",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "test",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "within",
+    "trans": "preposition, adverb"
+  },
+  {
+    "name": "along",
+    "trans": "preposition, adverb"
+  },
+  {
+    "name": "answer",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "increase",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "oven",
+    "trans": "noun"
+  },
+  {
+    "name": "quite",
+    "trans": "adverb, interjection"
+  },
+  {
+    "name": "single",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "sound",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "again",
+    "trans": "adverb"
+  },
+  {
+    "name": "community",
+    "trans": "noun"
+  },
+  {
+    "name": "focus",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "individual",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "matter",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "percent",
+    "trans": "adverb, noun"
+  },
+  {
+    "name": "turn",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "kind",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "quality",
+    "trans": "noun"
+  },
+  {
+    "name": "soil",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "ask",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "board",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "buy",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "guard",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "hold",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "language",
+    "trans": "noun"
+  },
+  {
+    "name": "main",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "offer",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "oil",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "picture",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "potential",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "professional",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "rather",
+    "trans": "adverb"
+  },
+  {
+    "name": "access",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "almost",
+    "trans": "adverb"
+  },
+  {
+    "name": "garden",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "international",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "open",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "range",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rate",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "reason",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "travel",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "variety",
+    "trans": "noun"
+  },
+  {
+    "name": "video",
+    "trans": "noun"
+  },
+  {
+    "name": "week",
+    "trans": "noun"
+  },
+  {
+    "name": "above",
+    "trans": "adverb, preposition, adjective, noun"
+  },
+  {
+    "name": "according",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "cook",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "determine",
+    "trans": "verb"
+  },
+  {
+    "name": "future",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "site",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "alternative",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "demand",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "ever",
+    "trans": "adverb"
+  },
+  {
+    "name": "exercise",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "image",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "special",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "case",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cause",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "coast",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "TRUE",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "whole",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "age",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "among",
+    "trans": "preposition"
+  },
+  {
+    "name": "bad",
+    "trans": "noun, adverb, adjective"
+  },
+  {
+    "name": "boat",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "country",
+    "trans": "noun"
+  },
+  {
+    "name": "dance",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "exam",
+    "trans": "noun"
+  },
+  {
+    "name": "excuse",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "grow",
+    "trans": "verb"
+  },
+  {
+    "name": "movie",
+    "trans": "noun"
+  },
+  {
+    "name": "record",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "result",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "section",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "across",
+    "trans": "preposition, adverb, adjective"
+  },
+  {
+    "name": "already",
+    "trans": "adverb"
+  },
+  {
+    "name": "below",
+    "trans": "adverb"
+  },
+  {
+    "name": "mouse",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "allow",
+    "trans": "verb"
+  },
+  {
+    "name": "cash",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "class",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "clear",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "dry",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "easy",
+    "trans": "adjective, adverb, interjection"
+  },
+  {
+    "name": "live",
+    "trans": "verb, adjective, adverb"
+  },
+  {
+    "name": "period",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "physics",
+    "trans": "noun"
+  },
+  {
+    "name": "plan",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "store",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "tax",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cold",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "full",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "low",
+    "trans": "adjective, noun, adverb, verb"
+  },
+  {
+    "name": "old",
+    "trans": "adjective"
+  },
+  {
+    "name": "policy",
+    "trans": "noun"
+  },
+  {
+    "name": "purchase",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "series",
+    "trans": "noun"
+  },
+  {
+    "name": "side",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "subject",
+    "trans": "noun, adjective, adverb, verb"
+  },
+  {
+    "name": "supply",
+    "trans": "verb"
+  },
+  {
+    "name": "therefore",
+    "trans": "adverb"
+  },
+  {
+    "name": "basis",
+    "trans": "noun"
+  },
+  {
+    "name": "boyfriend",
+    "trans": "noun"
+  },
+  {
+    "name": "deal",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "direction",
+    "trans": "noun"
+  },
+  {
+    "name": "mean",
+    "trans": "verb, adjective, noun"
+  },
+  {
+    "name": "primary",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "space",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "strategy",
+    "trans": "noun"
+  },
+  {
+    "name": "technology",
+    "trans": "noun"
+  },
+  {
+    "name": "worth",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "army",
+    "trans": "noun"
+  },
+  {
+    "name": "camera",
+    "trans": "noun"
+  },
+  {
+    "name": "fall",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "paper",
+    "trans": "noun"
+  },
+  {
+    "name": "rule",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "similar",
+    "trans": "adjective"
+  },
+  {
+    "name": "stock",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "weather",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "yet",
+    "trans": "adverb, conjunction"
+  },
+  {
+    "name": "bring",
+    "trans": "verb"
+  },
+  {
+    "name": "chance",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "environment",
+    "trans": "noun"
+  },
+  {
+    "name": "figure",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "improve",
+    "trans": "verb"
+  },
+  {
+    "name": "man",
+    "trans": "noun, verb, interjection"
+  },
+  {
+    "name": "mathematics",
+    "trans": "noun"
+  },
+  {
+    "name": "model",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "necessary",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "positive",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "produce",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "search",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "source",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "child",
+    "trans": "noun"
+  },
+  {
+    "name": "earth",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "else",
+    "trans": "adverb"
+  },
+  {
+    "name": "instance",
+    "trans": "noun"
+  },
+  {
+    "name": "maintain",
+    "trans": "verb"
+  },
+  {
+    "name": "month",
+    "trans": "noun"
+  },
+  {
+    "name": "present",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "program",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "spend",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "talk",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "upset",
+    "trans": "verb, adjective"
+  },
+  {
+    "name": "begin",
+    "trans": "verb"
+  },
+  {
+    "name": "chicken",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "close",
+    "trans": "adjective, adverb, verb, noun"
+  },
+  {
+    "name": "design",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "feature",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "head",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "material",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "medical",
+    "trans": "adjective"
+  },
+  {
+    "name": "purpose",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "question",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rock",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "salt",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "tell",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "university",
+    "trans": "noun"
+  },
+  {
+    "name": "act",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "article",
+    "trans": "noun"
+  },
+  {
+    "name": "birth",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "car",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "cost",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "department",
+    "trans": "noun"
+  },
+  {
+    "name": "difference",
+    "trans": "noun"
+  },
+  {
+    "name": "dog",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "drive",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "essential",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "exist",
+    "trans": "verb"
+  },
+  {
+    "name": "federal",
+    "trans": "adjective"
+  },
+  {
+    "name": "goal",
+    "trans": "noun"
+  },
+  {
+    "name": "green",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "intelligence",
+    "trans": "noun"
+  },
+  {
+    "name": "late",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "news",
+    "trans": "noun"
+  },
+  {
+    "name": "object",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "scale",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sun",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "support",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "tend",
+    "trans": "verb"
+  },
+  {
+    "name": "thus",
+    "trans": "adverb"
+  },
+  {
+    "name": "audience",
+    "trans": "noun"
+  },
+  {
+    "name": "enjoy",
+    "trans": "verb"
+  },
+  {
+    "name": "entire",
+    "trans": "adjective"
+  },
+  {
+    "name": "fit",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "glad",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "income",
+    "trans": "noun"
+  },
+  {
+    "name": "note",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "perform",
+    "trans": "verb"
+  },
+  {
+    "name": "profit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "proper",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "remove",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "rent",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "return",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "run",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "speed",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "strong",
+    "trans": "adjective"
+  },
+  {
+    "name": "style",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "war",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "actual",
+    "trans": "adjective"
+  },
+  {
+    "name": "appropriate",
+    "trans": "verb, adjective"
+  },
+  {
+    "name": "bank",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "complex",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "content",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "craft",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "due",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "failure",
+    "trans": "noun"
+  },
+  {
+    "name": "half",
+    "trans": "noun, predeterminer, adverb"
+  },
+  {
+    "name": "inside",
+    "trans": "noun, adjective, preposition"
+  },
+  {
+    "name": "meaning",
+    "trans": "noun"
+  },
+  {
+    "name": "medicine",
+    "trans": "noun"
+  },
+  {
+    "name": "middle",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "philosophy",
+    "trans": "noun"
+  },
+  {
+    "name": "regular",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "reserve",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "standard",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "bus",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "decide",
+    "trans": "verb"
+  },
+  {
+    "name": "exchange",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "eye",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "fast",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "fire",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "identify",
+    "trans": "verb"
+  },
+  {
+    "name": "independent",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "leave",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "original",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "position",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "pressure",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "reach",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "rest",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "serve",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "stress",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "watch",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "wide",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "advantage",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "benefit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "box",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "charge",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "complete",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "continue",
+    "trans": "verb"
+  },
+  {
+    "name": "frame",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "issue",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "night",
+    "trans": "noun"
+  },
+  {
+    "name": "protect",
+    "trans": "verb"
+  },
+  {
+    "name": "require",
+    "trans": "verb"
+  },
+  {
+    "name": "significant",
+    "trans": "adjective"
+  },
+  {
+    "name": "step",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "unless",
+    "trans": "conjunction"
+  },
+  {
+    "name": "active",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "break",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "chemistry",
+    "trans": "noun"
+  },
+  {
+    "name": "cycle",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "disease",
+    "trans": "noun"
+  },
+  {
+    "name": "energy",
+    "trans": "noun"
+  },
+  {
+    "name": "face",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "item",
+    "trans": "noun, adverb"
+  },
+  {
+    "name": "metal",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "nation",
+    "trans": "noun"
+  },
+  {
+    "name": "negative",
+    "trans": "adjective, noun, interjection, verb"
+  },
+  {
+    "name": "occur",
+    "trans": "verb"
+  },
+  {
+    "name": "paint",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "pregnant",
+    "trans": "adjective"
+  },
+  {
+    "name": "review",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "road",
+    "trans": "noun"
+  },
+  {
+    "name": "role",
+    "trans": "noun"
+  },
+  {
+    "name": "room",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "safe",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "screen",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "soup",
+    "trans": "noun"
+  },
+  {
+    "name": "stay",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "structure",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "view",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "visit",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "visual",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "write",
+    "trans": "verb"
+  },
+  {
+    "name": "wrong",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "account",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "affect",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "ago",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "approach",
+    "trans": "verb"
+  },
+  {
+    "name": "avoid",
+    "trans": "verb"
+  },
+  {
+    "name": "ball",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "behind",
+    "trans": "preposition, adverb, adjective, noun"
+  },
+  {
+    "name": "cover",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "discipline",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "medium",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "prepare",
+    "trans": "verb"
+  },
+  {
+    "name": "quick",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "ready",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "report",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "rise",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "share",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "apartment",
+    "trans": "noun"
+  },
+  {
+    "name": "balance",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "black",
+    "trans": "noun, verb, adjective, adverb"
+  },
+  {
+    "name": "bottom",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "build",
+    "trans": "verb"
+  },
+  {
+    "name": "choice",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "gift",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "impact",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "machine",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "moment",
+    "trans": "noun"
+  },
+  {
+    "name": "shape",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "straight",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "tool",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "walk",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "white",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "wind",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "achieve",
+    "trans": "verb"
+  },
+  {
+    "name": "address",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "average",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "believe",
+    "trans": "verb"
+  },
+  {
+    "name": "beyond",
+    "trans": "preposition, noun"
+  },
+  {
+    "name": "career",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "culture",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "decision",
+    "trans": "noun"
+  },
+  {
+    "name": "direct",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "event",
+    "trans": "noun"
+  },
+  {
+    "name": "excellent",
+    "trans": "adjective, interjection"
+  },
+  {
+    "name": "extra",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "junior",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "morning",
+    "trans": "noun, adverb"
+  },
+  {
+    "name": "pick",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "poor",
+    "trans": "adjective"
+  },
+  {
+    "name": "pot",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "pretty",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "property",
+    "trans": "noun"
+  },
+  {
+    "name": "receive",
+    "trans": "verb"
+  },
+  {
+    "name": "seem",
+    "trans": "verb"
+  },
+  {
+    "name": "sign",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "student",
+    "trans": "noun"
+  },
+  {
+    "name": "table",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "task",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "unique",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "wood",
+    "trans": "noun"
+  },
+  {
+    "name": "classic",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "competition",
+    "trans": "noun"
+  },
+  {
+    "name": "condition",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "contact",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "credit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "discuss",
+    "trans": "verb"
+  },
+  {
+    "name": "egg",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "final",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "happy",
+    "trans": "adjective"
+  },
+  {
+    "name": "hope",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "ice",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "lift",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "mix",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "network",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "north",
+    "trans": "noun, adjective, adverb"
+  },
+  {
+    "name": "office",
+    "trans": "noun"
+  },
+  {
+    "name": "overall",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "population",
+    "trans": "noun"
+  },
+  {
+    "name": "president",
+    "trans": "noun"
+  },
+  {
+    "name": "private",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "realize",
+    "trans": "verb"
+  },
+  {
+    "name": "responsible",
+    "trans": "adjective"
+  },
+  {
+    "name": "separate",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "square",
+    "trans": "noun, adjective, adverb"
+  },
+  {
+    "name": "stop",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "teach",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "unit",
+    "trans": "noun"
+  },
+  {
+    "name": "western",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "yes",
+    "trans": "interjection"
+  },
+  {
+    "name": "alone",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "attempt",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "category",
+    "trans": "noun"
+  },
+  {
+    "name": "cigarette",
+    "trans": "noun"
+  },
+  {
+    "name": "concern",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "contain",
+    "trans": "verb"
+  },
+  {
+    "name": "context",
+    "trans": "noun"
+  },
+  {
+    "name": "cute",
+    "trans": "adjective"
+  },
+  {
+    "name": "date",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "effect",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "familiar",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "fly",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "follow",
+    "trans": "verb"
+  },
+  {
+    "name": "link",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "official",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "opportunity",
+    "trans": "noun"
+  },
+  {
+    "name": "perfect",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "post",
+    "trans": "noun, verb, adverb"
+  },
+  {
+    "name": "recent",
+    "trans": "adjective"
+  },
+  {
+    "name": "refer",
+    "trans": "verb"
+  },
+  {
+    "name": "solve",
+    "trans": "verb"
+  },
+  {
+    "name": "star",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "toward",
+    "trans": "preposition, adjective"
+  },
+  {
+    "name": "voice",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bright",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "broad",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "capital",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "challenge",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "describe",
+    "trans": "verb"
+  },
+  {
+    "name": "despite",
+    "trans": "preposition"
+  },
+  {
+    "name": "flat",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "flight",
+    "trans": "noun"
+  },
+  {
+    "name": "friend",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "gain",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "length",
+    "trans": "noun"
+  },
+  {
+    "name": "magazine",
+    "trans": "noun"
+  },
+  {
+    "name": "maybe",
+    "trans": "adverb, noun"
+  },
+  {
+    "name": "newspaper",
+    "trans": "noun"
+  },
+  {
+    "name": "nice",
+    "trans": "adjective"
+  },
+  {
+    "name": "prefer",
+    "trans": "verb"
+  },
+  {
+    "name": "prevent",
+    "trans": "verb"
+  },
+  {
+    "name": "rich",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "save",
+    "trans": "verb, noun, preposition"
+  },
+  {
+    "name": "self",
+    "trans": "noun, pronoun, adjective, verb"
+  },
+  {
+    "name": "soon",
+    "trans": "adverb"
+  },
+  {
+    "name": "stand",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "warm",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "young",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "ahead",
+    "trans": "adverb"
+  },
+  {
+    "name": "beauty",
+    "trans": "noun"
+  },
+  {
+    "name": "brush",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cell",
+    "trans": "noun"
+  },
+  {
+    "name": "couple",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "debate",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "discover",
+    "trans": "verb"
+  },
+  {
+    "name": "ensure",
+    "trans": "verb"
+  },
+  {
+    "name": "exit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "expect",
+    "trans": "verb"
+  },
+  {
+    "name": "fail",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "front",
+    "trans": "noun, adjective, verb, interjection"
+  },
+  {
+    "name": "function",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "heavy",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "invest",
+    "trans": "verb"
+  },
+  {
+    "name": "lack",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "lake",
+    "trans": "noun"
+  },
+  {
+    "name": "lead",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "listen",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "member",
+    "trans": "noun"
+  },
+  {
+    "name": "message",
+    "trans": "noun"
+  },
+  {
+    "name": "plant",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "plastic",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "reduce",
+    "trans": "verb"
+  },
+  {
+    "name": "scene",
+    "trans": "noun"
+  },
+  {
+    "name": "serious",
+    "trans": "adjective"
+  },
+  {
+    "name": "speak",
+    "trans": "verb"
+  },
+  {
+    "name": "spot",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "summer",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "taste",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "theme",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "track",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "wing",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "worry",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "appear",
+    "trans": "verb"
+  },
+  {
+    "name": "brain",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "button",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "click",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "concept",
+    "trans": "noun"
+  },
+  {
+    "name": "correct",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "customer",
+    "trans": "noun"
+  },
+  {
+    "name": "death",
+    "trans": "noun"
+  },
+  {
+    "name": "desire",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "explain",
+    "trans": "verb"
+  },
+  {
+    "name": "explore",
+    "trans": "verb"
+  },
+  {
+    "name": "express",
+    "trans": "verb, adjective, adverb, noun"
+  },
+  {
+    "name": "foot",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "gas",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "handle",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "huge",
+    "trans": "adjective"
+  },
+  {
+    "name": "influence",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "involve",
+    "trans": "verb"
+  },
+  {
+    "name": "lose",
+    "trans": "verb"
+  },
+  {
+    "name": "meet",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "mood",
+    "trans": "noun"
+  },
+  {
+    "name": "notice",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rain",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rare",
+    "trans": "adjective"
+  },
+  {
+    "name": "release",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "sell",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "slow",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "technical",
+    "trans": "adjective"
+  },
+  {
+    "name": "typical",
+    "trans": "adjective"
+  },
+  {
+    "name": "upon",
+    "trans": "preposition"
+  },
+  {
+    "name": "wall",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "woman",
+    "trans": "noun"
+  },
+  {
+    "name": "advice",
+    "trans": "noun"
+  },
+  {
+    "name": "afford",
+    "trans": "verb"
+  },
+  {
+    "name": "agree",
+    "trans": "verb"
+  },
+  {
+    "name": "base",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "blood",
+    "trans": "noun"
+  },
+  {
+    "name": "clean",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "damage",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "distance",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "effort",
+    "trans": "noun"
+  },
+  {
+    "name": "electronic",
+    "trans": "adjective"
+  },
+  {
+    "name": "finish",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "fresh",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "hear",
+    "trans": "verb"
+  },
+  {
+    "name": "immediate",
+    "trans": "adjective"
+  },
+  {
+    "name": "importance",
+    "trans": "noun"
+  },
+  {
+    "name": "normal",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "opinion",
+    "trans": "noun"
+  },
+  {
+    "name": "otherwise",
+    "trans": "adverb, adjective"
+  },
+  {
+    "name": "pair",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "plus",
+    "trans": "preposition, adjective, noun, conjunction"
+  },
+  {
+    "name": "press",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "remain",
+    "trans": "verb"
+  },
+  {
+    "name": "represent",
+    "trans": "verb"
+  },
+  {
+    "name": "ride",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "secret",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "skill",
+    "trans": "noun"
+  },
+  {
+    "name": "spread",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "spring",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "staff",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sugar",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "target",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "text",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "tough",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "wait",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "wealth",
+    "trans": "noun"
+  },
+  {
+    "name": "animal",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "apply",
+    "trans": "verb"
+  },
+  {
+    "name": "author",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "aware",
+    "trans": "adjective"
+  },
+  {
+    "name": "brown",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "budget",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "cheap",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "city",
+    "trans": "noun"
+  },
+  {
+    "name": "county",
+    "trans": "noun"
+  },
+  {
+    "name": "deep",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "discount",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "display",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "estate",
+    "trans": "noun"
+  },
+  {
+    "name": "file",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "flow",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "forget",
+    "trans": "verb"
+  },
+  {
+    "name": "foundation",
+    "trans": "noun"
+  },
+  {
+    "name": "global",
+    "trans": "adjective"
+  },
+  {
+    "name": "ground",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "heart",
+    "trans": "noun"
+  },
+  {
+    "name": "hit",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "legal",
+    "trans": "adjective"
+  },
+  {
+    "name": "lesson",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "measure",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "minute",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "near",
+    "trans": "adverb, preposition, adjective, verb"
+  },
+  {
+    "name": "objective",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "perspective",
+    "trans": "noun"
+  },
+  {
+    "name": "phase",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "promote",
+    "trans": "verb"
+  },
+  {
+    "name": "recipe",
+    "trans": "noun"
+  },
+  {
+    "name": "recommend",
+    "trans": "verb"
+  },
+  {
+    "name": "register",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "relevant",
+    "trans": "adjective"
+  },
+  {
+    "name": "rely",
+    "trans": "verb"
+  },
+  {
+    "name": "secure",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "shoot",
+    "trans": "verb, noun, interjection"
+  },
+  {
+    "name": "sky",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "stage",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "stick",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "studio",
+    "trans": "noun"
+  },
+  {
+    "name": "thin",
+    "trans": "adjective, adverb, verb"
+  },
+  {
+    "name": "title",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "topic",
+    "trans": "noun"
+  },
+  {
+    "name": "touch",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "trouble",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "vary",
+    "trans": "verb"
+  },
+  {
+    "name": "absolute",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "accurate",
+    "trans": "adjective"
+  },
+  {
+    "name": "bowl",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bridge",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "campaign",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cancel",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "capable",
+    "trans": "adjective"
+  },
+  {
+    "name": "character",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "chemical",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "club",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cool",
+    "trans": "adjective, adverb, noun, verb"
+  },
+  {
+    "name": "cry",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "dump",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "edge",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "evidence",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "extreme",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "fan",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "generate",
+    "trans": "verb"
+  },
+  {
+    "name": "letter",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "lock",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "maximum",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "novel",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "obtain",
+    "trans": "verb"
+  },
+  {
+    "name": "option",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "pack",
+    "trans": "noun, verb, adjective, idiom"
+  },
+  {
+    "name": "park",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "passion",
+    "trans": "noun"
+  },
+  {
+    "name": "plenty",
+    "trans": "noun, adjective, adverb"
+  },
+  {
+    "name": "push",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "quarter",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "resource",
+    "trans": "noun"
+  },
+  {
+    "name": "select",
+    "trans": "verb, adjective"
+  },
+  {
+    "name": "skin",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sort",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "accept",
+    "trans": "verb"
+  },
+  {
+    "name": "baby",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "background",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "carry",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "college",
+    "trans": "noun"
+  },
+  {
+    "name": "communicate",
+    "trans": "verb"
+  },
+  {
+    "name": "complain",
+    "trans": "verb"
+  },
+  {
+    "name": "conflict",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "criticism",
+    "trans": "noun"
+  },
+  {
+    "name": "debt",
+    "trans": "noun"
+  },
+  {
+    "name": "define",
+    "trans": "verb"
+  },
+  {
+    "name": "depend",
+    "trans": "verb"
+  },
+  {
+    "name": "die",
+    "trans": "verb, idiom"
+  },
+  {
+    "name": "dish",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "eat",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "efficient",
+    "trans": "adjective"
+  },
+  {
+    "name": "enter",
+    "trans": "verb"
+  },
+  {
+    "name": "exact",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "factor",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "fair",
+    "trans": "adjective, adverb, noun, idiom"
+  },
+  {
+    "name": "fill",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "fine",
+    "trans": "adjective, adverb, verb, noun"
+  },
+  {
+    "name": "formal",
+    "trans": "adjective, noun, adverb"
+  },
+  {
+    "name": "forward",
+    "trans": "adverb, adjective, noun, verb"
+  },
+  {
+    "name": "fruit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "glass",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "happen",
+    "trans": "verb"
+  },
+  {
+    "name": "indicate",
+    "trans": "verb"
+  },
+  {
+    "name": "joint",
+    "trans": "noun, adjective, verb, idiom"
+  },
+  {
+    "name": "jump",
+    "trans": "verb, noun, adjective, adverb"
+  },
+  {
+    "name": "kick",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "master",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "memory",
+    "trans": "noun"
+  },
+  {
+    "name": "muscle",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "opposite",
+    "trans": "adjective, noun, preposition, adverb"
+  },
+  {
+    "name": "pass",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "pitch",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "red",
+    "trans": "noun, adjective, idiom"
+  },
+  {
+    "name": "remote",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "secretary",
+    "trans": "noun"
+  },
+  {
+    "name": "solution",
+    "trans": "noun"
+  },
+  {
+    "name": "somewhat",
+    "trans": "adverb"
+  },
+  {
+    "name": "strength",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "suggest",
+    "trans": "verb"
+  },
+  {
+    "name": "survive",
+    "trans": "verb"
+  },
+  {
+    "name": "total",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "traffic",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "treat",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "trip",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "vast",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "vegetable",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "abuse",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "administration",
+    "trans": "noun"
+  },
+  {
+    "name": "appeal",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "appreciate",
+    "trans": "verb"
+  },
+  {
+    "name": "aspect",
+    "trans": "noun"
+  },
+  {
+    "name": "attitude",
+    "trans": "noun"
+  },
+  {
+    "name": "beat",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "burn",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "chart",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "compare",
+    "trans": "verb"
+  },
+  {
+    "name": "deposit",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "foreign",
+    "trans": "adjective"
+  },
+  {
+    "name": "gear",
+    "trans": "noun, verb, adjective, idiom"
+  },
+  {
+    "name": "ideal",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "imagine",
+    "trans": "verb"
+  },
+  {
+    "name": "kitchen",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "land",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "log",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "manage",
+    "trans": "verb"
+  },
+  {
+    "name": "mother",
+    "trans": "noun, adjective, verb, idiom"
+  },
+  {
+    "name": "net",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "party",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "personality",
+    "trans": "noun"
+  },
+  {
+    "name": "photograph",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "practical",
+    "trans": "adjective"
+  },
+  {
+    "name": "principle",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "print",
+    "trans": "verb, noun, adjective, idiom"
+  },
+  {
+    "name": "psychology",
+    "trans": "noun"
+  },
+  {
+    "name": "raise",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "relative",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "response",
+    "trans": "noun"
+  },
+  {
+    "name": "sale",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "season",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "severe",
+    "trans": "adjective"
+  },
+  {
+    "name": "signal",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "sleep",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "smooth",
+    "trans": "adjective, adverb, verb, noun"
+  },
+  {
+    "name": "spirit",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "street",
+    "trans": "noun, adjective, idiom"
+  },
+  {
+    "name": "tree",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "version",
+    "trans": "noun"
+  },
+  {
+    "name": "wave",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "advance",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "alcohol",
+    "trans": "noun"
+  },
+  {
+    "name": "belt",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bench",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "commission",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "connect",
+    "trans": "verb, adjective"
+  },
+  {
+    "name": "consist",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "contract",
+    "trans": "noun"
+  },
+  {
+    "name": "contribute",
+    "trans": "verb, idiom"
+  },
+  {
+    "name": "copy",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "dark",
+    "trans": "adjective, noun, idiom"
+  },
+  {
+    "name": "differ",
+    "trans": "verb"
+  },
+  {
+    "name": "double",
+    "trans": "adjective, noun, verb, adverb"
+  },
+  {
+    "name": "draw",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "drop",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "emphasis",
+    "trans": "noun"
+  },
+  {
+    "name": "encourage",
+    "trans": "verb"
+  },
+  {
+    "name": "equal",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "expand",
+    "trans": "verb"
+  },
+  {
+    "name": "firm",
+    "trans": "adjective, verb, adverb, noun"
+  },
+  {
+    "name": "fix",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "frequent",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "hire",
+    "trans": "verb, noun, adjective, idiom"
+  },
+  {
+    "name": "internal",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "join",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "kill",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "loss",
+    "trans": "noun"
+  },
+  {
+    "name": "mere",
+    "trans": "adjective"
+  },
+  {
+    "name": "minimum",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "numerous",
+    "trans": "adjective"
+  },
+  {
+    "name": "path",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "progress",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "project",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "prove",
+    "trans": "verb"
+  },
+  {
+    "name": "react",
+    "trans": "verb"
+  },
+  {
+    "name": "recognize",
+    "trans": "verb"
+  },
+  {
+    "name": "relax",
+    "trans": "verb"
+  },
+  {
+    "name": "replace",
+    "trans": "verb"
+  },
+  {
+    "name": "sea",
+    "trans": "noun, adjective, idiom"
+  },
+  {
+    "name": "sensitive",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "sit",
+    "trans": "verb, idiom"
+  },
+  {
+    "name": "south",
+    "trans": "noun, adjective, adverb, verb"
+  },
+  {
+    "name": "status",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "steak",
+    "trans": "noun"
+  },
+  {
+    "name": "stuff",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sufficient",
+    "trans": "adjective"
+  },
+  {
+    "name": "tap",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "ticket",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "tour",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "union",
+    "trans": "noun"
+  },
+  {
+    "name": "win",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "angle",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "attack",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "blue",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "borrow",
+    "trans": "verb"
+  },
+  {
+    "name": "breakfast",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cancer",
+    "trans": "noun"
+  },
+  {
+    "name": "claim",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "confidence",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "consistent",
+    "trans": "adjective"
+  },
+  {
+    "name": "constant",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "currency",
+    "trans": "noun"
+  },
+  {
+    "name": "daughter",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "degree",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "doctor",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "dot",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "drag",
+    "trans": "verb, noun, adjective, idiom"
+  },
+  {
+    "name": "dream",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "drink",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "duty",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "earn",
+    "trans": "verb"
+  },
+  {
+    "name": "enable",
+    "trans": "verb"
+  },
+  {
+    "name": "essay",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "famous",
+    "trans": "adjective"
+  },
+  {
+    "name": "father",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "fee",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "finance",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "guess",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "hour",
+    "trans": "noun, adjective, idiom"
+  },
+  {
+    "name": "juice",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "limit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "luck",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "milk",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "minor",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "mixture",
+    "trans": "noun"
+  },
+  {
+    "name": "mouth",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "nor",
+    "trans": "conjunction"
+  },
+  {
+    "name": "operate",
+    "trans": "verb"
+  },
+  {
+    "name": "peace",
+    "trans": "noun, interjection, verb, idiom"
+  },
+  {
+    "name": "pipe",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "please",
+    "trans": "adverb, verb, idiom"
+  },
+  {
+    "name": "previous",
+    "trans": "adjective, idiom"
+  },
+  {
+    "name": "pull",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "pure",
+    "trans": "adjective"
+  },
+  {
+    "name": "raw",
+    "trans": "adjective, noun, idiom"
+  },
+  {
+    "name": "reflect",
+    "trans": "verb"
+  },
+  {
+    "name": "region",
+    "trans": "noun"
+  },
+  {
+    "name": "republic",
+    "trans": "noun"
+  },
+  {
+    "name": "seat",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "send",
+    "trans": "verb"
+  },
+  {
+    "name": "soft",
+    "trans": "adjective, noun, adverb, interjection"
+  },
+  {
+    "name": "solid",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "stable",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "storm",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "substance",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "team",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "tradition",
+    "trans": "noun"
+  },
+  {
+    "name": "trick",
+    "trans": "noun, adjective, verb, idiom"
+  },
+  {
+    "name": "virus",
+    "trans": "noun"
+  },
+  {
+    "name": "wear",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "weird",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "wonder",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "afraid",
+    "trans": "adjective"
+  },
+  {
+    "name": "afternoon",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "analyze",
+    "trans": "verb"
+  },
+  {
+    "name": "annual",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "anticipate",
+    "trans": "verb"
+  },
+  {
+    "name": "assume",
+    "trans": "verb"
+  },
+  {
+    "name": "bat",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "beach",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "blank",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "busy",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "catch",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "chain",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "count",
+    "trans": "verb, noun, adjective, idiom"
+  },
+  {
+    "name": "cream",
+    "trans": "noun, verb, adjective, idiom"
+  },
+  {
+    "name": "crew",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "dead",
+    "trans": "adjective, noun, adverb, idiom"
+  },
+  {
+    "name": "detail",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "device",
+    "trans": "noun"
+  },
+  {
+    "name": "doubt",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "drama",
+    "trans": "noun"
+  },
+  {
+    "name": "engage",
+    "trans": "verb"
+  },
+  {
+    "name": "engine",
+    "trans": "noun"
+  },
+  {
+    "name": "enhance",
+    "trans": "verb"
+  },
+  {
+    "name": "examine",
+    "trans": "verb"
+  },
+  {
+    "name": "expense",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "FALSE",
+    "trans": "adjective, adverb, idiom"
+  },
+  {
+    "name": "feed",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "forever",
+    "trans": "adverb, noun, idiom"
+  },
+  {
+    "name": "gold",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "hotel",
+    "trans": "noun"
+  },
+  {
+    "name": "impress",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "install",
+    "trans": "verb"
+  },
+  {
+    "name": "interact",
+    "trans": "verb"
+  },
+  {
+    "name": "interview",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "kid",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "logic",
+    "trans": "noun"
+  },
+  {
+    "name": "mark",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "match",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "mission",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "obvious",
+    "trans": "adjective"
+  },
+  {
+    "name": "pain",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "participate",
+    "trans": "verb"
+  },
+  {
+    "name": "pleasure",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "priority",
+    "trans": "noun"
+  },
+  {
+    "name": "repeat",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "round",
+    "trans": "adjective, noun, adverb, verb"
+  },
+  {
+    "name": "score",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "screw",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "seek",
+    "trans": "verb, idiom"
+  },
+  {
+    "name": "sex",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "sharp",
+    "trans": "adjective, verb, adverb, noun"
+  },
+  {
+    "name": "shop",
+    "trans": "noun, verb, interjection, idiom"
+  },
+  {
+    "name": "shower",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "sing",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "slide",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "strip",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "suit",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "thick",
+    "trans": "adjective, adverb, noun, idiom"
+  },
+  {
+    "name": "tone",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "whereas",
+    "trans": "conjunction, noun"
+  },
+  {
+    "name": "window",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "wise",
+    "trans": "adjective, verb, idiom"
+  },
+  {
+    "name": "wish",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "agent",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "anxiety",
+    "trans": "noun"
+  },
+  {
+    "name": "atmosphere",
+    "trans": "noun"
+  },
+  {
+    "name": "band",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bath",
+    "trans": "noun"
+  },
+  {
+    "name": "block",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bone",
+    "trans": "noun, verb, adverb"
+  },
+  {
+    "name": "bread",
+    "trans": "noun"
+  },
+  {
+    "name": "calendar",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "candidate",
+    "trans": "noun"
+  },
+  {
+    "name": "cap",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "climate",
+    "trans": "noun"
+  },
+  {
+    "name": "coat",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "collect",
+    "trans": "verb, adverb, noun"
+  },
+  {
+    "name": "combine",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "command",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "contest",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "corner",
+    "trans": "noun, adjective, verb, idiom"
+  },
+  {
+    "name": "court",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "cup",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "dig",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "district",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "divide",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "door",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "east",
+    "trans": "noun, adjective, adverb"
+  },
+  {
+    "name": "electric",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "emotion",
+    "trans": "noun"
+  },
+  {
+    "name": "equivalent",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "except",
+    "trans": "preposition, conjunction, idiom"
+  },
+  {
+    "name": "finger",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "garage",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "guarantee",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "guest",
+    "trans": "noun"
+  },
+  {
+    "name": "hang",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "height",
+    "trans": "noun"
+  },
+  {
+    "name": "hole",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "hook",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "hunt",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "implement",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "initial",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "intend",
+    "trans": "verb"
+  },
+  {
+    "name": "introduce",
+    "trans": "verb"
+  },
+  {
+    "name": "latter",
+    "trans": "adjective"
+  },
+  {
+    "name": "layer",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "lecture",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "lie",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "mall",
+    "trans": "noun"
+  },
+  {
+    "name": "manner",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "march",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "mention",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "narrow",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "neither",
+    "trans": "conjunction, adjective, pronoun"
+  },
+  {
+    "name": "nose",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "partner",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "profile",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "proud",
+    "trans": "adjective, idiom"
+  },
+  {
+    "name": "respect",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rice",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "routine",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "sample",
+    "trans": "noun"
+  },
+  {
+    "name": "schedule",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "settle",
+    "trans": "verb"
+  },
+  {
+    "name": "smell",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "survey",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "telephone",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "tie",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "tip",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "wild",
+    "trans": "adjective, adverb, noun, idiom"
+  },
+  {
+    "name": "winter",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "adult",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "aggressive",
+    "trans": "adjective"
+  },
+  {
+    "name": "airline",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "apart",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "assure",
+    "trans": "verb"
+  },
+  {
+    "name": "attract",
+    "trans": "verb"
+  },
+  {
+    "name": "bag",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "battle",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bed",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bill",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "boring",
+    "trans": "adjective"
+  },
+  {
+    "name": "bother",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "brief",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "cake",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "charity",
+    "trans": "noun"
+  },
+  {
+    "name": "code",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "commerce",
+    "trans": "noun"
+  },
+  {
+    "name": "cousin",
+    "trans": "noun"
+  },
+  {
+    "name": "crazy",
+    "trans": "adjective, noun, idiom"
+  },
+  {
+    "name": "curve",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "dimension",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "disaster",
+    "trans": "noun"
+  },
+  {
+    "name": "distinct",
+    "trans": "adjective"
+  },
+  {
+    "name": "distribute",
+    "trans": "verb"
+  },
+  {
+    "name": "dress",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "ease",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "eastern",
+    "trans": "adjective"
+  },
+  {
+    "name": "emergency",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "escape",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "evening",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "expose",
+    "trans": "verb, idiom"
+  },
+  {
+    "name": "extension",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "extent",
+    "trans": "noun"
+  },
+  {
+    "name": "farm",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "feedback",
+    "trans": "noun"
+  },
+  {
+    "name": "fight",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "gap",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "gather",
+    "trans": "verb, noun, idiom"
+  },
+  {
+    "name": "gentle",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "govern",
+    "trans": "verb"
+  },
+  {
+    "name": "grade",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "guitar",
+    "trans": "noun"
+  },
+  {
+    "name": "hate",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "holiday",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "homework",
+    "trans": "noun"
+  },
+  {
+    "name": "horror",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "horse",
+    "trans": "noun, verb, adjective, idiom"
+  },
+  {
+    "name": "host",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "husband",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "loan",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "mistake",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "mountain",
+    "trans": "noun, adjective, idiom"
+  },
+  {
+    "name": "nail",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "noise",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "none",
+    "trans": "pronoun, adverb, adjective"
+  },
+  {
+    "name": "occasion",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "outcome",
+    "trans": "noun"
+  },
+  {
+    "name": "overcome",
+    "trans": "verb"
+  },
+  {
+    "name": "owe",
+    "trans": "verb"
+  },
+  {
+    "name": "patient",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "pause",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "phrase",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "prior",
+    "trans": "adjective, noun, idiom"
+  },
+  {
+    "name": "proof",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "race",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "relief",
+    "trans": "noun, idiom"
+  },
+  {
+    "name": "repair",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "resolution",
+    "trans": "noun"
+  },
+  {
+    "name": "revenue",
+    "trans": "noun"
+  },
+  {
+    "name": "rough",
+    "trans": "adjective, noun, adverb, verb"
+  },
+  {
+    "name": "sad",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "sand",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "scratch",
+    "trans": "verb, noun, adjective, idiom"
+  },
+  {
+    "name": "sentence",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "session",
+    "trans": "noun"
+  },
+  {
+    "name": "shoulder",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "sick",
+    "trans": "adjective, noun, idiom"
+  },
+  {
+    "name": "smoke",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "stomach",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "strange",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "strict",
+    "trans": "adjective"
+  },
+  {
+    "name": "strike",
+    "trans": "verb, noun, adjective, idiom"
+  },
+  {
+    "name": "string",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "succeed",
+    "trans": "verb"
+  },
+  {
+    "name": "suffer",
+    "trans": "verb"
+  },
+  {
+    "name": "tennis",
+    "trans": "noun"
+  },
+  {
+    "name": "throw",
+    "trans": "verb"
+  },
+  {
+    "name": "towel",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "vacation",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "virtual",
+    "trans": "adjective"
+  },
+  {
+    "name": "west",
+    "trans": "noun, adjective, adverb, idiom"
+  },
+  {
+    "name": "wheel",
+    "trans": "noun, verb, idiom"
+  },
+  {
+    "name": "wine",
+    "trans": "noun, adjective, verb, idiom"
+  },
+  {
+    "name": "acquire",
+    "trans": "verb"
+  },
+  {
+    "name": "adapt",
+    "trans": "verb"
+  },
+  {
+    "name": "adjust",
+    "trans": "verb"
+  },
+  {
+    "name": "administrative",
+    "trans": "adjective"
+  },
+  {
+    "name": "altogether",
+    "trans": "adverb"
+  },
+  {
+    "name": "argue",
+    "trans": "verb"
+  },
+  {
+    "name": "arise",
+    "trans": "verb"
+  },
+  {
+    "name": "arm",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "aside",
+    "trans": "noun, adverb"
+  },
+  {
+    "name": "assign",
+    "trans": "verb"
+  },
+  {
+    "name": "associate",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "automatic",
+    "trans": "adjective"
+  },
+  {
+    "name": "basket",
+    "trans": "noun"
+  },
+  {
+    "name": "bet",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "blow",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bonus",
+    "trans": "noun"
+  },
+  {
+    "name": "border",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "branch",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "breast",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "brother",
+    "trans": "noun, interjection"
+  },
+  {
+    "name": "buddy",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bunch",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cabinet",
+    "trans": "noun"
+  },
+  {
+    "name": "chip",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "church",
+    "trans": "noun"
+  },
+  {
+    "name": "civil",
+    "trans": "adjective"
+  },
+  {
+    "name": "coach",
+    "trans": "noun, verb, adverb"
+  },
+  {
+    "name": "coffee",
+    "trans": "noun"
+  },
+  {
+    "name": "confirm",
+    "trans": "verb"
+  },
+  {
+    "name": "construct",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "cross",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "danger",
+    "trans": "noun"
+  },
+  {
+    "name": "definite",
+    "trans": "adjective"
+  },
+  {
+    "name": "dinner",
+    "trans": "noun"
+  },
+  {
+    "name": "document",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "draft",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "dust",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "edit",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "employ",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "expert",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "external",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "floor",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "former",
+    "trans": "adjective"
+  },
+  {
+    "name": "god",
+    "trans": "noun, interjection"
+  },
+  {
+    "name": "golf",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "habit",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "hair",
+    "trans": "noun"
+  },
+  {
+    "name": "hardly",
+    "trans": "adverb"
+  },
+  {
+    "name": "hurt",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "incorporate",
+    "trans": "verb"
+  },
+  {
+    "name": "iron",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "judge",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "justify",
+    "trans": "verb"
+  },
+  {
+    "name": "knife",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "laboratory",
+    "trans": "noun"
+  },
+  {
+    "name": "landscape",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "laugh",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "lay",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "league",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "loud",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "mail",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "massive",
+    "trans": "adjective"
+  },
+  {
+    "name": "mess",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "mobile",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "mode",
+    "trans": "noun"
+  },
+  {
+    "name": "mud",
+    "trans": "noun"
+  },
+  {
+    "name": "nasty",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "native",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "orange",
+    "trans": "noun"
+  },
+  {
+    "name": "ordinary",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "organize",
+    "trans": "verb"
+  },
+  {
+    "name": "ought",
+    "trans": "verb"
+  },
+  {
+    "name": "parent",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "pattern",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "pin",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "police",
+    "trans": "noun"
+  },
+  {
+    "name": "pool",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "possess",
+    "trans": "verb"
+  },
+  {
+    "name": "pound",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "queen",
+    "trans": "noun"
+  },
+  {
+    "name": "ratio",
+    "trans": "noun"
+  },
+  {
+    "name": "relation",
+    "trans": "noun"
+  },
+  {
+    "name": "relieve",
+    "trans": "verb"
+  },
+  {
+    "name": "request",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "respond",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "restaurant",
+    "trans": "noun"
+  },
+  {
+    "name": "retain",
+    "trans": "verb"
+  },
+  {
+    "name": "royal",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "salary",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sector",
+    "trans": "noun"
+  },
+  {
+    "name": "senior",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "shame",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "shelter",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "shoe",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "shut",
+    "trans": "verb"
+  },
+  {
+    "name": "signature",
+    "trans": "noun"
+  },
+  {
+    "name": "silver",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "song",
+    "trans": "noun"
+  },
+  {
+    "name": "southern",
+    "trans": "adjective"
+  },
+  {
+    "name": "split",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "strain",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "struggle",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "super",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "swim",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "tackle",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "tank",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "tight",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "tooth",
+    "trans": "noun"
+  },
+  {
+    "name": "town",
+    "trans": "noun"
+  },
+  {
+    "name": "train",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "trust",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "upper",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "vehicle",
+    "trans": "noun"
+  },
+  {
+    "name": "visible",
+    "trans": "adjective"
+  },
+  {
+    "name": "volume",
+    "trans": "noun"
+  },
+  {
+    "name": "wash",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "waste",
+    "trans": "verb, adjective, noun"
+  },
+  {
+    "name": "wife",
+    "trans": "noun"
+  },
+  {
+    "name": "yellow",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "accident",
+    "trans": "noun"
+  },
+  {
+    "name": "advertise",
+    "trans": "verb"
+  },
+  {
+    "name": "airport",
+    "trans": "noun"
+  },
+  {
+    "name": "alive",
+    "trans": "adjective"
+  },
+  {
+    "name": "angry",
+    "trans": "adjective"
+  },
+  {
+    "name": "assist",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bake",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bar",
+    "trans": "noun, verb, preposition"
+  },
+  {
+    "name": "baseball",
+    "trans": "noun"
+  },
+  {
+    "name": "bell",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bike",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "blame",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "boy",
+    "trans": "noun, interjection"
+  },
+  {
+    "name": "brick",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "calculate",
+    "trans": "verb"
+  },
+  {
+    "name": "chair",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "chapter",
+    "trans": "noun"
+  },
+  {
+    "name": "closet",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "clue",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "collar",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "comment",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "committee",
+    "trans": "noun"
+  },
+  {
+    "name": "compete",
+    "trans": "verb"
+  },
+  {
+    "name": "confuse",
+    "trans": "verb"
+  },
+  {
+    "name": "consult",
+    "trans": "verb"
+  },
+  {
+    "name": "convert",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "crash",
+    "trans": "verb, noun, adjective, adverb"
+  },
+  {
+    "name": "database",
+    "trans": "noun"
+  },
+  {
+    "name": "deliver",
+    "trans": "verb"
+  },
+  {
+    "name": "desperate",
+    "trans": "adjective"
+  },
+  {
+    "name": "devil",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "diet",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "disc",
+    "trans": "noun"
+  },
+  {
+    "name": "educate",
+    "trans": "verb"
+  },
+  {
+    "name": "enthusiasm",
+    "trans": "noun"
+  },
+  {
+    "name": "error",
+    "trans": "noun"
+  },
+  {
+    "name": "extend",
+    "trans": "verb"
+  },
+  {
+    "name": "fear",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "fold",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "forth",
+    "trans": "adverb"
+  },
+  {
+    "name": "fuel",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "gate",
+    "trans": "noun"
+  },
+  {
+    "name": "girl",
+    "trans": "noun"
+  },
+  {
+    "name": "glove",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "grab",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "gross",
+    "trans": "adjective, adverb, verb, noun"
+  },
+  {
+    "name": "hall",
+    "trans": "noun"
+  },
+  {
+    "name": "hide",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "hospital",
+    "trans": "noun"
+  },
+  {
+    "name": "ill",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "insure",
+    "trans": "verb"
+  },
+  {
+    "name": "investigate",
+    "trans": "verb"
+  },
+  {
+    "name": "jacket",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "literal",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "lunch",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "meal",
+    "trans": "noun"
+  },
+  {
+    "name": "miss",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "monitor",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "mortgage",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "negotiate",
+    "trans": "verb"
+  },
+  {
+    "name": "nurse",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "pace",
+    "trans": "noun, verb, preposition"
+  },
+  {
+    "name": "panic",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "peak",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "perception",
+    "trans": "noun"
+  },
+  {
+    "name": "permit",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "pie",
+    "trans": "noun"
+  },
+  {
+    "name": "plane",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "poem",
+    "trans": "noun"
+  },
+  {
+    "name": "presence",
+    "trans": "noun"
+  },
+  {
+    "name": "qualify",
+    "trans": "verb"
+  },
+  {
+    "name": "quote",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "reception",
+    "trans": "noun"
+  },
+  {
+    "name": "recover",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "resolve",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "retire",
+    "trans": "verb"
+  },
+  {
+    "name": "revolution",
+    "trans": "noun"
+  },
+  {
+    "name": "reward",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rid",
+    "trans": "verb"
+  },
+  {
+    "name": "river",
+    "trans": "noun"
+  },
+  {
+    "name": "roll",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "row",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sandwich",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "satisfy",
+    "trans": "verb"
+  },
+  {
+    "name": "scare",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "shock",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sink",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "slip",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "son",
+    "trans": "noun"
+  },
+  {
+    "name": "sorry",
+    "trans": "adjective"
+  },
+  {
+    "name": "spare",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "speech",
+    "trans": "noun"
+  },
+  {
+    "name": "spite",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "spray",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "surprise",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "suspect",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "sweet",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "swing",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "tea",
+    "trans": "noun"
+  },
+  {
+    "name": "transition",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "transport",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "twist",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "ugly",
+    "trans": "adjective"
+  },
+  {
+    "name": "ultimate",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "usual",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "village",
+    "trans": "noun"
+  },
+  {
+    "name": "weigh",
+    "trans": "verb"
+  },
+  {
+    "name": "welcome",
+    "trans": "noun, interjection, verb, adjective"
+  },
+  {
+    "name": "yard",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "abroad",
+    "trans": "adverb, noun"
+  },
+  {
+    "name": "alarm",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "anxious",
+    "trans": "adjective"
+  },
+  {
+    "name": "apology",
+    "trans": "noun"
+  },
+  {
+    "name": "arrive",
+    "trans": "verb"
+  },
+  {
+    "name": "attach",
+    "trans": "verb"
+  },
+  {
+    "name": "behave",
+    "trans": "verb"
+  },
+  {
+    "name": "bend",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bicycle",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bite",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "blind",
+    "trans": "noun, verb, adjective, adverb"
+  },
+  {
+    "name": "bottle",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "brave",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "breath",
+    "trans": "noun"
+  },
+  {
+    "name": "cable",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "calm",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "candle",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "celebrate",
+    "trans": "verb"
+  },
+  {
+    "name": "chest",
+    "trans": "noun"
+  },
+  {
+    "name": "chocolate",
+    "trans": "noun"
+  },
+  {
+    "name": "clerk",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cloud",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "comprehensive",
+    "trans": "adjective"
+  },
+  {
+    "name": "concentrate",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "concert",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "conclusion",
+    "trans": "noun"
+  },
+  {
+    "name": "convince",
+    "trans": "verb"
+  },
+  {
+    "name": "cookie",
+    "trans": "noun"
+  },
+  {
+    "name": "counter",
+    "trans": "noun, verb, adverb, adjective"
+  },
+  {
+    "name": "courage",
+    "trans": "noun"
+  },
+  {
+    "name": "critic",
+    "trans": "noun"
+  },
+  {
+    "name": "curious",
+    "trans": "adjective"
+  },
+  {
+    "name": "dad",
+    "trans": "noun"
+  },
+  {
+    "name": "desk",
+    "trans": "noun"
+  },
+  {
+    "name": "dirty",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "downtown",
+    "trans": "adjective, adverb, noun"
+  },
+  {
+    "name": "drawer",
+    "trans": "noun"
+  },
+  {
+    "name": "elevate",
+    "trans": "verb"
+  },
+  {
+    "name": "entertain",
+    "trans": "verb"
+  },
+  {
+    "name": "establish",
+    "trans": "verb"
+  },
+  {
+    "name": "estimate",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "excite",
+    "trans": "verb"
+  },
+  {
+    "name": "flower",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "garbage",
+    "trans": "noun"
+  },
+  {
+    "name": "grand",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "grocery",
+    "trans": "noun"
+  },
+  {
+    "name": "harm",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "honest",
+    "trans": "adjective, adverb"
+  },
+  {
+    "name": "honey",
+    "trans": "noun"
+  },
+  {
+    "name": "imply",
+    "trans": "verb"
+  },
+  {
+    "name": "informal",
+    "trans": "adjective"
+  },
+  {
+    "name": "injure",
+    "trans": "verb"
+  },
+  {
+    "name": "insect",
+    "trans": "noun"
+  },
+  {
+    "name": "insist",
+    "trans": "verb"
+  },
+  {
+    "name": "inspect",
+    "trans": "verb"
+  },
+  {
+    "name": "king",
+    "trans": "noun"
+  },
+  {
+    "name": "knee",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "ladder",
+    "trans": "noun"
+  },
+  {
+    "name": "leather",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "load",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "loose",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "male",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "menu",
+    "trans": "noun"
+  },
+  {
+    "name": "mirror",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "moreover",
+    "trans": "adverb"
+  },
+  {
+    "name": "neck",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "okay",
+    "trans": "adjective, adverb, interjection"
+  },
+  {
+    "name": "penalty",
+    "trans": "noun"
+  },
+  {
+    "name": "pension",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "piano",
+    "trans": "noun"
+  },
+  {
+    "name": "plate",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "potato",
+    "trans": "noun"
+  },
+  {
+    "name": "proceed",
+    "trans": "verb"
+  },
+  {
+    "name": "profession",
+    "trans": "noun"
+  },
+  {
+    "name": "professor",
+    "trans": "noun"
+  },
+  {
+    "name": "prompt",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "purple",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "pursue",
+    "trans": "verb"
+  },
+  {
+    "name": "quantity",
+    "trans": "noun"
+  },
+  {
+    "name": "quiet",
+    "trans": "adjective, noun, verb"
+  },
+  {
+    "name": "refuse",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "regret",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "reveal",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "ruin",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rush",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "salad",
+    "trans": "noun"
+  },
+  {
+    "name": "shake",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "shift",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "shine",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "ship",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "sister",
+    "trans": "noun"
+  },
+  {
+    "name": "skirt",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "slice",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "snow",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "specify",
+    "trans": "verb"
+  },
+  {
+    "name": "stairs",
+    "trans": "noun"
+  },
+  {
+    "name": "steal",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "stroke",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "suck",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "sudden",
+    "trans": "adjective"
+  },
+  {
+    "name": "supermarket",
+    "trans": "noun"
+  },
+  {
+    "name": "surround",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "switch",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "terrible",
+    "trans": "adjective"
+  },
+  {
+    "name": "tire",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "tongue",
+    "trans": "noun"
+  },
+  {
+    "name": "trash",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "tune",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "warn",
+    "trans": "verb"
+  },
+  {
+    "name": "weak",
+    "trans": "adjective"
+  },
+  {
+    "name": "zone",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "accuse",
+    "trans": "verb"
+  },
+  {
+    "name": "admire",
+    "trans": "verb"
+  },
+  {
+    "name": "admit",
+    "trans": "verb"
+  },
+  {
+    "name": "adopt",
+    "trans": "verb"
+  },
+  {
+    "name": "affair",
+    "trans": "noun"
+  },
+  {
+    "name": "amaze",
+    "trans": "verb"
+  },
+  {
+    "name": "ambition",
+    "trans": "noun"
+  },
+  {
+    "name": "anger",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "announce",
+    "trans": "verb"
+  },
+  {
+    "name": "apple",
+    "trans": "noun"
+  },
+  {
+    "name": "approve",
+    "trans": "verb"
+  },
+  {
+    "name": "asleep",
+    "trans": "adjective"
+  },
+  {
+    "name": "attend",
+    "trans": "verb"
+  },
+  {
+    "name": "award",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bathroom",
+    "trans": "noun"
+  },
+  {
+    "name": "bear",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "beer",
+    "trans": "noun"
+  },
+  {
+    "name": "belong",
+    "trans": "verb"
+  },
+  {
+    "name": "bid",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "bitter",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "boot",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "brilliant",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "bug",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "camp",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "candy",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "carpet",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cat",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "champion",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "channel",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "cheek",
+    "trans": "noun"
+  },
+  {
+    "name": "client",
+    "trans": "noun"
+  },
+  {
+    "name": "clock",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "closes",
+    "trans": "verb"
+  },
+  {
+    "name": "comfort",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "commit",
+    "trans": "verb"
+  },
+  {
+    "name": "complaints",
+    "trans": "noun"
+  },
+  {
+    "name": "compute",
+    "trans": "verb"
+  },
+  {
+    "name": "conscious",
+    "trans": "adjective"
+  },
+  {
+    "name": "consequence",
+    "trans": "noun"
+  },
+  {
+    "name": "cow",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "crack",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "criticize",
+    "trans": "verb"
+  },
+  {
+    "name": "dare",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "dear",
+    "trans": "adjective, noun, adverb, interjection"
+  },
+  {
+    "name": "decent",
+    "trans": "adjective"
+  },
+  {
+    "name": "delay",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "deliberate",
+    "trans": "adjective, verb"
+  },
+  {
+    "name": "departure",
+    "trans": "noun"
+  },
+  {
+    "name": "deserve",
+    "trans": "verb"
+  },
+  {
+    "name": "destroy",
+    "trans": "verb"
+  },
+  {
+    "name": "diamond",
+    "trans": "noun"
+  },
+  {
+    "name": "ear",
+    "trans": "noun"
+  },
+  {
+    "name": "embarrass",
+    "trans": "verb"
+  },
+  {
+    "name": "empty",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "eventual",
+    "trans": "adjective"
+  },
+  {
+    "name": "fault",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "female",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "fortune",
+    "trans": "noun"
+  },
+  {
+    "name": "funeral",
+    "trans": "noun"
+  },
+  {
+    "name": "gene",
+    "trans": "noun"
+  },
+  {
+    "name": "girlfriend",
+    "trans": "noun"
+  },
+  {
+    "name": "grass",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "guilty",
+    "trans": "adjective"
+  },
+  {
+    "name": "guy",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "hat",
+    "trans": "noun"
+  },
+  {
+    "name": "hell",
+    "trans": "noun, interjection"
+  },
+  {
+    "name": "hesitate",
+    "trans": "verb"
+  },
+  {
+    "name": "highlight",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "hunger",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "hurry",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "illustrate",
+    "trans": "verb"
+  },
+  {
+    "name": "incident",
+    "trans": "noun, adjective"
+  },
+  {
+    "name": "inevitable",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "inform",
+    "trans": "verb"
+  },
+  {
+    "name": "initiate",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "intent",
+    "trans": "noun"
+  },
+  {
+    "name": "invite",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "island",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "joke",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "jury",
+    "trans": "noun, verb, adjective"
+  },
+  {
+    "name": "kiss",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "lady",
+    "trans": "noun"
+  },
+  {
+    "name": "leg",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "lip",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "locate",
+    "trans": "verb"
+  },
+  {
+    "name": "lone",
+    "trans": "adjective"
+  },
+  {
+    "name": "mad",
+    "trans": "adjective"
+  },
+  {
+    "name": "manufacture",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "marry",
+    "trans": "verb, interjection"
+  },
+  {
+    "name": "mate",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "motor",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "neat",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "nerve",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "nervous",
+    "trans": "adjective"
+  },
+  {
+    "name": "odd",
+    "trans": "adjective"
+  },
+  {
+    "name": "passage",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "passenger",
+    "trans": "noun"
+  },
+  {
+    "name": "pen",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "persuade",
+    "trans": "verb"
+  },
+  {
+    "name": "pizza",
+    "trans": "noun"
+  },
+  {
+    "name": "platform",
+    "trans": "noun"
+  },
+  {
+    "name": "poet",
+    "trans": "noun"
+  },
+  {
+    "name": "pop",
+    "trans": "verb, noun, adverb, adjective"
+  },
+  {
+    "name": "pour",
+    "trans": "verb"
+  },
+  {
+    "name": "pray",
+    "trans": "verb, adverb"
+  },
+  {
+    "name": "pretend",
+    "trans": "verb, adjective"
+  },
+  {
+    "name": "pride",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "priest",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "prize",
+    "trans": "noun, adjective, verb"
+  },
+  {
+    "name": "probable",
+    "trans": "adjective"
+  },
+  {
+    "name": "promise",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "propose",
+    "trans": "verb"
+  },
+  {
+    "name": "punch",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "quit",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "remark",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "remind",
+    "trans": "verb"
+  },
+  {
+    "name": "reply",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "reputation",
+    "trans": "noun"
+  },
+  {
+    "name": "resist",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "resort",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "ring",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rip",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "roof",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rope",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "rub",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "sail",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "scheme",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "script",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "shall",
+    "trans": "verb"
+  },
+  {
+    "name": "shirt",
+    "trans": "noun"
+  },
+  {
+    "name": "silly",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "sir",
+    "trans": "noun"
+  },
+  {
+    "name": "slight",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "smart",
+    "trans": "adjective, verb, noun"
+  },
+  {
+    "name": "smile",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "sock",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "spell",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "station",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "stretch",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "stupid",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "submit",
+    "trans": "verb"
+  },
+  {
+    "name": "substantial",
+    "trans": "adjective"
+  },
+  {
+    "name": "suppose",
+    "trans": "verb"
+  },
+  {
+    "name": "surgery",
+    "trans": "noun"
+  },
+  {
+    "name": "suspicious",
+    "trans": "adjective"
+  },
+  {
+    "name": "sympathy",
+    "trans": "noun"
+  },
+  {
+    "name": "tale",
+    "trans": "noun"
+  },
+  {
+    "name": "tall",
+    "trans": "adjective"
+  },
+  {
+    "name": "tear",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "temporary",
+    "trans": "adjective, noun"
+  },
+  {
+    "name": "throat",
+    "trans": "noun"
+  },
+  {
+    "name": "tiny",
+    "trans": "adjective"
+  },
+  {
+    "name": "toe",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "tomorrow",
+    "trans": "adverb, noun"
+  },
+  {
+    "name": "tower",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "translate",
+    "trans": "verb"
+  },
+  {
+    "name": "truck",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "uncle",
+    "trans": "noun"
+  },
+  {
+    "name": "wake",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "witness",
+    "trans": "noun, verb"
+  },
+  {
+    "name": "wrap",
+    "trans": "verb, noun"
+  },
+  {
+    "name": "yesterday",
+    "trans": "adverb, noun"
+  },
+  {
+    "name": "youth",
+    "trans": "noun"
+  },
+  {
+    "name": "appoint",
+    "trans": "verb"
+  },
+  {
+    "name": "clothe",
+    "trans": "verb"
+  },
+  {
+    "name": "complicate",
+    "trans": "verb"
+  },
+  {
+    "name": "confer",
+    "trans": "verb"
+  },
+  {
+    "name": "converse",
+    "trans": "verb, noun, adjective"
+  },
+  {
+    "name": "depress",
+    "trans": "verb"
+  },
+  {
+    "name": "disappoint",
+    "trans": "verb"
+  },
+  {
+    "name": "elect",
+    "trans": "verb"
+  },
+  {
+    "name": "equip",
+    "trans": "verb"
+  },
+  {
+    "name": "ignorant",
+    "trans": "adjective"
+  },
+  {
+    "name": "inflate",
+    "trans": "verb"
+  },
+  {
+    "name": "instruct",
+    "trans": "verb"
+  },
+  {
+    "name": "oblige",
+    "trans": "verb"
+  },
+  {
+    "name": "politic",
+    "trans": "adjective"
+  },
+  {
+    "name": "pollute",
+    "trans": "verb"
+  },
+  {
+    "name": "refrigerate",
+    "trans": "verb"
+  },
+  {
+    "name": "reside",
+    "trans": "verb"
+  },
+  {
+    "name": "situate",
+    "trans": "verb, adjective"
+  },
+  {
+    "name": "unite",
+    "trans": "verb"
+  }
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -124,6 +124,17 @@ const chinaExam: DictionaryResource[] = [
     languageCategory: 'en',
   },
   {
+    id: 'top_1500_nouns_Words',
+    name: 'Top 1.5k Nouns',
+    description: 'Top 1.5k nouns with highest frequency',
+    category: '中国考试',
+    tags: ['其他'],
+    url: '/dicts/Top1500NounWords.json',
+    length: 1525,
+    language: 'en',
+    languageCategory: 'en',
+  },
+  {
     id: 'suffix word',
     name: 'suffix word',
     description: 'common suffix',

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -113,6 +113,17 @@ const chinaExam: DictionaryResource[] = [
     languageCategory: 'en',
   },
   {
+    id: 'top_2000_English_Words',
+    name: 'Top 2k words',
+    description: 'The top 2000 words with the highest frequency',
+    category: '中国考试',
+    tags: ['其他'],
+    url: '/dicts/top2000words.json',
+    length: 1867,
+    language: 'en',
+    languageCategory: 'en',
+  },
+  {
     id: 'suffix word',
     name: 'suffix word',
     description: 'common suffix',


### PR DESCRIPTION
trans 部分由chatGPT生成
> 除了2265个常用的单词以外，还有1524个名词。但是1144个单词常常作为名词使用，而其他380个单词属于不同的类型，它们也可以作为名词使用。例如：单词"play"是一个动词，如"My kids are going outside to play."然而，它也可以作为一个名词使用，如 "I am going to watch a play."
> 由于单词的多义性 ，我们首先按名词的频率来进行排序，然后再按“名词+其他类型”的频率来进行排序，最后按“其他类型+名词”的频率进行排序

来源：[top-1500-nouns](http://www.talkenglish.com/vocabulary/top-1500-nouns.aspx)
