### PR TITLE
fix: some keys do not have toLowerCase prop

### DIFF
--- a/src/pages/Typing/components/WordPanel/components/Word/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Word/index.tsx
@@ -105,7 +105,11 @@ export default function Word({ word, onFinish }: { word: string; onFinish: () =>
 
     const inputChar = wordState.inputWord[inputLength - 1]
     const correctChar = wordState.displayWord[inputLength - 1]
-    const isEqual = isIgnoreCase ? inputChar.toLowerCase() === correctChar.toLowerCase() : inputChar === correctChar
+
+    let isEqual = false
+    if (inputChar != undefined && correctChar != undefined) {
+      isEqual = isIgnoreCase ? inputChar.toLowerCase() === correctChar.toLowerCase() : inputChar === correctChar
+    }
 
     if (isEqual) {
       // 输入正确时


### PR DESCRIPTION
Some buttons, such as Fn+A on the Bluetooth keyboard, may trigger errors similar to 
```
properties of undefined (reading 'toLowerCase')
    at index.tsx:101:45
```

when adjusting the volume