### PR TITLE
feat: add a blurred mask during pause and display "继续" instead of "开始".

### DIFF
--- a/src/pages/Typing/components/WordPanel/components/Translation/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Translation/index.tsx
@@ -8,7 +8,7 @@ export default function Translation({ trans }: TranslationProps) {
   const isTextSelectable = useAtomValue(isTextSelectableAtom)
   return (
     <div
-      className={`max-w-4xl pb-4 pt-5 font-sans text-lg transition-colors duration-300 dark:text-white dark:text-opacity-80 ${
+      className={`max-w-4xl pb-4 pt-5 text-center font-sans text-lg transition-colors duration-300 dark:text-white dark:text-opacity-80 ${
         !isTextSelectable && 'select-none'
       }`}
     >

--- a/src/pages/Typing/components/WordPanel/index.tsx
+++ b/src/pages/Typing/components/WordPanel/index.tsx
@@ -9,7 +9,7 @@ import { useAtomValue } from 'jotai'
 import { useCallback, useContext, useState } from 'react'
 
 const maskBg = {
-  transparent: 'bg-[#faf9ffcc] dark:bg-[#1f1f1fcc]',
+  transparent: 'bg-[#faf9ffcc] dark:bg-gray-900 dark:opacity-90',
   opaque: 'bg-[#faf9ff] dark:bg-[#1f1f1f]',
 }
 
@@ -60,7 +60,7 @@ export default function WordPanel() {
                   state.timerData.time ? maskBg.transparent : maskBg.opaque
                 }`}
               >
-                <p className="w-full animate-pulse select-none text-center text-3xl text-gray-600 dark:text-gray-50">
+                <p className="w-full animate-pulse select-none text-center text-xl text-gray-600 dark:text-gray-50">
                   按任意键{state.timerData.time ? '继续' : '开始'}
                 </p>
               </div>
@@ -73,7 +73,7 @@ export default function WordPanel() {
           </div>
         )}
       </div>
-      <Progress className={`mb-10 mt-auto ${state.isTyping ? 'text-opacity-100' : 'opacity-0'}`} />
+      <Progress className={`mb-10 mt-auto ${state.isTyping ? 'opacity-100' : 'opacity-0'}`} />
     </div>
   )
 }

--- a/src/pages/Typing/components/WordPanel/index.tsx
+++ b/src/pages/Typing/components/WordPanel/index.tsx
@@ -8,6 +8,11 @@ import { isShowPrevAndNextWordAtom, phoneticConfigAtom } from '@/store'
 import { useAtomValue } from 'jotai'
 import { useCallback, useContext, useState } from 'react'
 
+const maskBg = {
+  transparent: 'bg-[#faf9ffcc] dark:bg-[#1f1f1fcc]',
+  opaque: 'bg-[#faf9ff] dark:bg-[#1f1f1f]',
+}
+
 export default function WordPanel() {
   // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
   const { state, dispatch } = useContext(TypingContext)!
@@ -47,17 +52,28 @@ export default function WordPanel() {
         )}
       </div>
       <div className="container flex flex-grow flex-col items-center justify-center">
-        {currentWord && state.isTyping ? (
-          <>
-            <WordComponent word={currentWord.name} onFinish={onFinish} key={wordComponentKey} />
-            {phoneticConfig.isOpen && <Phonetic word={currentWord} />}
-            {state.isTransVisible && <Translation trans={currentWord.trans.join('；')} />}
-          </>
-        ) : (
-          <div className="animate-pulse select-none  text-xl text-gray-600 dark:text-gray-50">按任意键开始</div>
+        {currentWord && (
+          <div className="relative flex w-full justify-center">
+            {!state.isTyping && (
+              <div
+                className={`absolute left-0 top-0 z-10 flex h-full w-full items-center backdrop-blur-sm ${
+                  state.chapterData.index === 0 ? maskBg.opaque : maskBg.transparent
+                }`}
+              >
+                <p className="w-full animate-pulse select-none text-center text-3xl text-gray-600 dark:text-gray-50">
+                  按任意键{state.chapterData.index === 0 ? '开始' : '继续'}
+                </p>
+              </div>
+            )}
+            <div className="relative">
+              <WordComponent word={currentWord.name} onFinish={onFinish} key={wordComponentKey} />
+              {phoneticConfig.isOpen && <Phonetic word={currentWord} />}
+              {state.isTransVisible && <Translation trans={currentWord.trans.join('；')} />}
+            </div>
+          </div>
         )}
       </div>
-      {state.isTyping && <Progress className="mb-10 mt-auto" />}
+      <Progress className={`mb-10 mt-auto ${state.isTyping ? 'text-opacity-100' : 'opacity-0'}`} />
     </div>
   )
 }

--- a/src/pages/Typing/components/WordPanel/index.tsx
+++ b/src/pages/Typing/components/WordPanel/index.tsx
@@ -57,11 +57,11 @@ export default function WordPanel() {
             {!state.isTyping && (
               <div
                 className={`absolute left-0 top-0 z-10 flex h-full w-full items-center backdrop-blur-sm ${
-                  state.chapterData.index === 0 ? maskBg.opaque : maskBg.transparent
+                  state.timerData.time ? maskBg.transparent : maskBg.opaque
                 }`}
               >
                 <p className="w-full animate-pulse select-none text-center text-3xl text-gray-600 dark:text-gray-50">
-                  按任意键{state.chapterData.index === 0 ? '开始' : '继续'}
+                  按任意键{state.timerData.time ? '继续' : '开始'}
                 </p>
               </div>
             )}


### PR DESCRIPTION
- 开始练习后暂停时为 “任意键开始” 提示字样添加背景模糊遮罩层而不是直接替换单词内容
- 开始练习后将提示字样中的 “开始” 替换为 “继续”

https://github.com/Kaiyiwing/qwerty-learner/issues/480