### PR TITLE
fix: change Drawer's z-index to prevent Header floating onto Drawer

### DIFF
--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -28,7 +28,7 @@ export default function Drawer(props: DrawerProps) {
 
   return (
     <Transition show={open} appear as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={onCloseDrawer}>
+      <Dialog as="div" className="relative z-30" onClose={onCloseDrawer}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"


### PR DESCRIPTION
#506 给Header添加了z-index, 会导致顶部的Header显示在左侧单词列表之上

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/21275170/c67140db-0c82-490f-a88a-fcea43d6f8e7)


修改了Drawer的z-index, 让Drawer层在Header之上

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/21275170/59a40cd8-db8e-49b4-a7f2-35fbc056c8b8)
