### PR TITLE
fix: set a higher z-index to Drawer and StarCard to prevent Header floating onto them

### DIFF
--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -28,7 +28,7 @@ export default function Drawer(props: DrawerProps) {
 
   return (
     <Transition show={open} appear as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={onCloseDrawer}>
+      <Dialog as="div" className="relative z-30" onClose={onCloseDrawer}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/src/components/StarCard/index.tsx
+++ b/src/components/StarCard/index.tsx
@@ -86,9 +86,9 @@ export default function StarCard() {
       leave="transition ease-in duration-500 transform"
       leaveFrom="translate-x-0 translate-y-0"
       leaveTo="translate-x-full -translate-y-full"
-      className="fixed  inset-0 z-20 flex h-0 justify-center"
+      className="fixed inset-0 z-30 flex h-0 justify-center"
     >
-      <div className=" fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800">
+      <div className="fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800">
         <div className="absolute right-3 top-3">
           {isCounting && (
             <span className="m-1.5 dark:text-gray-100">

--- a/src/pages/Typing/components/WordPanel/index.tsx
+++ b/src/pages/Typing/components/WordPanel/index.tsx
@@ -53,7 +53,7 @@ export default function WordPanel() {
 
   return (
     <div className="container flex h-full w-full flex-col items-center justify-center">
-      <div className="container flex h-24 w-full shrink-0 grow-0 justify-between px-12 pt-10">
+      <div className="container z-30 flex h-24 w-full shrink-0 grow-0 justify-between px-12 pt-10">
         {isShowPrevAndNextWord && state.isTyping && (
           <>
             <PrevAndNextWord type="prev" />


### PR DESCRIPTION
#506  给Header添加了z-index, 会导致顶部的Header显示在左侧单词列表和提示收藏的提示框之上

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/21275170/56c0e431-7b6b-499f-87a0-53921eefa20f)

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/21275170/fc53a8f5-f758-4766-bbc7-b345a35f7985)

修改了Drawer和StarCard的z-index

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/21275170/f94c3d09-b6a1-41e7-93b9-5155fbd4588f)

![image](https://github.com/Kaiyiwing/qwerty-learner/assets/21275170/517d3676-bded-4f63-ab23-76d47ec823ca)

