### PR TITLE
fix: "Press any key" style override

### DIFF
--- a/src/pages/Typing/components/WordPanel/index.tsx
+++ b/src/pages/Typing/components/WordPanel/index.tsx
@@ -8,11 +8,6 @@ import { isShowPrevAndNextWordAtom, phoneticConfigAtom } from '@/store'
 import { useAtomValue } from 'jotai'
 import { useCallback, useContext, useState } from 'react'
 
-const maskBg = {
-  transparent: 'bg-[#faf9ffcc] dark:bg-gray-900 dark:opacity-90',
-  opaque: 'bg-[#faf9ff] dark:bg-[#1f1f1f]',
-}
-
 export default function WordPanel() {
   // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
   const { state, dispatch } = useContext(TypingContext)!
@@ -55,14 +50,12 @@ export default function WordPanel() {
         {currentWord && (
           <div className="relative flex w-full justify-center">
             {!state.isTyping && (
-              <div
-                className={`absolute left-0 top-0 z-10 flex h-full w-full items-center backdrop-blur-sm ${
-                  state.timerData.time ? maskBg.transparent : maskBg.opaque
-                }`}
-              >
-                <p className="w-full animate-pulse select-none text-center text-xl text-gray-600 dark:text-gray-50">
-                  按任意键{state.timerData.time ? '继续' : '开始'}
-                </p>
+              <div className="absolute flex h-full w-full justify-center">
+                <div className="z-10 flex w-3/5 items-center backdrop-blur-sm">
+                  <p className="w-full select-none text-center text-xl text-gray-600 dark:text-gray-50">
+                    按任意键{state.timerData.time ? '继续' : '开始'}
+                  </p>
+                </div>
               </div>
             )}
             <div className="relative">


### PR DESCRIPTION
## Before
![image](https://github.com/Kaiyiwing/qwerty-learner/assets/48512251/bbc0c0db-61cc-48f2-923d-8749756a2dd8)
![image](https://github.com/Kaiyiwing/qwerty-learner/assets/48512251/a48683b4-e5fe-4a1b-80f9-5f732d375fa8)

## After

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/48512251/e0026ed7-13ff-43ae-a03f-a014bd49aa1a)
![image](https://github.com/Kaiyiwing/qwerty-learner/assets/48512251/7f8258ba-e315-4cf9-bf1c-458b5af47238)
