### PR TITLE
fix: zh visibility hotkey

### DIFF
--- a/src/pages/Typing/components/Switcher/index.tsx
+++ b/src/pages/Typing/components/Switcher/index.tsx
@@ -60,7 +60,7 @@ export default function Switcher() {
     [],
   )
   useHotkeys(
-    'ctrl+t',
+    'ctrl+shift+v',
     () => {
       changeTransVisibleState()
     },
@@ -108,7 +108,7 @@ export default function Switcher() {
           {state?.isWordVisible ? <IconEye className="icon" /> : <IconEyeSlash className="icon" />}
         </button>
       </Tooltip>
-      <Tooltip className="h-7 w-7" content="开关释义显示（Ctrl + T）">
+      <Tooltip className="h-7 w-7" content="开关释义显示（Ctrl + Shift + V）">
         <button
           className={`p-[2px] ${state?.isTransVisible ? 'text-indigo-500' : 'text-gray-500'} text-lg focus:outline-none`}
           type="button"


### PR DESCRIPTION
fix: https://github.com/Kaiyiwing/qwerty-learner/issues/376

据所使用的 react-hotkeys-hook [文档](https://react-hotkeys-hook.vercel.app/docs/documentation/useHotkeys/basic-usage#multiple-hotkeys)所示,部分快捷键无法覆盖:
![image](https://github.com/Kaiyiwing/qwerty-learner/assets/44502608/591342ed-2e38-43ca-8720-d04eaaaf84d1)

将快捷键由 `ctrl + t` 修改为 `ctrl + shift + v` 此处 `v` 解释与英文保持一致, `visible`

gpt 认为 `ctrl + c` 也是可行的, 解释为 `chinese`