### PR TITLE
fix: 修复按任意键继续遮罩层挡住了顶部选择框的问题

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,7 +5,7 @@ import { NavLink } from 'react-router-dom'
 
 const Header: React.FC<PropsWithChildren> = ({ children }) => {
   return (
-    <header className="container mx-auto w-full px-10 py-6">
+    <header className="container z-20 mx-auto w-full px-10 py-6">
       <div className="flex w-full flex-col items-center justify-between space-y-3 lg:flex-row lg:space-y-0">
         <NavLink
           className="flex items-center text-2xl font-bold text-indigo-500 no-underline hover:no-underline lg:text-4xl"


### PR DESCRIPTION
bug fix: 修复按任意键继续遮罩层挡住了顶部选择框的问题

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/33367187/80219ded-4a86-4033-b501-9397b97818d1)