### PR TITLE
feat(dicts): add Longman Communication 3000

### DIFF
--- a/public/dicts/Longman_Communication_3000.json
+++ b/public/dicts/Longman_Communication_3000.json
@@ -1,0 +1,19010 @@
+[
+  {
+    "name": "a",
+    "trans": [
+      "一个, 一, 个, 一种 (det.)"
+    ]
+  },
+  {
+    "name": "abandon",
+    "trans": [
+      "放弃, 抛弃, 弃, 摒弃 (verb.)"
+    ]
+  },
+  {
+    "name": "ability",
+    "trans": [
+      "能力, 才能, 力, 技能 (noun.)"
+    ]
+  },
+  {
+    "name": "able",
+    "trans": [
+      "能, 可以, 能够, 能力 (adj.)"
+    ]
+  },
+  {
+    "name": "about",
+    "trans": [
+      "关于, 约, 大约 (prep.)"
+    ]
+  },
+  {
+    "name": "above",
+    "trans": [
+      "以上 (prep.); 上面 (adv.); 上述 (adj.)"
+    ]
+  },
+  {
+    "name": "abroad",
+    "trans": [
+      "国外, 出国, 海外, 境外 (adv.)"
+    ]
+  },
+  {
+    "name": "absence",
+    "trans": [
+      "缺席, 缺失, 缺位, 缺乏 (noun.)"
+    ]
+  },
+  {
+    "name": "absolute",
+    "trans": [
+      "绝对, 绝对值 (adj.)"
+    ]
+  },
+  {
+    "name": "absolutely",
+    "trans": [
+      "绝对, 完全, 当然, 绝 (adv.)"
+    ]
+  },
+  {
+    "name": "absorb",
+    "trans": [
+      "吸收, 吸纳, 吸取, 吸 (verb.)"
+    ]
+  },
+  {
+    "name": "abuse",
+    "trans": [
+      "滥用, 虐待, 滥用职权, 辱骂 (noun.); 骂 (verb.)"
+    ]
+  },
+  {
+    "name": "academic",
+    "trans": [
+      "学术, 学业, 学术界, 学术性 (adj.)"
+    ]
+  },
+  {
+    "name": "accept",
+    "trans": [
+      "接受, 接纳, 收, 接收 (verb.)"
+    ]
+  },
+  {
+    "name": "acceptable",
+    "trans": [
+      "接受, 允, 接纳, 合格 (adj.)"
+    ]
+  },
+  {
+    "name": "access",
+    "trans": [
+      "访问, 接入, 存取, 访问权限 (noun.)"
+    ]
+  },
+  {
+    "name": "accident",
+    "trans": [
+      "事故, 意外, 车祸, 意外事故 (noun.)"
+    ]
+  },
+  {
+    "name": "accommodation",
+    "trans": [
+      "住宿, 食宿, 居所, 舱位 (noun.)"
+    ]
+  },
+  {
+    "name": "accompany",
+    "trans": [
+      "陪, 陪伴, 陪同, 伴随 (verb.)"
+    ]
+  },
+  {
+    "name": "according to",
+    "trans": [
+      "按照, 取决于 (perp.)"
+    ]
+  },
+  {
+    "name": "account",
+    "trans": [
+      "帐户, 账户, 帐号, 账号 (noun.); 占, 解释 (verb.)"
+    ]
+  },
+  {
+    "name": "accurate",
+    "trans": [
+      "准确, 精确, 精准, 准确无误 (adj.)"
+    ]
+  },
+  {
+    "name": "accuse",
+    "trans": [
+      "指责, 控告, 指控, 告 (verb.)"
+    ]
+  },
+  {
+    "name": "achieve",
+    "trans": [
+      "实现, 达到, 达致, 取得 (verb.)"
+    ]
+  },
+  {
+    "name": "achievement",
+    "trans": [
+      "成就, 成果, 成绩, 业绩 (noun.)"
+    ]
+  },
+  {
+    "name": "acid",
+    "trans": [
+      "酸, 酸性, 耐酸 (noun.)"
+    ]
+  },
+  {
+    "name": "acknowledge",
+    "trans": [
+      "承认, 答谢, 认 (verb.)"
+    ]
+  },
+  {
+    "name": "acquire",
+    "trans": [
+      "获得, 获取, 收购, 取得 (verb.)"
+    ]
+  },
+  {
+    "name": "across",
+    "trans": [
+      "跨, 跨越, 横跨, 在 (prep.)"
+    ]
+  },
+  {
+    "name": "act",
+    "trans": [
+      "行为, 法案, 法, 幕 (noun.); 行动, 采取行动, 行事, 表现 (verb.)"
+    ]
+  },
+  {
+    "name": "action",
+    "trans": [
+      "行动, 动作, 作用, 采取行动 (noun.)"
+    ]
+  },
+  {
+    "name": "active",
+    "trans": [
+      "活跃, 主动, 积极, 活性 (adj.)"
+    ]
+  },
+  {
+    "name": "activist",
+    "trans": [
+      "活动家, 社会活动家, 积极分子, 维权 (noun.)"
+    ]
+  },
+  {
+    "name": "activity",
+    "trans": [
+      "活动, 活性, 活力, 行为 (noun.)"
+    ]
+  },
+  {
+    "name": "actor",
+    "trans": [
+      "演员, 男演员, 男主角, 参与者 (noun.)"
+    ]
+  },
+  {
+    "name": "actual",
+    "trans": [
+      "实际, 真实, 实效, 现实 (adj.)"
+    ]
+  },
+  {
+    "name": "actually",
+    "trans": [
+      "实际上, 其实, 事实上, 实际 (adv.)"
+    ]
+  },
+  {
+    "name": "ad",
+    "trans": [
+      "广告, 专案, 公元, 专责 (noun.)"
+    ]
+  },
+  {
+    "name": "adapt",
+    "trans": [
+      "适应, 相适应, 顺应, 调整 (verb.)"
+    ]
+  },
+  {
+    "name": "add",
+    "trans": [
+      "添加, 加, 增加, 补充 (verb.)"
+    ]
+  },
+  {
+    "name": "addition",
+    "trans": [
+      "除了, 此外, 另外, 除 (noun.)"
+    ]
+  },
+  {
+    "name": "additional",
+    "trans": [
+      "额外, 附加, 另外, 其他 (adj.)"
+    ]
+  },
+  {
+    "name": "address",
+    "trans": [
+      "地址, 住址, 报告 (noun.); 解决 (verb.)"
+    ]
+  },
+  {
+    "name": "adequate",
+    "trans": [
+      "足够, 充足, 充分, 适当 (adj.)"
+    ]
+  },
+  {
+    "name": "adjust",
+    "trans": [
+      "调整, 调节, 适应, 调 (verb.)"
+    ]
+  },
+  {
+    "name": "administration",
+    "trans": [
+      "政府当局, 行政, 管理, 政府 (noun.)"
+    ]
+  },
+  {
+    "name": "administrative",
+    "trans": [
+      "行政, 行政管理, 管理, 政务 (adj.)"
+    ]
+  },
+  {
+    "name": "admire",
+    "trans": [
+      "佩服, 钦佩, 敬佩, 欣赏 (verb.)"
+    ]
+  },
+  {
+    "name": "admission",
+    "trans": [
+      "入场, 入学, 入院, 录取 (noun.)"
+    ]
+  },
+  {
+    "name": "admit",
+    "trans": [
+      "承认, 认错, 接纳, 录取 (verb.)"
+    ]
+  },
+  {
+    "name": "adopt",
+    "trans": [
+      "采用, 采取, 采纳, 收养 (verb.)"
+    ]
+  },
+  {
+    "name": "adult",
+    "trans": [
+      "成人, 成年, 成年人, 成体 (noun.)"
+    ]
+  },
+  {
+    "name": "advance",
+    "trans": [
+      "提前, 进展, 推进, 事先 (noun.); 促进, 推动 (verb.)"
+    ]
+  },
+  {
+    "name": "advanced",
+    "trans": [
+      "先进, 高级, 晚期, 高等 (adj.)"
+    ]
+  },
+  {
+    "name": "advantage",
+    "trans": [
+      "优势, 优点, 好处, 有利条件 (noun.)"
+    ]
+  },
+  {
+    "name": "advert",
+    "trans": [
+      "广告 (noun.)"
+    ]
+  },
+  {
+    "name": "advertise",
+    "trans": [
+      "做广告, 登广告, 宣传, 刊登广告 (verb.)"
+    ]
+  },
+  {
+    "name": "advertisement",
+    "trans": [
+      "广告 (noun.)"
+    ]
+  },
+  {
+    "name": "advertising",
+    "trans": [
+      "广告, 广告宣传, 做广告, 宣传 (noun.)"
+    ]
+  },
+  {
+    "name": "advice",
+    "trans": [
+      "建议, 忠告, 意见, 劝告 (noun.)"
+    ]
+  },
+  {
+    "name": "advise",
+    "trans": [
+      "建议, 劝, 奉劝, 告知 (verb.)"
+    ]
+  },
+  {
+    "name": "adviser",
+    "trans": [
+      "顾问, 导师 (noun.)"
+    ]
+  },
+  {
+    "name": "affair",
+    "trans": [
+      "外遇, 恋情, 事件, 事情 (noun.)"
+    ]
+  },
+  {
+    "name": "affect",
+    "trans": [
+      "影响 (verb.)"
+    ]
+  },
+  {
+    "name": "afford",
+    "trans": [
+      "负担得起, 负担, 承受, 起 (verb.)"
+    ]
+  },
+  {
+    "name": "afraid",
+    "trans": [
+      "害怕, 怕, 惧怕, 不敢 (adj.)"
+    ]
+  },
+  {
+    "name": "after",
+    "trans": [
+      "后, 之后, 经过 (prep.)"
+    ]
+  },
+  {
+    "name": "afternoon",
+    "trans": [
+      "下午, 午后, 午, 午安 (noun.)"
+    ]
+  },
+  {
+    "name": "afterwards",
+    "trans": [
+      "事后, 后来, 之后, 算账 (adv.)"
+    ]
+  },
+  {
+    "name": "again",
+    "trans": [
+      "再次, 再, 又, 一遍 (adv.)"
+    ]
+  },
+  {
+    "name": "against",
+    "trans": [
+      "反对, 对 (prep.)"
+    ]
+  },
+  {
+    "name": "age",
+    "trans": [
+      "年龄, 时代, 年纪, 岁 (noun.)"
+    ]
+  },
+  {
+    "name": "aged",
+    "trans": [
+      "老年, 老龄, 中年, 老化 (adj.); 老年人, 岁, 年龄, 老人 (verb.)"
+    ]
+  },
+  {
+    "name": "agency",
+    "trans": [
+      "代理, 机构, 签约, 局 (noun.)"
+    ]
+  },
+  {
+    "name": "agent",
+    "trans": [
+      "代理, 剂, 探员, 代理人 (noun.)"
+    ]
+  },
+  {
+    "name": "aggressive",
+    "trans": [
+      "侵略性, 咄咄逼人, 好斗, 积极 (adj.)"
+    ]
+  },
+  {
+    "name": "ago",
+    "trans": [
+      "前, 以前, 之前 (adv.)"
+    ]
+  },
+  {
+    "name": "agree",
+    "trans": [
+      "同意, 达成一致, 认同, 赞成 (verb.)"
+    ]
+  },
+  {
+    "name": "agreement",
+    "trans": [
+      "协议, 协定, 协议书, 约定 (noun.)"
+    ]
+  },
+  {
+    "name": "agriculture",
+    "trans": [
+      "农业, 农, 农业部 (noun.)"
+    ]
+  },
+  {
+    "name": "ahead",
+    "trans": [
+      "提前, 前方, 前面, 领先 (adv.)"
+    ]
+  },
+  {
+    "name": "aid",
+    "trans": [
+      "援助, 援, 救援, 救助 (noun.); 有助于 (verb.)"
+    ]
+  },
+  {
+    "name": "aim",
+    "trans": [
+      "目的, 目标, 宗旨, 旨在 (noun.); 瞄准 (verb.)"
+    ]
+  },
+  {
+    "name": "air",
+    "trans": [
+      "空气, 空中, 航空, 空 (noun.)"
+    ]
+  },
+  {
+    "name": "aircraft",
+    "trans": [
+      "飞机, 飞行器, 航空器, 架飞机 (noun.)"
+    ]
+  },
+  {
+    "name": "airline",
+    "trans": [
+      "航空公司, 航空, 航线, 航班 (noun.)"
+    ]
+  },
+  {
+    "name": "airport",
+    "trans": [
+      "机场, 飞机场, 空港 (noun.)"
+    ]
+  },
+  {
+    "name": "alarm",
+    "trans": [
+      "报警, 警报, 报警器, 告警 (noun.)"
+    ]
+  },
+  {
+    "name": "album",
+    "trans": [
+      "专辑, 张专辑, 相册, 画册 (noun.)"
+    ]
+  },
+  {
+    "name": "alcohol",
+    "trans": [
+      "酒精, 醇, 乙醇, 酒 (noun.)"
+    ]
+  },
+  {
+    "name": "alive",
+    "trans": [
+      "活着, 活著, 活, 活下来 (adj.)"
+    ]
+  },
+  {
+    "name": "all",
+    "trans": [
+      "所有, 都, 一切, 全部 (det.)"
+    ]
+  },
+  {
+    "name": "all right",
+    "trans": [
+      "好, 顺利, 正确的"
+    ]
+  },
+  {
+    "name": "allow",
+    "trans": [
+      "允许, 容许, 让, 使 (verb.)"
+    ]
+  },
+  {
+    "name": "allowance",
+    "trans": [
+      "津贴, 免税额, 零用钱, 零花钱 (noun.)"
+    ]
+  },
+  {
+    "name": "almost",
+    "trans": [
+      "几乎, 差点, 差不多, 近 (adv.)"
+    ]
+  },
+  {
+    "name": "alone",
+    "trans": [
+      "独自, 单独, 孤单, 孤独 (adv.)"
+    ]
+  },
+  {
+    "name": "along",
+    "trans": [
+      "沿, 沿着, 沿线 (prep.)"
+    ]
+  },
+  {
+    "name": "alongside",
+    "trans": [
+      "旁边 (prep.)"
+    ]
+  },
+  {
+    "name": "already",
+    "trans": [
+      "已经, 已, 早已, 早就 (adv.)"
+    ]
+  },
+  {
+    "name": "also",
+    "trans": [
+      "也, 还, 亦, 也是 (adv.)"
+    ]
+  },
+  {
+    "name": "alter",
+    "trans": [
+      "改变, 更改, 涂改, 改动 (verb.); 圣坛 (noun.)"
+    ]
+  },
+  {
+    "name": "alternative",
+    "trans": [
+      "替代, 另类, 备选, 可供选择 (adj.); 替代品, 选择 (noun.)"
+    ]
+  },
+  {
+    "name": "although",
+    "trans": [
+      "虽然, 尽管 (prep.)"
+    ]
+  },
+  {
+    "name": "altogether",
+    "trans": [
+      "完全, 共, 一共, 总共 (adv.)"
+    ]
+  },
+  {
+    "name": "always",
+    "trans": [
+      "总是, 始终, 一直, 永远 (adv.)"
+    ]
+  },
+  {
+    "name": "amazing",
+    "trans": [
+      "惊人, 神奇, 令人惊异, 了不起 (adj.)"
+    ]
+  },
+  {
+    "name": "ambition",
+    "trans": [
+      "野心, 雄心, 抱负, 雄心壮志 (noun.)"
+    ]
+  },
+  {
+    "name": "ambulance",
+    "trans": [
+      "救护车, 救护, 辆救护车, 救护员 (noun.)"
+    ]
+  },
+  {
+    "name": "among",
+    "trans": [
+      "之间 (prep.)"
+    ]
+  },
+  {
+    "name": "amount",
+    "trans": [
+      "金额, 量, 数额, 数量 (noun.)"
+    ]
+  },
+  {
+    "name": "an",
+    "trans": [
+      "一个 (det.)"
+    ]
+  },
+  {
+    "name": "analyse",
+    "trans": [
+      "分析, 浅析 (verb.)"
+    ]
+  },
+  {
+    "name": "analysis",
+    "trans": [
+      "分析, 剖析, 解析, 析 (noun.)"
+    ]
+  },
+  {
+    "name": "analyst",
+    "trans": [
+      "分析师, 分析家 (noun.)"
+    ]
+  },
+  {
+    "name": "ancient",
+    "trans": [
+      "古代, 古, 古老, 远古 (adj.)"
+    ]
+  },
+  {
+    "name": "and",
+    "trans": [
+      "和, 与, 及, 并 (conj.)"
+    ]
+  },
+  {
+    "name": "anger",
+    "trans": [
+      "愤怒, 怒气, 怒火, 怒 (noun.); 激怒 (verb.)"
+    ]
+  },
+  {
+    "name": "angle",
+    "trans": [
+      "角度, 角, 视角, 夹角 (noun.)"
+    ]
+  },
+  {
+    "name": "angry",
+    "trans": [
+      "生气, 愤怒, 气愤, 发怒 (adj.)"
+    ]
+  },
+  {
+    "name": "animal",
+    "trans": [
+      "动物, 畜禽, 兽, 畜生 (noun.)"
+    ]
+  },
+  {
+    "name": "announce",
+    "trans": [
+      "宣布, 公布, 宣告, 揭示 (verb.)"
+    ]
+  },
+  {
+    "name": "announcement",
+    "trans": [
+      "公告, 宣布, 宣传短片, 声明 (noun.)"
+    ]
+  },
+  {
+    "name": "annoy",
+    "trans": [
+      "惹恼, 烦扰, 烦, 惹怒 (verb.)"
+    ]
+  },
+  {
+    "name": "annual",
+    "trans": [
+      "年度, 每年, 一年一度, 年 (adj.)"
+    ]
+  },
+  {
+    "name": "another",
+    "trans": [
+      "另一个, 另 (det.)"
+    ]
+  },
+  {
+    "name": "answer",
+    "trans": [
+      "回答, 解答, 接, 回应 (verb.); 答案, 答复, 答覆, 答 (noun.)"
+    ]
+  },
+  {
+    "name": "anticipate",
+    "trans": [
+      "预见, 预期, 预计, 预料 (verb.)"
+    ]
+  },
+  {
+    "name": "anxiety",
+    "trans": [
+      "焦虑, 焦虑症, 焦虑情绪, 忧虑 (noun.)"
+    ]
+  },
+  {
+    "name": "anxious",
+    "trans": [
+      "焦虑, 焦急, 着急, 急 (adj.)"
+    ]
+  },
+  {
+    "name": "any",
+    "trans": [
+      "任何 (det.)"
+    ]
+  },
+  {
+    "name": "anybody",
+    "trans": [
+      "任何人, 有人, 谁, 别人 (noun.)"
+    ]
+  },
+  {
+    "name": "anyhow",
+    "trans": [
+      "无论如何, 总之, 不管怎样, 不管怎么样 (noun.); 反正 (adv.)"
+    ]
+  },
+  {
+    "name": "anyone",
+    "trans": [
+      "任何人, 有人, 别人, 谁 (noun.)"
+    ]
+  },
+  {
+    "name": "anything",
+    "trans": [
+      "什么, 任何, 东西, 一切 (noun.)"
+    ]
+  },
+  {
+    "name": "anyway",
+    "trans": [
+      "反正, 无论如何, 不管怎样, 总之 (adv.)"
+    ]
+  },
+  {
+    "name": "anywhere",
+    "trans": [
+      "随时随地, 地方, 随处, 哪儿 (adv.)"
+    ]
+  },
+  {
+    "name": "apart",
+    "trans": [
+      "分开, 拆开, 拆散, 相隔 (adv.)"
+    ]
+  },
+  {
+    "name": "apartment",
+    "trans": [
+      "公寓, 套公寓, 寓所, 房子 (noun.)"
+    ]
+  },
+  {
+    "name": "apologize",
+    "trans": [
+      "道歉, 表示歉意, 致歉, 深表歉意 (verb.)"
+    ]
+  },
+  {
+    "name": "apology",
+    "trans": [
+      "道歉, 歉意, 致歉, 赔礼道歉 (noun.)"
+    ]
+  },
+  {
+    "name": "apparent",
+    "trans": [
+      "明显, 视, 显而易见, 显然 (adj.)"
+    ]
+  },
+  {
+    "name": "apparently",
+    "trans": [
+      "显然, 表面看似, 明显, 似乎 (adv.)"
+    ]
+  },
+  {
+    "name": "appeal",
+    "trans": [
+      "上诉, 吸引力, 呼吁, 感染力 (noun.); 提出上诉, 吸引 (verb.)"
+    ]
+  },
+  {
+    "name": "appear",
+    "trans": [
+      "出现, 显得, 显现, 显示 (verb.)"
+    ]
+  },
+  {
+    "name": "appearance",
+    "trans": [
+      "外观, 外表, 外貌, 出现 (noun.)"
+    ]
+  },
+  {
+    "name": "apple",
+    "trans": [
+      "苹果 (noun.)"
+    ]
+  },
+  {
+    "name": "application",
+    "trans": [
+      "应用, 应用程序, 申请, 运用 (noun.)"
+    ]
+  },
+  {
+    "name": "apply",
+    "trans": [
+      "适用, 申请, 应用, 运用 (verb.)"
+    ]
+  },
+  {
+    "name": "appoint",
+    "trans": [
+      "委任, 任命, 指定, 委派 (verb.)"
+    ]
+  },
+  {
+    "name": "appointment",
+    "trans": [
+      "委任, 任命, 预约, 约会 (noun.)"
+    ]
+  },
+  {
+    "name": "appreciate",
+    "trans": [
+      "欣赏, 感激, 感谢, 升值 (verb.)"
+    ]
+  },
+  {
+    "name": "approach",
+    "trans": [
+      "方法, 途径, 做法, 方针 (noun.); 接近 (verb.)"
+    ]
+  },
+  {
+    "name": "appropriate",
+    "trans": [
+      "适当, 合适, 恰当, 相应 (adj.)"
+    ]
+  },
+  {
+    "name": "approval",
+    "trans": [
+      "批准, 审批, 核准, 认可 (noun.)"
+    ]
+  },
+  {
+    "name": "approve",
+    "trans": [
+      "批准, 赞成, 赞同, 同意 (verb.)"
+    ]
+  },
+  {
+    "name": "approximate",
+    "trans": [
+      "近似, 逼近, 大致 (adj.)"
+    ]
+  },
+  {
+    "name": "architect",
+    "trans": [
+      "建筑师, 架构师, 构架师, 设计师 (noun.)"
+    ]
+  },
+  {
+    "name": "architecture",
+    "trans": [
+      "架构, 建筑, 建筑学, 结构 (noun.)"
+    ]
+  },
+  {
+    "name": "area",
+    "trans": [
+      "地区, 面积, 区, 区域 (noun.)"
+    ]
+  },
+  {
+    "name": "argue",
+    "trans": [
+      "争辩, 争论, 辩, 争吵 (verb.)"
+    ]
+  },
+  {
+    "name": "argument",
+    "trans": [
+      "论点, 论据, 争论, 参数 (noun.)"
+    ]
+  },
+  {
+    "name": "arise",
+    "trans": [
+      "出现, 升起 (verb.)"
+    ]
+  },
+  {
+    "name": "arm",
+    "trans": [
+      "手臂, 胳膊, 臂, 胳臂 (noun.); 武装 (verb.)"
+    ]
+  },
+  {
+    "name": "armed",
+    "trans": [
+      "武装, 持械, 持枪, 全副武装 (adj.); 装备 (verb.)"
+    ]
+  },
+  {
+    "name": "army",
+    "trans": [
+      "军队, 陆军, 军, 部队 (noun.)"
+    ]
+  },
+  {
+    "name": "around",
+    "trans": [
+      "周围, 围绕, 左右 (prep.)"
+    ]
+  },
+  {
+    "name": "arrange",
+    "trans": [
+      "安排, 排列, 整理, 布置 (verb.)"
+    ]
+  },
+  {
+    "name": "arrangement",
+    "trans": [
+      "安排, 布置, 排列, 编排 (noun.)"
+    ]
+  },
+  {
+    "name": "arrest",
+    "trans": [
+      "逮捕, 抓 (verb.); 拘捕, 骤停, 被捕, 停搏 (noun.)"
+    ]
+  },
+  {
+    "name": "arrival",
+    "trans": [
+      "到来, 到达, 抵达, 到货 (noun.)"
+    ]
+  },
+  {
+    "name": "arrive",
+    "trans": [
+      "到达, 抵达, 到来, 抵 (verb.)"
+    ]
+  },
+  {
+    "name": "art",
+    "trans": [
+      "艺术, 美术, 艺术品, 艺术作品 (noun.)"
+    ]
+  },
+  {
+    "name": "article",
+    "trans": [
+      "文章, 篇文章, 第, 篇 (noun.)"
+    ]
+  },
+  {
+    "name": "artificial",
+    "trans": [
+      "人工, 人造, 人为 (adj.)"
+    ]
+  },
+  {
+    "name": "artist",
+    "trans": [
+      "艺术家, 画家, 艺人, 画师 (noun.)"
+    ]
+  },
+  {
+    "name": "as",
+    "trans": [
+      "作为 (prep.)"
+    ]
+  },
+  {
+    "name": "ashamed",
+    "trans": [
+      "惭愧, 羞愧, 羞耻, 羞 (adj.)"
+    ]
+  },
+  {
+    "name": "aside",
+    "trans": [
+      "一旁, 一边, 预留, 抛开 (adv.)"
+    ]
+  },
+  {
+    "name": "ask",
+    "trans": [
+      "问, 要求, 询问, 请 (verb.)"
+    ]
+  },
+  {
+    "name": "asleep",
+    "trans": [
+      "睡着, 睡觉, 睡, 熟睡 (adj.)"
+    ]
+  },
+  {
+    "name": "aspect",
+    "trans": [
+      "方面, 环节, 一方面, 层面 (noun.)"
+    ]
+  },
+  {
+    "name": "assess",
+    "trans": [
+      "评估, 评价, 评定, 考核 (verb.)"
+    ]
+  },
+  {
+    "name": "assessment",
+    "trans": [
+      "评估, 评价, 评定, 考核 (noun.)"
+    ]
+  },
+  {
+    "name": "assignment",
+    "trans": [
+      "分配, 赋值, 任务, 转让 (noun.)"
+    ]
+  },
+  {
+    "name": "assist",
+    "trans": [
+      "协助, 帮助, 辅助 (verb.)"
+    ]
+  },
+  {
+    "name": "assistance",
+    "trans": [
+      "援助, 协助, 帮助, 救助 (noun.)"
+    ]
+  },
+  {
+    "name": "assistant",
+    "trans": [
+      "助理, 助手, 辅助, 副 (noun.)"
+    ]
+  },
+  {
+    "name": "associate",
+    "trans": [
+      "副学士, 副, 准 (adj.); 联想, 助理, 同事 (noun.); 关联, 交往 (verb.)"
+    ]
+  },
+  {
+    "name": "association",
+    "trans": [
+      "协会, 关联, 公会, 联想 (noun.)"
+    ]
+  },
+  {
+    "name": "assume",
+    "trans": [
+      "假设, 承担, 假定, 猜 (verb.)"
+    ]
+  },
+  {
+    "name": "assumption",
+    "trans": [
+      "假设, 假定, 设想, 假想 (noun.)"
+    ]
+  },
+  {
+    "name": "assure",
+    "trans": [
+      "保证, 确保 (verb.)"
+    ]
+  },
+  {
+    "name": "at",
+    "trans": [
+      "在 (prep.)"
+    ]
+  },
+  {
+    "name": "atmosphere",
+    "trans": [
+      "气氛, 大气, 氛围, 大气层 (noun.)"
+    ]
+  },
+  {
+    "name": "attach",
+    "trans": [
+      "附加, 附上, 附, 附着 (verb.)"
+    ]
+  },
+  {
+    "name": "attack",
+    "trans": [
+      "攻击, 袭击, 进攻, 发作 (noun.); 攻打 (verb.)"
+    ]
+  },
+  {
+    "name": "attempt",
+    "trans": [
+      "尝试, 企图, 试图, 试 (noun.)"
+    ]
+  },
+  {
+    "name": "attend",
+    "trans": [
+      "出席, 参加, 就读, 参与 (verb.)"
+    ]
+  },
+  {
+    "name": "attention",
+    "trans": [
+      "注意, 注意力, 关注, 重视 (noun.)"
+    ]
+  },
+  {
+    "name": "attitude",
+    "trans": [
+      "态度, 姿态, 心态, 姿 (noun.)"
+    ]
+  },
+  {
+    "name": "attorney",
+    "trans": [
+      "律师, 检察官, 受权, 检察长 (noun.)"
+    ]
+  },
+  {
+    "name": "attract",
+    "trans": [
+      "吸引, 招揽, 吸纳, 引来 (verb.)"
+    ]
+  },
+  {
+    "name": "attraction",
+    "trans": [
+      "吸引力, 吸引, 景点, 胜地 (noun.)"
+    ]
+  },
+  {
+    "name": "attractive",
+    "trans": [
+      "具吸引力, 吸引力, 诱人, 迷人 (adj.)"
+    ]
+  },
+  {
+    "name": "audience",
+    "trans": [
+      "观众, 听众, 受众, 观众席 (noun.)"
+    ]
+  },
+  {
+    "name": "aunt",
+    "trans": [
+      "阿姨, 姑姑, 姨妈, 姑妈 (noun.)"
+    ]
+  },
+  {
+    "name": "author",
+    "trans": [
+      "作者, 笔者, 作家, 本文 (noun.)"
+    ]
+  },
+  {
+    "name": "authority",
+    "trans": [
+      "权威, 管理局, 事务监督, 权力 (noun.)"
+    ]
+  },
+  {
+    "name": "automatic",
+    "trans": [
+      "自动, 全自动, 自动化 (adj.)"
+    ]
+  },
+  {
+    "name": "automatically",
+    "trans": [
+      "自动 (adv.)"
+    ]
+  },
+  {
+    "name": "autumn",
+    "trans": [
+      "秋天, 秋, 秋季, 秋日 (noun.)"
+    ]
+  },
+  {
+    "name": "available",
+    "trans": [
+      "可用, 可, 提供, 现有 (adj.)"
+    ]
+  },
+  {
+    "name": "average",
+    "trans": [
+      "平均, 普通, 一般, 人均 (adj.); 平均水平, 平均值, 平均数, 海损 (noun.)"
+    ]
+  },
+  {
+    "name": "avoid",
+    "trans": [
+      "避免, 避开, 躲避, 回避 (verb.)"
+    ]
+  },
+  {
+    "name": "awake",
+    "trans": [
+      "清醒, 醒, 醒来, 苏醒 (adj.); 唤醒 (verb.)"
+    ]
+  },
+  {
+    "name": "award",
+    "trans": [
+      "奖, 奖项, 奖励, 裁决 (noun.)"
+    ]
+  },
+  {
+    "name": "aware",
+    "trans": [
+      "意识到, 知道, 知悉, 察觉 (adj.)"
+    ]
+  },
+  {
+    "name": "awareness",
+    "trans": [
+      "意识, 觉知, 认识, 觉察 (noun.)"
+    ]
+  },
+  {
+    "name": "away",
+    "trans": [
+      "走, 带走, 离开, 远离 (adv.)"
+    ]
+  },
+  {
+    "name": "awful",
+    "trans": [
+      "可怕, 糟糕, 糟透, 糟 (adj.)"
+    ]
+  },
+  {
+    "name": "awkward",
+    "trans": [
+      "尴尬, 笨拙, 别扭, 令人尴尬 (adj.)"
+    ]
+  },
+  {
+    "name": "baby",
+    "trans": [
+      "宝贝, 婴儿, 宝宝, 孩子 (noun.)"
+    ]
+  },
+  {
+    "name": "back",
+    "trans": [
+      "回来, 回, 回去, 回到 (adv.); 背, 背部, 后面, 背面 (noun.)"
+    ]
+  },
+  {
+    "name": "background",
+    "trans": [
+      "背景, 后台, 背景下, 底色 (noun.)"
+    ]
+  },
+  {
+    "name": "backwards",
+    "trans": [
+      "向后, 倒退, 后退, 往后 (noun.); 颠倒 (adv.)"
+    ]
+  },
+  {
+    "name": "bacon",
+    "trans": [
+      "培根, 熏肉, 咸肉, 腊肉 (noun.)"
+    ]
+  },
+  {
+    "name": "bad",
+    "trans": [
+      "坏, 不好, 糟糕, 糟 (adj.)"
+    ]
+  },
+  {
+    "name": "badly",
+    "trans": [
+      "严重, 不好, 糟糕, 厉害 (adv.)"
+    ]
+  },
+  {
+    "name": "bag",
+    "trans": [
+      "袋, 袋子, 包, 书包 (noun.)"
+    ]
+  },
+  {
+    "name": "bake",
+    "trans": [
+      "烤, 烘培, 烙 (verb.); 烘烤, 烘, 烘焙, 焙烧 (noun.)"
+    ]
+  },
+  {
+    "name": "balance",
+    "trans": [
+      "平衡, 余额, 天平, 均衡 (noun.)"
+    ]
+  },
+  {
+    "name": "ball",
+    "trans": [
+      "球, 舞会, 滚珠, 球类 (noun.)"
+    ]
+  },
+  {
+    "name": "ban",
+    "trans": [
+      "禁令, 办, 坂, 潘基文 (noun.); 禁止, 取缔 (verb.)"
+    ]
+  },
+  {
+    "name": "band",
+    "trans": [
+      "乐队, 波段, 带, 乐团 (noun.)"
+    ]
+  },
+  {
+    "name": "bang",
+    "trans": [
+      "浜, 爆炸, 砰, 邦 (noun.)"
+    ]
+  },
+  {
+    "name": "bank",
+    "trans": [
+      "银行, 世行, 岸, 行 (noun.)"
+    ]
+  },
+  {
+    "name": "bar",
+    "trans": [
+      "酒吧, 栏, 杆, 棒材 (noun.)"
+    ]
+  },
+  {
+    "name": "barrier",
+    "trans": [
+      "屏障, 壁垒, 障碍, 阻隔 (noun.)"
+    ]
+  },
+  {
+    "name": "base",
+    "trans": [
+      "基地, 基, 基础, 基部 (noun.)"
+    ]
+  },
+  {
+    "name": "baseball",
+    "trans": [
+      "棒球, 垒球 (noun.)"
+    ]
+  },
+  {
+    "name": "basic",
+    "trans": [
+      "基本, 基本法, 基础, 根本 (adj.)"
+    ]
+  },
+  {
+    "name": "basically",
+    "trans": [
+      "基本上, 基本, 根本上, 本质上 (adv.)"
+    ]
+  },
+  {
+    "name": "basis",
+    "trans": [
+      "基础, 依据, 根据, 基 (noun.)"
+    ]
+  },
+  {
+    "name": "basket",
+    "trans": [
+      "篮子, 篮, 篮子里, 筐 (noun.)"
+    ]
+  },
+  {
+    "name": "bat",
+    "trans": [
+      "蝙蝠, 棍, 蝠, 球拍 (noun.)"
+    ]
+  },
+  {
+    "name": "bath",
+    "trans": [
+      "浴, 澡, 洗澡, 沐浴 (noun.)"
+    ]
+  },
+  {
+    "name": "bathroom",
+    "trans": [
+      "浴室, 卫生间, 洗手间, 卫浴 (noun.)"
+    ]
+  },
+  {
+    "name": "battery",
+    "trans": [
+      "电池, 蓄电池, 电瓶, 电池充电 (noun.)"
+    ]
+  },
+  {
+    "name": "battle",
+    "trans": [
+      "战斗, 战役, 战, 场战役 (noun.)"
+    ]
+  },
+  {
+    "name": "be",
+    "trans": [
+      "被, 是, 成为, 会 (verb.)"
+    ]
+  },
+  {
+    "name": "beach",
+    "trans": [
+      "海滩, 沙滩, 海边, 泳滩 (noun.)"
+    ]
+  },
+  {
+    "name": "bean",
+    "trans": [
+      "bean, 豆, 憨豆, 比恩 (noun.)"
+    ]
+  },
+  {
+    "name": "bear",
+    "trans": [
+      "熊, 贝尔斯登 (noun.); 承担, 承受, 忍受, 背负 (verb.)"
+    ]
+  },
+  {
+    "name": "beard",
+    "trans": [
+      "胡子, 胡须, 留胡子, 络腮胡子 (noun.)"
+    ]
+  },
+  {
+    "name": "beat",
+    "trans": [
+      "击败, 打败, 打, 揍 (verb.); 节拍, 跳动, 节奏, 拍 (noun.)"
+    ]
+  },
+  {
+    "name": "beautiful",
+    "trans": [
+      "美丽, 漂亮, 美, 优美 (adj.)"
+    ]
+  },
+  {
+    "name": "beauty",
+    "trans": [
+      "美, 美容, 美丽, 美貌 (noun.)"
+    ]
+  },
+  {
+    "name": "because",
+    "trans": [
+      "因为, 由于 (prep.)"
+    ]
+  },
+  {
+    "name": "become",
+    "trans": [
+      "成为, 变得, 变成, 成 (verb.)"
+    ]
+  },
+  {
+    "name": "bed",
+    "trans": [
+      "床, 睡觉, 张床, 睡 (noun.)"
+    ]
+  },
+  {
+    "name": "bedroom",
+    "trans": [
+      "卧室, 间卧室, 寝室, 卧房 (noun.)"
+    ]
+  },
+  {
+    "name": "beef",
+    "trans": [
+      "牛肉, 肉牛, 牛, 牛排 (noun.)"
+    ]
+  },
+  {
+    "name": "beer",
+    "trans": [
+      "啤酒, 杯啤酒, 啤, 瓶啤酒 (noun.)"
+    ]
+  },
+  {
+    "name": "before",
+    "trans": [
+      "之前, 前 (prep.); 以前 (adv.)"
+    ]
+  },
+  {
+    "name": "beforehand",
+    "trans": [
+      "事先, 事前, 预先, 提前 (adv.)"
+    ]
+  },
+  {
+    "name": "begin",
+    "trans": [
+      "开始, 首先, 开头, 展开 (verb.)"
+    ]
+  },
+  {
+    "name": "beginning",
+    "trans": [
+      "开始, 开端, 开头, 初 (noun.)"
+    ]
+  },
+  {
+    "name": "behalf",
+    "trans": [
+      "代表, 名义, 代, 说情 (noun.)"
+    ]
+  },
+  {
+    "name": "behave",
+    "trans": [
+      "行为, 表现, 做人, 行为举止 (verb.)"
+    ]
+  },
+  {
+    "name": "behaviour",
+    "trans": [
+      "行为, 举止, 举动 (noun.)"
+    ]
+  },
+  {
+    "name": "behind",
+    "trans": [
+      "背后, 后面, 身后 (prep.)"
+    ]
+  },
+  {
+    "name": "being",
+    "trans": [
+      "被, 正在, 作为, 成为 (verb.)"
+    ]
+  },
+  {
+    "name": "belief",
+    "trans": [
+      "信念, 信仰, 相信, 信心 (noun.)"
+    ]
+  },
+  {
+    "name": "believe",
+    "trans": [
+      "相信, 认为, 信, 坚信 (verb.)"
+    ]
+  },
+  {
+    "name": "bell",
+    "trans": [
+      "贝尔, 铃, 钟, 钟声 (noun.)"
+    ]
+  },
+  {
+    "name": "belong",
+    "trans": [
+      "属于, 归属, 所属, 属於 (verb.)"
+    ]
+  },
+  {
+    "name": "below",
+    "trans": [
+      "下面 (adv.); 低于, 以下, 下 (prep.)"
+    ]
+  },
+  {
+    "name": "belt",
+    "trans": [
+      "皮带, 带, 腰带, 胶带 (noun.)"
+    ]
+  },
+  {
+    "name": "bench",
+    "trans": [
+      "板凳, 长凳上, 长椅上, 长凳 (noun.)"
+    ]
+  },
+  {
+    "name": "bend",
+    "trans": [
+      "弯曲, 弯腰, 屈服, 曲 (verb.); 弯, 折弯, 弯道, 弯管 (noun.)"
+    ]
+  },
+  {
+    "name": "beneath",
+    "trans": [
+      "下方, 下 (prep.)"
+    ]
+  },
+  {
+    "name": "benefit",
+    "trans": [
+      "效益, 利益, 好处, 造福 (noun.); 受益, 获益, 得益, 有利于 (verb.)"
+    ]
+  },
+  {
+    "name": "beside",
+    "trans": [
+      "旁边, 旁 (prep.)"
+    ]
+  },
+  {
+    "name": "best",
+    "trans": [
+      "最好, 最佳, 最棒, 最 (adj.)"
+    ]
+  },
+  {
+    "name": "bet",
+    "trans": [
+      "打赌, 敢打赌, 赌, 猜 (verb.); 赌注, 下注 (noun.)"
+    ]
+  },
+  {
+    "name": "better",
+    "trans": [
+      "更好, 较好, 好些, 美好 (adj.); 最好 (adv.)"
+    ]
+  },
+  {
+    "name": "between",
+    "trans": [
+      "之间, 间 (prep.)"
+    ]
+  },
+  {
+    "name": "beyond",
+    "trans": [
+      "超越, 超出 (prep.)"
+    ]
+  },
+  {
+    "name": "bicycle",
+    "trans": [
+      "自行车, 辆自行车, 脚踏车, 单车 (noun.)"
+    ]
+  },
+  {
+    "name": "bid",
+    "trans": [
+      "出价, 投标, 申办, 竞标 (noun.)"
+    ]
+  },
+  {
+    "name": "big",
+    "trans": [
+      "大, 大型, 重大, 巨大 (adj.)"
+    ]
+  },
+  {
+    "name": "bike",
+    "trans": [
+      "自行车, 辆自行车, 脚踏车, 骑自行车 (noun.)"
+    ]
+  },
+  {
+    "name": "bill",
+    "trans": [
+      "条例草案, 比尔, 法案, 本条例草案 (noun.)"
+    ]
+  },
+  {
+    "name": "bin",
+    "trans": [
+      "滨, 斌, 彬, 滨河路 (noun.)"
+    ]
+  },
+  {
+    "name": "bird",
+    "trans": [
+      "鸟, 只鸟, 鸟儿, 小鸟 (noun.)"
+    ]
+  },
+  {
+    "name": "birth",
+    "trans": [
+      "出生, 诞生, 生育, 降生 (noun.)"
+    ]
+  },
+  {
+    "name": "birthday",
+    "trans": [
+      "生日, 岁生日, 过生日, 生日那天 (noun.)"
+    ]
+  },
+  {
+    "name": "biscuit",
+    "trans": [
+      "饼干, 饼乾, 块饼干, 饼 (noun.)"
+    ]
+  },
+  {
+    "name": "bit",
+    "trans": [
+      "位, 比特, 咬, 钻头 (noun.)"
+    ]
+  },
+  {
+    "name": "bite",
+    "trans": [
+      "咬, 咬住, 啃 (verb.); 咬一口, 咬伤, 叮咬, 撕咬 (noun.)"
+    ]
+  },
+  {
+    "name": "bitter",
+    "trans": [
+      "苦, 苦涩, 苦味, 痛苦 (adj.)"
+    ]
+  },
+  {
+    "name": "black",
+    "trans": [
+      "黑色, 黑, 黑人, 黑衣 (adj.); 布莱克 (noun.)"
+    ]
+  },
+  {
+    "name": "blade",
+    "trans": [
+      "叶片, 刀片, 刀锋, 刀刃 (noun.)"
+    ]
+  },
+  {
+    "name": "blame",
+    "trans": [
+      "责怪, 怪, 责备, 指责 (verb.); 责任 (noun.)"
+    ]
+  },
+  {
+    "name": "blank",
+    "trans": [
+      "空白, 毛坯, 坯料, 坯 (adj.)"
+    ]
+  },
+  {
+    "name": "bless",
+    "trans": [
+      "保佑, 祝福, 赐福, 佑 (verb.)"
+    ]
+  },
+  {
+    "name": "blind",
+    "trans": [
+      "盲, 盲目, 盲人, 瞎 (adj.)"
+    ]
+  },
+  {
+    "name": "block",
+    "trans": [
+      "块, 砌块, 阻滞, 街区 (noun.); 阻止, 阻塞, 阻碍 (verb.)"
+    ]
+  },
+  {
+    "name": "bloke",
+    "trans": [
+      "家伙, 小伙 (noun.)"
+    ]
+  },
+  {
+    "name": "blonde",
+    "trans": [
+      "金发, 金发女郎, 金发碧眼, 金发美女 (adj.)"
+    ]
+  },
+  {
+    "name": "blood",
+    "trans": [
+      "血, 血液, 鲜血, 血迹 (noun.)"
+    ]
+  },
+  {
+    "name": "blow",
+    "trans": [
+      "吹, 炸, 打爆, 炸掉 (verb.); 打击, 击, 冲击 (noun.)"
+    ]
+  },
+  {
+    "name": "blue",
+    "trans": [
+      "蓝色, 蓝, 兰色, 蔚蓝 (adj.)"
+    ]
+  },
+  {
+    "name": "board",
+    "trans": [
+      "董事会, 板, 委员会, 董事局 (noun.)"
+    ]
+  },
+  {
+    "name": "boat",
+    "trans": [
+      "船, 小船, 艘船, 舟 (noun.)"
+    ]
+  },
+  {
+    "name": "body",
+    "trans": [
+      "身体, 体, 尸体, 车身 (noun.)"
+    ]
+  },
+  {
+    "name": "boil",
+    "trans": [
+      "煮沸, 烧, 沸, 辛劳 (noun.); 煮, 熬, 沸腾, 煮熟 (verb.)"
+    ]
+  },
+  {
+    "name": "boiler",
+    "trans": [
+      "锅炉, 炉, 锅炉炉 (noun.)"
+    ]
+  },
+  {
+    "name": "boiling",
+    "trans": [
+      "沸腾, 煮沸, 沸, 沸点 (verb.)"
+    ]
+  },
+  {
+    "name": "bomb",
+    "trans": [
+      "炸弹, 枚炸弹, 颗炸弹, 弹 (noun.); 轰炸, 炸 (verb.)"
+    ]
+  },
+  {
+    "name": "bone",
+    "trans": [
+      "骨, 骨头, 骨骼, 骨质 (noun.)"
+    ]
+  },
+  {
+    "name": "bonus",
+    "trans": [
+      "奖金, 红利, 奖励, 花红 (noun.)"
+    ]
+  },
+  {
+    "name": "book",
+    "trans": [
+      "书, 本书, 图书, 簿 (noun.); 预订, 预定, 订 (verb.)"
+    ]
+  },
+  {
+    "name": "boom",
+    "trans": [
+      "繁荣, 热潮, 繁荣时期, 景气 (noun.)"
+    ]
+  },
+  {
+    "name": "boot",
+    "trans": [
+      "引导, 开机, 启动, 靴子 (noun.)"
+    ]
+  },
+  {
+    "name": "border",
+    "trans": [
+      "边境, 边界, 境, 边框 (noun.)"
+    ]
+  },
+  {
+    "name": "bored",
+    "trans": [
+      "无聊, 钻孔灌注, 钻孔, 烦 (adj.); 厌烦, 厌倦 (verb.)"
+    ]
+  },
+  {
+    "name": "boring",
+    "trans": [
+      "无聊, 枯燥, 乏味, 镗 (adj.)"
+    ]
+  },
+  {
+    "name": "born",
+    "trans": [
+      "出生, 天生, 诞生, 生 (verb.)"
+    ]
+  },
+  {
+    "name": "borrow",
+    "trans": [
+      "借, 借用, 借用一下, 借入 (verb.)"
+    ]
+  },
+  {
+    "name": "boss",
+    "trans": [
+      "老板, 老大, 上司, 老闆 (noun.)"
+    ]
+  },
+  {
+    "name": "both",
+    "trans": [
+      "都 (det.)"
+    ]
+  },
+  {
+    "name": "bother",
+    "trans": [
+      "打扰, 费心, 烦, 麻烦 (verb.)"
+    ]
+  },
+  {
+    "name": "bottle",
+    "trans": [
+      "瓶, 瓶子, 酒瓶, 奶瓶 (noun.)"
+    ]
+  },
+  {
+    "name": "bottom",
+    "trans": [
+      "底部, 底, 底层, 底端 (noun.)"
+    ]
+  },
+  {
+    "name": "bounce",
+    "trans": [
+      "反弹, 弹跳, 跳出, 跳动 (noun.); 蹦蹦跳跳 (verb.)"
+    ]
+  },
+  {
+    "name": "bound",
+    "trans": [
+      "绑定, 束缚, 约束, 势必 (verb.)"
+    ]
+  },
+  {
+    "name": "bowl",
+    "trans": [
+      "碗, 钵, 盆, 杯 (noun.)"
+    ]
+  },
+  {
+    "name": "box",
+    "trans": [
+      "箱, 盒, 盒子, 框 (noun.)"
+    ]
+  },
+  {
+    "name": "boy",
+    "trans": [
+      "男孩, 孩子, 小子, 男孩子 (noun.)"
+    ]
+  },
+  {
+    "name": "boyfriend",
+    "trans": [
+      "男朋友, 男友 (noun.)"
+    ]
+  },
+  {
+    "name": "brain",
+    "trans": [
+      "大脑, 脑, 脑子, 颅脑 (noun.)"
+    ]
+  },
+  {
+    "name": "branch",
+    "trans": [
+      "分公司, 分支, 分行, 科 (noun.)"
+    ]
+  },
+  {
+    "name": "brave",
+    "trans": [
+      "勇敢, 英勇, 勇者, 勇 (adj.)"
+    ]
+  },
+  {
+    "name": "bread",
+    "trans": [
+      "面包, 饼, 馒头, 粮 (noun.)"
+    ]
+  },
+  {
+    "name": "break",
+    "trans": [
+      "打破, 分手, 破, 断 (verb.); 休息, 突破, 中断, 断裂 (noun.)"
+    ]
+  },
+  {
+    "name": "breakfast",
+    "trans": [
+      "早餐, 早饭, 过早饭, 早点 (noun.)"
+    ]
+  },
+  {
+    "name": "breast",
+    "trans": [
+      "乳腺, 丰胸, 胸膛, 乳腺癌 (noun.)"
+    ]
+  },
+  {
+    "name": "breath",
+    "trans": [
+      "呼吸, 气息, 一口气, 呼气 (noun.)"
+    ]
+  },
+  {
+    "name": "breathe",
+    "trans": [
+      "呼吸, 吸气, 深呼吸, 喘口气 (verb.)"
+    ]
+  },
+  {
+    "name": "brick",
+    "trans": [
+      "砖, 砖头, 砖砌, 砖块 (noun.)"
+    ]
+  },
+  {
+    "name": "bridge",
+    "trans": [
+      "桥, 桥梁, 大桥, 座桥 (noun.)"
+    ]
+  },
+  {
+    "name": "brief",
+    "trans": [
+      "简短, 短暂, 简要, 简略 (adj.); 简介, 简报 (noun.)"
+    ]
+  },
+  {
+    "name": "briefly",
+    "trans": [
+      "简要, 扼要, 简述 (noun.); 简略, 简单, 短暂, 简短 (adv.)"
+    ]
+  },
+  {
+    "name": "bright",
+    "trans": [
+      "明亮, 光明, 亮, 鲜艳 (adj.)"
+    ]
+  },
+  {
+    "name": "brilliant",
+    "trans": [
+      "辉煌, 灿烂, 才华横溢, 光辉 (adj.)"
+    ]
+  },
+  {
+    "name": "bring",
+    "trans": [
+      "带来, 带, 把, 使 (verb.)"
+    ]
+  },
+  {
+    "name": "broad",
+    "trans": [
+      "广阔, 广泛, 宽阔, 宽广 (adj.)"
+    ]
+  },
+  {
+    "name": "brother",
+    "trans": [
+      "哥哥, 兄弟, 哥, 大哥 (noun.)"
+    ]
+  },
+  {
+    "name": "brown",
+    "trans": [
+      "棕色, 褐色, 咖啡色 (adj.); 布朗, 棕, 褐, 布朗大学 (noun.)"
+    ]
+  },
+  {
+    "name": "brush",
+    "trans": [
+      "刷, 刷子, 画笔, 电刷 (noun.); 刷牙 (verb.)"
+    ]
+  },
+  {
+    "name": "buck",
+    "trans": [
+      "降压, 巴克, 龅, 赛珍珠 (noun.); 振作 (verb.)"
+    ]
+  },
+  {
+    "name": "bucket",
+    "trans": [
+      "桶, 水桶, 斗, 铲斗 (noun.)"
+    ]
+  },
+  {
+    "name": "buddy",
+    "trans": [
+      "巴迪, 伙计, 哥们, 好友 (noun.)"
+    ]
+  },
+  {
+    "name": "budget",
+    "trans": [
+      "预算, 预算案, 财政预算案, 财政预算 (noun.)"
+    ]
+  },
+  {
+    "name": "bug",
+    "trans": [
+      "臭虫, 虫子, 虫, 错误 (noun.)"
+    ]
+  },
+  {
+    "name": "build",
+    "trans": [
+      "建立, 构建, 建造, 打造 (verb.)"
+    ]
+  },
+  {
+    "name": "builder",
+    "trans": [
+      "建设者, 成器, 建筑工地, 助剂 (noun.)"
+    ]
+  },
+  {
+    "name": "building",
+    "trans": [
+      "建筑, 建设, 大楼, 建筑物 (noun.); 构建, 建立, 建造, 建 (verb.)"
+    ]
+  },
+  {
+    "name": "bump",
+    "trans": [
+      "凹凸, 撞, 磕碰, 肿块 (noun.)"
+    ]
+  },
+  {
+    "name": "bunch",
+    "trans": [
+      "堆, 束, 串, 一群 (noun.)"
+    ]
+  },
+  {
+    "name": "burn",
+    "trans": [
+      "烧伤 (noun.); 烧, 燃烧, 烧掉, 刻录 (verb.)"
+    ]
+  },
+  {
+    "name": "burst",
+    "trans": [
+      "爆裂, 突发, 爆, 迸发 (noun.)"
+    ]
+  },
+  {
+    "name": "bury",
+    "trans": [
+      "埋葬, 埋, 掩埋, 葬 (verb.); 埋没 (noun.)"
+    ]
+  },
+  {
+    "name": "bus",
+    "trans": [
+      "总线, 巴士, 公共汽车, 公交车 (noun.)"
+    ]
+  },
+  {
+    "name": "business",
+    "trans": [
+      "业务, 商业, 商务, 生意 (noun.)"
+    ]
+  },
+  {
+    "name": "busy",
+    "trans": [
+      "忙, 忙碌, 繁忙, 忙于 (adj.)"
+    ]
+  },
+  {
+    "name": "but",
+    "trans": [
+      "但, 但是, 不过 (conj.)"
+    ]
+  },
+  {
+    "name": "butcher",
+    "trans": [
+      "屠夫, 屠户, 肉店, 杀人狂 (noun.); 宰 (verb.)"
+    ]
+  },
+  {
+    "name": "butter",
+    "trans": [
+      "黄油, 奶油, 牛油, 酥油 (noun.)"
+    ]
+  },
+  {
+    "name": "button",
+    "trans": [
+      "按钮, 键, 钮, 钮扣 (noun.)"
+    ]
+  },
+  {
+    "name": "buy",
+    "trans": [
+      "买, 购买, 采购, 买入 (verb.)"
+    ]
+  },
+  {
+    "name": "buyer",
+    "trans": [
+      "买方, 买家, 买主, 采购员 (noun.)"
+    ]
+  },
+  {
+    "name": "by",
+    "trans": [
+      "由, 通过, 的 (prep.)"
+    ]
+  },
+  {
+    "name": "bye",
+    "trans": [
+      "再见, 拜拜, 拜, 回见 (noun.)"
+    ]
+  },
+  {
+    "name": "bye",
+    "trans": [
+      "再见, 拜拜, 拜, 回见 (noun.)"
+    ]
+  },
+  {
+    "name": "cabinet",
+    "trans": [
+      "内阁, 柜, 橱柜, 柜子 (noun.)"
+    ]
+  },
+  {
+    "name": "cable",
+    "trans": [
+      "电缆, 索, 有线, 有线电视 (noun.)"
+    ]
+  },
+  {
+    "name": "cake",
+    "trans": [
+      "蛋糕, 饼, 糕, 块蛋糕 (noun.)"
+    ]
+  },
+  {
+    "name": "calculate",
+    "trans": [
+      "计算, 算, 测算 (verb.); 算了 (noun.)"
+    ]
+  },
+  {
+    "name": "calculation",
+    "trans": [
+      "计算, 测算, 核算, 运算 (noun.)"
+    ]
+  },
+  {
+    "name": "calculator",
+    "trans": [
+      "计算器 (noun.)"
+    ]
+  },
+  {
+    "name": "calendar",
+    "trans": [
+      "日历, 历法, 历, 日程表 (noun.)"
+    ]
+  },
+  {
+    "name": "call",
+    "trans": [
+      "叫, 打电话给, 打电话, 称呼 (verb.); 调用, 呼叫, 电话 (noun.)"
+    ]
+  },
+  {
+    "name": "calm",
+    "trans": [
+      "平静, 冷静, 镇静, 镇定 (adj.); 平息 (verb.)"
+    ]
+  },
+  {
+    "name": "camera",
+    "trans": [
+      "相机, 照相机, 摄像机, 摄像头 (noun.)"
+    ]
+  },
+  {
+    "name": "camp",
+    "trans": [
+      "营地, 阵营, 营, 夏令营 (noun.)"
+    ]
+  },
+  {
+    "name": "campaign",
+    "trans": [
+      "竞选, 运动, 战役, 竞选活动 (noun.)"
+    ]
+  },
+  {
+    "name": "can",
+    "trans": [
+      "可以, 能, 能够 (modal.)"
+    ]
+  },
+  {
+    "name": "can",
+    "trans": [
+      "可以, 能, 能够 (modal.)"
+    ]
+  },
+  {
+    "name": "cancel",
+    "trans": [
+      "取消, 撤销, 注销, 抵消 (verb.)"
+    ]
+  },
+  {
+    "name": "cancer",
+    "trans": [
+      "癌症, 癌, 肿瘤, 患癌症 (noun.)"
+    ]
+  },
+  {
+    "name": "candidate",
+    "trans": [
+      "候选人, 候选, 人选, 应聘者 (noun.)"
+    ]
+  },
+  {
+    "name": "candle",
+    "trans": [
+      "蜡烛, 支蜡烛, 烛, 根蜡烛 (noun.)"
+    ]
+  },
+  {
+    "name": "candy",
+    "trans": [
+      "糖果, 糖, 坎蒂, 凯蒂 (noun.)"
+    ]
+  },
+  {
+    "name": "cap",
+    "trans": [
+      "帽, 帽子, 上限, 盖 (noun.)"
+    ]
+  },
+  {
+    "name": "capable",
+    "trans": [
+      "能干, 能够, 能力, 精干 (adj.)"
+    ]
+  },
+  {
+    "name": "capacity",
+    "trans": [
+      "容量, 能力, 产能, 力 (noun.)"
+    ]
+  },
+  {
+    "name": "capital",
+    "trans": [
+      "资本, 首都, 资金, 资本金 (noun.)"
+    ]
+  },
+  {
+    "name": "captain",
+    "trans": [
+      "船长, 队长, 上尉, 舰长 (noun.)"
+    ]
+  },
+  {
+    "name": "capture",
+    "trans": [
+      "捕获, 俘获, 采集 (noun.); 捕捉, 抓住, 获取, 占领 (verb.)"
+    ]
+  },
+  {
+    "name": "car",
+    "trans": [
+      "车, 汽车, 辆车, 车子 (noun.)"
+    ]
+  },
+  {
+    "name": "card",
+    "trans": [
+      "卡, 卡片, 名片, 牌 (noun.)"
+    ]
+  },
+  {
+    "name": "care",
+    "trans": [
+      "护理, 照顾, 关怀, 保健 (noun.); 关心, 在乎, 在意, 不在乎 (verb.)"
+    ]
+  },
+  {
+    "name": "career",
+    "trans": [
+      "职业生涯, 事业, 职业, 生涯 (noun.)"
+    ]
+  },
+  {
+    "name": "careful",
+    "trans": [
+      "小心, 仔细, 细心, 谨慎 (adj.)"
+    ]
+  },
+  {
+    "name": "carefully",
+    "trans": [
+      "仔细, 精心, 小心, 认真 (adv.)"
+    ]
+  },
+  {
+    "name": "carpet",
+    "trans": [
+      "地毯, 毯, 毡 (noun.)"
+    ]
+  },
+  {
+    "name": "carrot",
+    "trans": [
+      "胡萝卜, 红萝卜, 萝卜 (noun.)"
+    ]
+  },
+  {
+    "name": "carry",
+    "trans": [
+      "携带, 随身携带, 进行, 带 (verb.)"
+    ]
+  },
+  {
+    "name": "cartoon",
+    "trans": [
+      "卡通, 动画片, 漫画, 动漫 (noun.)"
+    ]
+  },
+  {
+    "name": "case",
+    "trans": [
+      "案例, 情况下, 案子, 案件 (noun.)"
+    ]
+  },
+  {
+    "name": "cash",
+    "trans": [
+      "现金, 资金, 钱, 现货 (noun.); 兑现, 兑换 (verb.)"
+    ]
+  },
+  {
+    "name": "cast",
+    "trans": [
+      "投, 施放, 投射, 赶 (verb.); 铸, 铸造, 强制转换, 铸态 (noun.)"
+    ]
+  },
+  {
+    "name": "castle",
+    "trans": [
+      "城堡, 座城堡, 古堡, 卡塞尔 (noun.)"
+    ]
+  },
+  {
+    "name": "cat",
+    "trans": [
+      "猫, 只猫, 猫咪 (noun.)"
+    ]
+  },
+  {
+    "name": "catalogue",
+    "trans": [
+      "目录, 编目, 目录册, 书目 (noun.)"
+    ]
+  },
+  {
+    "name": "catch",
+    "trans": [
+      "赶上, 抓住, 抓, 抓到 (verb.)"
+    ]
+  },
+  {
+    "name": "category",
+    "trans": [
+      "类别, 范畴, 类, 品类 (noun.)"
+    ]
+  },
+  {
+    "name": "cause",
+    "trans": [
+      "原因, 事业, 成因, 病因 (noun.); 引起, 导致, 造成, 因为 (verb.)"
+    ]
+  },
+  {
+    "name": "CD",
+    "trans": [
+      "CD, 光盘, 镉, 张CD (noun.)"
+    ]
+  },
+  {
+    "name": "cease",
+    "trans": [
+      "停止, 不再, 停息, 止息 (verb.)"
+    ]
+  },
+  {
+    "name": "ceiling",
+    "trans": [
+      "天花板, 上限, 吊顶, 最高限额 (noun.)"
+    ]
+  },
+  {
+    "name": "celebrate",
+    "trans": [
+      "庆祝, 庆贺, 欢庆, 庆祝一番 (verb.)"
+    ]
+  },
+  {
+    "name": "celebration",
+    "trans": [
+      "庆典, 庆祝活动, 庆祝, 庆祝会 (noun.)"
+    ]
+  },
+  {
+    "name": "cell",
+    "trans": [
+      "细胞, 单元格, 电池, 牢房 (noun.)"
+    ]
+  },
+  {
+    "name": "cellphone",
+    "trans": [
+      "手机 (noun.)"
+    ]
+  },
+  {
+    "name": "cent",
+    "trans": [
+      "时分, 美分, 分, 百分之 (noun.)"
+    ]
+  },
+  {
+    "name": "centimetre",
+    "trans": [
+      "厘米 (noun.)"
+    ]
+  },
+  {
+    "name": "central",
+    "trans": [
+      "中央, 中部, 中心, 中枢 (adj.); 中区, 环 (noun.)"
+    ]
+  },
+  {
+    "name": "centre",
+    "trans": [
+      "中心, 市中心, 中央 (noun.)"
+    ]
+  },
+  {
+    "name": "century",
+    "trans": [
+      "世纪, 世纪以来, 本世纪, 世纪末 (noun.)"
+    ]
+  },
+  {
+    "name": "cereal",
+    "trans": [
+      "麦片, 谷物, 麦片粥, 谷类 (noun.)"
+    ]
+  },
+  {
+    "name": "certain",
+    "trans": [
+      "某些, 一定, 特定, 某 (adj.)"
+    ]
+  },
+  {
+    "name": "certainly",
+    "trans": [
+      "当然, 肯定, 一定, 无疑 (adv.)"
+    ]
+  },
+  {
+    "name": "certificate",
+    "trans": [
+      "证书, 证明书, 证, 合格证书 (noun.)"
+    ]
+  },
+  {
+    "name": "chain",
+    "trans": [
+      "链, 连锁, 链条, 链子 (noun.)"
+    ]
+  },
+  {
+    "name": "chair",
+    "trans": [
+      "椅子, 椅, 张椅子, 张椅子上 (noun.)"
+    ]
+  },
+  {
+    "name": "chairman",
+    "trans": [
+      "主席, 董事长, 委会主席, 委员长 (noun.)"
+    ]
+  },
+  {
+    "name": "challenge",
+    "trans": [
+      "挑战, 挑战性, 难题 (noun.); 质疑 (verb.)"
+    ]
+  },
+  {
+    "name": "champion",
+    "trans": [
+      "冠军, 拳王, 状元, 战神 (noun.)"
+    ]
+  },
+  {
+    "name": "championship",
+    "trans": [
+      "锦标赛, 冠军, 总冠军, 冠军赛 (noun.)"
+    ]
+  },
+  {
+    "name": "chance",
+    "trans": [
+      "机会, 几率, 机遇, 机率 (noun.)"
+    ]
+  },
+  {
+    "name": "change",
+    "trans": [
+      "改变, 更改, 换, 修改 (verb.); 变化, 变更, 变革, 转变 (noun.)"
+    ]
+  },
+  {
+    "name": "channel",
+    "trans": [
+      "通道, 信道, 频道, 渠道 (noun.)"
+    ]
+  },
+  {
+    "name": "chap",
+    "trans": [
+      "章, 小伙子, 伙计, 龟裂 (noun.)"
+    ]
+  },
+  {
+    "name": "chapter",
+    "trans": [
+      "章, 章节, 篇章, 第 (noun.)"
+    ]
+  },
+  {
+    "name": "character",
+    "trans": [
+      "字符, 性格, 品格, 人物 (noun.)"
+    ]
+  },
+  {
+    "name": "characteristic",
+    "trans": [
+      "特性, 特点, 性能 (noun.); 特征, 特色, 特有 (adj.)"
+    ]
+  },
+  {
+    "name": "characterize",
+    "trans": [
+      "表征, 刻画 (verb.)"
+    ]
+  },
+  {
+    "name": "charge",
+    "trans": [
+      "电荷, 负责, 收费, 充电 (noun.); 收取, 收 (verb.)"
+    ]
+  },
+  {
+    "name": "charity",
+    "trans": [
+      "慈善, 慈善机构, 慈善事业, 慈善团体 (noun.)"
+    ]
+  },
+  {
+    "name": "chart",
+    "trans": [
+      "图表, 图, 海图, 表 (noun.)"
+    ]
+  },
+  {
+    "name": "chase",
+    "trans": [
+      "追逐, 大通, 蔡斯, 追赶 (noun.); 追, 追求 (verb.)"
+    ]
+  },
+  {
+    "name": "chat",
+    "trans": [
+      "聊天, 聊, 闲谈, 谈话 (noun.); 聊聊天, 闲聊, 聊聊, 交谈 (verb.)"
+    ]
+  },
+  {
+    "name": "cheap",
+    "trans": [
+      "廉价, 便宜, 价廉, 物美价廉 (adj.)"
+    ]
+  },
+  {
+    "name": "cheat",
+    "trans": [
+      "作弊, 欺骗, 骗, 骗人 (verb.); 骗子, 备忘, 欺诈 (noun.)"
+    ]
+  },
+  {
+    "name": "check",
+    "trans": [
+      "检查, 核对, 查, 查看 (verb.); 支票, 复选 (noun.)"
+    ]
+  },
+  {
+    "name": "cheek",
+    "trans": [
+      "脸颊, 面颊, 颊, 腮 (noun.)"
+    ]
+  },
+  {
+    "name": "cheese",
+    "trans": [
+      "奶酪, 干酪, 乳酪, 芝士 (noun.)"
+    ]
+  },
+  {
+    "name": "chemical",
+    "trans": [
+      "化学, 化工, 化学品, 化学物质 (noun.)"
+    ]
+  },
+  {
+    "name": "chemist",
+    "trans": [
+      "化学家, 化验师, 药剂师, 药店 (noun.)"
+    ]
+  },
+  {
+    "name": "chemistry",
+    "trans": [
+      "化学, 化学反应, 化工, 化学物质 (noun.)"
+    ]
+  },
+  {
+    "name": "cheque",
+    "trans": [
+      "支票, 张支票, 支票付款, 支票兑现 (noun.)"
+    ]
+  },
+  {
+    "name": "cherry",
+    "trans": [
+      "樱桃, 樱花, 樱桃木 (noun.); 樱 (adj.)"
+    ]
+  },
+  {
+    "name": "chest",
+    "trans": [
+      "胸部, 胸, 胸口, 胸前 (noun.)"
+    ]
+  },
+  {
+    "name": "chicken",
+    "trans": [
+      "鸡, 鸡肉, 凤, 小鸡 (noun.)"
+    ]
+  },
+  {
+    "name": "chief",
+    "trans": [
+      "首席, 主要, 总 (adj.); 布政, 政务, 头儿, 酋长 (noun.)"
+    ]
+  },
+  {
+    "name": "child",
+    "trans": [
+      "孩子, 儿童, 小孩, 子 (noun.)"
+    ]
+  },
+  {
+    "name": "childhood",
+    "trans": [
+      "童年, 儿时, 童年时代, 小时候 (noun.)"
+    ]
+  },
+  {
+    "name": "chip",
+    "trans": [
+      "芯片, 晶片, 切屑, 片 (noun.)"
+    ]
+  },
+  {
+    "name": "chocolate",
+    "trans": [
+      "巧克力, 朱古力 (noun.)"
+    ]
+  },
+  {
+    "name": "choice",
+    "trans": [
+      "选择, 抉择, 选, 首选 (noun.)"
+    ]
+  },
+  {
+    "name": "choose",
+    "trans": [
+      "选择, 选, 挑选, 选用 (verb.)"
+    ]
+  },
+  {
+    "name": "chop",
+    "trans": [
+      "砍, 剁, 斩, 劈 (verb.); 印章, 排骨, 排 (noun.)"
+    ]
+  },
+  {
+    "name": "chuck",
+    "trans": [
+      "恰克, 查克, 恰, 卡盘 (noun.); 扔掉 (verb.)"
+    ]
+  },
+  {
+    "name": "church",
+    "trans": [
+      "教堂, 教会, 座教堂, 堂 (noun.)"
+    ]
+  },
+  {
+    "name": "cigarette",
+    "trans": [
+      "香烟, 卷烟, 支烟, 根烟 (noun.)"
+    ]
+  },
+  {
+    "name": "cinema",
+    "trans": [
+      "电影院, 影院, 电影, 电影院看电影 (noun.)"
+    ]
+  },
+  {
+    "name": "circle",
+    "trans": [
+      "圈, 圆圈, 圆, 圈子 (noun.)"
+    ]
+  },
+  {
+    "name": "circuit",
+    "trans": [
+      "电路, 回路, 线路, 巡回 (noun.)"
+    ]
+  },
+  {
+    "name": "circumstance",
+    "trans": [
+      "情况, 情况下, 环境, 形势下 (noun.)"
+    ]
+  },
+  {
+    "name": "citizen",
+    "trans": [
+      "公民, 市民, 国民, 居民 (noun.)"
+    ]
+  },
+  {
+    "name": "city",
+    "trans": [
+      "城市, 城, 市, 座城市 (noun.)"
+    ]
+  },
+  {
+    "name": "civil",
+    "trans": [
+      "民事, 民用, 公民, 民间 (adj.)"
+    ]
+  },
+  {
+    "name": "claim",
+    "trans": [
+      "索赔, 申索, 主张, 说法 (noun.); 声称, 宣称, 称 (verb.)"
+    ]
+  },
+  {
+    "name": "class",
+    "trans": [
+      "类, 班, 课, 班级 (noun.)"
+    ]
+  },
+  {
+    "name": "classic",
+    "trans": [
+      "经典, 古典, 典型 (adj.); 名著 (noun.)"
+    ]
+  },
+  {
+    "name": "classical",
+    "trans": [
+      "古典, 经典, 传统, 古代 (adj.)"
+    ]
+  },
+  {
+    "name": "classroom",
+    "trans": [
+      "课堂, 教室, 教室里, 课室 (noun.)"
+    ]
+  },
+  {
+    "name": "clean",
+    "trans": [
+      "干净, 清洁, 洁净, 乾净 (adj.); 打扫, 清理, 清洗, 清扫 (verb.)"
+    ]
+  },
+  {
+    "name": "cleaner",
+    "trans": [
+      "清洁, 干净, 洁净 (adj.); 清洁工, 清洁剂, 滤清器, 吸尘器 (noun.)"
+    ]
+  },
+  {
+    "name": "clear",
+    "trans": [
+      "清晰, 明确, 清楚, 清除 (adj.)"
+    ]
+  },
+  {
+    "name": "clearly",
+    "trans": [
+      "显然, 清楚, 明确, 清晰 (adv.)"
+    ]
+  },
+  {
+    "name": "clerk",
+    "trans": [
+      "秘书, 店员, 职员, 业务员 (noun.)"
+    ]
+  },
+  {
+    "name": "clever",
+    "trans": [
+      "聪明, 巧妙, 机灵, 巧 (adj.)"
+    ]
+  },
+  {
+    "name": "click",
+    "trans": [
+      "单击, 点击, 击, 按 (verb.)"
+    ]
+  },
+  {
+    "name": "client",
+    "trans": [
+      "客户端, 客户机, 客户, 委托人 (noun.)"
+    ]
+  },
+  {
+    "name": "climate",
+    "trans": [
+      "气候, 气氛, 氛围, 天气 (noun.)"
+    ]
+  },
+  {
+    "name": "climb",
+    "trans": [
+      "爬, 攀登, 爬上, 攀爬 (verb.); 爬升 (noun.)"
+    ]
+  },
+  {
+    "name": "clock",
+    "trans": [
+      "时钟, 钟, 钟表, 闹钟 (noun.)"
+    ]
+  },
+  {
+    "name": "close",
+    "trans": [
+      "密切, 接近, 亲密, 紧密 (adj.); 关闭, 闭, 关, 结束 (verb.); 靠近 (adv.)"
+    ]
+  },
+  {
+    "name": "closed",
+    "trans": [
+      "封闭, 闭, 关闭, 关门 (verb.); 闭合, 封闭式, 密闭 (adj.)"
+    ]
+  },
+  {
+    "name": "closely",
+    "trans": [
+      "密切, 紧密, 紧紧, 严密 (adv.)"
+    ]
+  },
+  {
+    "name": "closet",
+    "trans": [
+      "壁橱, 壁橱里, 衣柜里, 衣柜 (noun.)"
+    ]
+  },
+  {
+    "name": "cloth",
+    "trans": [
+      "布, 布料, 布匹, 布艺 (noun.)"
+    ]
+  },
+  {
+    "name": "clothes",
+    "trans": [
+      "衣服, 衣裳, 衣物, 服装 (noun.)"
+    ]
+  },
+  {
+    "name": "cloud",
+    "trans": [
+      "云, 朵云, 云计算, 云端 (noun.)"
+    ]
+  },
+  {
+    "name": "club",
+    "trans": [
+      "俱乐部, 会所, 夜总会, 夜店 (noun.)"
+    ]
+  },
+  {
+    "name": "clue",
+    "trans": [
+      "线索, 头绪, 提示 (noun.)"
+    ]
+  },
+  {
+    "name": "coach",
+    "trans": [
+      "教练, 主教练, 教练员, 长途汽车 (noun.); 执教 (verb.)"
+    ]
+  },
+  {
+    "name": "coal",
+    "trans": [
+      "煤, 煤炭, 燃煤, 煤矿 (noun.)"
+    ]
+  },
+  {
+    "name": "coast",
+    "trans": [
+      "海岸, 沿岸, 沿海, 岸 (noun.)"
+    ]
+  },
+  {
+    "name": "coat",
+    "trans": [
+      "外套, 大衣, 外衣, 件外套 (noun.)"
+    ]
+  },
+  {
+    "name": "code",
+    "trans": [
+      "代码, 码, 程式码, 守则 (noun.)"
+    ]
+  },
+  {
+    "name": "coffee",
+    "trans": [
+      "咖啡, 喝咖啡 (noun.)"
+    ]
+  },
+  {
+    "name": "coin",
+    "trans": [
+      "硬币, 枚硬币, 钱币, 投币 (noun.)"
+    ]
+  },
+  {
+    "name": "cold",
+    "trans": [
+      "冷, 寒冷, 感冒, 冰冷 (adj.)"
+    ]
+  },
+  {
+    "name": "collapse",
+    "trans": [
+      "崩溃, 倒塌, 塌陷, 坍塌 (noun.)"
+    ]
+  },
+  {
+    "name": "collar",
+    "trans": [
+      "衣领, 项圈, 领子, 领 (noun.)"
+    ]
+  },
+  {
+    "name": "colleague",
+    "trans": [
+      "同事, 同僚, 同行, 同仁 (noun.)"
+    ]
+  },
+  {
+    "name": "collect",
+    "trans": [
+      "收集, 搜集, 采集, 收藏 (verb.); 对方付费 (noun.)"
+    ]
+  },
+  {
+    "name": "collection",
+    "trans": [
+      "集合, 收集, 收藏, 采集 (noun.)"
+    ]
+  },
+  {
+    "name": "college",
+    "trans": [
+      "大学, 学院, 高校, 大学生 (noun.)"
+    ]
+  },
+  {
+    "name": "colour",
+    "trans": [
+      "颜色, 色彩, 彩色, 色 (noun.)"
+    ]
+  },
+  {
+    "name": "column",
+    "trans": [
+      "列, 柱, 专栏, 栏 (noun.)"
+    ]
+  },
+  {
+    "name": "combination",
+    "trans": [
+      "组合, 结合, 相结合, 联合 (noun.)"
+    ]
+  },
+  {
+    "name": "combine",
+    "trans": [
+      "结合, 相结合, 组合, 合并 (verb.); 联合收割机 (noun.)"
+    ]
+  },
+  {
+    "name": "come",
+    "trans": [
+      "来, 过来, 到来, 来到 (verb.)"
+    ]
+  },
+  {
+    "name": "comfort",
+    "trans": [
+      "安慰, 舒适, 抚慰, 慰藉 (noun.)"
+    ]
+  },
+  {
+    "name": "comfortable",
+    "trans": [
+      "舒适, 舒服, 自在, 惬意 (adj.)"
+    ]
+  },
+  {
+    "name": "command",
+    "trans": [
+      "命令, 指挥, 司令部, 指挥部 (noun.)"
+    ]
+  },
+  {
+    "name": "comment",
+    "trans": [
+      "评论, 注释, 意见, 评述 (noun.); 发表评论, 置评, 发表意见, 述评 (verb.)"
+    ]
+  },
+  {
+    "name": "commercial",
+    "trans": [
+      "商业, 商用, 商业性, 商务 (adj.); 广告 (noun.)"
+    ]
+  },
+  {
+    "name": "commission",
+    "trans": [
+      "委员会, 佣金, 监察委员会, 统筹委员会 (noun.)"
+    ]
+  },
+  {
+    "name": "commit",
+    "trans": [
+      "提交 (noun.); 犯, 承诺, 触犯 (verb.)"
+    ]
+  },
+  {
+    "name": "commitment",
+    "trans": [
+      "承诺, 承担, 决心, 致力于 (noun.)"
+    ]
+  },
+  {
+    "name": "committee",
+    "trans": [
+      "委员会, 委, 委员, 事务委员会 (noun.)"
+    ]
+  },
+  {
+    "name": "common",
+    "trans": [
+      "常见, 共同, 普通, 普遍 (adj.)"
+    ]
+  },
+  {
+    "name": "communicate",
+    "trans": [
+      "沟通, 交流, 传达, 通信 (verb.)"
+    ]
+  },
+  {
+    "name": "communication",
+    "trans": [
+      "通信, 沟通, 通讯, 交际 (noun.)"
+    ]
+  },
+  {
+    "name": "community",
+    "trans": [
+      "社区, 社会, 小区, 群落 (noun.)"
+    ]
+  },
+  {
+    "name": "company",
+    "trans": [
+      "公司, 企业 (noun.)"
+    ]
+  },
+  {
+    "name": "compare",
+    "trans": [
+      "比较, 相比, 对比, 比拟 (verb.)"
+    ]
+  },
+  {
+    "name": "comparison",
+    "trans": [
+      "比较, 对比, 相比, 对照 (noun.)"
+    ]
+  },
+  {
+    "name": "compete",
+    "trans": [
+      "竞争, 竞相, 争, 比赛 (verb.)"
+    ]
+  },
+  {
+    "name": "competition",
+    "trans": [
+      "竞争, 比赛, 竞赛, 大赛 (noun.)"
+    ]
+  },
+  {
+    "name": "competitive",
+    "trans": [
+      "竞争, 竞争力, 竞争性, 具竞争力 (adj.)"
+    ]
+  },
+  {
+    "name": "complain",
+    "trans": [
+      "抱怨, 埋怨, 投诉, 报怨 (verb.)"
+    ]
+  },
+  {
+    "name": "complaint",
+    "trans": [
+      "投诉, 申诉, 抱怨, 怨言 (noun.)"
+    ]
+  },
+  {
+    "name": "complete",
+    "trans": [
+      "完整, 齐全, 完全, 完备 (adj.); 完成, 填写 (verb.)"
+    ]
+  },
+  {
+    "name": "completely",
+    "trans": [
+      "完全, 彻底, 全面, 全然 (adv.)"
+    ]
+  },
+  {
+    "name": "complex",
+    "trans": [
+      "复杂, 复, 复合, 复数 (adj.); 情结, 配合物, 复合物 (noun.)"
+    ]
+  },
+  {
+    "name": "complicated",
+    "trans": [
+      "复杂, 繁复, 复杂性, 错综复杂 (adj.); 复杂化, 并发, 合并 (verb.)"
+    ]
+  },
+  {
+    "name": "component",
+    "trans": [
+      "组件, 组成部分, 构件, 分量 (noun.)"
+    ]
+  },
+  {
+    "name": "comprehensive",
+    "trans": [
+      "综合, 全面, 综合性, 全方位 (adj.)"
+    ]
+  },
+  {
+    "name": "comprise",
+    "trans": [
+      "包括 (verb.)"
+    ]
+  },
+  {
+    "name": "computer",
+    "trans": [
+      "计算机, 电脑, 台电脑, 台计算机 (noun.)"
+    ]
+  },
+  {
+    "name": "concentrate",
+    "trans": [
+      "精矿, 浓缩, 浓缩物, 精 (noun.); 集中精力, 集中, 集中注意力, 专心 (verb.)"
+    ]
+  },
+  {
+    "name": "concentration",
+    "trans": [
+      "浓度, 集中, 浓缩, 药浓度 (noun.)"
+    ]
+  },
+  {
+    "name": "concept",
+    "trans": [
+      "概念, 理念, 观念, 观 (noun.)"
+    ]
+  },
+  {
+    "name": "concern",
+    "trans": [
+      "关注, 关心, 关怀, 关切 (noun.)"
+    ]
+  },
+  {
+    "name": "concerned",
+    "trans": [
+      "关心, 有关, 担心, 而言 (adj.); 关注, 涉及 (verb.)"
+    ]
+  },
+  {
+    "name": "concerning",
+    "trans": [
+      "关于, 有关 (verb.)"
+    ]
+  },
+  {
+    "name": "concert",
+    "trans": [
+      "音乐会, 演唱会, 场音乐会, 听音乐会 (noun.)"
+    ]
+  },
+  {
+    "name": "conclude",
+    "trans": [
+      "得出结论, 总结, 缔结, 结束 (verb.)"
+    ]
+  },
+  {
+    "name": "conclusion",
+    "trans": [
+      "结论, 结语, 得出结论, 总结 (noun.)"
+    ]
+  },
+  {
+    "name": "condition",
+    "trans": [
+      "条件, 状况, 状态, 条件下 (noun.)"
+    ]
+  },
+  {
+    "name": "conduct",
+    "trans": [
+      "进行, 开展 (verb.); 行为, 操守, 品行 (noun.)"
+    ]
+  },
+  {
+    "name": "conference",
+    "trans": [
+      "会议, 大会, 研讨会, 发布会 (noun.)"
+    ]
+  },
+  {
+    "name": "confidence",
+    "trans": [
+      "信心, 自信, 自信心, 置信 (noun.)"
+    ]
+  },
+  {
+    "name": "confident",
+    "trans": [
+      "自信, 信心, 充满信心, 充满自信 (adj.)"
+    ]
+  },
+  {
+    "name": "confine",
+    "trans": [
+      "局限, 限制, 限于, 局限于 (verb.)"
+    ]
+  },
+  {
+    "name": "confirm",
+    "trans": [
+      "确认, 证实, 确定, 印证 (verb.)"
+    ]
+  },
+  {
+    "name": "conflict",
+    "trans": [
+      "冲突, 矛盾, 抵触, 争端 (noun.)"
+    ]
+  },
+  {
+    "name": "confused",
+    "trans": [
+      "困惑, 迷茫, 糊涂, 混淆 (adj.)"
+    ]
+  },
+  {
+    "name": "confusing",
+    "trans": [
+      "令人困惑, 混乱, 令人迷惑, 困惑 (adj.); 混淆 (verb.)"
+    ]
+  },
+  {
+    "name": "confusion",
+    "trans": [
+      "混乱, 困惑, 混淆, 迷茫 (noun.)"
+    ]
+  },
+  {
+    "name": "congratulation",
+    "trans": [
+      "祝贺, 贺信, 恭喜, 庆贺 (noun.)"
+    ]
+  },
+  {
+    "name": "connect",
+    "trans": [
+      "连接, 联系, 连, 接通 (verb.)"
+    ]
+  },
+  {
+    "name": "connection",
+    "trans": [
+      "连接, 联系, 接线, 涉嫌 (noun.)"
+    ]
+  },
+  {
+    "name": "conscious",
+    "trans": [
+      "有意识, 自觉, 意识, 意识到 (adj.)"
+    ]
+  },
+  {
+    "name": "consciousness",
+    "trans": [
+      "意识, 知觉, 自觉性, 自觉 (noun.)"
+    ]
+  },
+  {
+    "name": "consent",
+    "trans": [
+      "同意, 征得, 许可 (noun.)"
+    ]
+  },
+  {
+    "name": "consequence",
+    "trans": [
+      "后果, 结果, 推论 (noun.)"
+    ]
+  },
+  {
+    "name": "consider",
+    "trans": [
+      "考虑, 否考虑, 认为, 思考 (verb.)"
+    ]
+  },
+  {
+    "name": "considerable",
+    "trans": [
+      "相当, 可观, 相当可观, 长足 (adj.)"
+    ]
+  },
+  {
+    "name": "considerably",
+    "trans": [
+      "大大, 相当, 大幅, 大幅度 (adv.)"
+    ]
+  },
+  {
+    "name": "consideration",
+    "trans": [
+      "考虑, 思考, 审议, 考量 (noun.)"
+    ]
+  },
+  {
+    "name": "consist",
+    "trans": [
+      "由, 组成, 包含 (verb.)"
+    ]
+  },
+  {
+    "name": "consistent",
+    "trans": [
+      "一致, 一贯, 相一致, 始终如一 (adj.)"
+    ]
+  },
+  {
+    "name": "constant",
+    "trans": [
+      "恒, 常数, 恒定, 不断 (adj.)"
+    ]
+  },
+  {
+    "name": "constantly",
+    "trans": [
+      "不断, 经常, 不停地, 不停 (adv.)"
+    ]
+  },
+  {
+    "name": "constitute",
+    "trans": [
+      "构成, 组成 (verb.)"
+    ]
+  },
+  {
+    "name": "construct",
+    "trans": [
+      "构建, 构造, 建设, 建构 (verb.)"
+    ]
+  },
+  {
+    "name": "construction",
+    "trans": [
+      "建设, 施工, 构建, 建筑 (noun.)"
+    ]
+  },
+  {
+    "name": "consult",
+    "trans": [
+      "咨询, 征询, 请教, 查阅 (verb.)"
+    ]
+  },
+  {
+    "name": "consumer",
+    "trans": [
+      "消费者, 消费, 消费品, 用户 (noun.)"
+    ]
+  },
+  {
+    "name": "consumption",
+    "trans": [
+      "消费, 消耗, 消耗量, 消费量 (noun.)"
+    ]
+  },
+  {
+    "name": "contact",
+    "trans": [
+      "接触, 联络, 联系人, 触头 (noun.); 联系 (verb.)"
+    ]
+  },
+  {
+    "name": "contain",
+    "trans": [
+      "包含, 含有, 含, 遏制 (verb.)"
+    ]
+  },
+  {
+    "name": "contemporary",
+    "trans": [
+      "当代, 现代, 当今, 当下 (adj.)"
+    ]
+  },
+  {
+    "name": "content",
+    "trans": [
+      "内容, 含量, 内涵, 量 (noun.); 满足 (adj.)"
+    ]
+  },
+  {
+    "name": "contest",
+    "trans": [
+      "竞赛, 大赛, 比赛, 较量 (noun.)"
+    ]
+  },
+  {
+    "name": "context",
+    "trans": [
+      "上下文, 语境, 上下文中, 背景下 (noun.)"
+    ]
+  },
+  {
+    "name": "continue",
+    "trans": [
+      "继续, 不断, 持续, 继续下去 (verb.)"
+    ]
+  },
+  {
+    "name": "continuous",
+    "trans": [
+      "连续, 持续, 不断, 连 (adj.)"
+    ]
+  },
+  {
+    "name": "contract",
+    "trans": [
+      "合同, 契约, 合约, 承包 (noun.)"
+    ]
+  },
+  {
+    "name": "contrast",
+    "trans": [
+      "对比, 对比度, 反差, 相反 (noun.)"
+    ]
+  },
+  {
+    "name": "contribute",
+    "trans": [
+      "贡献, 作出贡献, 做出贡献, 有助于 (verb.)"
+    ]
+  },
+  {
+    "name": "contribution",
+    "trans": [
+      "贡献, 供款, 做出贡献, 捐款 (noun.)"
+    ]
+  },
+  {
+    "name": "control",
+    "trans": [
+      "控制, 控件, 管制, 控 (noun.)"
+    ]
+  },
+  {
+    "name": "convenient",
+    "trans": [
+      "方便, 便利, 便捷, 方便快捷 (adj.)"
+    ]
+  },
+  {
+    "name": "convention",
+    "trans": [
+      "公约, 大会, 惯例, 约定 (noun.)"
+    ]
+  },
+  {
+    "name": "conventional",
+    "trans": [
+      "常规, 传统, 普通, 常用 (adj.)"
+    ]
+  },
+  {
+    "name": "conversation",
+    "trans": [
+      "谈话, 对话, 交谈, 会话 (noun.)"
+    ]
+  },
+  {
+    "name": "convert",
+    "trans": [
+      "转换, 皈依, 转化, 换算 (verb.)"
+    ]
+  },
+  {
+    "name": "conviction",
+    "trans": [
+      "定罪, 信念, 被定罪, 判罪 (noun.)"
+    ]
+  },
+  {
+    "name": "convince",
+    "trans": [
+      "说服, 信服, 劝服, 劝 (verb.)"
+    ]
+  },
+  {
+    "name": "cook",
+    "trans": [
+      "厨师, 库克, 厨子 (noun.); 做饭, 煮, 烹调, 烹饪 (verb.)"
+    ]
+  },
+  {
+    "name": "cooker",
+    "trans": [
+      "炊具, 灶具, 炖锅, 炉 (noun.)"
+    ]
+  },
+  {
+    "name": "cookie",
+    "trans": [
+      "饼干, 曲奇, 曲奇饼, 小甜饼 (noun.)"
+    ]
+  },
+  {
+    "name": "cool",
+    "trans": [
+      "酷, 凉爽, 冷静, 凉 (adj.); 冷却, 降温 (verb.)"
+    ]
+  },
+  {
+    "name": "cooperation",
+    "trans": [
+      "合作, 协作, 配合, 协同 (noun.)"
+    ]
+  },
+  {
+    "name": "cope",
+    "trans": [
+      "应付, 应付自如 (verb.)"
+    ]
+  },
+  {
+    "name": "copy",
+    "trans": [
+      "复制, 抄, 模仿, 收到 (verb.); 副本, 拷贝, 复印, 复印件 (noun.)"
+    ]
+  },
+  {
+    "name": "core",
+    "trans": [
+      "核心, 芯, 核, 铁心 (noun.)"
+    ]
+  },
+  {
+    "name": "corn",
+    "trans": [
+      "玉米, 谷物 (noun.)"
+    ]
+  },
+  {
+    "name": "corner",
+    "trans": [
+      "角落, 角落里, 角, 拐角处 (noun.)"
+    ]
+  },
+  {
+    "name": "correct",
+    "trans": [
+      "正确, 正确性, 准确, 校正 (adj.); 纠正, 改正, 更正, 矫正 (verb.)"
+    ]
+  },
+  {
+    "name": "corridor",
+    "trans": [
+      "走廊, 廊道, 楼道, 长廊 (noun.)"
+    ]
+  },
+  {
+    "name": "cost",
+    "trans": [
+      "成本, 费用, 造价, 代价 (noun.); 花 (verb.)"
+    ]
+  },
+  {
+    "name": "cottage",
+    "trans": [
+      "山寨, 平房, 村舍, 间小屋 (noun.)"
+    ]
+  },
+  {
+    "name": "cotton",
+    "trans": [
+      "棉花, 棉, 纯棉, 棉织 (noun.)"
+    ]
+  },
+  {
+    "name": "could",
+    "trans": [
+      "可以, 能, 可能 (modal.)"
+    ]
+  },
+  {
+    "name": "council",
+    "trans": [
+      "局, 理事会, 委员会, 议会 (noun.)"
+    ]
+  },
+  {
+    "name": "count",
+    "trans": [
+      "计数, 伯爵, 项, 统计 (noun.); 数, 算, 算数, 指望 (verb.)"
+    ]
+  },
+  {
+    "name": "counter",
+    "trans": [
+      "计数器, 柜台, 反, 计数 (noun.); 反击, 对抗, 对付 (verb.); 对策, 逆 (adv.)"
+    ]
+  },
+  {
+    "name": "country",
+    "trans": [
+      "国家, 国, 乡村, 全国 (noun.)"
+    ]
+  },
+  {
+    "name": "countryside",
+    "trans": [
+      "农村, 乡下, 乡村, 乡间 (noun.)"
+    ]
+  },
+  {
+    "name": "county",
+    "trans": [
+      "县, 县域, 郡, 县级 (noun.)"
+    ]
+  },
+  {
+    "name": "couple",
+    "trans": [
+      "夫妇, 情侣, 夫妻, 两三 (noun.)"
+    ]
+  },
+  {
+    "name": "courage",
+    "trans": [
+      "勇气, 勇敢, 胆量, 胆识 (noun.)"
+    ]
+  },
+  {
+    "name": "course",
+    "trans": [
+      "课程, 当然, 过程, 课 (noun.)"
+    ]
+  },
+  {
+    "name": "court",
+    "trans": [
+      "法院, 法庭, 宫廷, 庭 (noun.)"
+    ]
+  },
+  {
+    "name": "cousin",
+    "trans": [
+      "表弟, 表妹, 表哥, 堂兄 (noun.)"
+    ]
+  },
+  {
+    "name": "cover",
+    "trans": [
+      "封面, 盖, 掩护, 罩 (noun.); 覆盖, 涵盖, 掩盖, 支付 (verb.)"
+    ]
+  },
+  {
+    "name": "cow",
+    "trans": [
+      "牛, 奶牛, 母牛, 头牛 (noun.)"
+    ]
+  },
+  {
+    "name": "crack",
+    "trans": [
+      "裂纹, 裂缝, 裂, 开裂 (noun.); 破解, 破裂, 打击 (verb.)"
+    ]
+  },
+  {
+    "name": "craft",
+    "trans": [
+      "工艺, 手艺, 门手艺, 飞船 (noun.)"
+    ]
+  },
+  {
+    "name": "crash",
+    "trans": [
+      "崩溃, 坠毁, 失事, 坠机 (noun.)"
+    ]
+  },
+  {
+    "name": "crazy",
+    "trans": [
+      "疯狂, 疯, 发疯, 疯子 (adj.)"
+    ]
+  },
+  {
+    "name": "create",
+    "trans": [
+      "创建, 创造, 共创, 营造 (verb.)"
+    ]
+  },
+  {
+    "name": "creation",
+    "trans": [
+      "创作, 创造, 创建, 造物 (noun.)"
+    ]
+  },
+  {
+    "name": "creative",
+    "trans": [
+      "创造性, 创意, 创新, 创作 (adj.)"
+    ]
+  },
+  {
+    "name": "creature",
+    "trans": [
+      "生物, 动物, 怪物, 生灵 (noun.)"
+    ]
+  },
+  {
+    "name": "credit",
+    "trans": [
+      "信用, 信贷, 信用证, 资信 (noun.)"
+    ]
+  },
+  {
+    "name": "credit card",
+    "trans": [
+      "信用卡, 记帐卡"
+    ]
+  },
+  {
+    "name": "crew",
+    "trans": [
+      "船员, 机组人员, 乘员组, 工作人员 (noun.)"
+    ]
+  },
+  {
+    "name": "crime",
+    "trans": [
+      "犯罪, 罪, 罪案, 罪行 (noun.)"
+    ]
+  },
+  {
+    "name": "criminal",
+    "trans": [
+      "刑事, 犯罪, 刑法, 刑事诉讼 (adj.); 罪犯, 犯人 (noun.)"
+    ]
+  },
+  {
+    "name": "crisis",
+    "trans": [
+      "危机, 危机爆发, 经济危机, 风暴 (noun.)"
+    ]
+  },
+  {
+    "name": "criterion",
+    "trans": [
+      "准则, 判据, 标准, 准绳 (noun.)"
+    ]
+  },
+  {
+    "name": "critic",
+    "trans": [
+      "评论家, 批评家, 批评, 批判 (noun.)"
+    ]
+  },
+  {
+    "name": "critical",
+    "trans": [
+      "临界, 关键, 批判, 至关重要 (adj.)"
+    ]
+  },
+  {
+    "name": "criticism",
+    "trans": [
+      "批评, 批判, 非议, 评论 (noun.)"
+    ]
+  },
+  {
+    "name": "criticize",
+    "trans": [
+      "批评, 批判, 抨击, 指责 (verb.)"
+    ]
+  },
+  {
+    "name": "crop",
+    "trans": [
+      "作物, 农作物, 麦田, 庄稼 (noun.)"
+    ]
+  },
+  {
+    "name": "cross",
+    "trans": [
+      "交叉, 十字架, 十字, 跨 (noun.); 穿越, 穿过, 跨越, 越过 (verb.)"
+    ]
+  },
+  {
+    "name": "crowd",
+    "trans": [
+      "人群, 群众, 观众, 众人 (noun.)"
+    ]
+  },
+  {
+    "name": "crown",
+    "trans": [
+      "冠, 皇冠, 王冠, 冠冕 (noun.)"
+    ]
+  },
+  {
+    "name": "crucial",
+    "trans": [
+      "至关重要, 关键, 重要, 关键性 (adj.)"
+    ]
+  },
+  {
+    "name": "cruel",
+    "trans": [
+      "残酷, 残忍, 狠心, 残暴 (adj.)"
+    ]
+  },
+  {
+    "name": "cry",
+    "trans": [
+      "哭, 哭泣, 流泪, 落泪 (verb.); 呐喊, 哭声, 叫声, 声 (noun.)"
+    ]
+  },
+  {
+    "name": "cultural",
+    "trans": [
+      "文化, 栽培, 人文 (adj.)"
+    ]
+  },
+  {
+    "name": "culture",
+    "trans": [
+      "文化, 培养, 栽培, 养殖 (noun.)"
+    ]
+  },
+  {
+    "name": "cup",
+    "trans": [
+      "杯, 杯子, 茶杯, 杯赛 (noun.)"
+    ]
+  },
+  {
+    "name": "cupboard",
+    "trans": [
+      "橱柜, 碗柜, 碗橱里, 柜子 (noun.)"
+    ]
+  },
+  {
+    "name": "curious",
+    "trans": [
+      "好奇, 奇怪, 出于好奇, 好奇心 (adj.)"
+    ]
+  },
+  {
+    "name": "currency",
+    "trans": [
+      "货币, 汇率, 币种, 通货 (noun.)"
+    ]
+  },
+  {
+    "name": "current",
+    "trans": [
+      "当前, 电流, 目前, 现行 (adj.)"
+    ]
+  },
+  {
+    "name": "currently",
+    "trans": [
+      "目前, 当前, 现时, 现有 (adv.)"
+    ]
+  },
+  {
+    "name": "curtain",
+    "trans": [
+      "窗帘, 帷幕, 帘, 幕 (noun.)"
+    ]
+  },
+  {
+    "name": "curve",
+    "trans": [
+      "曲线, 曲线图, 弯道, 曲 (noun.)"
+    ]
+  },
+  {
+    "name": "cushion",
+    "trans": [
+      "垫层, 坐垫, 靠垫, 垫 (noun.)"
+    ]
+  },
+  {
+    "name": "custom",
+    "trans": [
+      "自定义, 定制, 习俗, 风俗 (noun.)"
+    ]
+  },
+  {
+    "name": "customer",
+    "trans": [
+      "客户, 顾客, 用户, 客 (noun.)"
+    ]
+  },
+  {
+    "name": "cut",
+    "trans": [
+      "削减, 切, 剪, 割 (verb.); 切割 (noun.)"
+    ]
+  },
+  {
+    "name": "cute",
+    "trans": [
+      "可爱, 逗人喜爱, 帅, 漂亮 (adj.)"
+    ]
+  },
+  {
+    "name": "cycle",
+    "trans": [
+      "周期, 循环, 旋回, 轮回 (noun.)"
+    ]
+  },
+  {
+    "name": "dad",
+    "trans": [
+      "爸爸, 爸, 老爸, 父亲 (noun.)"
+    ]
+  },
+  {
+    "name": "daddy",
+    "trans": [
+      "爸爸, 爹地, 老爸, 爸 (noun.)"
+    ]
+  },
+  {
+    "name": "daft",
+    "trans": [
+      "愚蠢 (adj.)"
+    ]
+  },
+  {
+    "name": "daily",
+    "trans": [
+      "每日, 日常, 每天, 日用 (adj.); 日报, 报 (noun.)"
+    ]
+  },
+  {
+    "name": "damage",
+    "trans": [
+      "损伤, 损害, 损坏, 破坏 (noun.)"
+    ]
+  },
+  {
+    "name": "dance",
+    "trans": [
+      "舞蹈, 舞, 舞会, 起舞 (noun.); 跳舞, 跳, 共舞, 跳支舞 (verb.)"
+    ]
+  },
+  {
+    "name": "danger",
+    "trans": [
+      "危险, 危险之中, 危险性, 险境 (noun.)"
+    ]
+  },
+  {
+    "name": "dangerous",
+    "trans": [
+      "危险, 危, 危险性 (adj.)"
+    ]
+  },
+  {
+    "name": "dare",
+    "trans": [
+      "敢, 敢不敢, 不敢, 竟敢 (verb.)"
+    ]
+  },
+  {
+    "name": "dark",
+    "trans": [
+      "黑暗, 暗, 黑, 深色 (adj.); 黑夜 (noun.)"
+    ]
+  },
+  {
+    "name": "darkness",
+    "trans": [
+      "黑暗, 黑暗之中, 一片黑暗, 黑夜 (noun.)"
+    ]
+  },
+  {
+    "name": "darling",
+    "trans": [
+      "亲爱的, 宠儿, 达林, 宝宝 (noun.)"
+    ]
+  },
+  {
+    "name": "data",
+    "trans": [
+      "数据, 资料 (noun.)"
+    ]
+  },
+  {
+    "name": "database",
+    "trans": [
+      "数据库, 资料库, 库 (noun.)"
+    ]
+  },
+  {
+    "name": "date",
+    "trans": [
+      "日期, 约会, 迄今为止, 日 (noun.)"
+    ]
+  },
+  {
+    "name": "daughter",
+    "trans": [
+      "女儿 (noun.)"
+    ]
+  },
+  {
+    "name": "day",
+    "trans": [
+      "一天, 天, 日, 日子 (noun.)"
+    ]
+  },
+  {
+    "name": "dead",
+    "trans": [
+      "死, 死去, 死人, 死亡 (adj.)"
+    ]
+  },
+  {
+    "name": "deaf",
+    "trans": [
+      "聋, 聋子, 聋哑, 失聪 (adj.); 盲 (noun.)"
+    ]
+  },
+  {
+    "name": "deal",
+    "trans": [
+      "交易, 笔交易, 协议, 大不了 (noun.); 打交道, 处理, 解决 (verb.)"
+    ]
+  },
+  {
+    "name": "dealer",
+    "trans": [
+      "经销商, 交易商, 贩子, 庄家 (noun.)"
+    ]
+  },
+  {
+    "name": "dear",
+    "trans": [
+      "亲爱的, 亲爱, 敬爱, 尊敬 (adj.)"
+    ]
+  },
+  {
+    "name": "dear",
+    "trans": [
+      "亲爱的, 亲爱, 敬爱, 尊敬 (adj.)"
+    ]
+  },
+  {
+    "name": "death",
+    "trans": [
+      "死亡, 死, 死神, 去世 (noun.)"
+    ]
+  },
+  {
+    "name": "debate",
+    "trans": [
+      "辩论, 争论, 论战, 讨论 (noun.)"
+    ]
+  },
+  {
+    "name": "debt",
+    "trans": [
+      "债务, 债, 负债, 债券 (noun.)"
+    ]
+  },
+  {
+    "name": "decade",
+    "trans": [
+      "十年, 十年间, 十年内, 数十年 (noun.)"
+    ]
+  },
+  {
+    "name": "decent",
+    "trans": [
+      "体面, 像样, 正派, 得体 (adj.)"
+    ]
+  },
+  {
+    "name": "decide",
+    "trans": [
+      "决定, 确定, 判定, 判断 (verb.)"
+    ]
+  },
+  {
+    "name": "decision",
+    "trans": [
+      "决策, 决定, 判决, 裁决 (noun.)"
+    ]
+  },
+  {
+    "name": "declare",
+    "trans": [
+      "申报, 声明, 宣布, 宣告 (verb.)"
+    ]
+  },
+  {
+    "name": "decline",
+    "trans": [
+      "下降, 衰落, 下滑, 衰退 (noun.); 拒绝 (verb.)"
+    ]
+  },
+  {
+    "name": "deep",
+    "trans": [
+      "深, 深层, 深部, 深刻 (adj.)"
+    ]
+  },
+  {
+    "name": "deeply",
+    "trans": [
+      "深深, 深深地, 深入, 深感 (adv.)"
+    ]
+  },
+  {
+    "name": "defeat",
+    "trans": [
+      "打败, 击败, 战胜 (verb.); 失败, 战败, 失利, 挫败 (noun.)"
+    ]
+  },
+  {
+    "name": "defence",
+    "trans": [
+      "国防, 防御, 防务, 防卫 (noun.)"
+    ]
+  },
+  {
+    "name": "defend",
+    "trans": [
+      "捍卫, 保卫, 辩护, 保护 (verb.)"
+    ]
+  },
+  {
+    "name": "define",
+    "trans": [
+      "定义, 界定, 确定, 明确 (verb.)"
+    ]
+  },
+  {
+    "name": "definite",
+    "trans": [
+      "明确, 定, 确切, 确定性 (adj.)"
+    ]
+  },
+  {
+    "name": "definitely",
+    "trans": [
+      "绝对, 肯定, 一定, 当然 (adv.)"
+    ]
+  },
+  {
+    "name": "definition",
+    "trans": [
+      "定义, 界定, 清晰度, 概念 (noun.)"
+    ]
+  },
+  {
+    "name": "degree",
+    "trans": [
+      "程度, 学位, 度, 学历 (noun.)"
+    ]
+  },
+  {
+    "name": "delay",
+    "trans": [
+      "延迟, 延误, 时滞, 延时 (noun.); 推迟, 延缓, 耽误 (verb.)"
+    ]
+  },
+  {
+    "name": "deliberately",
+    "trans": [
+      "故意, 刻意, 蓄意, 有意 (adv.)"
+    ]
+  },
+  {
+    "name": "deliver",
+    "trans": [
+      "交付, 提供, 送, 传递 (verb.)"
+    ]
+  },
+  {
+    "name": "delivery",
+    "trans": [
+      "交货, 交付, 送货, 发货 (noun.)"
+    ]
+  },
+  {
+    "name": "demand",
+    "trans": [
+      "需求, 要求, 需求量, 需 (noun.)"
+    ]
+  },
+  {
+    "name": "democracy",
+    "trans": [
+      "民主, 民主政治, 民主体制, 民主政体 (noun.)"
+    ]
+  },
+  {
+    "name": "democratic",
+    "trans": [
+      "民主, 民主党, 民主化, 民主政治 (adj.)"
+    ]
+  },
+  {
+    "name": "demonstrate",
+    "trans": [
+      "演示, 展示, 证明, 表明 (verb.)"
+    ]
+  },
+  {
+    "name": "demonstration",
+    "trans": [
+      "示范, 演示, 论证, 示威 (noun.)"
+    ]
+  },
+  {
+    "name": "dentist",
+    "trans": [
+      "牙医, 牙科医生, 牙医诊所, 牙科 (noun.)"
+    ]
+  },
+  {
+    "name": "deny",
+    "trans": [
+      "否认, 否定, 拒绝, 抵赖 (verb.)"
+    ]
+  },
+  {
+    "name": "department",
+    "trans": [
+      "署, 部门, 部, 处 (noun.)"
+    ]
+  },
+  {
+    "name": "departure",
+    "trans": [
+      "离境, 出发, 离去, 离职 (noun.)"
+    ]
+  },
+  {
+    "name": "depend",
+    "trans": [
+      "依赖, 取决于, 依靠 (verb.)"
+    ]
+  },
+  {
+    "name": "dependent",
+    "trans": [
+      "依赖, 依赖性, 相依, 供养 (adj.)"
+    ]
+  },
+  {
+    "name": "deposit",
+    "trans": [
+      "存款, 矿床, 押金, 定金 (noun.); 存入, 存放 (verb.)"
+    ]
+  },
+  {
+    "name": "depression",
+    "trans": [
+      "抑郁症, 抑郁, 萧条, 坳陷 (noun.)"
+    ]
+  },
+  {
+    "name": "depth",
+    "trans": [
+      "深度, 深入, 纵深, 水深 (noun.)"
+    ]
+  },
+  {
+    "name": "derive",
+    "trans": [
+      "派生, 推导出, 推导, 导出 (verb.); 衍生 (adj.)"
+    ]
+  },
+  {
+    "name": "describe",
+    "trans": [
+      "描述, 形容, 描绘, 描写 (verb.)"
+    ]
+  },
+  {
+    "name": "description",
+    "trans": [
+      "描述, 说明, 描写, 著录 (noun.)"
+    ]
+  },
+  {
+    "name": "desert",
+    "trans": [
+      "沙漠, 荒漠, 大漠, 漠 (noun.); 抛弃 (verb.)"
+    ]
+  },
+  {
+    "name": "deserve",
+    "trans": [
+      "应得, 值得, 活该, 应有 (verb.)"
+    ]
+  },
+  {
+    "name": "design",
+    "trans": [
+      "设计, 工程设计 (noun.)"
+    ]
+  },
+  {
+    "name": "designer",
+    "trans": [
+      "设计师, 设计者, 名牌 (noun.)"
+    ]
+  },
+  {
+    "name": "desire",
+    "trans": [
+      "欲望, 愿望, 渴望, 欲 (noun.)"
+    ]
+  },
+  {
+    "name": "desk",
+    "trans": [
+      "书桌, 办公桌, 桌子, 桌 (noun.)"
+    ]
+  },
+  {
+    "name": "desperate",
+    "trans": [
+      "绝望, 不顾一切, 孤注一掷, 走投无路 (adj.)"
+    ]
+  },
+  {
+    "name": "despite",
+    "trans": [
+      "尽管 (prep.)"
+    ]
+  },
+  {
+    "name": "destroy",
+    "trans": [
+      "摧毁, 毁掉, 破坏, 毁灭 (verb.)"
+    ]
+  },
+  {
+    "name": "destruction",
+    "trans": [
+      "破坏, 毁灭, 杀伤性, 销毁 (noun.)"
+    ]
+  },
+  {
+    "name": "detail",
+    "trans": [
+      "细节, 详细, 细部, 明细 (noun.)"
+    ]
+  },
+  {
+    "name": "detailed",
+    "trans": [
+      "详细, 详尽, 细致, 具体 (adj.); 详述 (verb.)"
+    ]
+  },
+  {
+    "name": "detect",
+    "trans": [
+      "检测, 探测, 侦测, 察觉 (verb.)"
+    ]
+  },
+  {
+    "name": "determination",
+    "trans": [
+      "测定, 决心, 确定, 含量测定 (noun.)"
+    ]
+  },
+  {
+    "name": "determine",
+    "trans": [
+      "确定, 决定, 判断, 测定 (verb.)"
+    ]
+  },
+  {
+    "name": "determined",
+    "trans": [
+      "决心, 确定, 下定决心, 决定 (verb.); 坚定 (adj.)"
+    ]
+  },
+  {
+    "name": "develop",
+    "trans": [
+      "发展, 开发, 制定, 培养 (verb.)"
+    ]
+  },
+  {
+    "name": "development",
+    "trans": [
+      "发展, 开发, 研制, 发育 (noun.)"
+    ]
+  },
+  {
+    "name": "device",
+    "trans": [
+      "装置, 设备, 器件, 器 (noun.)"
+    ]
+  },
+  {
+    "name": "devil",
+    "trans": [
+      "魔鬼, 恶魔, 鬼子, 撒旦 (noun.)"
+    ]
+  },
+  {
+    "name": "diagram",
+    "trans": [
+      "图, 图表, 示意图, 框图 (noun.)"
+    ]
+  },
+  {
+    "name": "diamond",
+    "trans": [
+      "金刚石, 钻石, 颗钻石, 菱形 (noun.)"
+    ]
+  },
+  {
+    "name": "diary",
+    "trans": [
+      "日记, 写日记, 日记本, 记日记 (noun.)"
+    ]
+  },
+  {
+    "name": "die",
+    "trans": [
+      "死, 死去, 模具, 模 (verb.)"
+    ]
+  },
+  {
+    "name": "diet",
+    "trans": [
+      "饮食, 节食, 膳食, 日常饮食 (noun.)"
+    ]
+  },
+  {
+    "name": "differ",
+    "trans": [
+      "不同, 有所不同, 不一, 相差 (verb.)"
+    ]
+  },
+  {
+    "name": "difference",
+    "trans": [
+      "差异, 差分, 区别, 差别 (noun.)"
+    ]
+  },
+  {
+    "name": "different",
+    "trans": [
+      "不同, 与众不同, 一样, 差异 (adj.)"
+    ]
+  },
+  {
+    "name": "difficult",
+    "trans": [
+      "困难, 难, 艰难, 很难 (adj.)"
+    ]
+  },
+  {
+    "name": "difficulty",
+    "trans": [
+      "困难, 难度, 难点, 难以 (noun.)"
+    ]
+  },
+  {
+    "name": "dig",
+    "trans": [
+      "挖, 挖掘, 掘, 掏 (verb.)"
+    ]
+  },
+  {
+    "name": "dimension",
+    "trans": [
+      "维度, 维数, 维, 尺寸 (noun.)"
+    ]
+  },
+  {
+    "name": "dinner",
+    "trans": [
+      "晚餐, 晚饭, 吃饭, 晚宴 (noun.)"
+    ]
+  },
+  {
+    "name": "direct",
+    "trans": [
+      "直接, 直, 直达, 直销 (adj.); 指导, 指示, 指挥, 引导 (verb.)"
+    ]
+  },
+  {
+    "name": "direction",
+    "trans": [
+      "方向, 方向前进, 指示, 路向 (noun.)"
+    ]
+  },
+  {
+    "name": "directly",
+    "trans": [
+      "直接, 直, 好坏直接 (adv.)"
+    ]
+  },
+  {
+    "name": "director",
+    "trans": [
+      "导演, 主任, 董事, 署长 (noun.)"
+    ]
+  },
+  {
+    "name": "directory",
+    "trans": [
+      "目录, 名录, 簿, 指南 (noun.)"
+    ]
+  },
+  {
+    "name": "dirt",
+    "trans": [
+      "污垢, 污物, 泥土, 灰尘 (noun.)"
+    ]
+  },
+  {
+    "name": "dirty",
+    "trans": [
+      "脏, 肮脏, 脏兮兮, 弄脏 (adj.)"
+    ]
+  },
+  {
+    "name": "disabled",
+    "trans": [
+      "禁用, 残疾人, 残疾, 残疾人士 (adj.)"
+    ]
+  },
+  {
+    "name": "disagree",
+    "trans": [
+      "不以为然, 意见不一, 意见不一致, 反对 (verb.)"
+    ]
+  },
+  {
+    "name": "disappear",
+    "trans": [
+      "消失, 消失不见, 不见, 消 (verb.)"
+    ]
+  },
+  {
+    "name": "disappoint",
+    "trans": [
+      "失望, 辜负, 令人失望 (verb.)"
+    ]
+  },
+  {
+    "name": "disappointed",
+    "trans": [
+      "失望, 大失所望, 失意, 沮丧 (adj.)"
+    ]
+  },
+  {
+    "name": "disaster",
+    "trans": [
+      "灾难, 灾害, 灾, 场灾难 (noun.)"
+    ]
+  },
+  {
+    "name": "disc",
+    "trans": [
+      "椎间盘, 光盘, 阀瓣, 盘 (noun.)"
+    ]
+  },
+  {
+    "name": "discipline",
+    "trans": [
+      "纪律, 学科, 管教, 门学科 (noun.)"
+    ]
+  },
+  {
+    "name": "discount",
+    "trans": [
+      "折扣, 打折, 贴现, 折价 (noun.)"
+    ]
+  },
+  {
+    "name": "discover",
+    "trans": [
+      "发现, 发掘, 探索, 找出 (verb.)"
+    ]
+  },
+  {
+    "name": "discovery",
+    "trans": [
+      "发现, 探索, 发掘 (noun.)"
+    ]
+  },
+  {
+    "name": "discuss",
+    "trans": [
+      "讨论, 探讨, 洽谈, 商讨 (verb.)"
+    ]
+  },
+  {
+    "name": "discussion",
+    "trans": [
+      "讨论, 探讨, 浅, 研讨 (noun.)"
+    ]
+  },
+  {
+    "name": "disease",
+    "trans": [
+      "疾病, 病, 病害, 症 (noun.)"
+    ]
+  },
+  {
+    "name": "disgusting",
+    "trans": [
+      "恶心, 令人厌恶, 令人作呕, 令人讨厌 (adj.)"
+    ]
+  },
+  {
+    "name": "dish",
+    "trans": [
+      "菜, 道菜, 盘, 碟 (noun.)"
+    ]
+  },
+  {
+    "name": "disk",
+    "trans": [
+      "磁盘, 盘, 花盘, 圆盘 (noun.)"
+    ]
+  },
+  {
+    "name": "dismiss",
+    "trans": [
+      "解雇, 驳回, 辞退, 解散 (verb.)"
+    ]
+  },
+  {
+    "name": "display",
+    "trans": [
+      "显示, 展示, 显示器, 陈列 (noun.)"
+    ]
+  },
+  {
+    "name": "dispute",
+    "trans": [
+      "纠纷, 争端, 争议, 争执 (noun.); 争 (verb.)"
+    ]
+  },
+  {
+    "name": "distance",
+    "trans": [
+      "距离, 远程, 远处, 远方 (noun.)"
+    ]
+  },
+  {
+    "name": "distant",
+    "trans": [
+      "遥远, 远处, 远方, 远房 (adj.)"
+    ]
+  },
+  {
+    "name": "distinct",
+    "trans": [
+      "鲜明, 截然不同, 独特, 不同 (adj.)"
+    ]
+  },
+  {
+    "name": "distinction",
+    "trans": [
+      "区别, 区分, 差别, 鉴别 (noun.)"
+    ]
+  },
+  {
+    "name": "distinguish",
+    "trans": [
+      "区分, 分辨, 分清, 区别 (verb.)"
+    ]
+  },
+  {
+    "name": "distribute",
+    "trans": [
+      "分发, 分配, 派发, 分布 (verb.); 分布式 (noun.)"
+    ]
+  },
+  {
+    "name": "distribution",
+    "trans": [
+      "分布, 分配, 配电, 配送 (noun.)"
+    ]
+  },
+  {
+    "name": "district",
+    "trans": [
+      "区, 地区, 区域, 小区 (noun.)"
+    ]
+  },
+  {
+    "name": "disturb",
+    "trans": [
+      "打扰, 扰乱, 打搅, 干扰 (verb.)"
+    ]
+  },
+  {
+    "name": "divide",
+    "trans": [
+      "鸿沟, 分歧 (noun.); 划分, 分裂, 分割, 分化 (verb.)"
+    ]
+  },
+  {
+    "name": "division",
+    "trans": [
+      "划分, 分工, 师, 分部 (noun.)"
+    ]
+  },
+  {
+    "name": "divorce",
+    "trans": [
+      "离婚, 离异 (noun.)"
+    ]
+  },
+  {
+    "name": "do",
+    "trans": [
+      "做, 做到, 干, 怎么办 (verb.)"
+    ]
+  },
+  {
+    "name": "doctor",
+    "trans": [
+      "医生, 大夫, 看医生, 博士 (noun.)"
+    ]
+  },
+  {
+    "name": "document",
+    "trans": [
+      "文档, 文件, 文献, 单据 (noun.); 记录 (verb.)"
+    ]
+  },
+  {
+    "name": "dog",
+    "trans": [
+      "狗, 犬, 狗狗, 狗儿 (noun.)"
+    ]
+  },
+  {
+    "name": "dollar",
+    "trans": [
+      "美元, 兑美元, 美元汇率, 兑美元汇率 (noun.)"
+    ]
+  },
+  {
+    "name": "domestic",
+    "trans": [
+      "国内, 国产, 家庭, 家用 (adj.)"
+    ]
+  },
+  {
+    "name": "dominant",
+    "trans": [
+      "主导, 显性, 占主导地位, 优势 (adj.)"
+    ]
+  },
+  {
+    "name": "dominate",
+    "trans": [
+      "主宰, 支配, 占据主导地位, 称霸 (verb.)"
+    ]
+  },
+  {
+    "name": "door",
+    "trans": [
+      "门, 扇门, 门口, 大门 (noun.)"
+    ]
+  },
+  {
+    "name": "dot",
+    "trans": [
+      "点, 网点, 斑点, 科 (noun.); 点缀 (verb.)"
+    ]
+  },
+  {
+    "name": "double",
+    "trans": [
+      "双, 双重, 双倍, 双层 (adj.); 加倍, 翻倍 (verb.)"
+    ]
+  },
+  {
+    "name": "doubt",
+    "trans": [
+      "怀疑 (verb.); 疑问, 疑惑, 质疑, 疑虑 (noun.)"
+    ]
+  },
+  {
+    "name": "down",
+    "trans": [
+      "下来, 向下, 放下, 下降 (adv.); 失望, 下, 倒 (prep.)"
+    ]
+  },
+  {
+    "name": "downstairs",
+    "trans": [
+      "楼下, 下楼 (adv.)"
+    ]
+  },
+  {
+    "name": "downtown",
+    "trans": [
+      "市中心, 市区, 闹市区, 商业区 (noun.)"
+    ]
+  },
+  {
+    "name": "dozen",
+    "trans": [
+      "打, 十几, 十二, 几十 (noun.)"
+    ]
+  },
+  {
+    "name": "draft",
+    "trans": [
+      "草案, 草稿, 起草, 稿 (noun.)"
+    ]
+  },
+  {
+    "name": "drag",
+    "trans": [
+      "拖动, 拖, 鼠标拖动, 拖曳 (verb.); 阻力, 拖累, 拖放, 阻 (noun.)"
+    ]
+  },
+  {
+    "name": "drama",
+    "trans": [
+      "戏剧, 话剧, 戏曲, 剧 (noun.)"
+    ]
+  },
+  {
+    "name": "dramatic",
+    "trans": [
+      "戏剧性, 戏剧化, 戏剧, 引人注目 (adj.)"
+    ]
+  },
+  {
+    "name": "draw",
+    "trans": [
+      "画, 绘制, 画画, 得出 (verb.)"
+    ]
+  },
+  {
+    "name": "drawer",
+    "trans": [
+      "抽屉, 抽屉里 (noun.)"
+    ]
+  },
+  {
+    "name": "drawing",
+    "trans": [
+      "绘图, 图纸, 制图, 绘画 (noun.); 绘制, 画, 画画, 拉伸 (verb.)"
+    ]
+  },
+  {
+    "name": "dream",
+    "trans": [
+      "梦想, 梦, 梦境, 梦幻 (noun.); 做梦, 梦见 (verb.)"
+    ]
+  },
+  {
+    "name": "dress",
+    "trans": [
+      "礼服, 裙子, 衣服, 连衣裙 (noun.); 打扮, 穿 (verb.)"
+    ]
+  },
+  {
+    "name": "drink",
+    "trans": [
+      "喝, 喝酒, 饮用, 喝水 (verb.); 饮料, 饮, 杯, 酒后 (noun.)"
+    ]
+  },
+  {
+    "name": "drive",
+    "trans": [
+      "开车, 驾驶, 开车送, 开 (verb.); 驱动器, 驱动, 传动, 动力 (noun.)"
+    ]
+  },
+  {
+    "name": "driver",
+    "trans": [
+      "司机, 驱动程序, 驾驶员, 驱动 (noun.)"
+    ]
+  },
+  {
+    "name": "drop",
+    "trans": [
+      "滴, 下降, 降, 下跌 (noun.); 放下, 放弃, 掉, 删除 (verb.)"
+    ]
+  },
+  {
+    "name": "drug",
+    "trans": [
+      "药物, 药品, 毒品, 药 (noun.)"
+    ]
+  },
+  {
+    "name": "drunk",
+    "trans": [
+      "醉, 喝醉, 醉酒, 灌醉 (adj.)"
+    ]
+  },
+  {
+    "name": "dry",
+    "trans": [
+      "干, 干燥, 乾, 干爽 (adj.); 擦干 (verb.)"
+    ]
+  },
+  {
+    "name": "duck",
+    "trans": [
+      "鸭, 鸭子, 只鸭子, 烤鸭 (noun.)"
+    ]
+  },
+  {
+    "name": "dude",
+    "trans": [
+      "老兄, 伙计, 哥们, 花花公子 (noun.)"
+    ]
+  },
+  {
+    "name": "due",
+    "trans": [
+      "由于, 因, 到期, 应有 (adj.)"
+    ]
+  },
+  {
+    "name": "dull",
+    "trans": [
+      "沉闷, 枯燥, 平淡, 乏味 (adj.)"
+    ]
+  },
+  {
+    "name": "dumb",
+    "trans": [
+      "哑, 哑巴, 蠢, 愚蠢 (adj.)"
+    ]
+  },
+  {
+    "name": "dump",
+    "trans": [
+      "转储, 排土场, 垃圾场, 垃圾堆 (noun.); 甩, 甩掉, 倾倒, 抛弃 (verb.)"
+    ]
+  },
+  {
+    "name": "during",
+    "trans": [
+      "期间, 在 (prep.)"
+    ]
+  },
+  {
+    "name": "dust",
+    "trans": [
+      "灰尘, 尘埃, 粉尘, 尘土 (noun.)"
+    ]
+  },
+  {
+    "name": "duty",
+    "trans": [
+      "职责, 责任, 义务, 税 (noun.)"
+    ]
+  },
+  {
+    "name": "DVD",
+    "trans": [
+      "DVD, 影碟 (noun.)"
+    ]
+  },
+  {
+    "name": "each",
+    "trans": [
+      "每个, 每, 每一 (det.)"
+    ]
+  },
+  {
+    "name": "each other",
+    "trans": [
+      "互相, 各自 (pron.)"
+    ]
+  },
+  {
+    "name": "ear",
+    "trans": [
+      "耳朵, 耳, 耳边, 穗 (noun.)"
+    ]
+  },
+  {
+    "name": "early",
+    "trans": [
+      "早期, 初, 初期, 年初 (adj.); 早, 早点, 早早, 提前 (adv.)"
+    ]
+  },
+  {
+    "name": "earn",
+    "trans": [
+      "赚取, 赚, 挣, 赢得 (verb.)"
+    ]
+  },
+  {
+    "name": "earth",
+    "trans": [
+      "地球, 大地, 土, 泥土 (noun.)"
+    ]
+  },
+  {
+    "name": "ease",
+    "trans": [
+      "缓解, 减轻, 缓和, 纾缓 (verb.); 轻松, 易于, 便于, 方便 (noun.)"
+    ]
+  },
+  {
+    "name": "easily",
+    "trans": [
+      "容易, 轻易, 轻松, 易 (adv.)"
+    ]
+  },
+  {
+    "name": "east",
+    "trans": [
+      "东, 东部, 东方, 东边 (noun.)"
+    ]
+  },
+  {
+    "name": "eastern",
+    "trans": [
+      "东部, 东区, 东方, 东 (noun.); 东部地区, 东面 (adj.)"
+    ]
+  },
+  {
+    "name": "easy",
+    "trans": [
+      "容易, 易, 简单, 轻松 (adj.)"
+    ]
+  },
+  {
+    "name": "eat",
+    "trans": [
+      "吃, 吃饭, 吃掉, 食用 (verb.)"
+    ]
+  },
+  {
+    "name": "economic",
+    "trans": [
+      "经济, 经济学 (adj.)"
+    ]
+  },
+  {
+    "name": "economics",
+    "trans": [
+      "经济学, 经济 (noun.)"
+    ]
+  },
+  {
+    "name": "economy",
+    "trans": [
+      "经济 (noun.)"
+    ]
+  },
+  {
+    "name": "edge",
+    "trans": [
+      "边缘, 边, 缘, 边沿 (noun.)"
+    ]
+  },
+  {
+    "name": "edition",
+    "trans": [
+      "版, 版本, 编辑 (noun.)"
+    ]
+  },
+  {
+    "name": "editor",
+    "trans": [
+      "编辑器, 编辑, 主编, 编者 (noun.)"
+    ]
+  },
+  {
+    "name": "education",
+    "trans": [
+      "教育, 教学 (noun.)"
+    ]
+  },
+  {
+    "name": "educational",
+    "trans": [
+      "教育, 育人, 教学 (adj.); 教务 (noun.)"
+    ]
+  },
+  {
+    "name": "efficiency",
+    "trans": [
+      "效率, 工作效率, 效能, 效益 (noun.)"
+    ]
+  },
+  {
+    "name": "efficient",
+    "trans": [
+      "高效, 有效, 高效率, 效率 (adj.)"
+    ]
+  },
+  {
+    "name": "effect",
+    "trans": [
+      "影响, 效果, 效应, 作用 (noun.)"
+    ]
+  },
+  {
+    "name": "effective",
+    "trans": [
+      "有效, 行之有效, 高效, 效益 (adj.)"
+    ]
+  },
+  {
+    "name": "effectively",
+    "trans": [
+      "有效, 切实, 实际上, 高效 (adv.)"
+    ]
+  },
+  {
+    "name": "effort",
+    "trans": [
+      "努力, 精力, 力气, 工作量 (noun.)"
+    ]
+  },
+  {
+    "name": "egg",
+    "trans": [
+      "蛋, 鸡蛋, 卵子, 卵 (noun.)"
+    ]
+  },
+  {
+    "name": "either",
+    "trans": [
+      "要么 (conj.)"
+    ]
+  },
+  {
+    "name": "elderly",
+    "trans": [
+      "老人, 老年人, 老年, 长者 (adj.); 安老 (noun.)"
+    ]
+  },
+  {
+    "name": "elect",
+    "trans": [
+      "选出, 选举, 推选, 推举 (verb.); 当选 (noun.)"
+    ]
+  },
+  {
+    "name": "election",
+    "trans": [
+      "选举, 大选, 竞选, 选 (noun.)"
+    ]
+  },
+  {
+    "name": "electric",
+    "trans": [
+      "电动, 电, 电气, 电力 (adj.); 电器, 电机 (noun.)"
+    ]
+  },
+  {
+    "name": "electrical",
+    "trans": [
+      "电气, 电, 电器, 电工 (adj.)"
+    ]
+  },
+  {
+    "name": "electricity",
+    "trans": [
+      "电力, 电, 用电, 电能 (noun.)"
+    ]
+  },
+  {
+    "name": "electronic",
+    "trans": [
+      "电子, 电 (adj.)"
+    ]
+  },
+  {
+    "name": "element",
+    "trans": [
+      "元素, 元, 元件, 单元 (noun.)"
+    ]
+  },
+  {
+    "name": "elevator",
+    "trans": [
+      "电梯, 升降机, 梯, 升降 (noun.)"
+    ]
+  },
+  {
+    "name": "else",
+    "trans": [
+      "别的, 其他, 还, 否则 (adv.)"
+    ]
+  },
+  {
+    "name": "elsewhere",
+    "trans": [
+      "别处, 他处, 外地 (adv.)"
+    ]
+  },
+  {
+    "name": "email",
+    "trans": [
+      "电子邮件, 电邮, 邮件, 封电子邮件 (noun.)"
+    ]
+  },
+  {
+    "name": "embarrassed",
+    "trans": [
+      "尴尬, 不好意思, 难堪, 为难 (adj.)"
+    ]
+  },
+  {
+    "name": "emerge",
+    "trans": [
+      "出现, 浮现, 涌现, 显现 (verb.)"
+    ]
+  },
+  {
+    "name": "emergency",
+    "trans": [
+      "紧急, 应急, 急诊, 急救 (noun.)"
+    ]
+  },
+  {
+    "name": "emotion",
+    "trans": [
+      "情感, 情绪, 感情, 感慨 (noun.)"
+    ]
+  },
+  {
+    "name": "emotional",
+    "trans": [
+      "情感, 情绪, 感情, 感性 (adj.)"
+    ]
+  },
+  {
+    "name": "emphasis",
+    "trans": [
+      "重点, 强调, 重视, 侧重点 (noun.)"
+    ]
+  },
+  {
+    "name": "emphasize",
+    "trans": [
+      "强调, 注重, 着重 (verb.)"
+    ]
+  },
+  {
+    "name": "empire",
+    "trans": [
+      "帝国, 王国, 王朝 (noun.)"
+    ]
+  },
+  {
+    "name": "employ",
+    "trans": [
+      "雇用, 聘请, 聘用, 雇佣 (verb.)"
+    ]
+  },
+  {
+    "name": "employee",
+    "trans": [
+      "员工, 雇员, 职工, 职员 (noun.)"
+    ]
+  },
+  {
+    "name": "employer",
+    "trans": [
+      "雇主, 用人单位, 老板, 业主 (noun.)"
+    ]
+  },
+  {
+    "name": "employment",
+    "trans": [
+      "就业, 雇佣, 就业率, 就业人数 (noun.)"
+    ]
+  },
+  {
+    "name": "empty",
+    "trans": [
+      "空, 空虚, 空荡荡, 空洞 (adj.); 清空 (verb.)"
+    ]
+  },
+  {
+    "name": "enable",
+    "trans": [
+      "启用, 使, 允许, 使得 (verb.)"
+    ]
+  },
+  {
+    "name": "encounter",
+    "trans": [
+      "遇到, 碰到, 遇, 遭到 (verb.); 遭遇, 邂逅, 相遇 (noun.)"
+    ]
+  },
+  {
+    "name": "encourage",
+    "trans": [
+      "鼓励, 激励, 助长, 鼓舞 (verb.)"
+    ]
+  },
+  {
+    "name": "encouraging",
+    "trans": [
+      "鼓励 (verb.); 令人鼓舞, 鼓舞人心, 激励, 鼓舞 (adj.)"
+    ]
+  },
+  {
+    "name": "end",
+    "trans": [
+      "结束, 端, 终结, 尽头 (noun.)"
+    ]
+  },
+  {
+    "name": "enemy",
+    "trans": [
+      "敌人, 敌军, 敌, 敌方 (noun.)"
+    ]
+  },
+  {
+    "name": "energy",
+    "trans": [
+      "能源, 能量, 精力, 活力 (noun.)"
+    ]
+  },
+  {
+    "name": "engage",
+    "trans": [
+      "搞, 从事, 聘请, 参与 (verb.)"
+    ]
+  },
+  {
+    "name": "engine",
+    "trans": [
+      "发动机, 引擎, 内燃机, 柴油机 (noun.)"
+    ]
+  },
+  {
+    "name": "engineer",
+    "trans": [
+      "工程师, 师 (noun.)"
+    ]
+  },
+  {
+    "name": "engineering",
+    "trans": [
+      "工程, 工程学, 工科, 工程设计 (noun.)"
+    ]
+  },
+  {
+    "name": "enhance",
+    "trans": [
+      "提高, 增强, 加强, 提升 (verb.)"
+    ]
+  },
+  {
+    "name": "enjoy",
+    "trans": [
+      "享受, 享有, 喜欢, 欣赏 (verb.)"
+    ]
+  },
+  {
+    "name": "enjoyable",
+    "trans": [
+      "愉快, 令人愉快, 其乐融融, 过瘾 (adj.)"
+    ]
+  },
+  {
+    "name": "enormous",
+    "trans": [
+      "巨大, 庞大, 极大, 巨额 (adj.)"
+    ]
+  },
+  {
+    "name": "enough",
+    "trans": [
+      "足够, 充足, 充分 (adj.); 够, 不够, 足以, 足 (adv.)"
+    ]
+  },
+  {
+    "name": "enquiry",
+    "trans": [
+      "查询, 询盘, 探询, 询问 (noun.)"
+    ]
+  },
+  {
+    "name": "ensure",
+    "trans": [
+      "确保, 保证, 保障 (verb.)"
+    ]
+  },
+  {
+    "name": "enter",
+    "trans": [
+      "进入, 输入, 进, 进军 (verb.)"
+    ]
+  },
+  {
+    "name": "enterprise",
+    "trans": [
+      "企业, 事业 (noun.)"
+    ]
+  },
+  {
+    "name": "entertainment",
+    "trans": [
+      "娱乐, 娱乐场所, 娱乐节目, 娱乐业 (noun.)"
+    ]
+  },
+  {
+    "name": "enthusiasm",
+    "trans": [
+      "热情, 积极性, 热忱, 热诚 (noun.)"
+    ]
+  },
+  {
+    "name": "enthusiastic",
+    "trans": [
+      "热情, 热心, 热烈, 热情洋溢 (adj.)"
+    ]
+  },
+  {
+    "name": "entire",
+    "trans": [
+      "整个, 全缘, 整, 全 (adj.)"
+    ]
+  },
+  {
+    "name": "entirely",
+    "trans": [
+      "完全, 全部, 全, 全然 (adv.)"
+    ]
+  },
+  {
+    "name": "entitle",
+    "trans": [
+      "有权 (verb.)"
+    ]
+  },
+  {
+    "name": "entrance",
+    "trans": [
+      "入口, 入口处, 入学, 门口 (noun.)"
+    ]
+  },
+  {
+    "name": "entry",
+    "trans": [
+      "条目, 入境, 入口, 入门 (noun.)"
+    ]
+  },
+  {
+    "name": "envelope",
+    "trans": [
+      "信封, 包络, 围护结构, 包络线 (noun.)"
+    ]
+  },
+  {
+    "name": "environment",
+    "trans": [
+      "环境, 环保 (noun.)"
+    ]
+  },
+  {
+    "name": "environmental",
+    "trans": [
+      "环境, 环保, 环境保护 (adj.)"
+    ]
+  },
+  {
+    "name": "equal",
+    "trans": [
+      "平等, 相等, 同等, 等于 (adj.)"
+    ]
+  },
+  {
+    "name": "equally",
+    "trans": [
+      "同样, 同等, 平等, 相等 (adv.)"
+    ]
+  },
+  {
+    "name": "equipment",
+    "trans": [
+      "设备, 装备, 器材, 装置 (noun.)"
+    ]
+  },
+  {
+    "name": "equivalent",
+    "trans": [
+      "等效, 相当于, 等价, 当量 (adj.)"
+    ]
+  },
+  {
+    "name": "era",
+    "trans": [
+      "时代, 年代, 纪元, 时期 (noun.)"
+    ]
+  },
+  {
+    "name": "error",
+    "trans": [
+      "误差, 错误, 差错, 出错 (noun.)"
+    ]
+  },
+  {
+    "name": "escape",
+    "trans": [
+      "逃脱, 逃避, 逃跑, 逃走 (verb.); 逃生, 逃逸, 越狱 (noun.)"
+    ]
+  },
+  {
+    "name": "especially",
+    "trans": [
+      "特别是, 尤其是, 尤其, 特别 (adv.)"
+    ]
+  },
+  {
+    "name": "essay",
+    "trans": [
+      "短文, 随笔, 篇文章, 作文 (noun.)"
+    ]
+  },
+  {
+    "name": "essential",
+    "trans": [
+      "必不可少, 本质, 必要, 基本 (adj.)"
+    ]
+  },
+  {
+    "name": "essentially",
+    "trans": [
+      "本质上, 基本上, 实质上, 从本质上讲 (adv.)"
+    ]
+  },
+  {
+    "name": "establish",
+    "trans": [
+      "建立, 树立, 确立, 设立 (verb.)"
+    ]
+  },
+  {
+    "name": "establishment",
+    "trans": [
+      "建立, 成立, 确立, 设立 (noun.)"
+    ]
+  },
+  {
+    "name": "estate",
+    "trans": [
+      "恏, 地产, 遗产, 房地产 (noun.)"
+    ]
+  },
+  {
+    "name": "estimate",
+    "trans": [
+      "估计, 估算, 评估, 预估 (noun.)"
+    ]
+  },
+  {
+    "name": "ethnic",
+    "trans": [
+      "民族, 种族, 少数民族, 族群 (adj.)"
+    ]
+  },
+  {
+    "name": "even",
+    "trans": [
+      "甚至, 即使, 即便, 连 (adv.)"
+    ]
+  },
+  {
+    "name": "evening",
+    "trans": [
+      "晚上, 傍晚, 晚间, 夜晚 (noun.)"
+    ]
+  },
+  {
+    "name": "event",
+    "trans": [
+      "事件, 活动, 盛会, 赛事 (noun.)"
+    ]
+  },
+  {
+    "name": "eventually",
+    "trans": [
+      "最终, 最后, 终究, 终于 (adv.)"
+    ]
+  },
+  {
+    "name": "ever",
+    "trans": [
+      "以往任何时候都, 曾经, 过, 永远 (adv.)"
+    ]
+  },
+  {
+    "name": "every",
+    "trans": [
+      "每, 每个, 每一 (det.)"
+    ]
+  },
+  {
+    "name": "everybody",
+    "trans": [
+      "每个人都, 大家, 每个人, 人人都 (noun.)"
+    ]
+  },
+  {
+    "name": "everyone",
+    "trans": [
+      "每个人都, 每个人, 大家, 人人都 (noun.)"
+    ]
+  },
+  {
+    "name": "everything",
+    "trans": [
+      "一切, 每件事, 所有, 万物 (noun.)"
+    ]
+  },
+  {
+    "name": "everywhere",
+    "trans": [
+      "到处, 无处不在, 处处, 随处可见 (adv.)"
+    ]
+  },
+  {
+    "name": "evidence",
+    "trans": [
+      "证据, 证物, 证据证明, 证供 (noun.)"
+    ]
+  },
+  {
+    "name": "evil",
+    "trans": [
+      "邪恶, 恶, 邪, 恶魔 (adj.); 罪恶, 善恶, 坏事 (noun.)"
+    ]
+  },
+  {
+    "name": "exact",
+    "trans": [
+      "确切, 精确, 准确, 具体 (adj.)"
+    ]
+  },
+  {
+    "name": "exactly",
+    "trans": [
+      "完全, 到底, 确切, 究竟 (adv.)"
+    ]
+  },
+  {
+    "name": "exam",
+    "trans": [
+      "考试, 及格, 考, 考试及格 (noun.)"
+    ]
+  },
+  {
+    "name": "examination",
+    "trans": [
+      "考试, 检查, 检验, 考核 (noun.)"
+    ]
+  },
+  {
+    "name": "examine",
+    "trans": [
+      "检查, 审视, 审查, 检验 (verb.)"
+    ]
+  },
+  {
+    "name": "example",
+    "trans": [
+      "例子, 示例, 例, 榜样 (noun.)"
+    ]
+  },
+  {
+    "name": "excellent",
+    "trans": [
+      "优秀, 优良, 优异, 出色 (adj.)"
+    ]
+  },
+  {
+    "name": "except",
+    "trans": [
+      "除了, 除, 除外 (prep.)"
+    ]
+  },
+  {
+    "name": "exception",
+    "trans": [
+      "例外, 异常, 除外, 除了 (noun.)"
+    ]
+  },
+  {
+    "name": "exchange",
+    "trans": [
+      "交换, 交易所, 交流, 外汇 (noun.)"
+    ]
+  },
+  {
+    "name": "excitement",
+    "trans": [
+      "兴奋, 激动, 刺激, 兴奋之情 (noun.)"
+    ]
+  },
+  {
+    "name": "exciting",
+    "trans": [
+      "令人兴奋, 激动人心, 令人激动, 令人振奋 (adj.)"
+    ]
+  },
+  {
+    "name": "exclude",
+    "trans": [
+      "排除, 排斥, 排除在外 (verb.)"
+    ]
+  },
+  {
+    "name": "excuse",
+    "trans": [
+      "借口, 藉口, 辩解, 理由 (noun.); 原谅, 请原谅 (verb.)"
+    ]
+  },
+  {
+    "name": "executive",
+    "trans": [
+      "行政, 执行, 高管, 常务 (noun.)"
+    ]
+  },
+  {
+    "name": "exercise",
+    "trans": [
+      "锻炼, 运动, 行使, 练习 (noun.)"
+    ]
+  },
+  {
+    "name": "exhibition",
+    "trans": [
+      "展览, 展览会, 展, 会展 (noun.)"
+    ]
+  },
+  {
+    "name": "exist",
+    "trans": [
+      "存在, 生存, 存活 (verb.)"
+    ]
+  },
+  {
+    "name": "existence",
+    "trans": [
+      "存在, 生存 (noun.)"
+    ]
+  },
+  {
+    "name": "existing",
+    "trans": [
+      "现有, 现行, 存在, 现存 (verb.)"
+    ]
+  },
+  {
+    "name": "exit",
+    "trans": [
+      "退出, 出口, 出境, 出入境 (noun.)"
+    ]
+  },
+  {
+    "name": "expand",
+    "trans": [
+      "扩大, 拓展, 扩展, 扩张 (verb.)"
+    ]
+  },
+  {
+    "name": "expansion",
+    "trans": [
+      "扩张, 膨胀, 扩展, 扩建 (noun.)"
+    ]
+  },
+  {
+    "name": "expect",
+    "trans": [
+      "期望, 指望, 期待, 预计 (verb.)"
+    ]
+  },
+  {
+    "name": "expectation",
+    "trans": [
+      "期望, 期待, 展望, 预期 (noun.)"
+    ]
+  },
+  {
+    "name": "expenditure",
+    "trans": [
+      "开支, 支出, 费用, 经费 (noun.)"
+    ]
+  },
+  {
+    "name": "expense",
+    "trans": [
+      "费用, 牺牲, 支出, 开支 (noun.)"
+    ]
+  },
+  {
+    "name": "expensive",
+    "trans": [
+      "昂贵, 贵, 贵重, 便宜 (adj.)"
+    ]
+  },
+  {
+    "name": "experience",
+    "trans": [
+      "经验, 体验, 经历, 体会 (noun.)"
+    ]
+  },
+  {
+    "name": "experienced",
+    "trans": [
+      "经验丰富, 支经验丰富, 资深, 经验 (adj.); 经历, 体验 (verb.)"
+    ]
+  },
+  {
+    "name": "experiment",
+    "trans": [
+      "实验, 试验, 尝试 (noun.)"
+    ]
+  },
+  {
+    "name": "experimental",
+    "trans": [
+      "实验, 试验 (adj.)"
+    ]
+  },
+  {
+    "name": "expert",
+    "trans": [
+      "专家, 行家, 高手 (noun.)"
+    ]
+  },
+  {
+    "name": "explain",
+    "trans": [
+      "解释, 说明, 讲解, 阐释 (verb.)"
+    ]
+  },
+  {
+    "name": "explanation",
+    "trans": [
+      "解释, 阐释, 说明, 解说 (noun.)"
+    ]
+  },
+  {
+    "name": "explore",
+    "trans": [
+      "探讨, 探索, 探究, 发掘 (verb.)"
+    ]
+  },
+  {
+    "name": "explosion",
+    "trans": [
+      "爆炸, 爆, 爆破, 防爆 (noun.)"
+    ]
+  },
+  {
+    "name": "export",
+    "trans": [
+      "出口, 导出, 外销, 输出 (noun.)"
+    ]
+  },
+  {
+    "name": "expose",
+    "trans": [
+      "揭露, 暴露, 揭发, 公开 (verb.)"
+    ]
+  },
+  {
+    "name": "express",
+    "trans": [
+      "表达, 表示, 表现, 发表 (verb.); 快递, 快车, 运通, 特快 (noun.)"
+    ]
+  },
+  {
+    "name": "expression",
+    "trans": [
+      "表达, 表达式, 表情, 表现 (noun.)"
+    ]
+  },
+  {
+    "name": "extend",
+    "trans": [
+      "延长, 扩展, 延伸, 扩大 (verb.)"
+    ]
+  },
+  {
+    "name": "extension",
+    "trans": [
+      "扩展, 延伸, 可拓, 分机 (noun.)"
+    ]
+  },
+  {
+    "name": "extensive",
+    "trans": [
+      "广泛, 粗放, 粗放型, 丰富 (adj.)"
+    ]
+  },
+  {
+    "name": "extent",
+    "trans": [
+      "程度, 种程度上, 范围, 种程度上讲 (noun.)"
+    ]
+  },
+  {
+    "name": "external",
+    "trans": [
+      "外部, 对外, 外, 外在 (adj.)"
+    ]
+  },
+  {
+    "name": "extra",
+    "trans": [
+      "额外, 多余, 特, 超 (adj.)"
+    ]
+  },
+  {
+    "name": "extraordinary",
+    "trans": [
+      "非凡, 非同寻常, 超凡, 不凡 (adj.)"
+    ]
+  },
+  {
+    "name": "extreme",
+    "trans": [
+      "极端, 极度, 极限, 偏激 (adj.); 极致 (noun.)"
+    ]
+  },
+  {
+    "name": "extremely",
+    "trans": [
+      "极其, 极, 极为, 非常 (adv.)"
+    ]
+  },
+  {
+    "name": "eye",
+    "trans": [
+      "眼, 眼睛, 眼部, 眼球 (noun.)"
+    ]
+  },
+  {
+    "name": "face",
+    "trans": [
+      "脸, 面, 面孔, 脸庞 (noun.); 面对, 面临 (verb.)"
+    ]
+  },
+  {
+    "name": "facility",
+    "trans": [
+      "设施, 设备, 工厂, 装置 (noun.)"
+    ]
+  },
+  {
+    "name": "fact",
+    "trans": [
+      "事实, 事实上, 实际上, 其实 (noun.)"
+    ]
+  },
+  {
+    "name": "factor",
+    "trans": [
+      "因子, 因素, 因数, 要素 (noun.)"
+    ]
+  },
+  {
+    "name": "factory",
+    "trans": [
+      "厂, 工厂, 出厂, 制造厂 (noun.)"
+    ]
+  },
+  {
+    "name": "fail",
+    "trans": [
+      "失败, 倒闭, 失效, 故障 (verb.)"
+    ]
+  },
+  {
+    "name": "failure",
+    "trans": [
+      "失败, 衰竭, 失效, 故障 (noun.)"
+    ]
+  },
+  {
+    "name": "fair",
+    "trans": [
+      "公平, 公允, 公正, 公道 (adj.); 博览会, 交易会, 展览会, 集市 (noun.)"
+    ]
+  },
+  {
+    "name": "fairly",
+    "trans": [
+      "相当, 公平, 公正 (adv.)"
+    ]
+  },
+  {
+    "name": "faith",
+    "trans": [
+      "信仰, 信念, 信心, 秉 (noun.)"
+    ]
+  },
+  {
+    "name": "fall",
+    "trans": [
+      "秋天, 秋季 (noun.); 下降, 跌倒, 落, 下跌 (verb.)"
+    ]
+  },
+  {
+    "name": "false",
+    "trans": [
+      "虚假, 假, 错误, 虚伪 (adj.)"
+    ]
+  },
+  {
+    "name": "familiar",
+    "trans": [
+      "熟悉, 眼熟, 面熟, 耳熟 (adj.)"
+    ]
+  },
+  {
+    "name": "family",
+    "trans": [
+      "家庭, 家人, 家族, 家 (noun.)"
+    ]
+  },
+  {
+    "name": "famous",
+    "trans": [
+      "著名, 有名, 出名, 知名 (adj.)"
+    ]
+  },
+  {
+    "name": "fan",
+    "trans": [
+      "风扇, 风机, 扇, 粉丝 (noun.)"
+    ]
+  },
+  {
+    "name": "fancy",
+    "trans": [
+      "看中, 花哨, 幻想, 高档 (adj.); 看上 (verb.)"
+    ]
+  },
+  {
+    "name": "fantastic",
+    "trans": [
+      "梦幻般, 奇妙, 神奇, 棒极 (adj.)"
+    ]
+  },
+  {
+    "name": "far",
+    "trans": [
+      "远, 远远, 遥远, 远处 (adv.)"
+    ]
+  },
+  {
+    "name": "farm",
+    "trans": [
+      "农场, 农庄, 农用, 养殖场 (noun.)"
+    ]
+  },
+  {
+    "name": "farmer",
+    "trans": [
+      "农民, 农夫, 农场主, 法默 (noun.)"
+    ]
+  },
+  {
+    "name": "fascinating",
+    "trans": [
+      "迷人, 引人入胜, 令人着迷, 奇妙 (adj.)"
+    ]
+  },
+  {
+    "name": "fashion",
+    "trans": [
+      "时尚, 时装, 时尚界, 服装 (noun.)"
+    ]
+  },
+  {
+    "name": "fast",
+    "trans": [
+      "快速, 快, 快捷, 迅速 (adj.); 很快 (adv.)"
+    ]
+  },
+  {
+    "name": "fat",
+    "trans": [
+      "脂肪, 胖, 脂, 肥 (adj.); 肥肉, 油脂 (noun.)"
+    ]
+  },
+  {
+    "name": "father",
+    "trans": [
+      "父亲, 爸爸, 父, 爸 (noun.)"
+    ]
+  },
+  {
+    "name": "fault",
+    "trans": [
+      "故障, 错, 断层, 过错 (noun.)"
+    ]
+  },
+  {
+    "name": "favour",
+    "trans": [
+      "赞成, 青睐, 忙, 有利于 (noun.)"
+    ]
+  },
+  {
+    "name": "favourite",
+    "trans": [
+      "最喜爱, 喜爱, 喜欢, 钟爱 (adj.); 宠儿 (noun.)"
+    ]
+  },
+  {
+    "name": "fear",
+    "trans": [
+      "恐惧, 害怕, 怕, 惧怕 (noun.); 担心, 恐怕 (verb.)"
+    ]
+  },
+  {
+    "name": "feature",
+    "trans": [
+      "特征, 功能, 特点, 特性 (noun.)"
+    ]
+  },
+  {
+    "name": "federal",
+    "trans": [
+      "联邦 (adj.)"
+    ]
+  },
+  {
+    "name": "fee",
+    "trans": [
+      "费, 费用, 收费, 手续费 (noun.)"
+    ]
+  },
+  {
+    "name": "feed",
+    "trans": [
+      "饲料, 提要, 料 (noun.); 喂, 养活, 喂养, 食 (verb.)"
+    ]
+  },
+  {
+    "name": "feedback",
+    "trans": [
+      "反馈, 反馈意见, 回馈, 信息反馈 (noun.)"
+    ]
+  },
+  {
+    "name": "feel",
+    "trans": [
+      "感觉, 感到, 觉得, 感受 (verb.)"
+    ]
+  },
+  {
+    "name": "feeling",
+    "trans": [
+      "感觉, 感受, 感, 感情 (noun.); 感到, 觉得 (verb.)"
+    ]
+  },
+  {
+    "name": "fellow",
+    "trans": [
+      "同胞, 老乡, 家伙, 研究员 (noun.); 同伴, 同行, 各位, 同事 (adj.)"
+    ]
+  },
+  {
+    "name": "female",
+    "trans": [
+      "女性, 女, 雌性, 雌 (adj.)"
+    ]
+  },
+  {
+    "name": "fence",
+    "trans": [
+      "栅栏, 篱笆, 围栏, 围墙 (noun.)"
+    ]
+  },
+  {
+    "name": "festival",
+    "trans": [
+      "节日, 节, 艺术节, 节庆 (noun.)"
+    ]
+  },
+  {
+    "name": "fetch",
+    "trans": [
+      "取, 获取 (verb.)"
+    ]
+  },
+  {
+    "name": "few",
+    "trans": [
+      "几个, 几, 很少, 少数 (adj.)"
+    ]
+  },
+  {
+    "name": "field",
+    "trans": [
+      "场, 领域, 字段, 现场 (noun.)"
+    ]
+  },
+  {
+    "name": "fight",
+    "trans": [
+      "战斗, 打架, 打, 打仗 (verb.); 斗争, 吵架 (noun.)"
+    ]
+  },
+  {
+    "name": "figure",
+    "trans": [
+      "图, 身影, 数字, 人物 (noun.)"
+    ]
+  },
+  {
+    "name": "file",
+    "trans": [
+      "文件, 档案, 档 (noun.)"
+    ]
+  },
+  {
+    "name": "fill",
+    "trans": [
+      "填补, 填充, 填, 填满 (verb.)"
+    ]
+  },
+  {
+    "name": "film",
+    "trans": [
+      "电影, 膜, 部电影, 薄膜 (noun.)"
+    ]
+  },
+  {
+    "name": "filthy",
+    "trans": [
+      "肮脏, 污秽, 脏, 污浊 (adj.)"
+    ]
+  },
+  {
+    "name": "final",
+    "trans": [
+      "最终, 最后, 期末, 决赛 (adj.)"
+    ]
+  },
+  {
+    "name": "finally",
+    "trans": [
+      "最后, 终于, 最终, 总算 (adv.)"
+    ]
+  },
+  {
+    "name": "finance",
+    "trans": [
+      "金融, 财务, 财政, 融资 (noun.); 资助 (verb.)"
+    ]
+  },
+  {
+    "name": "financial",
+    "trans": [
+      "金融, 财务, 财政, 理财 (adj.); 财经 (noun.)"
+    ]
+  },
+  {
+    "name": "find",
+    "trans": [
+      "找到, 找, 发现, 寻找 (verb.)"
+    ]
+  },
+  {
+    "name": "finding",
+    "trans": [
+      "寻找, 找到, 发现, 查找 (verb.)"
+    ]
+  },
+  {
+    "name": "fine",
+    "trans": [
+      "罚款, 精细, 细, 好 (adj.)"
+    ]
+  },
+  {
+    "name": "finger",
+    "trans": [
+      "手指, 根手指, 指头, 手指头 (noun.)"
+    ]
+  },
+  {
+    "name": "finish",
+    "trans": [
+      "完成, 完, 做完, 按时完成 (verb.); 终点, 整理 (noun.)"
+    ]
+  },
+  {
+    "name": "fire",
+    "trans": [
+      "火, 火灾, 消防, 防火 (noun.); 解雇 (verb.)"
+    ]
+  },
+  {
+    "name": "firm",
+    "trans": [
+      "坚定, 公司, 事务所, 商行 (noun.)"
+    ]
+  },
+  {
+    "name": "first",
+    "trans": [
+      "第一, 第一次, 首次, 首 (adj.); 首先, 先, 开始 (adv.)"
+    ]
+  },
+  {
+    "name": "firstly",
+    "trans": [
+      "首先, 第一, 其一, 首次 (adv.)"
+    ]
+  },
+  {
+    "name": "fish",
+    "trans": [
+      "鱼, 鱼类, 鱼儿, 鱼肉 (noun.)"
+    ]
+  },
+  {
+    "name": "fishing",
+    "trans": [
+      "钓鱼, 捕鱼, 垂钓, 捕捞 (noun.)"
+    ]
+  },
+  {
+    "name": "fit",
+    "trans": [
+      "适合, 适应, 合身, 符合 (verb.); 合适, 健康, 适当, 适用 (adj.); 拟合, 配合 (noun.)"
+    ]
+  },
+  {
+    "name": "fix",
+    "trans": [
+      "修复, 修好, 修, 修理 (verb.)"
+    ]
+  },
+  {
+    "name": "fixed",
+    "trans": [
+      "固定, 定额, 修好, 动 (verb.)"
+    ]
+  },
+  {
+    "name": "flash",
+    "trans": [
+      "闪光, 闪光灯, 闪, 闪存 (noun.)"
+    ]
+  },
+  {
+    "name": "flat",
+    "trans": [
+      "平, 平坦, 扁, 扁平 (adj.)"
+    ]
+  },
+  {
+    "name": "flavour",
+    "trans": [
+      "风味, 味道, 味, 香味 (noun.)"
+    ]
+  },
+  {
+    "name": "flesh",
+    "trans": [
+      "肉, 肉体, 血肉, 果肉 (noun.)"
+    ]
+  },
+  {
+    "name": "flight",
+    "trans": [
+      "飞行, 航班, 班机, 外逃 (noun.)"
+    ]
+  },
+  {
+    "name": "flood",
+    "trans": [
+      "洪水, 水灾, 洪灾, 洪 (noun.); 淹没 (verb.)"
+    ]
+  },
+  {
+    "name": "floor",
+    "trans": [
+      "地板, 楼, 楼层, 地上 (noun.)"
+    ]
+  },
+  {
+    "name": "flow",
+    "trans": [
+      "流, 流动, 流量, 流程 (noun.)"
+    ]
+  },
+  {
+    "name": "flower",
+    "trans": [
+      "花, 朵花, 花卉, 花朵 (noun.)"
+    ]
+  },
+  {
+    "name": "fly",
+    "trans": [
+      "飞, 飞翔, 飞行, 乘飞机 (verb.); 只苍蝇, 苍蝇 (noun.)"
+    ]
+  },
+  {
+    "name": "focus",
+    "trans": [
+      "焦点, 重点, 聚焦, 关注 (noun.); 集中, 专注, 集中精力 (verb.)"
+    ]
+  },
+  {
+    "name": "fold",
+    "trans": [
+      "折叠, 折, 叠, 折边 (verb.); 倍, 褶皱, 褶, 折页 (noun.)"
+    ]
+  },
+  {
+    "name": "folk",
+    "trans": [
+      "民间, 民俗, 民族民间, 民谣 (noun.)"
+    ]
+  },
+  {
+    "name": "follow",
+    "trans": [
+      "遵循, 跟随, 跟着, 追随 (verb.)"
+    ]
+  },
+  {
+    "name": "following",
+    "trans": [
+      "以下, 下列, 下面, 如下 (verb.)"
+    ]
+  },
+  {
+    "name": "food",
+    "trans": [
+      "食品, 食物, 粮食, 菜 (noun.)"
+    ]
+  },
+  {
+    "name": "foot",
+    "trans": [
+      "脚, 足, 足部, 脚下 (noun.)"
+    ]
+  },
+  {
+    "name": "football",
+    "trans": [
+      "足球, 橄榄球, 足球场, 踢球 (noun.)"
+    ]
+  },
+  {
+    "name": "for",
+    "trans": [
+      "为 (prep.)"
+    ]
+  },
+  {
+    "name": "force",
+    "trans": [
+      "力, 力量, 武力, 力量雄厚 (noun.); 强迫, 迫使, 强制, 逼 (verb.)"
+    ]
+  },
+  {
+    "name": "foreign",
+    "trans": [
+      "外国, 国外, 外商, 外交 (adj.)"
+    ]
+  },
+  {
+    "name": "forest",
+    "trans": [
+      "森林, 林, 林业, 林木 (noun.)"
+    ]
+  },
+  {
+    "name": "forever",
+    "trans": [
+      "永远, 一辈子, 永恒, 永久 (adv.)"
+    ]
+  },
+  {
+    "name": "forget",
+    "trans": [
+      "忘记, 忘, 忘掉, 忘不了 (verb.)"
+    ]
+  },
+  {
+    "name": "forgive",
+    "trans": [
+      "原谅, 宽恕, 请原谅, 饶恕 (verb.)"
+    ]
+  },
+  {
+    "name": "fork",
+    "trans": [
+      "叉, 叉子, 餐叉, 岔路口 (noun.); 餐桌 (verb.)"
+    ]
+  },
+  {
+    "name": "form",
+    "trans": [
+      "形式, 表单, 表格, 形态 (noun.); 形成, 构成, 组成 (verb.)"
+    ]
+  },
+  {
+    "name": "formal",
+    "trans": [
+      "正式, 正规, 形式化, 形式 (adj.)"
+    ]
+  },
+  {
+    "name": "formally",
+    "trans": [
+      "正式, 形式上, 形式化, 郑重 (adv.)"
+    ]
+  },
+  {
+    "name": "formation",
+    "trans": [
+      "形成, 地层, 编队, 生成 (noun.)"
+    ]
+  },
+  {
+    "name": "former",
+    "trans": [
+      "前, 前者, 前任, 以前 (adj.)"
+    ]
+  },
+  {
+    "name": "formula",
+    "trans": [
+      "公式, 配方, 计算公式, 配方奶粉 (noun.)"
+    ]
+  },
+  {
+    "name": "forth",
+    "trans": [
+      "来回, 提出, 向前, 反复 (adv.); 第四 (adj.)"
+    ]
+  },
+  {
+    "name": "fortnight",
+    "trans": [
+      "两个 (noun.)"
+    ]
+  },
+  {
+    "name": "fortunate",
+    "trans": [
+      "幸运, 幸, 有幸, 不幸 (adj.)"
+    ]
+  },
+  {
+    "name": "fortune",
+    "trans": [
+      "财富, 发财, 财产, 命运 (noun.)"
+    ]
+  },
+  {
+    "name": "forward",
+    "trans": [
+      "向前, 前进, 转发, 前锋 (adv.); 远期 (adj.)"
+    ]
+  },
+  {
+    "name": "foundation",
+    "trans": [
+      "基础, 地基, 基金会, 基 (noun.)"
+    ]
+  },
+  {
+    "name": "frame",
+    "trans": [
+      "框架, 帧, 架, 车架 (noun.); 陷害 (verb.)"
+    ]
+  },
+  {
+    "name": "frankly",
+    "trans": [
+      "坦率地说, 坦白地说, 坦白, 坦白讲 (adv.)"
+    ]
+  },
+  {
+    "name": "free",
+    "trans": [
+      "免费, 自由, 游离, 空闲 (adj.)"
+    ]
+  },
+  {
+    "name": "freedom",
+    "trans": [
+      "自由, 言论自由, 自由度 (noun.)"
+    ]
+  },
+  {
+    "name": "freeway",
+    "trans": [
+      "高速公路, 高速 (noun.)"
+    ]
+  },
+  {
+    "name": "freeze",
+    "trans": [
+      "冻结, 冻死, 结冰, 冻僵 (verb.); 冷冻, 冻, 冰冻 (noun.)"
+    ]
+  },
+  {
+    "name": "freezer",
+    "trans": [
+      "冰柜, 冰箱, 冷藏室, 冷柜 (noun.)"
+    ]
+  },
+  {
+    "name": "frequent",
+    "trans": [
+      "频繁, 频发, 经常, 常见 (adj.)"
+    ]
+  },
+  {
+    "name": "frequently",
+    "trans": [
+      "经常, 频繁, 频频, 常常 (adv.)"
+    ]
+  },
+  {
+    "name": "fresh",
+    "trans": [
+      "新鲜, 鲜, 清新, 应届 (adj.)"
+    ]
+  },
+  {
+    "name": "fridge",
+    "trans": [
+      "冰箱, 冰箱里, 电冰箱 (noun.)"
+    ]
+  },
+  {
+    "name": "friend",
+    "trans": [
+      "朋友, 好友 (noun.)"
+    ]
+  },
+  {
+    "name": "friendly",
+    "trans": [
+      "友好, 友善, 友军, 友谊赛 (adj.)"
+    ]
+  },
+  {
+    "name": "friendship",
+    "trans": [
+      "友谊, 友情, 友好, 情谊 (noun.)"
+    ]
+  },
+  {
+    "name": "frightened",
+    "trans": [
+      "害怕, 受惊, 惊恐, 受惊吓 (adj.); 吓坏, 吓, 惊 (verb.)"
+    ]
+  },
+  {
+    "name": "from",
+    "trans": [
+      "从, 来自 (prep.)"
+    ]
+  },
+  {
+    "name": "front",
+    "trans": [
+      "前面, 面前, 前, 前方 (noun.); 前排 (adj.)"
+    ]
+  },
+  {
+    "name": "fruit",
+    "trans": [
+      "水果, 果, 果实, 果子 (noun.)"
+    ]
+  },
+  {
+    "name": "fry",
+    "trans": [
+      "弗莱, 鱼苗, 炒, 炸 (noun.); 煎 (verb.)"
+    ]
+  },
+  {
+    "name": "fuel",
+    "trans": [
+      "燃料, 燃油, 燃, 油 (noun.)"
+    ]
+  },
+  {
+    "name": "full",
+    "trans": [
+      "充满, 满, 充分, 全 (adj.)"
+    ]
+  },
+  {
+    "name": "fully",
+    "trans": [
+      "充分, 完全, 全面, 全力 (adv.)"
+    ]
+  },
+  {
+    "name": "fun",
+    "trans": [
+      "乐趣, 有趣, 好玩, 开心 (noun.); 有意思 (adj.)"
+    ]
+  },
+  {
+    "name": "function",
+    "trans": [
+      "功能, 函数, 作用, 职能 (noun.)"
+    ]
+  },
+  {
+    "name": "fund",
+    "trans": [
+      "基金, 资金, 基金会, IMF (noun.); 资助 (verb.)"
+    ]
+  },
+  {
+    "name": "fundamental",
+    "trans": [
+      "基本, 根本, 根本性, 基础 (adj.)"
+    ]
+  },
+  {
+    "name": "funeral",
+    "trans": [
+      "葬礼, 丧葬, 殡葬, 丧礼 (noun.)"
+    ]
+  },
+  {
+    "name": "funny",
+    "trans": [
+      "有趣, 好笑, 滑稽, 搞笑 (adj.)"
+    ]
+  },
+  {
+    "name": "furniture",
+    "trans": [
+      "家具, 家俱, 家私 (noun.)"
+    ]
+  },
+  {
+    "name": "further",
+    "trans": [
+      "进一步, 更进一步, 深入, 再 (adj.); 远, 此外 (adv.)"
+    ]
+  },
+  {
+    "name": "fuss",
+    "trans": [
+      "大惊小怪, 做文章, 小题大做, 大做文章 (noun.)"
+    ]
+  },
+  {
+    "name": "future",
+    "trans": [
+      "未来, 将来, 今后, 日后 (noun.)"
+    ]
+  },
+  {
+    "name": "gain",
+    "trans": [
+      "增益, 收获, 收益, 增加 (noun.); 获得, 获取, 得到, 赢得 (verb.)"
+    ]
+  },
+  {
+    "name": "gallery",
+    "trans": [
+      "画廊, 库, 图库, 廊 (noun.)"
+    ]
+  },
+  {
+    "name": "game",
+    "trans": [
+      "游戏, 博弈, 比赛, 场比赛 (noun.)"
+    ]
+  },
+  {
+    "name": "gang",
+    "trans": [
+      "岗, 团伙, 帮派, 港 (noun.)"
+    ]
+  },
+  {
+    "name": "gap",
+    "trans": [
+      "差距, 间隙, 缺口, 隙 (noun.)"
+    ]
+  },
+  {
+    "name": "garage",
+    "trans": [
+      "车库, 修车厂, 修理厂, 汽车修理厂 (noun.)"
+    ]
+  },
+  {
+    "name": "garbage",
+    "trans": [
+      "垃圾, 倒垃圾, 垃圾堆 (noun.)"
+    ]
+  },
+  {
+    "name": "garden",
+    "trans": [
+      "花园, 园林, 园, 庭院 (noun.)"
+    ]
+  },
+  {
+    "name": "garlic",
+    "trans": [
+      "大蒜, 蒜, 蒜头, 蒜味 (noun.)"
+    ]
+  },
+  {
+    "name": "gas",
+    "trans": [
+      "气体, 气, 煤气, 瓦斯 (noun.)"
+    ]
+  },
+  {
+    "name": "gasoline",
+    "trans": [
+      "汽油, 汽油机, 汽 (noun.)"
+    ]
+  },
+  {
+    "name": "gate",
+    "trans": [
+      "门, 闸门, 大门, 门口 (noun.)"
+    ]
+  },
+  {
+    "name": "gather",
+    "trans": [
+      "收集, 聚集, 搜集, 聚 (verb.); 集聚 (noun.)"
+    ]
+  },
+  {
+    "name": "gay",
+    "trans": [
+      "同性恋, 同志, 同性, 男同性恋 (adj.)"
+    ]
+  },
+  {
+    "name": "gear",
+    "trans": [
+      "齿轮, 齿, 装备, 传动装置 (noun.)"
+    ]
+  },
+  {
+    "name": "gene",
+    "trans": [
+      "基因 (noun.)"
+    ]
+  },
+  {
+    "name": "general",
+    "trans": [
+      "一般, 通用, 总体, 普通 (adj.); 将军 (noun.)"
+    ]
+  },
+  {
+    "name": "generally",
+    "trans": [
+      "一般, 普遍, 通常, 一般来说 (adv.)"
+    ]
+  },
+  {
+    "name": "generate",
+    "trans": [
+      "生成, 产生, 创造, 带来 (verb.)"
+    ]
+  },
+  {
+    "name": "generation",
+    "trans": [
+      "一代, 代, 生成, 世代 (noun.)"
+    ]
+  },
+  {
+    "name": "generous",
+    "trans": [
+      "慷慨, 大方, 慷慨大方, 宽厚 (adj.)"
+    ]
+  },
+  {
+    "name": "gentle",
+    "trans": [
+      "温柔, 温和, 轻柔, 柔和 (adj.)"
+    ]
+  },
+  {
+    "name": "gentleman",
+    "trans": [
+      "绅士, 君子, 绅士风度, 先生 (noun.)"
+    ]
+  },
+  {
+    "name": "gently",
+    "trans": [
+      "轻轻, 轻轻地, 温柔, 轻柔 (adv.)"
+    ]
+  },
+  {
+    "name": "genuine",
+    "trans": [
+      "真正, 正版, 正品, 货真价实 (adj.)"
+    ]
+  },
+  {
+    "name": "get",
+    "trans": [
+      "得到, 获得, 拿, 让 (verb.)"
+    ]
+  },
+  {
+    "name": "giant",
+    "trans": [
+      "巨人, 巨头, 业巨头, 巨星 (noun.); 巨, 巨型, 巨大, 大型 (adj.)"
+    ]
+  },
+  {
+    "name": "gift",
+    "trans": [
+      "礼物, 礼品, 份礼物, 天赋 (noun.)"
+    ]
+  },
+  {
+    "name": "girl",
+    "trans": [
+      "女孩, 姑娘, 女孩子, 女生 (noun.)"
+    ]
+  },
+  {
+    "name": "girlfriend",
+    "trans": [
+      "女朋友, 女友, 马子 (noun.)"
+    ]
+  },
+  {
+    "name": "give",
+    "trans": [
+      "给, 给予, 放弃, 让 (verb.)"
+    ]
+  },
+  {
+    "name": "glad",
+    "trans": [
+      "高兴, 庆幸, 开心, 欣慰 (adj.)"
+    ]
+  },
+  {
+    "name": "glance",
+    "trans": [
+      "一目了然, 一瞥, 目光, 眼 (noun.)"
+    ]
+  },
+  {
+    "name": "glass",
+    "trans": [
+      "玻璃, 玻璃杯, 杯, 杯子 (noun.)"
+    ]
+  },
+  {
+    "name": "global",
+    "trans": [
+      "全球, 全局, 全球性, 环球 (adj.)"
+    ]
+  },
+  {
+    "name": "glove",
+    "trans": [
+      "手套, 杂物 (noun.)"
+    ]
+  },
+  {
+    "name": "go",
+    "trans": [
+      "去, 走, 离开, 转 (verb.)"
+    ]
+  },
+  {
+    "name": "goal",
+    "trans": [
+      "目标, 目的, 进球, 球门 (noun.)"
+    ]
+  },
+  {
+    "name": "god",
+    "trans": [
+      "上帝, 神, 天主, 老天 (noun.)"
+    ]
+  },
+  {
+    "name": "gold",
+    "trans": [
+      "黄金, 金, 金子, 金色 (noun.)"
+    ]
+  },
+  {
+    "name": "golden",
+    "trans": [
+      "金色, 黄金, 金黄, 金黄色 (adj.); 金 (noun.)"
+    ]
+  },
+  {
+    "name": "golf",
+    "trans": [
+      "高尔夫, 高尔夫球 (noun.)"
+    ]
+  },
+  {
+    "name": "good",
+    "trans": [
+      "好, 良好, 不错, 好处 (adj.)"
+    ]
+  },
+  {
+    "name": "good morning",
+    "trans": [
+      "早安, 你(们)好"
+    ]
+  },
+  {
+    "name": "good night",
+    "trans": [
+      "晚安"
+    ]
+  },
+  {
+    "name": "goodbye",
+    "trans": [
+      "再见, 道别, 告别, 吻别 (noun.)"
+    ]
+  },
+  {
+    "name": "goodness",
+    "trans": [
+      "善良, 善, 良善, 仁慈 (noun.)"
+    ]
+  },
+  {
+    "name": "goods",
+    "trans": [
+      "货物, 商品, 货品, 货 (noun.)"
+    ]
+  },
+  {
+    "name": "gorgeous",
+    "trans": [
+      "华丽, 绚烂, 艳丽, 绚丽 (adj.); 美女 (noun.)"
+    ]
+  },
+  {
+    "name": "gosh",
+    "trans": [
+      "唉, 天, 老天 (noun.)"
+    ]
+  },
+  {
+    "name": "govern",
+    "trans": [
+      "治理, 支配, 执政, 统治 (verb.)"
+    ]
+  },
+  {
+    "name": "government",
+    "trans": [
+      "政府, 港府 (noun.)"
+    ]
+  },
+  {
+    "name": "governor",
+    "trans": [
+      "总督, 州长, 省长, 调速器 (noun.)"
+    ]
+  },
+  {
+    "name": "grab",
+    "trans": [
+      "抓住, 抢, 抓, 攫取 (verb.); 抓斗 (noun.)"
+    ]
+  },
+  {
+    "name": "grade",
+    "trans": [
+      "年级, 品位, 等级, 级 (noun.)"
+    ]
+  },
+  {
+    "name": "gradually",
+    "trans": [
+      "逐渐, 逐步, 渐渐, 渐 (adv.)"
+    ]
+  },
+  {
+    "name": "gram",
+    "trans": [
+      "克, 革, 绿豆 (noun.)"
+    ]
+  },
+  {
+    "name": "grammar",
+    "trans": [
+      "语法, 文法 (noun.)"
+    ]
+  },
+  {
+    "name": "grand",
+    "trans": [
+      "盛大, 隆重, 宏伟, 宏大 (adj.); 大, 侠 (noun.)"
+    ]
+  },
+  {
+    "name": "grandad",
+    "trans": [
+      "爷爷, 外公 (noun.)"
+    ]
+  },
+  {
+    "name": "grandfather",
+    "trans": [
+      "祖父, 爷爷, 外公, 外祖父 (noun.)"
+    ]
+  },
+  {
+    "name": "grandma",
+    "trans": [
+      "奶奶, 外婆, 祖母, 姥姥 (noun.)"
+    ]
+  },
+  {
+    "name": "grandmother",
+    "trans": [
+      "祖母, 奶奶, 外婆, 姥姥 (noun.)"
+    ]
+  },
+  {
+    "name": "grandpa",
+    "trans": [
+      "爷爷, 外公, 祖父, 老爷爷 (noun.)"
+    ]
+  },
+  {
+    "name": "granny",
+    "trans": [
+      "奶奶, 老奶奶, 外婆, 婆婆 (noun.)"
+    ]
+  },
+  {
+    "name": "grant",
+    "trans": [
+      "格兰特, 补助金, 批予, 批出 (noun.); 授予, 给予, 批准 (verb.)"
+    ]
+  },
+  {
+    "name": "graph",
+    "trans": [
+      "图, 图形, 图表, 曲线图 (noun.)"
+    ]
+  },
+  {
+    "name": "grass",
+    "trans": [
+      "草, 草地, 小草, 青草 (noun.)"
+    ]
+  },
+  {
+    "name": "grateful",
+    "trans": [
+      "感激, 感谢, 感恩, 心存感激 (adj.)"
+    ]
+  },
+  {
+    "name": "great",
+    "trans": [
+      "伟大, 巨大, 大, 极大 (adj.)"
+    ]
+  },
+  {
+    "name": "greatly",
+    "trans": [
+      "大大, 极大, 大为, 大幅度 (adv.)"
+    ]
+  },
+  {
+    "name": "green",
+    "trans": [
+      "绿色, 绿, 青, 绿化 (adj.); 格林 (noun.)"
+    ]
+  },
+  {
+    "name": "grey",
+    "trans": [
+      "灰色, 灰, 灰暗, 灰白 (adj.); 格雷, 格蕾 (noun.)"
+    ]
+  },
+  {
+    "name": "grocery",
+    "trans": [
+      "杂货, 杂货店, 食品杂货, 购物 (noun.)"
+    ]
+  },
+  {
+    "name": "gross",
+    "trans": [
+      "恶心, 总量, 总, 总额 (adj.)"
+    ]
+  },
+  {
+    "name": "ground",
+    "trans": [
+      "地面, 地上, 地基, 地 (noun.)"
+    ]
+  },
+  {
+    "name": "group",
+    "trans": [
+      "组, 集团, 小组, 群 (noun.)"
+    ]
+  },
+  {
+    "name": "grow",
+    "trans": [
+      "成长, 生长, 增长, 种植 (verb.)"
+    ]
+  },
+  {
+    "name": "growth",
+    "trans": [
+      "增长, 生长, 成长, 生长发育 (noun.)"
+    ]
+  },
+  {
+    "name": "guarantee",
+    "trans": [
+      "保证, 保障, 担保 (noun.); 确保 (verb.)"
+    ]
+  },
+  {
+    "name": "guard",
+    "trans": [
+      "警卫队, 警卫, 后卫, 守卫 (noun.); 守护 (verb.)"
+    ]
+  },
+  {
+    "name": "guess",
+    "trans": [
+      "猜, 想, 猜猜, 猜测 (verb.)"
+    ]
+  },
+  {
+    "name": "guest",
+    "trans": [
+      "客人, 嘉宾, 来宾, 客 (noun.)"
+    ]
+  },
+  {
+    "name": "guidance",
+    "trans": [
+      "指导, 制导, 引导, 指引 (noun.)"
+    ]
+  },
+  {
+    "name": "guide",
+    "trans": [
+      "指南, 指导, 导, 导游 (noun.); 引导, 指引, 引领 (verb.)"
+    ]
+  },
+  {
+    "name": "guilty",
+    "trans": [
+      "有罪, 内疚, 愧疚, 犯 (adj.)"
+    ]
+  },
+  {
+    "name": "guitar",
+    "trans": [
+      "吉他, 弹吉他, 吉它, 吉他演奏 (noun.)"
+    ]
+  },
+  {
+    "name": "gun",
+    "trans": [
+      "枪, 枪支, 支枪, 炮 (noun.)"
+    ]
+  },
+  {
+    "name": "guy",
+    "trans": [
+      "家伙, 人, 男人, 男 (noun.)"
+    ]
+  },
+  {
+    "name": "habit",
+    "trans": [
+      "习惯, 习性, 养成, 习气 (noun.)"
+    ]
+  },
+  {
+    "name": "hair",
+    "trans": [
+      "头发, 发, 毛发, 毛 (noun.)"
+    ]
+  },
+  {
+    "name": "half",
+    "trans": [
+      "一半, 半, 半数, 半年 (noun.); 半个 (adj.)"
+    ]
+  },
+  {
+    "name": "half",
+    "trans": [
+      "一半, 半, 半数, 半年 (noun.); 半个 (adj.)"
+    ]
+  },
+  {
+    "name": "halfway",
+    "trans": [
+      "半路, 中途, 半途, 半途而废 (adv.)"
+    ]
+  },
+  {
+    "name": "hall",
+    "trans": [
+      "大厅, 厅, 霍尔, 礼堂 (noun.)"
+    ]
+  },
+  {
+    "name": "hand",
+    "trans": [
+      "手, 手工, 手中, 手头 (noun.); 交 (verb.)"
+    ]
+  },
+  {
+    "name": "handbag",
+    "trans": [
+      "手提包, 手袋, 手提袋, 提包 (noun.)"
+    ]
+  },
+  {
+    "name": "handle",
+    "trans": [
+      "处理, 应付, 办理, 搞定 (verb.); 手柄, 句柄, 柄, 把手 (noun.)"
+    ]
+  },
+  {
+    "name": "handy",
+    "trans": [
+      "得心应手, 方便, 派上用场, 手边 (adj.)"
+    ]
+  },
+  {
+    "name": "hang",
+    "trans": [
+      "挂, 杭, 吊死, 绞死 (verb.); 坑, 航 (noun.)"
+    ]
+  },
+  {
+    "name": "happen",
+    "trans": [
+      "发生, 正好 (verb.)"
+    ]
+  },
+  {
+    "name": "happy",
+    "trans": [
+      "快乐, 高兴, 开心, 幸福 (adj.)"
+    ]
+  },
+  {
+    "name": "hard",
+    "trans": [
+      "硬, 辛苦, 艰苦, 难 (adj.); 努力 (adv.)"
+    ]
+  },
+  {
+    "name": "hardly",
+    "trans": [
+      "很难, 几乎, 难以, 很难说 (adv.)"
+    ]
+  },
+  {
+    "name": "harm",
+    "trans": [
+      "危害, 伤害, 损害, 害处 (noun.); 伤 (verb.)"
+    ]
+  },
+  {
+    "name": "hat",
+    "trans": [
+      "帽子, 顶帽子, 帽, 戴帽子 (noun.)"
+    ]
+  },
+  {
+    "name": "hate",
+    "trans": [
+      "讨厌, 恨, 憎恨, 痛恨 (verb.); 仇恨 (noun.)"
+    ]
+  },
+  {
+    "name": "have",
+    "trans": [
+      "有, 已经, 拥有, 已 (verb.)"
+    ]
+  },
+  {
+    "name": "he",
+    "trans": [
+      "他 (pron.)"
+    ]
+  },
+  {
+    "name": "head",
+    "trans": [
+      "头, 头部, 脑袋, 头顶 (noun.)"
+    ]
+  },
+  {
+    "name": "headquarters",
+    "trans": [
+      "总部, 司令部, 指挥部, 总部设 (noun.)"
+    ]
+  },
+  {
+    "name": "health",
+    "trans": [
+      "健康, 卫生, 保健, 健康状况 (noun.)"
+    ]
+  },
+  {
+    "name": "healthy",
+    "trans": [
+      "健康, 身体健康, 保健, 健全 (adj.)"
+    ]
+  },
+  {
+    "name": "hear",
+    "trans": [
+      "听到, 听见, 听, 听说 (verb.)"
+    ]
+  },
+  {
+    "name": "hearing",
+    "trans": [
+      "听力, 听证会, 听证, 聆讯 (noun.); 听到, 听, 听见, 聆听 (verb.)"
+    ]
+  },
+  {
+    "name": "heart",
+    "trans": [
+      "心, 心脏, 心里, 心中 (noun.)"
+    ]
+  },
+  {
+    "name": "heat",
+    "trans": [
+      "热, 热量, 加热, 热能 (noun.)"
+    ]
+  },
+  {
+    "name": "heater",
+    "trans": [
+      "加热器, 取暖器, 热水器, 暖炉 (noun.)"
+    ]
+  },
+  {
+    "name": "heating",
+    "trans": [
+      "加热, 供暖, 采暖, 供热 (noun.)"
+    ]
+  },
+  {
+    "name": "heaven",
+    "trans": [
+      "天堂, 天上, 天国, 上天 (noun.)"
+    ]
+  },
+  {
+    "name": "heavily",
+    "trans": [
+      "巨资, 严重, 大量, 沉重 (adv.)"
+    ]
+  },
+  {
+    "name": "heavy",
+    "trans": [
+      "重, 沉重, 重型, 稠 (adj.)"
+    ]
+  },
+  {
+    "name": "height",
+    "trans": [
+      "高度, 身高, 高程, 高 (noun.)"
+    ]
+  },
+  {
+    "name": "hell",
+    "trans": [
+      "地狱, 见鬼, 到底, 鬼 (noun.)"
+    ]
+  },
+  {
+    "name": "hello",
+    "trans": [
+      "你好, 您好, 哈罗, 喂 (noun.)"
+    ]
+  },
+  {
+    "name": "help",
+    "trans": [
+      "帮助, 帮, 帮忙, 有助于 (verb.)"
+    ]
+  },
+  {
+    "name": "helpful",
+    "trans": [
+      "乐于助人, 有用, 有益, 有助于 (adj.)"
+    ]
+  },
+  {
+    "name": "hence",
+    "trans": [
+      "因此, 于是, 遂, 因而 (adv.)"
+    ]
+  },
+  {
+    "name": "her",
+    "trans": [
+      "她 (pron.)"
+    ]
+  },
+  {
+    "name": "here",
+    "trans": [
+      "这里, 这儿, 来, 这 (adv.)"
+    ]
+  },
+  {
+    "name": "hero",
+    "trans": [
+      "英雄, 主人公, 男主角, 好汉 (noun.)"
+    ]
+  },
+  {
+    "name": "hers",
+    "trans": [
+      "她 (adj.)"
+    ]
+  },
+  {
+    "name": "herself",
+    "trans": [
+      "自己 (pron.)"
+    ]
+  },
+  {
+    "name": "hesitate",
+    "trans": [
+      "犹豫, 毫不犹豫, 犹豫不决, 迟疑 (verb.)"
+    ]
+  },
+  {
+    "name": "hi",
+    "trans": [
+      "嗨, 你好, 喜, 您好 (noun.)"
+    ]
+  },
+  {
+    "name": "hide",
+    "trans": [
+      "隐藏, 躲, 藏起来, 隐瞒 (verb.)"
+    ]
+  },
+  {
+    "name": "high",
+    "trans": [
+      "高, 较高, 偏 高, 高度 (adj.)"
+    ]
+  },
+  {
+    "name": "highlight",
+    "trans": [
+      "突出, 凸显, 强调, 彰显 (verb.); 亮点, 高亮 (noun.)"
+    ]
+  },
+  {
+    "name": "highly",
+    "trans": [
+      "高度, 高, 极, 非常 (adv.)"
+    ]
+  },
+  {
+    "name": "highway",
+    "trans": [
+      "公路, 高速公路, 道路, 高速 (noun.)"
+    ]
+  },
+  {
+    "name": "hill",
+    "trans": [
+      "山, 希尔, 山丘, 山坡 (noun.)"
+    ]
+  },
+  {
+    "name": "him",
+    "trans": [
+      "他 (pron.)"
+    ]
+  },
+  {
+    "name": "himself",
+    "trans": [
+      "自己 (pron.)"
+    ]
+  },
+  {
+    "name": "hire",
+    "trans": [
+      "雇, 雇用, 雇佣, 聘请 (verb.); 出租 (noun.)"
+    ]
+  },
+  {
+    "name": "his",
+    "trans": [
+      "他 (pron.)"
+    ]
+  },
+  {
+    "name": "historian",
+    "trans": [
+      "史学家, 史家, 史学 (noun.)"
+    ]
+  },
+  {
+    "name": "historical",
+    "trans": [
+      "历史, 历史性, 史料, 史学 (adj.)"
+    ]
+  },
+  {
+    "name": "history",
+    "trans": [
+      "历史, 史, 病史, 历史悠久 (noun.)"
+    ]
+  },
+  {
+    "name": "hit",
+    "trans": [
+      "击中, 打, 撞, 撞到 (verb.); 命中, 打击 (noun.)"
+    ]
+  },
+  {
+    "name": "hold",
+    "trans": [
+      "持有, 举行, 抱着, 抱 (verb.)"
+    ]
+  },
+  {
+    "name": "holder",
+    "trans": [
+      "霍尔德, 持有, 架, 支架 (noun.)"
+    ]
+  },
+  {
+    "name": "holding",
+    "trans": [
+      "控股, 持有, 抱着, 握着 (verb.)"
+    ]
+  },
+  {
+    "name": "hole",
+    "trans": [
+      "孔, 洞, 窟窿, 洞口 (noun.)"
+    ]
+  },
+  {
+    "name": "holiday",
+    "trans": [
+      "假日, 假期, 节日, 度假 (noun.)"
+    ]
+  },
+  {
+    "name": "holy",
+    "trans": [
+      "神圣, 圣, 圣洁, 圣地 (adj.); 圣母 (noun.)"
+    ]
+  },
+  {
+    "name": "home",
+    "trans": [
+      "回家, 家, 家里, 在家 (noun.)"
+    ]
+  },
+  {
+    "name": "homework",
+    "trans": [
+      "家庭作业, 作业, 功课 (noun.)"
+    ]
+  },
+  {
+    "name": "honest",
+    "trans": [
+      "诚实, 老实, 诚信, 老实说 (adj.)"
+    ]
+  },
+  {
+    "name": "honestly",
+    "trans": [
+      "老实说, 诚实, 老老实实, 真 (adv.)"
+    ]
+  },
+  {
+    "name": "honey",
+    "trans": [
+      "蜂蜜, 亲爱的, 蜜, 甜心 (noun.)"
+    ]
+  },
+  {
+    "name": "honour",
+    "trans": [
+      "荣誉, 荣幸, 荣耀, 光荣 (noun.); 履行, 尊敬 (verb.)"
+    ]
+  },
+  {
+    "name": "hook",
+    "trans": [
+      "钩, 钩子, 勾, 挂钩 (noun.)"
+    ]
+  },
+  {
+    "name": "hope",
+    "trans": [
+      "希望, 盼望, 期望, 但愿 (verb.)"
+    ]
+  },
+  {
+    "name": "hopefully",
+    "trans": [
+      "希望, 但愿, 满怀希望地, 有望 (adv.)"
+    ]
+  },
+  {
+    "name": "hopeless",
+    "trans": [
+      "无望, 绝望, 不可救药, 无可救药 (adj.)"
+    ]
+  },
+  {
+    "name": "horrible",
+    "trans": [
+      "可怕, 恐怖, 糟糕, 糟透 (adj.)"
+    ]
+  },
+  {
+    "name": "horror",
+    "trans": [
+      "恐怖, 恐惧, 惊恐, 惊骇 (noun.)"
+    ]
+  },
+  {
+    "name": "horse",
+    "trans": [
+      "马, 匹马, 马匹, 匹 (noun.)"
+    ]
+  },
+  {
+    "name": "hospital",
+    "trans": [
+      "医院, 院, 住院 (noun.)"
+    ]
+  },
+  {
+    "name": "host",
+    "trans": [
+      "主机, 宿主, 主持人, 主办 (noun.); 举办, 主持 (verb.)"
+    ]
+  },
+  {
+    "name": "hot",
+    "trans": [
+      "热, 炎热, 热点, 热门 (adj.)"
+    ]
+  },
+  {
+    "name": "hotel",
+    "trans": [
+      "酒店, 饭店, 旅馆, 宾馆 (noun.)"
+    ]
+  },
+  {
+    "name": "hour",
+    "trans": [
+      "小时, 时辰, 钟头, 时刻 (noun.)"
+    ]
+  },
+  {
+    "name": "house",
+    "trans": [
+      "房子, 家, 屋, 众议院 (noun.)"
+    ]
+  },
+  {
+    "name": "household",
+    "trans": [
+      "家用, 家庭, 家居, 住户 (noun.)"
+    ]
+  },
+  {
+    "name": "housing",
+    "trans": [
+      "房屋, 住房, 住宅, 屋 (noun.)"
+    ]
+  },
+  {
+    "name": "how",
+    "trans": [
+      "如何, 怎么, 怎样, 多么 (prep.)"
+    ]
+  },
+  {
+    "name": "however",
+    "trans": [
+      "然而, 不过, 但是, 但 (adv.)"
+    ]
+  },
+  {
+    "name": "huge",
+    "trans": [
+      "巨大, 庞大, 巨额, 大 (adj.)"
+    ]
+  },
+  {
+    "name": "human",
+    "trans": [
+      "人类, 人力, 人, 人体 (adj.)"
+    ]
+  },
+  {
+    "name": "hungry",
+    "trans": [
+      "饿, 饥饿, 肚子饿, 挨饿 (adj.)"
+    ]
+  },
+  {
+    "name": "hunt",
+    "trans": [
+      "狩猎, 亨特, 追捕, 猎 (noun.); 打猎, 捕猎, 猎杀 (verb.)"
+    ]
+  },
+  {
+    "name": "hurry",
+    "trans": [
+      "快点, 赶快, 赶紧, 快 (verb.); 匆忙, 着急, 急, 匆匆 (noun.)"
+    ]
+  },
+  {
+    "name": "hurt",
+    "trans": [
+      "伤害, 伤, 受伤, 疼 (verb.)"
+    ]
+  },
+  {
+    "name": "husband",
+    "trans": [
+      "丈夫, 老公, 任丈夫, 夫 (noun.)"
+    ]
+  },
+  {
+    "name": "I",
+    "trans": [
+      "我 (pron.)"
+    ]
+  },
+  {
+    "name": "ice",
+    "trans": [
+      "冰, 冰块, 冰河, 冰雪 (noun.)"
+    ]
+  },
+  {
+    "name": "ice cream",
+    "trans": [
+      "冰淇淋 (noun.)"
+    ]
+  },
+  {
+    "name": "idea",
+    "trans": [
+      "主意, 想法, 理念, 观念 (noun.)"
+    ]
+  },
+  {
+    "name": "ideal",
+    "trans": [
+      "理想, 完美 (adj.); 理念 (noun.)"
+    ]
+  },
+  {
+    "name": "ideally",
+    "trans": [
+      "理想, 理论上, 理想化 (adv.)"
+    ]
+  },
+  {
+    "name": "identify",
+    "trans": [
+      "识别, 确定, 标识, 找出 (verb.)"
+    ]
+  },
+  {
+    "name": "identity",
+    "trans": [
+      "身份, 认同, 同一性, 标识 (noun.)"
+    ]
+  },
+  {
+    "name": "idiot",
+    "trans": [
+      "白痴, 笨蛋, 傻瓜, 蠢货 (noun.)"
+    ]
+  },
+  {
+    "name": "if",
+    "trans": [
+      "如果, 要是 (prep.)"
+    ]
+  },
+  {
+    "name": "ignore",
+    "trans": [
+      "忽略, 忽视, 无视, 漠视 (verb.)"
+    ]
+  },
+  {
+    "name": "ill",
+    "trans": [
+      "生病, 病, 不适, 虐待 (adj.); 坏话 (adv.)"
+    ]
+  },
+  {
+    "name": "illegal",
+    "trans": [
+      "非法, 违法, 不法, 僭 (adj.)"
+    ]
+  },
+  {
+    "name": "illness",
+    "trans": [
+      "病情, 疾病, 病, 生病 (noun.)"
+    ]
+  },
+  {
+    "name": "illustrate",
+    "trans": [
+      "说明, 举例说明, 阐明, 演示 (verb.)"
+    ]
+  },
+  {
+    "name": "image",
+    "trans": [
+      "图像, 形象, 图象, 影像 (noun.)"
+    ]
+  },
+  {
+    "name": "imagination",
+    "trans": [
+      "想象力, 想象, 想像力, 想像 (noun.)"
+    ]
+  },
+  {
+    "name": "imagine",
+    "trans": [
+      "想象, 想像, 想象一下, 试想一下 (verb.)"
+    ]
+  },
+  {
+    "name": "immediate",
+    "trans": [
+      "立即, 即时, 直接, 即刻 (adj.)"
+    ]
+  },
+  {
+    "name": "immediately",
+    "trans": [
+      "立即, 立刻, 马上, 紧接 (adv.)"
+    ]
+  },
+  {
+    "name": "impact",
+    "trans": [
+      "影响, 冲击, 撞击, 冲击力 (noun.)"
+    ]
+  },
+  {
+    "name": "implement",
+    "trans": [
+      "实施, 实现, 落实, 贯彻 (verb.)"
+    ]
+  },
+  {
+    "name": "implication",
+    "trans": [
+      "意蕴, 蕴涵, 含义, 涵义 (noun.)"
+    ]
+  },
+  {
+    "name": "imply",
+    "trans": [
+      "暗示, 意味着, 隐含, 意味著 (verb.); 意味 (noun.)"
+    ]
+  },
+  {
+    "name": "import",
+    "trans": [
+      "进口, 导入, 进口货, 汇入 (noun.)"
+    ]
+  },
+  {
+    "name": "importance",
+    "trans": [
+      "重要性, 重要, 重视, 意义 (noun.)"
+    ]
+  },
+  {
+    "name": "important",
+    "trans": [
+      "重要, 重大, 重要性, 主要 (adj.)"
+    ]
+  },
+  {
+    "name": "impose",
+    "trans": [
+      "施加, 强加, 征收, 处以 (verb.)"
+    ]
+  },
+  {
+    "name": "impossible",
+    "trans": [
+      "不可能, 无法 (adj.)"
+    ]
+  },
+  {
+    "name": "impress",
+    "trans": [
+      "打动, 留下深刻印象, 讨好, 印象深刻 (verb.)"
+    ]
+  },
+  {
+    "name": "impression",
+    "trans": [
+      "印象 (noun.)"
+    ]
+  },
+  {
+    "name": "impressive",
+    "trans": [
+      "令人印象深刻, 印象深刻, 骄人, 可观 (adj.)"
+    ]
+  },
+  {
+    "name": "improve",
+    "trans": [
+      "提高, 改善, 改进, 完善 (verb.)"
+    ]
+  },
+  {
+    "name": "improvement",
+    "trans": [
+      "改进, 改善, 改良, 提高 (noun.)"
+    ]
+  },
+  {
+    "name": "in",
+    "trans": [
+      "在, 中 (prep.)"
+    ]
+  },
+  {
+    "name": "inch",
+    "trans": [
+      "英寸, 寸, 英制, 吋 (noun.)"
+    ]
+  },
+  {
+    "name": "incident",
+    "trans": [
+      "事件, 入射, 事变, 事故 (noun.)"
+    ]
+  },
+  {
+    "name": "include",
+    "trans": [
+      "包括, 包含 (verb.)"
+    ]
+  },
+  {
+    "name": "including",
+    "trans": [
+      "包括, 其中, 含, 包含 (verb.)"
+    ]
+  },
+  {
+    "name": "income",
+    "trans": [
+      "收入, 收益, 入息, 所得 (noun.)"
+    ]
+  },
+  {
+    "name": "incorporate",
+    "trans": [
+      "纳入, 合并, 融入, 将 (verb.); 一体化 (noun.)"
+    ]
+  },
+  {
+    "name": "increase",
+    "trans": [
+      "增加, 提高, 加大, 增强 (verb.); 增长, 增大, 增幅, 增 (noun.)"
+    ]
+  },
+  {
+    "name": "increasingly",
+    "trans": [
+      "日益, 越来越, 日趋, 愈加 (adv.)"
+    ]
+  },
+  {
+    "name": "incredible",
+    "trans": [
+      "令人难以置信, 难以置信, 不可思议, 惊人 (adj.)"
+    ]
+  },
+  {
+    "name": "incredibly",
+    "trans": [
+      "令人难以置信, 居然, 难以置信, 不可思议 (adv.)"
+    ]
+  },
+  {
+    "name": "indeed",
+    "trans": [
+      "事实上, 的确, 确实, 实际上 (adv.)"
+    ]
+  },
+  {
+    "name": "independence",
+    "trans": [
+      "独立性, 独立, 独立自主, 自主 (noun.)"
+    ]
+  },
+  {
+    "name": "independent",
+    "trans": [
+      "独立, 自主, 无关, 独立自主 (adj.)"
+    ]
+  },
+  {
+    "name": "index",
+    "trans": [
+      "指数, 指标, 索引 (noun.)"
+    ]
+  },
+  {
+    "name": "indicate",
+    "trans": [
+      "表明, 指示, 注明, 显示 (verb.)"
+    ]
+  },
+  {
+    "name": "indication",
+    "trans": [
+      "适应证, 指示, 迹象, 适应症 (noun.)"
+    ]
+  },
+  {
+    "name": "individual",
+    "trans": [
+      "个人, 个体, 个别, 单个 (adj.)"
+    ]
+  },
+  {
+    "name": "industrial",
+    "trans": [
+      "工业, 产业, 工控, 工业化 (adj.); 实业 (noun.)"
+    ]
+  },
+  {
+    "name": "industry",
+    "trans": [
+      "行业, 产业, 工业, 业 (noun.)"
+    ]
+  },
+  {
+    "name": "inevitable",
+    "trans": [
+      "不可避免, 必然, 在所难免, 难免 (adj.)"
+    ]
+  },
+  {
+    "name": "inevitably",
+    "trans": [
+      "不可避免地, 不可避免, 必然, 难免 (adv.)"
+    ]
+  },
+  {
+    "name": "infant",
+    "trans": [
+      "婴儿, 婴幼儿, 幼儿, 婴 (noun.)"
+    ]
+  },
+  {
+    "name": "infection",
+    "trans": [
+      "感染, 传染, 侵染, 感染者 (noun.)"
+    ]
+  },
+  {
+    "name": "inflation",
+    "trans": [
+      "通胀, 通货膨胀, 通胀率, 通货膨胀率 (noun.)"
+    ]
+  },
+  {
+    "name": "influence",
+    "trans": [
+      "影响, 影响力 (noun.)"
+    ]
+  },
+  {
+    "name": "inform",
+    "trans": [
+      "可否告知, 通知, 告知 (verb.)"
+    ]
+  },
+  {
+    "name": "informal",
+    "trans": [
+      "非正式, 非正规, 不拘, 正规 (adj.)"
+    ]
+  },
+  {
+    "name": "information",
+    "trans": [
+      "信息, 资料, 资讯, 信息化 (noun.)"
+    ]
+  },
+  {
+    "name": "initial",
+    "trans": [
+      "初始, 最初, 初步, 初期 (adj.)"
+    ]
+  },
+  {
+    "name": "initially",
+    "trans": [
+      "最初, 起初, 初步, 初期 (adv.)"
+    ]
+  },
+  {
+    "name": "initiative",
+    "trans": [
+      "倡议, 主动性, 主动, 主动权 (noun.)"
+    ]
+  },
+  {
+    "name": "injure",
+    "trans": [
+      "伤害, 中伤, 弄伤 (verb.); 虐 (noun.)"
+    ]
+  },
+  {
+    "name": "injury",
+    "trans": [
+      "损伤, 伤, 伤害, 受伤 (noun.)"
+    ]
+  },
+  {
+    "name": "inner",
+    "trans": [
+      "内在, 内心, 内部, 内 (adj.)"
+    ]
+  },
+  {
+    "name": "innocent",
+    "trans": [
+      "无辜, 清白, 天真, 无罪 (adj.)"
+    ]
+  },
+  {
+    "name": "innovation",
+    "trans": [
+      "创新, 革新, 改革, 变革 (noun.)"
+    ]
+  },
+  {
+    "name": "input",
+    "trans": [
+      "输入, 投入, 录入 (noun.)"
+    ]
+  },
+  {
+    "name": "inquiry",
+    "trans": [
+      "询价, 研讯, 查询, 探究 (noun.)"
+    ]
+  },
+  {
+    "name": "insect",
+    "trans": [
+      "昆虫, 虫, 虫子, 害虫 (noun.)"
+    ]
+  },
+  {
+    "name": "inside",
+    "trans": [
+      "里面, 内心, 进去, 内在 (adv.); 内, 内部, 里, 体内 (prep.)"
+    ]
+  },
+  {
+    "name": "insist",
+    "trans": [
+      "坚持, 坚称, 强求, 对峙 (verb.)"
+    ]
+  },
+  {
+    "name": "inspection",
+    "trans": [
+      "检验, 检查, 检测, 查阅 (noun.)"
+    ]
+  },
+  {
+    "name": "inspector",
+    "trans": [
+      "督察, 探长, 巡官, 督学 (noun.)"
+    ]
+  },
+  {
+    "name": "install",
+    "trans": [
+      "安装, 装, 装设 (verb.)"
+    ]
+  },
+  {
+    "name": "instance",
+    "trans": [
+      "实例, 举例来说, 审, 例子 (noun.)"
+    ]
+  },
+  {
+    "name": "instant",
+    "trans": [
+      "即时, 速溶, 瞬时, 即刻 (adj.); 瞬间, 一瞬间 (noun.)"
+    ]
+  },
+  {
+    "name": "instead",
+    "trans": [
+      "相反, 代替, 反而, 取而代之 (adv.)"
+    ]
+  },
+  {
+    "name": "institute",
+    "trans": [
+      "研究所, 学院, 研究院, 学会 (noun.)"
+    ]
+  },
+  {
+    "name": "institution",
+    "trans": [
+      "机构, 制度, 事业单位, 机关 (noun.)"
+    ]
+  },
+  {
+    "name": "instruction",
+    "trans": [
+      "指令, 教学, 指导, 指示 (noun.)"
+    ]
+  },
+  {
+    "name": "instrument",
+    "trans": [
+      "仪器, 仪表, 仪, 乐器 (noun.)"
+    ]
+  },
+  {
+    "name": "insurance",
+    "trans": [
+      "保险, 保险业, 保险费, 险 (noun.)"
+    ]
+  },
+  {
+    "name": "intellectual",
+    "trans": [
+      "智力, 知识分子, 智能, 知识 (adj.)"
+    ]
+  },
+  {
+    "name": "intelligence",
+    "trans": [
+      "情报, 智力, 智能, 智慧 (noun.)"
+    ]
+  },
+  {
+    "name": "intelligent",
+    "trans": [
+      "智能, 智能化, 聪明, 智慧 (adj.)"
+    ]
+  },
+  {
+    "name": "intend",
+    "trans": [
+      "意愿, 打算, 拟, 有意 (verb.)"
+    ]
+  },
+  {
+    "name": "intense",
+    "trans": [
+      "激烈, 强烈, 紧张, 剧烈 (adj.)"
+    ]
+  },
+  {
+    "name": "intention",
+    "trans": [
+      "意图, 意向, 用意, 打算 (noun.)"
+    ]
+  },
+  {
+    "name": "interaction",
+    "trans": [
+      "互动, 相互作用, 交互, 交互作用 (noun.)"
+    ]
+  },
+  {
+    "name": "interest",
+    "trans": [
+      "兴趣, 利益, 利息, 感兴趣 (noun.)"
+    ]
+  },
+  {
+    "name": "interested",
+    "trans": [
+      "感兴趣, 兴趣, 有意, 关心 (adj.)"
+    ]
+  },
+  {
+    "name": "interesting",
+    "trans": [
+      "有趣, 有意思, 感兴趣, 趣味 (adj.)"
+    ]
+  },
+  {
+    "name": "internal",
+    "trans": [
+      "内部, 内, 内在, 对内 (adj.)"
+    ]
+  },
+  {
+    "name": "international",
+    "trans": [
+      "国际, 国际性, 国际化 (adj.)"
+    ]
+  },
+  {
+    "name": "internet",
+    "trans": [
+      "互联网, 因特网, 网络, 网上 (noun.)"
+    ]
+  },
+  {
+    "name": "interpret",
+    "trans": [
+      "解释, 解读, 诠释, 口译 (verb.)"
+    ]
+  },
+  {
+    "name": "interpretation",
+    "trans": [
+      "解释, 释义, 诠释, 解读 (noun.)"
+    ]
+  },
+  {
+    "name": "interval",
+    "trans": [
+      "区间, 间隔, 时间间隔, 间距 (noun.); 间歇 (adj.)"
+    ]
+  },
+  {
+    "name": "intervention",
+    "trans": [
+      "干预, 介入, 干涉, 干预措施 (noun.)"
+    ]
+  },
+  {
+    "name": "interview",
+    "trans": [
+      "面试, 采访, 访谈, 面谈 (noun.)"
+    ]
+  },
+  {
+    "name": "into",
+    "trans": [
+      "成, 进, 入, 进入 (prep.)"
+    ]
+  },
+  {
+    "name": "introduce",
+    "trans": [
+      "介绍, 引入, 引进, 推出 (verb.)"
+    ]
+  },
+  {
+    "name": "introduction",
+    "trans": [
+      "介绍, 引进, 引入, 引种 (noun.)"
+    ]
+  },
+  {
+    "name": "invest",
+    "trans": [
+      "投资, 投入 (verb.)"
+    ]
+  },
+  {
+    "name": "investigate",
+    "trans": [
+      "探讨, 调查, 观察, 考察 (verb.)"
+    ]
+  },
+  {
+    "name": "investigation",
+    "trans": [
+      "调查, 侦查, 调查研究, 研究 (noun.)"
+    ]
+  },
+  {
+    "name": "investment",
+    "trans": [
+      "投资, 投入, 招商, 投资额 (noun.)"
+    ]
+  },
+  {
+    "name": "invite",
+    "trans": [
+      "邀请, 请, 诚邀, 邀 (verb.)"
+    ]
+  },
+  {
+    "name": "involve",
+    "trans": [
+      "涉及, 涉及到, 牵涉, 包括 (verb.)"
+    ]
+  },
+  {
+    "name": "involved",
+    "trans": [
+      "涉及, 参与, 涉及到, 牵涉 (verb.)"
+    ]
+  },
+  {
+    "name": "involvement",
+    "trans": [
+      "参与, 介入, 受累, 涉入 (noun.)"
+    ]
+  },
+  {
+    "name": "iron",
+    "trans": [
+      "铁, 铁矿, 铁质, 熨斗 (noun.)"
+    ]
+  },
+  {
+    "name": "island",
+    "trans": [
+      "岛, 岛屿, 海岛, 岛国 (noun.)"
+    ]
+  },
+  {
+    "name": "issue",
+    "trans": [
+      "问题, 发行, 议题, 课题 (noun.); 发出, 发布 (verb.)"
+    ]
+  },
+  {
+    "name": "it",
+    "trans": [
+      "它, 这 (pron.)"
+    ]
+  },
+  {
+    "name": "item",
+    "trans": [
+      "项目, 项, 条目, 物品 (noun.)"
+    ]
+  },
+  {
+    "name": "its",
+    "trans": [
+      "其, 它 (pron.)"
+    ]
+  },
+  {
+    "name": "itself",
+    "trans": [
+      "本身, 自身 (pron.)"
+    ]
+  },
+  {
+    "name": "jacket",
+    "trans": [
+      "夹克, 外套, 件夹克, 夹克衫 (noun.)"
+    ]
+  },
+  {
+    "name": "jam",
+    "trans": [
+      "果酱, 堵塞, 拥堵, 酱 (noun.); 干扰 (verb.)"
+    ]
+  },
+  {
+    "name": "job",
+    "trans": [
+      "工作, 作业, 职位, 就业 (noun.)"
+    ]
+  },
+  {
+    "name": "join",
+    "trans": [
+      "加入, 加盟, 参加, 连接 (verb.); 联接 (noun.)"
+    ]
+  },
+  {
+    "name": "joint",
+    "trans": [
+      "联合, 关节, 共同, 接缝 (adj.); 接头, 缝, 节点, 节 (noun.)"
+    ]
+  },
+  {
+    "name": "joke",
+    "trans": [
+      "笑话, 玩笑, 开玩笑, 笑料 (noun.)"
+    ]
+  },
+  {
+    "name": "journalist",
+    "trans": [
+      "记者, 新闻记者, 新闻工作者 (noun.)"
+    ]
+  },
+  {
+    "name": "journey",
+    "trans": [
+      "旅程, 旅途, 旅行, 之旅 (noun.)"
+    ]
+  },
+  {
+    "name": "joy",
+    "trans": [
+      "喜悦, 欢乐, 快乐, 喜乐 (noun.)"
+    ]
+  },
+  {
+    "name": "judge",
+    "trans": [
+      "法官, 评委, 裁判, 大法官 (noun.); 判断, 评判, 审判, 判定 (verb.)"
+    ]
+  },
+  {
+    "name": "judgment",
+    "trans": [
+      "判断, 判断力, 判决, 审判 (noun.)"
+    ]
+  },
+  {
+    "name": "juice",
+    "trans": [
+      "汁, 果汁, 汁液, 汁饮料 (noun.)"
+    ]
+  },
+  {
+    "name": "jump",
+    "trans": [
+      "跳, 跳转, 跳下去, 跳出 (verb.); 跳跃, 跃, 跳伞, 跃迁 (noun.)"
+    ]
+  },
+  {
+    "name": "jumper",
+    "trans": [
+      "跳线, 跳投, 飞船, 套头衫 (noun.)"
+    ]
+  },
+  {
+    "name": "junior",
+    "trans": [
+      "初级, 初中, 大三, 低年级 (noun.); 低级 (adj.)"
+    ]
+  },
+  {
+    "name": "jury",
+    "trans": [
+      "陪审团, 陪审, 评审团, 评委会 (noun.)"
+    ]
+  },
+  {
+    "name": "just",
+    "trans": [
+      "只是, 刚, 刚刚, 只 (adv.)"
+    ]
+  },
+  {
+    "name": "justice",
+    "trans": [
+      "正义, 公正, 司法, 大法官 (noun.)"
+    ]
+  },
+  {
+    "name": "justify",
+    "trans": [
+      "证明, 辩解, 理由, 辩护 (verb.)"
+    ]
+  },
+  {
+    "name": "keen",
+    "trans": [
+      "敏锐, 热衷于, 热衷, 浓厚 (adj.)"
+    ]
+  },
+  {
+    "name": "keep",
+    "trans": [
+      "保持, 继续, 保留, 一直 (verb.)"
+    ]
+  },
+  {
+    "name": "kettle",
+    "trans": [
+      "水壶, 釜, 壶, 烧水 (noun.)"
+    ]
+  },
+  {
+    "name": "key",
+    "trans": [
+      "关键, 密钥, 重点, 关键性 (adj.); 钥匙, 键, 关键所在 (noun.)"
+    ]
+  },
+  {
+    "name": "keyboard",
+    "trans": [
+      "键盘 (noun.)"
+    ]
+  },
+  {
+    "name": "kick",
+    "trans": [
+      "踢, 踹, 揍 (verb.); 踢腿, 任意球, 踢球, 脚 (noun.)"
+    ]
+  },
+  {
+    "name": "kid",
+    "trans": [
+      "孩子, 小孩, 小子, 小鬼 (noun.)"
+    ]
+  },
+  {
+    "name": "kill",
+    "trans": [
+      "杀, 杀死, 杀掉, 杀人 (verb.)"
+    ]
+  },
+  {
+    "name": "kilometre",
+    "trans": [
+      "公里, 千米 (noun.)"
+    ]
+  },
+  {
+    "name": "kind",
+    "trans": [
+      "善良, 那种, 类, 一种 (noun.)"
+    ]
+  },
+  {
+    "name": "king",
+    "trans": [
+      "国王, 王, 大王, 王者 (noun.)"
+    ]
+  },
+  {
+    "name": "kiss",
+    "trans": [
+      "吻, 飞吻 (noun.); 亲吻, 亲, 接吻, 亲亲 (verb.)"
+    ]
+  },
+  {
+    "name": "kit",
+    "trans": [
+      "试剂盒, 套件, 工具箱, 包 (noun.)"
+    ]
+  },
+  {
+    "name": "kitchen",
+    "trans": [
+      "厨房, 厨, 厨卫, 厨具 (noun.)"
+    ]
+  },
+  {
+    "name": "knee",
+    "trans": [
+      "膝盖, 膝, 膝关节, 膝部 (noun.)"
+    ]
+  },
+  {
+    "name": "knife",
+    "trans": [
+      "刀, 刀子, 小刀, 匕首 (noun.)"
+    ]
+  },
+  {
+    "name": "knock",
+    "trans": [
+      "敲, 敲门, 击倒, 撞 (verb.); 敲门声, 爆震, 敲打 (noun.)"
+    ]
+  },
+  {
+    "name": "know",
+    "trans": [
+      "知道, 认识, 了解, 知 (verb.)"
+    ]
+  },
+  {
+    "name": "knowledge",
+    "trans": [
+      "知识, 认识, 学问, 了解 (noun.)"
+    ]
+  },
+  {
+    "name": "known",
+    "trans": [
+      "已知, 众所周知, 知道, 著名 (verb.)"
+    ]
+  },
+  {
+    "name": "lab",
+    "trans": [
+      "实验室, 劳顾会, 实验, 室 (noun.)"
+    ]
+  },
+  {
+    "name": "label",
+    "trans": [
+      "标签, 标号, 吊牌, 标注 (noun.)"
+    ]
+  },
+  {
+    "name": "laboratory",
+    "trans": [
+      "实验室, 实验, 化验, 化验室 (noun.)"
+    ]
+  },
+  {
+    "name": "labour",
+    "trans": [
+      "劳工, 劳动力, 劳动, 工党 (noun.)"
+    ]
+  },
+  {
+    "name": "lack",
+    "trans": [
+      "缺乏, 缺少, 缺失, 不足 (noun.)"
+    ]
+  },
+  {
+    "name": "lad",
+    "trans": [
+      "小伙子, 童子, 小伙, 小子 (noun.)"
+    ]
+  },
+  {
+    "name": "ladder",
+    "trans": [
+      "梯子, 阶梯, 梯, 架梯子 (noun.)"
+    ]
+  },
+  {
+    "name": "lady",
+    "trans": [
+      "女士, 夫人, 淑女, 女人 (noun.)"
+    ]
+  },
+  {
+    "name": "lake",
+    "trans": [
+      "湖, 湖泊, 湖边, 湖里 (noun.)"
+    ]
+  },
+  {
+    "name": "lamb",
+    "trans": [
+      "羔羊, 羊肉, 羊羔, 羔羊肉 (noun.)"
+    ]
+  },
+  {
+    "name": "lamp",
+    "trans": [
+      "灯, 盏灯, 台灯, 灯具 (noun.)"
+    ]
+  },
+  {
+    "name": "land",
+    "trans": [
+      "土地, 陆地, 陆, 地 (noun.); 降落, 着陆 (verb.)"
+    ]
+  },
+  {
+    "name": "landlord",
+    "trans": [
+      "房东, 地主, 业主, 楼主 (noun.)"
+    ]
+  },
+  {
+    "name": "landscape",
+    "trans": [
+      "景观, 风景, 山水, 园林 (noun.)"
+    ]
+  },
+  {
+    "name": "lane",
+    "trans": [
+      "车道, 巷, 行车线, 小巷 (noun.)"
+    ]
+  },
+  {
+    "name": "language",
+    "trans": [
+      "语言, 语, 语文, 言语 (noun.)"
+    ]
+  },
+  {
+    "name": "large",
+    "trans": [
+      "大型, 大, 庞大, 较大 (adj.)"
+    ]
+  },
+  {
+    "name": "largely",
+    "trans": [
+      "大程度上, 基本上, 主要, 大部分 (adv.)"
+    ]
+  },
+  {
+    "name": "last",
+    "trans": [
+      "最后, 上次, 去年, 上个 (adj.); 持续 (verb.)"
+    ]
+  },
+  {
+    "name": "late",
+    "trans": [
+      "晚, 迟, 后期, 已故 (adj.); 迟到 (adv.)"
+    ]
+  },
+  {
+    "name": "later",
+    "trans": [
+      "后来, 稍后, 以后, 后 (adv.)"
+    ]
+  },
+  {
+    "name": "latter",
+    "trans": [
+      "后者, 后期, 后面 (adj.)"
+    ]
+  },
+  {
+    "name": "laugh",
+    "trans": [
+      "笑, 发笑, 大笑, 开怀大笑 (noun.)"
+    ]
+  },
+  {
+    "name": "launch",
+    "trans": [
+      "发射, 发布 (noun.); 推出, 启动, 发动, 发起 (verb.)"
+    ]
+  },
+  {
+    "name": "law",
+    "trans": [
+      "法律, 法, 规律, 法学 (noun.)"
+    ]
+  },
+  {
+    "name": "lawyer",
+    "trans": [
+      "律师 (noun.)"
+    ]
+  },
+  {
+    "name": "lay",
+    "trans": [
+      "奠定, 躺, 打下, 铺设 (verb.)"
+    ]
+  },
+  {
+    "name": "layer",
+    "trans": [
+      "层, 图层, 蛋鸡, 分层 (noun.)"
+    ]
+  },
+  {
+    "name": "lazy",
+    "trans": [
+      "懒, 懒惰, 懒散, 偷懒 (adj.)"
+    ]
+  },
+  {
+    "name": "lead",
+    "trans": [
+      "铅, 领先 (noun.); 导致, 带领, 领导, 引领 (verb.)"
+    ]
+  },
+  {
+    "name": "leader",
+    "trans": [
+      "领袖, 领导者, 领导人, 领导 (noun.)"
+    ]
+  },
+  {
+    "name": "leadership",
+    "trans": [
+      "领导, 领导力, 领导地位, 领导班子 (noun.)"
+    ]
+  },
+  {
+    "name": "leading",
+    "trans": [
+      "领先, 主导, 领导, 龙头 (verb.)"
+    ]
+  },
+  {
+    "name": "leaf",
+    "trans": [
+      "叶, 叶片, 叶子, 树叶 (noun.)"
+    ]
+  },
+  {
+    "name": "league",
+    "trans": [
+      "联赛, 联盟, 盟, 联赛冠军 (noun.)"
+    ]
+  },
+  {
+    "name": "lean",
+    "trans": [
+      "精益, 瘦, 贫, 瘦肉 (adj.); 靠 (verb.)"
+    ]
+  },
+  {
+    "name": "learn",
+    "trans": [
+      "学习, 学, 学会, 了解 (verb.)"
+    ]
+  },
+  {
+    "name": "least",
+    "trans": [
+      "最小, 最少, 至少, 最 (adj.)"
+    ]
+  },
+  {
+    "name": "leather",
+    "trans": [
+      "皮革, 革, 皮, 皮具 (noun.)"
+    ]
+  },
+  {
+    "name": "leave",
+    "trans": [
+      "离开, 留下, 走, 留 (verb.)"
+    ]
+  },
+  {
+    "name": "lecture",
+    "trans": [
+      "讲座, 演讲, 讲课, 讲演 (noun.); 课堂 (adj.); 教训 (verb.)"
+    ]
+  },
+  {
+    "name": "left",
+    "trans": [
+      "左 (adj.); 离开, 留下, 剩下, 留 (verb.); 左边, 左侧 (noun.)"
+    ]
+  },
+  {
+    "name": "leg",
+    "trans": [
+      "腿, 条腿, 腿部, 小腿 (noun.)"
+    ]
+  },
+  {
+    "name": "legal",
+    "trans": [
+      "法律, 合法, 法定, 法制 (adj.)"
+    ]
+  },
+  {
+    "name": "legislation",
+    "trans": [
+      "立法, 法例, 法案, 法规 (noun.)"
+    ]
+  },
+  {
+    "name": "leisure",
+    "trans": [
+      "休闲, 康乐, 闲暇, 休閒 (noun.)"
+    ]
+  },
+  {
+    "name": "lend",
+    "trans": [
+      "借给, 借, 放贷, 出借 (verb.)"
+    ]
+  },
+  {
+    "name": "length",
+    "trans": [
+      "长度, 长, 长短, 篇幅 (noun.)"
+    ]
+  },
+  {
+    "name": "less",
+    "trans": [
+      "少, 较少, 减少, 较小 (adj.); 那么, 降低 (adv.)"
+    ]
+  },
+  {
+    "name": "lesson",
+    "trans": [
+      "教训, 课, 节课, 堂课 (noun.)"
+    ]
+  },
+  {
+    "name": "let",
+    "trans": [
+      "让, 就让, 我们, 放 (verb.)"
+    ]
+  },
+  {
+    "name": "letter",
+    "trans": [
+      "封信, 信, 字母, 来信 (noun.)"
+    ]
+  },
+  {
+    "name": "level",
+    "trans": [
+      "水平, 级别, 级, 层面 (noun.)"
+    ]
+  },
+  {
+    "name": "liberal",
+    "trans": [
+      "自由, 自由主义者 (noun.); 自由主义, 开明, 宽松, 开放 (adj.)"
+    ]
+  },
+  {
+    "name": "library",
+    "trans": [
+      "图书馆, 库, 文库, 图书 (noun.)"
+    ]
+  },
+  {
+    "name": "licence",
+    "trans": [
+      "牌照, 执照, 许可证, 特许 (noun.)"
+    ]
+  },
+  {
+    "name": "lick",
+    "trans": [
+      "舔, 舔舔, 添 (verb.); 舐 (noun.)"
+    ]
+  },
+  {
+    "name": "lid",
+    "trans": [
+      "盖子, 盖, 锅盖, 眼睑 (noun.)"
+    ]
+  },
+  {
+    "name": "lie",
+    "trans": [
+      "谎言, 谎, 谎话 (noun.); 撒谎, 说谎, 躺, 骗 (verb.)"
+    ]
+  },
+  {
+    "name": "life",
+    "trans": [
+      "生活, 生命, 人生, 一生 (noun.)"
+    ]
+  },
+  {
+    "name": "lift",
+    "trans": [
+      "电梯, 升降机, 升力, 举 (noun.); 解除, 举起, 抬起, 抬 (verb.)"
+    ]
+  },
+  {
+    "name": "light",
+    "trans": [
+      "光, 光线, 灯, 光明 (noun.); 轻, 轻型, 淡, 浅 (adj.)"
+    ]
+  },
+  {
+    "name": "lighting",
+    "trans": [
+      "照明, 灯饰, 灯光, 采光 (noun.); 点燃 (verb.)"
+    ]
+  },
+  {
+    "name": "like",
+    "trans": [
+      "像, 象, 如, 一样 (prep.); 喜欢 (verb.)"
+    ]
+  },
+  {
+    "name": "likely",
+    "trans": [
+      "可能, 可能性, 容易, 倾向 (adj.)"
+    ]
+  },
+  {
+    "name": "limit",
+    "trans": [
+      "限制, 极限, 限, 限度 (noun.)"
+    ]
+  },
+  {
+    "name": "limitation",
+    "trans": [
+      "局限性, 限制, 局限, 限度 (noun.)"
+    ]
+  },
+  {
+    "name": "limited",
+    "trans": [
+      "有限, 限量, 限, 受限 (adj.); 有限公司 (noun.); 限制, 局限, 局限于, 限于 (verb.)"
+    ]
+  },
+  {
+    "name": "line",
+    "trans": [
+      "线, 行, 线路, 一行 (noun.)"
+    ]
+  },
+  {
+    "name": "link",
+    "trans": [
+      "链接, 环节, 链路, 连结 (noun.)"
+    ]
+  },
+  {
+    "name": "lip",
+    "trans": [
+      "唇, 嘴唇, 李普, 唇形 (noun.)"
+    ]
+  },
+  {
+    "name": "liquid",
+    "trans": [
+      "液体, 液, 液态, 流体 (noun.); 流动性 (adj.)"
+    ]
+  },
+  {
+    "name": "list",
+    "trans": [
+      "列表, 名单, 清单, 列出 (noun.)"
+    ]
+  },
+  {
+    "name": "listen",
+    "trans": [
+      "听, 听取, 倾听, 听录音 (verb.)"
+    ]
+  },
+  {
+    "name": "literally",
+    "trans": [
+      "从字面上, 字面上, 字面意思, 字面 (adv.)"
+    ]
+  },
+  {
+    "name": "literary",
+    "trans": [
+      "文学, 文艺, 文坛, 文 (adj.)"
+    ]
+  },
+  {
+    "name": "literature",
+    "trans": [
+      "文学, 文献, 文学作品, 文学史 (noun.)"
+    ]
+  },
+  {
+    "name": "little",
+    "trans": [
+      "小, 小小, 少, 很少 (adj.)"
+    ]
+  },
+  {
+    "name": "live",
+    "trans": [
+      "住, 活, 生活, 居住 (verb.); 直播, 现场, 实时 (adj.)"
+    ]
+  },
+  {
+    "name": "lively",
+    "trans": [
+      "活泼, 生动, 热闹, 生动活泼 (adj.)"
+    ]
+  },
+  {
+    "name": "living",
+    "trans": [
+      "生活, 住, 居住, 活 (verb.); 生存 (noun.)"
+    ]
+  },
+  {
+    "name": "load",
+    "trans": [
+      "负荷, 负载, 荷载, 载荷 (noun.); 载入, 装 (verb.)"
+    ]
+  },
+  {
+    "name": "loan",
+    "trans": [
+      "贷款, 贷, 借款, 借 (noun.); 借给 (verb.)"
+    ]
+  },
+  {
+    "name": "local",
+    "trans": [
+      "当地, 本地, 局部, 地方 (adj.)"
+    ]
+  },
+  {
+    "name": "locate",
+    "trans": [
+      "定位, 找到, 查找, 找出 (verb.)"
+    ]
+  },
+  {
+    "name": "location",
+    "trans": [
+      "位置, 定位, 地点, 选址 (noun.)"
+    ]
+  },
+  {
+    "name": "lock",
+    "trans": [
+      "锁, 门锁, 船闸, 锁紧 (noun.); 锁定, 锁上, 锁门, 上锁 (verb.)"
+    ]
+  },
+  {
+    "name": "log",
+    "trans": [
+      "日志, 测井, 原木, 对数 (noun.); 登录, 记录, 登陆, 登 (verb.)"
+    ]
+  },
+  {
+    "name": "logical",
+    "trans": [
+      "逻辑, 合乎逻辑, 逻辑性, 合理 (adj.)"
+    ]
+  },
+  {
+    "name": "lonely",
+    "trans": [
+      "孤独, 寂寞, 孤单, 孤寂 (adj.)"
+    ]
+  },
+  {
+    "name": "long",
+    "trans": [
+      "长, 长期, 漫长, 长一段 (adj.); 久, 长久, 多久 (adv.)"
+    ]
+  },
+  {
+    "name": "long-term",
+    "trans": [
+      "长期, 远期 (adj.)"
+    ]
+  },
+  {
+    "name": "look",
+    "trans": [
+      "看起来, 看, 看上去, 听 (verb.); 外观, 样子 (noun.)"
+    ]
+  },
+  {
+    "name": "loose",
+    "trans": [
+      "松散, 宽松, 松动, 松 (adj.)"
+    ]
+  },
+  {
+    "name": "lord",
+    "trans": [
+      "主, 耶和华, 勋爵, 上帝 (noun.)"
+    ]
+  },
+  {
+    "name": "lorry",
+    "trans": [
+      "罗瑞, 货车, 卡车, 劳里 (noun.)"
+    ]
+  },
+  {
+    "name": "lose",
+    "trans": [
+      "失去, 输, 输掉, 丧失 (verb.)"
+    ]
+  },
+  {
+    "name": "loss",
+    "trans": [
+      "损失, 损耗, 丧失, 流失 (noun.)"
+    ]
+  },
+  {
+    "name": "lost",
+    "trans": [
+      "失去, 丢失, 迷失, 迷路 (verb.)"
+    ]
+  },
+  {
+    "name": "lot",
+    "trans": [
+      "很多, 许多, 不少, 大量 (noun.)"
+    ]
+  },
+  {
+    "name": "loud",
+    "trans": [
+      "响亮, 大声, 吵, 高声 (adj.)"
+    ]
+  },
+  {
+    "name": "lounge",
+    "trans": [
+      "休息室, 酒廊, 休息厅, 候机室 (noun.)"
+    ]
+  },
+  {
+    "name": "love",
+    "trans": [
+      "爱, 爱情, 恋爱, 爱心 (noun.); 喜欢, 热爱, 爱上, 喜爱 (verb.)"
+    ]
+  },
+  {
+    "name": "lovely",
+    "trans": [
+      "可爱, 漂亮, 美丽, 美好 (adj.)"
+    ]
+  },
+  {
+    "name": "lover",
+    "trans": [
+      "情人, 爱人, 恋人, 爱好者 (noun.)"
+    ]
+  },
+  {
+    "name": "low",
+    "trans": [
+      "低, 较低, 低廉, 低位 (adj.)"
+    ]
+  },
+  {
+    "name": "lower",
+    "trans": [
+      "较低, 降低, 低, 下部 (adj.); 放下 (verb.)"
+    ]
+  },
+  {
+    "name": "luck",
+    "trans": [
+      "运气, 好运, 幸运, 走运 (noun.)"
+    ]
+  },
+  {
+    "name": "luckily",
+    "trans": [
+      "幸好, 幸运, 幸亏, 幸 (adv.)"
+    ]
+  },
+  {
+    "name": "lucky",
+    "trans": [
+      "幸运, 走运, 幸运儿, 庆幸 (adj.)"
+    ]
+  },
+  {
+    "name": "lump",
+    "trans": [
+      "肿块, 疙瘩, 坨, 一次性 (noun.)"
+    ]
+  },
+  {
+    "name": "lunch",
+    "trans": [
+      "午餐, 午饭, 中饭, 共进午餐 (noun.)"
+    ]
+  },
+  {
+    "name": "lunchtime",
+    "trans": [
+      "午餐, 午饭, 午间, 中午 (noun.)"
+    ]
+  },
+  {
+    "name": "machine",
+    "trans": [
+      "机, 机器, 台机器, 机械 (noun.)"
+    ]
+  },
+  {
+    "name": "machinery",
+    "trans": [
+      "机械, 机器, 机 (noun.)"
+    ]
+  },
+  {
+    "name": "mad",
+    "trans": [
+      "疯, 疯狂, 生气, 发疯 (adj.)"
+    ]
+  },
+  {
+    "name": "madam",
+    "trans": [
+      "夫人, 女士, 主席, 太太 (noun.)"
+    ]
+  },
+  {
+    "name": "magazine",
+    "trans": [
+      "杂志, 杂志社, 期刊 (noun.)"
+    ]
+  },
+  {
+    "name": "magic",
+    "trans": [
+      "魔法, 魔术, 魔力, 神奇 (noun.)"
+    ]
+  },
+  {
+    "name": "mail",
+    "trans": [
+      "邮件, 邮寄, 邮报, 邮 (noun.); 寄 (verb.)"
+    ]
+  },
+  {
+    "name": "main",
+    "trans": [
+      "主要, 主, 主营, 主体 (adj.)"
+    ]
+  },
+  {
+    "name": "mainly",
+    "trans": [
+      "主要, 为主, 着重, 重点 (adv.)"
+    ]
+  },
+  {
+    "name": "maintain",
+    "trans": [
+      "保持, 维持, 维护, 维系 (verb.)"
+    ]
+  },
+  {
+    "name": "maintenance",
+    "trans": [
+      "维护, 维修, 保养, 养护 (noun.)"
+    ]
+  },
+  {
+    "name": "major",
+    "trans": [
+      "主要, 重大, 专业, 少校 (adj.)"
+    ]
+  },
+  {
+    "name": "majority",
+    "trans": [
+      "多数, 大多数, 大部分, 占多数 (noun.)"
+    ]
+  },
+  {
+    "name": "make",
+    "trans": [
+      "使, 让, 做出, 作出 (verb.)"
+    ]
+  },
+  {
+    "name": "male",
+    "trans": [
+      "男性, 男, 雄, 公 (noun.); 雄性, 男生 (adj.)"
+    ]
+  },
+  {
+    "name": "mall",
+    "trans": [
+      "商场, 商城, 购物中心, 商业街 (noun.)"
+    ]
+  },
+  {
+    "name": "man",
+    "trans": [
+      "男人, 人, 男子, 伙计 (noun.)"
+    ]
+  },
+  {
+    "name": "manage",
+    "trans": [
+      "管理, 经营, 治理, 应付 (verb.)"
+    ]
+  },
+  {
+    "name": "management",
+    "trans": [
+      "管理, 经营, 管理学, 治理 (noun.)"
+    ]
+  },
+  {
+    "name": "manager",
+    "trans": [
+      "经理, 经理人, 管理者, 主帅 (noun.)"
+    ]
+  },
+  {
+    "name": "manner",
+    "trans": [
+      "方式, 态度, 举止 (noun.)"
+    ]
+  },
+  {
+    "name": "manufacturer",
+    "trans": [
+      "制造商, 生产厂家, 生产商, 厂商 (noun.)"
+    ]
+  },
+  {
+    "name": "manufacturing",
+    "trans": [
+      "制造, 制造业, 生产, 制作 (noun.)"
+    ]
+  },
+  {
+    "name": "many",
+    "trans": [
+      "许多, 很多, 多, 众多 (adj.)"
+    ]
+  },
+  {
+    "name": "map",
+    "trans": [
+      "地图, 电子地图, 映射, 图 (noun.)"
+    ]
+  },
+  {
+    "name": "march",
+    "trans": [
+      "三月, 三月份, 3月份, 游行 (noun.)"
+    ]
+  },
+  {
+    "name": "margin",
+    "trans": [
+      "边缘, 保证金, 缘, 裕度 (noun.)"
+    ]
+  },
+  {
+    "name": "mark",
+    "trans": [
+      "马克, 标记, 标志, 印记 (noun.); 标志着, 纪念 (verb.)"
+    ]
+  },
+  {
+    "name": "market",
+    "trans": [
+      "市场, 行情, 市场化 (noun.)"
+    ]
+  },
+  {
+    "name": "marketing",
+    "trans": [
+      "营销, 市场营销, 行销, 销售 (noun.)"
+    ]
+  },
+  {
+    "name": "marriage",
+    "trans": [
+      "婚姻, 结婚, 婚, 婚事 (noun.)"
+    ]
+  },
+  {
+    "name": "married",
+    "trans": [
+      "结婚, 已婚, 婚, 婚姻 (adj.); 嫁给, 娶, 嫁, 结 (verb.)"
+    ]
+  },
+  {
+    "name": "marry",
+    "trans": [
+      "嫁给, 娶, 结婚, 嫁 (verb.)"
+    ]
+  },
+  {
+    "name": "marvellous",
+    "trans": [
+      "奇妙, 了不起, 妙不可言, 绝妙 (adj.); 神乎其神 (noun.)"
+    ]
+  },
+  {
+    "name": "mass",
+    "trans": [
+      "大众, 大规模, 大量 (adj.); 质, 质量, 群众, 传 (noun.)"
+    ]
+  },
+  {
+    "name": "massive",
+    "trans": [
+      "大规模, 大量, 海量, 巨大 (adj.)"
+    ]
+  },
+  {
+    "name": "master",
+    "trans": [
+      "主人, 大师, 掌握, 师父 (noun.)"
+    ]
+  },
+  {
+    "name": "match",
+    "trans": [
+      "比赛, 赛, 火柴, 场比赛 (noun.); 匹配, 搭配, 配合, 符合 (verb.)"
+    ]
+  },
+  {
+    "name": "mate",
+    "trans": [
+      "伴侣, 队友, 伙计, 配偶 (noun.); 交配 (verb.)"
+    ]
+  },
+  {
+    "name": "material",
+    "trans": [
+      "材料, 物质, 物料, 材质 (noun.)"
+    ]
+  },
+  {
+    "name": "math",
+    "trans": [
+      "数学, 算术 (noun.)"
+    ]
+  },
+  {
+    "name": "maths",
+    "trans": [
+      "数学 (noun.)"
+    ]
+  },
+  {
+    "name": "matter",
+    "trans": [
+      "物质, 件事, 事, 问题 (noun.); 重要 (verb.)"
+    ]
+  },
+  {
+    "name": "maximum",
+    "trans": [
+      "最大, 最高, 最大化, 最大限度地 (adj.); 最大限度, 最多, 极大 (noun.)"
+    ]
+  },
+  {
+    "name": "may",
+    "trans": [
+      "可能 (modal.); 五月 (noun.)"
+    ]
+  },
+  {
+    "name": "maybe",
+    "trans": [
+      "也许, 或许, 可能, 说不定 (adv.)"
+    ]
+  },
+  {
+    "name": "me",
+    "trans": [
+      "我 (pron.)"
+    ]
+  },
+  {
+    "name": "meal",
+    "trans": [
+      "餐, 顿饭, 饭, 吃饭 (noun.)"
+    ]
+  },
+  {
+    "name": "mean",
+    "trans": [
+      "意味着, 意思, 指, 代表 (verb.); 平均, 均 (adj.)"
+    ]
+  },
+  {
+    "name": "meaning",
+    "trans": [
+      "意义, 含义, 意思, 涵义 (noun.); 意味着 (verb.)"
+    ]
+  },
+  {
+    "name": "means",
+    "trans": [
+      "意味着, 指, 意思, 表示 (verb.); 手段, 方式, 方法, 途径 (noun.)"
+    ]
+  },
+  {
+    "name": "meanwhile",
+    "trans": [
+      "与此同时, 同时, 此外 (adv.)"
+    ]
+  },
+  {
+    "name": "measure",
+    "trans": [
+      "措施, 度量, 测度, 计量 (noun.); 衡量, 测量, 测定 (verb.)"
+    ]
+  },
+  {
+    "name": "measurement",
+    "trans": [
+      "测量, 计量, 测定, 度量 (noun.)"
+    ]
+  },
+  {
+    "name": "meat",
+    "trans": [
+      "肉, 肉类, 肉食, 肉制品 (noun.)"
+    ]
+  },
+  {
+    "name": "mechanism",
+    "trans": [
+      "机制, 机理, 机构, 机械 (noun.)"
+    ]
+  },
+  {
+    "name": "media",
+    "trans": [
+      "媒体, 传媒, 媒介, 介质 (noun.)"
+    ]
+  },
+  {
+    "name": "medical",
+    "trans": [
+      "医疗, 医学, 医务, 医用 (adj.)"
+    ]
+  },
+  {
+    "name": "medicine",
+    "trans": [
+      "医学, 药, 医药, 证医学 (noun.)"
+    ]
+  },
+  {
+    "name": "medieval",
+    "trans": [
+      "中世纪, 中古 (adj.)"
+    ]
+  },
+  {
+    "name": "medium",
+    "trans": [
+      "介质, 中等, 媒介, 培养基 (noun.)"
+    ]
+  },
+  {
+    "name": "meet",
+    "trans": [
+      "满足, 见面, 见到, 见 (verb.)"
+    ]
+  },
+  {
+    "name": "meeting",
+    "trans": [
+      "会议, 开会, 会面, 会晤 (noun.); 满足, 见, 见到 (verb.)"
+    ]
+  },
+  {
+    "name": "member",
+    "trans": [
+      "成员, 会员, 员, 成员国 (noun.)"
+    ]
+  },
+  {
+    "name": "membership",
+    "trans": [
+      "会员卡, 会员, 会员资格, 会籍 (noun.)"
+    ]
+  },
+  {
+    "name": "memory",
+    "trans": [
+      "记忆, 内存, 存储器, 记忆力 (noun.)"
+    ]
+  },
+  {
+    "name": "mental",
+    "trans": [
+      "心理, 精神, 心智, 脑力 (adj.)"
+    ]
+  },
+  {
+    "name": "mention",
+    "trans": [
+      "提到, 提及, 提, 提起 (verb.)"
+    ]
+  },
+  {
+    "name": "menu",
+    "trans": [
+      "菜单, 选单, 菜谱, 菜 (noun.)"
+    ]
+  },
+  {
+    "name": "mere",
+    "trans": [
+      "单纯, 仅仅, 纯粹, 仅 (adj.)"
+    ]
+  },
+  {
+    "name": "merely",
+    "trans": [
+      "仅仅, 只是, 只不过, 仅 (adv.)"
+    ]
+  },
+  {
+    "name": "mess",
+    "trans": [
+      "烂摊子, 一团糟, 混乱, 乱 (noun.); 搞砸 (verb.)"
+    ]
+  },
+  {
+    "name": "message",
+    "trans": [
+      "消息, 讯息, 留言, 口信 (noun.)"
+    ]
+  },
+  {
+    "name": "messy",
+    "trans": [
+      "凌乱, 杂乱, 混乱, 乱 (adj.)"
+    ]
+  },
+  {
+    "name": "metal",
+    "trans": [
+      "金属, 五金, 金属材料, 金 (noun.)"
+    ]
+  },
+  {
+    "name": "method",
+    "trans": [
+      "方法, 法, 方式, 手段 (noun.)"
+    ]
+  },
+  {
+    "name": "metre",
+    "trans": [
+      "米, 公尺, 节拍 (noun.)"
+    ]
+  },
+  {
+    "name": "middle",
+    "trans": [
+      "中间, 中部, 中段, 中期 (noun.); 中层, 中等 (adj.)"
+    ]
+  },
+  {
+    "name": "midnight",
+    "trans": [
+      "午夜, 半夜, 午夜时分, 子夜 (noun.)"
+    ]
+  },
+  {
+    "name": "might",
+    "trans": [
+      "可能 (modal.)"
+    ]
+  },
+  {
+    "name": "mile",
+    "trans": [
+      "英里, 哩, 英哩, 英里远 (noun.)"
+    ]
+  },
+  {
+    "name": "military",
+    "trans": [
+      "军事, 军用, 军方, 军队 (adj.)"
+    ]
+  },
+  {
+    "name": "milk",
+    "trans": [
+      "牛奶, 奶, 乳, 乳汁 (noun.)"
+    ]
+  },
+  {
+    "name": "millimetre",
+    "trans": [
+      "毫米 (noun.)"
+    ]
+  },
+  {
+    "name": "mind",
+    "trans": [
+      "介意 (verb.); 头脑, 脑海, 心灵, 心中 (noun.)"
+    ]
+  },
+  {
+    "name": "mine",
+    "trans": [
+      "矿井, 矿山, 矿 (noun.); 我 (pron.)"
+    ]
+  },
+  {
+    "name": "mineral",
+    "trans": [
+      "矿物, 矿质, 矿物质, 矿产 (noun.)"
+    ]
+  },
+  {
+    "name": "minimum",
+    "trans": [
+      "最低, 最小, 最少, 极小 (adj.); 最低限度, 至少 (noun.)"
+    ]
+  },
+  {
+    "name": "minister",
+    "trans": [
+      "部长, 大臣, 牧师, 公使 (noun.)"
+    ]
+  },
+  {
+    "name": "ministry",
+    "trans": [
+      "部, 铁道部, 事奉, 卫生部 (noun.)"
+    ]
+  },
+  {
+    "name": "minor",
+    "trans": [
+      "轻微, 次要, 小调, 未成年 (adj.)"
+    ]
+  },
+  {
+    "name": "minority",
+    "trans": [
+      "少数民族, 少数, 少数派, 少数人 (noun.)"
+    ]
+  },
+  {
+    "name": "minute",
+    "trans": [
+      "分钟, 一刻, 分, 微小 (noun.)"
+    ]
+  },
+  {
+    "name": "mirror",
+    "trans": [
+      "镜子, 镜, 镜像, 镜面 (noun.); 反映 (verb.)"
+    ]
+  },
+  {
+    "name": "misery",
+    "trans": [
+      "苦难, 痛苦, 不幸, 悲惨 (noun.)"
+    ]
+  },
+  {
+    "name": "miss",
+    "trans": [
+      "错过, 想念, 怀念, 思念 (verb.); 老师 (noun.)"
+    ]
+  },
+  {
+    "name": "mission",
+    "trans": [
+      "使命, 任务, 特派团, 使命感 (noun.)"
+    ]
+  },
+  {
+    "name": "mistake",
+    "trans": [
+      "错误, 错, 误会, 失误 (noun.)"
+    ]
+  },
+  {
+    "name": "mix",
+    "trans": [
+      "混合, 组合, 混, 拌 (noun.)"
+    ]
+  },
+  {
+    "name": "mixed",
+    "trans": [
+      "混合, 混, 混业, 混杂 (adj.); 掺 (verb.)"
+    ]
+  },
+  {
+    "name": "mixture",
+    "trans": [
+      "混合物, 混合料, 合剂, 混合 (noun.)"
+    ]
+  },
+  {
+    "name": "mobile",
+    "trans": [
+      "移动, 手机, 流动, 机动 (adj.)"
+    ]
+  },
+  {
+    "name": "mobile phone",
+    "trans": [
+      "行动电话, 手机"
+    ]
+  },
+  {
+    "name": "mode",
+    "trans": [
+      "模式, 模, 方式, 模态 (noun.)"
+    ]
+  },
+  {
+    "name": "model",
+    "trans": [
+      "模型, 模式, 型号, 模特 (noun.)"
+    ]
+  },
+  {
+    "name": "modern",
+    "trans": [
+      "现代, 近代, 现代化, 当代 (adj.)"
+    ]
+  },
+  {
+    "name": "mom",
+    "trans": [
+      "妈妈, 妈, 老妈, 母亲 (noun.)"
+    ]
+  },
+  {
+    "name": "moment",
+    "trans": [
+      "时刻, 一刻, 矩, 此刻 (noun.)"
+    ]
+  },
+  {
+    "name": "mommy",
+    "trans": [
+      "妈咪, 妈妈, 妈 (noun.)"
+    ]
+  },
+  {
+    "name": "money",
+    "trans": [
+      "钱, 金钱, 资金, 笔钱 (noun.)"
+    ]
+  },
+  {
+    "name": "monitor",
+    "trans": [
+      "监控, 监测, 监视, 监察 (verb.); 监视器, 班长, 显示器, 监测仪 (noun.)"
+    ]
+  },
+  {
+    "name": "month",
+    "trans": [
+      "月, 月份, 每月, 本月 (noun.)"
+    ]
+  },
+  {
+    "name": "mood",
+    "trans": [
+      "心情, 情绪, 心境, 意境 (noun.)"
+    ]
+  },
+  {
+    "name": "moon",
+    "trans": [
+      "月亮, 月球, 明月, 月光 (noun.)"
+    ]
+  },
+  {
+    "name": "moral",
+    "trans": [
+      "道德, 道义, 德育, 品德 (adj.); 寓意 (noun.)"
+    ]
+  },
+  {
+    "name": "more",
+    "trans": [
+      "更多, 多, 多个, 再 (adj.); 更, 更加, 更为, 越 (adv.)"
+    ]
+  },
+  {
+    "name": "moreover",
+    "trans": [
+      "此外, 而且, 另外, 再者 (adv.)"
+    ]
+  },
+  {
+    "name": "morning",
+    "trans": [
+      "早上, 早晨, 上午, 清晨 (noun.)"
+    ]
+  },
+  {
+    "name": "mortgage",
+    "trans": [
+      "按揭, 抵押贷款, 抵押, 房贷 (noun.)"
+    ]
+  },
+  {
+    "name": "most",
+    "trans": [
+      "最, 最为, 最大 (adv.); 大多数, 大部分, 多数, 大多数人 (adj.)"
+    ]
+  },
+  {
+    "name": "mostly",
+    "trans": [
+      "大多, 主要, 大都, 大部分 (adv.)"
+    ]
+  },
+  {
+    "name": "mother",
+    "trans": [
+      "母亲, 妈妈, 妈, 母 (noun.)"
+    ]
+  },
+  {
+    "name": "motion",
+    "trans": [
+      "议案, 运动, 动议, 项议案 (noun.)"
+    ]
+  },
+  {
+    "name": "motor",
+    "trans": [
+      "电机, 电动机, 马达, 发动机 (noun.)"
+    ]
+  },
+  {
+    "name": "motorway",
+    "trans": [
+      "高速公路 (noun.)"
+    ]
+  },
+  {
+    "name": "mountain",
+    "trans": [
+      "山, 山地, 座山, 山区 (noun.)"
+    ]
+  },
+  {
+    "name": "mouse",
+    "trans": [
+      "鼠标, 老鼠, 小鼠, 鼠 (noun.)"
+    ]
+  },
+  {
+    "name": "mouth",
+    "trans": [
+      "嘴, 嘴巴, 嘴里, 口 (noun.)"
+    ]
+  },
+  {
+    "name": "move",
+    "trans": [
+      "移动, 搬, 动, 动议 (verb.); 举动, 行动 (noun.)"
+    ]
+  },
+  {
+    "name": "movement",
+    "trans": [
+      "运动, 动作, 移动, 机芯 (noun.)"
+    ]
+  },
+  {
+    "name": "movie",
+    "trans": [
+      "电影, 部电影, 影片, 一部电影 (noun.)"
+    ]
+  },
+  {
+    "name": "much",
+    "trans": [
+      "多, 很多, 多少, 大部分 (adj.); 更, 非常, 太 (adv.)"
+    ]
+  },
+  {
+    "name": "mud",
+    "trans": [
+      "泥, 泥浆, 泥巴, 泥土 (noun.)"
+    ]
+  },
+  {
+    "name": "mum",
+    "trans": [
+      "妈妈, 妈, 母亲, 老妈 (noun.)"
+    ]
+  },
+  {
+    "name": "mummy",
+    "trans": [
+      "木乃伊, 妈咪, 妈妈 (noun.)"
+    ]
+  },
+  {
+    "name": "murder",
+    "trans": [
+      "谋杀, 谋杀案, 谋杀罪, 杀人 (noun.); 杀 (verb.)"
+    ]
+  },
+  {
+    "name": "muscle",
+    "trans": [
+      "肌肉, 肌, 骨骼肌, 筋 (noun.)"
+    ]
+  },
+  {
+    "name": "museum",
+    "trans": [
+      "博物馆, 馆, 美术馆 (noun.)"
+    ]
+  },
+  {
+    "name": "mushroom",
+    "trans": [
+      "蘑菇, 菇, 食用菌, 香菇 (noun.)"
+    ]
+  },
+  {
+    "name": "music",
+    "trans": [
+      "音乐, 乐, 乐曲, 歌 (noun.)"
+    ]
+  },
+  {
+    "name": "musical",
+    "trans": [
+      "音乐, 音乐剧, 悦耳 (adj.)"
+    ]
+  },
+  {
+    "name": "must",
+    "trans": [
+      "必须, 一定 (modal.)"
+    ]
+  },
+  {
+    "name": "my",
+    "trans": [
+      "我 (pron.)"
+    ]
+  },
+  {
+    "name": "myself",
+    "trans": [
+      "自己 (pron.)"
+    ]
+  },
+  {
+    "name": "mystery",
+    "trans": [
+      "神秘, 谜, 奥秘, 谜团 (noun.)"
+    ]
+  },
+  {
+    "name": "nail",
+    "trans": [
+      "钉, 指甲, 钉子, 颗钉子 (noun.)"
+    ]
+  },
+  {
+    "name": "naked",
+    "trans": [
+      "裸体, 裸, 赤裸裸, 赤身裸体 (adj.)"
+    ]
+  },
+  {
+    "name": "name",
+    "trans": [
+      "名字, 名称, 名, 姓名 (noun.)"
+    ]
+  },
+  {
+    "name": "narrow",
+    "trans": [
+      "窄, 狭窄, 狭隘, 狭小 (adj.); 缩小 (verb.)"
+    ]
+  },
+  {
+    "name": "nasty",
+    "trans": [
+      "讨厌, 急, 肮脏, 恶心 (adj.)"
+    ]
+  },
+  {
+    "name": "nation",
+    "trans": [
+      "国家, 民族, 全国, 国 (noun.)"
+    ]
+  },
+  {
+    "name": "national",
+    "trans": [
+      "国家, 全国, 民族, 国民 (adj.); 国立 (noun.)"
+    ]
+  },
+  {
+    "name": "native",
+    "trans": [
+      "本土, 原产, 本地, 本地人 (adj.); 土生土长 (noun.)"
+    ]
+  },
+  {
+    "name": "natural",
+    "trans": [
+      "自然, 天然, 天生, 固有 (adj.)"
+    ]
+  },
+  {
+    "name": "naturally",
+    "trans": [
+      "自然, 自然而然地, 自然而然, 当然 (adv.)"
+    ]
+  },
+  {
+    "name": "nature",
+    "trans": [
+      "性质, 自然, 大自然, 本质 (noun.)"
+    ]
+  },
+  {
+    "name": "naughty",
+    "trans": [
+      "淘气, 顽皮, 调皮 (adj.)"
+    ]
+  },
+  {
+    "name": "near",
+    "trans": [
+      "附近, 近, 靠近 (prep.)"
+    ]
+  },
+  {
+    "name": "nearby",
+    "trans": [
+      "附近, 邻近, 临近, 周边 (adj.); 就近, 身边, 旁边, 远处 (adv.)"
+    ]
+  },
+  {
+    "name": "nearly",
+    "trans": [
+      "近, 几乎, 将近, 差点 (adv.)"
+    ]
+  },
+  {
+    "name": "neat",
+    "trans": [
+      "整洁, 整齐, 齐, 干净 (adj.)"
+    ]
+  },
+  {
+    "name": "necessarily",
+    "trans": [
+      "必然, 不一定, 必定, 必 (adv.)"
+    ]
+  },
+  {
+    "name": "necessary",
+    "trans": [
+      "必要, 必需, 所需, 需要 (adj.)"
+    ]
+  },
+  {
+    "name": "neck",
+    "trans": [
+      "脖子, 颈部, 颈, 脖颈 (noun.)"
+    ]
+  },
+  {
+    "name": "need",
+    "trans": [
+      "需要, 要, 需, 必须 (verb.); 必要, 需求 (noun.)"
+    ]
+  },
+  {
+    "name": "negative",
+    "trans": [
+      "负面, 负, 消极, 阴性 (adj.)"
+    ]
+  },
+  {
+    "name": "negotiate",
+    "trans": [
+      "洽谈, 谈判, 协商, 商谈 (verb.)"
+    ]
+  },
+  {
+    "name": "negotiation",
+    "trans": [
+      "谈判, 协商, 议付, 洽淡 (noun.)"
+    ]
+  },
+  {
+    "name": "neighbour",
+    "trans": [
+      "邻居, 邻国, 邻邦, 邻人 (noun.)"
+    ]
+  },
+  {
+    "name": "neighbourhood",
+    "trans": [
+      "邻里, 居委会, 附近, 邻舍 (noun.)"
+    ]
+  },
+  {
+    "name": "neither",
+    "trans": [
+      "也 (det.)"
+    ]
+  },
+  {
+    "name": "nerve",
+    "trans": [
+      "神经, 胆量, 勇气, 神经系统 (noun.)"
+    ]
+  },
+  {
+    "name": "nervous",
+    "trans": [
+      "紧张, 紧张不安, 神经, 感到不安 (adj.)"
+    ]
+  },
+  {
+    "name": "net",
+    "trans": [
+      "净, 网络, 净额, 净值 (adj.); 网, 网上 (noun.)"
+    ]
+  },
+  {
+    "name": "network",
+    "trans": [
+      "网络, 网, 网络化, 网路 (noun.)"
+    ]
+  },
+  {
+    "name": "never",
+    "trans": [
+      "从来没有, 从未, 从没, 从不 (adv.)"
+    ]
+  },
+  {
+    "name": "nevertheless",
+    "trans": [
+      "尽管如此, 不过, 然而, 无论如何 (adv.)"
+    ]
+  },
+  {
+    "name": "new",
+    "trans": [
+      "新, 新型, 全新, 新建 (adj.)"
+    ]
+  },
+  {
+    "name": "newly",
+    "trans": [
+      "新, 新近, 最新, 刚 (adv.)"
+    ]
+  },
+  {
+    "name": "news",
+    "trans": [
+      "新闻, 消息, 新闻报道 (noun.)"
+    ]
+  },
+  {
+    "name": "newspaper",
+    "trans": [
+      "报纸, 报社, 报, 报业 (noun.)"
+    ]
+  },
+  {
+    "name": "next",
+    "trans": [
+      "下一个, 接下来, 下个, 下 (adj.)"
+    ]
+  },
+  {
+    "name": "nice",
+    "trans": [
+      "不错, 好, 漂亮, 尼斯 (adj.)"
+    ]
+  },
+  {
+    "name": "nicely",
+    "trans": [
+      "好听, 好 (adv.)"
+    ]
+  },
+  {
+    "name": "night",
+    "trans": [
+      "晚上, 夜晚, 夜, 晚 (noun.)"
+    ]
+  },
+  {
+    "name": "nil",
+    "trans": [
+      "零 (adj.); 空谈 (noun.)"
+    ]
+  },
+  {
+    "name": "no",
+    "trans": [
+      "没有, 无 (det.); 不 (noun.)"
+    ]
+  },
+  {
+    "name": "no one",
+    "trans": [
+      "没有谁, 没有人, 谁也没有"
+    ]
+  },
+  {
+    "name": "no way",
+    "trans": [
+      "决不, 一点也不"
+    ]
+  },
+  {
+    "name": "nobody",
+    "trans": [
+      "无人, 任何人, 无名小卒, 没 (noun.)"
+    ]
+  },
+  {
+    "name": "nod",
+    "trans": [
+      "点头, 点点头, 首肯, 致意 (noun.)"
+    ]
+  },
+  {
+    "name": "noise",
+    "trans": [
+      "噪声, 噪音, 噪, 隔音 (noun.)"
+    ]
+  },
+  {
+    "name": "noisy",
+    "trans": [
+      "嘈杂, 吵闹, 吵, 喧闹 (adj.)"
+    ]
+  },
+  {
+    "name": "none",
+    "trans": [
+      "没有, 忠县, 无, 无人 (noun.)"
+    ]
+  },
+  {
+    "name": "nonsense",
+    "trans": [
+      "废话, 无稽之谈, 胡说八道, 胡说 (noun.)"
+    ]
+  },
+  {
+    "name": "nope",
+    "trans": [
+      "不 (noun.)"
+    ]
+  },
+  {
+    "name": "nor",
+    "trans": [
+      "也 (conj.)"
+    ]
+  },
+  {
+    "name": "normal",
+    "trans": [
+      "正常, 师范, 正常人, 普通 (adj.)"
+    ]
+  },
+  {
+    "name": "normally",
+    "trans": [
+      "通常, 正常, 一般, 平时 (adv.)"
+    ]
+  },
+  {
+    "name": "north",
+    "trans": [
+      "北, 北方, 北部, 北面 (noun.)"
+    ]
+  },
+  {
+    "name": "northern",
+    "trans": [
+      "北部, 北方, 北, 北部地区 (adj.)"
+    ]
+  },
+  {
+    "name": "nose",
+    "trans": [
+      "鼻子, 鼻, 鼻梁, 鼻涕 (noun.)"
+    ]
+  },
+  {
+    "name": "not",
+    "trans": [
+      "不是, 不, 没有, 不会 (adv.)"
+    ]
+  },
+  {
+    "name": "notably",
+    "trans": [
+      "特别是, 尤其是, 值得注意 (adv.)"
+    ]
+  },
+  {
+    "name": "note",
+    "trans": [
+      "注意, 指出 (verb.); 注, 纸条, 张纸条, 音符 (noun.)"
+    ]
+  },
+  {
+    "name": "nothing",
+    "trans": [
+      "没什么, 什么, 没有, 没事 (noun.)"
+    ]
+  },
+  {
+    "name": "notice",
+    "trans": [
+      "通知, 通知书, 公告, 通告 (noun.); 注意, 发现, 留意, 察觉 (verb.)"
+    ]
+  },
+  {
+    "name": "notion",
+    "trans": [
+      "概念, 观念, 理念, 想法 (noun.)"
+    ]
+  },
+  {
+    "name": "novel",
+    "trans": [
+      "小说, 新型, 新颖, 部小说 (noun.)"
+    ]
+  },
+  {
+    "name": "now",
+    "trans": [
+      "现在, 如今, 目前, 现 (adv.)"
+    ]
+  },
+  {
+    "name": "nowadays",
+    "trans": [
+      "如今, 当今, 现今, 时下 (adv.)"
+    ]
+  },
+  {
+    "name": "nowhere",
+    "trans": [
+      "无处, 一事无成, 行不通, 无处不在 (adv.)"
+    ]
+  },
+  {
+    "name": "nuclear",
+    "trans": [
+      "核, 核子, 核能, 核电 (adj.)"
+    ]
+  },
+  {
+    "name": "nuisance",
+    "trans": [
+      "滋扰, 造成滋扰, 扰民, 妨害 (noun.)"
+    ]
+  },
+  {
+    "name": "number",
+    "trans": [
+      "数量, 号码, 数目, 数 (noun.)"
+    ]
+  },
+  {
+    "name": "numerous",
+    "trans": [
+      "众多, 无数, 纷繁, 许多 (adj.)"
+    ]
+  },
+  {
+    "name": "nurse",
+    "trans": [
+      "护士, 护, 护理, 保姆 (noun.)"
+    ]
+  },
+  {
+    "name": "nut",
+    "trans": [
+      "螺母, 坚果, 螺帽, 疯子 (noun.); 坚 (adj.)"
+    ]
+  },
+  {
+    "name": "o’clock",
+    "trans": [
+      "…点钟 (adv.)"
+    ]
+  },
+  {
+    "name": "object",
+    "trans": [
+      "对象, 物体, 客体, 物件 (noun.); 反对 (verb.)"
+    ]
+  },
+  {
+    "name": "objection",
+    "trans": [
+      "异议, 反对, 反对通知书, 提出异议 (noun.)"
+    ]
+  },
+  {
+    "name": "objective",
+    "trans": [
+      "目的, 目标, 前言, 宗旨 (noun.); 客观 (adj.)"
+    ]
+  },
+  {
+    "name": "obligation",
+    "trans": [
+      "义务, 责任, 职责, 债 (noun.)"
+    ]
+  },
+  {
+    "name": "observation",
+    "trans": [
+      "观察, 观测, 观察力 (noun.)"
+    ]
+  },
+  {
+    "name": "observe",
+    "trans": [
+      "观察, 遵守, 观测, 守 (verb.)"
+    ]
+  },
+  {
+    "name": "obtain",
+    "trans": [
+      "获得, 获取, 取得, 得到 (verb.)"
+    ]
+  },
+  {
+    "name": "obvious",
+    "trans": [
+      "明显, 显而易见, 显著, 显然 (adj.)"
+    ]
+  },
+  {
+    "name": "obviously",
+    "trans": [
+      "显然, 明显, 明明, 显而易见 (adv.)"
+    ]
+  },
+  {
+    "name": "occasion",
+    "trans": [
+      "场合, 之际, 时刻, 偶尔 (noun.)"
+    ]
+  },
+  {
+    "name": "occasional",
+    "trans": [
+      "偶尔, 偶然, 应景, 偶发 (adj.)"
+    ]
+  },
+  {
+    "name": "occasionally",
+    "trans": [
+      "偶尔, 偶, 有时, 不时 (adv.)"
+    ]
+  },
+  {
+    "name": "occupation",
+    "trans": [
+      "职业, 占领, 占用, 入伙 (noun.)"
+    ]
+  },
+  {
+    "name": "occupy",
+    "trans": [
+      "占据, 占领, 占用, 占有 (verb.)"
+    ]
+  },
+  {
+    "name": "occur",
+    "trans": [
+      "发生, 出现 (verb.)"
+    ]
+  },
+  {
+    "name": "ocean",
+    "trans": [
+      "海洋, 洋, 大洋, 远洋 (noun.)"
+    ]
+  },
+  {
+    "name": "odd",
+    "trans": [
+      "奇怪, 奇数, 奇, 古怪 (adj.)"
+    ]
+  },
+  {
+    "name": "odds",
+    "trans": [
+      "赔率, 几率, 机率, 胜算 (noun.)"
+    ]
+  },
+  {
+    "name": "of",
+    "trans": [
+      "的 (prep.)"
+    ]
+  },
+  {
+    "name": "of course",
+    "trans": [
+      "一定, 当然"
+    ]
+  },
+  {
+    "name": "off",
+    "trans": [
+      "了 (prep.)"
+    ]
+  },
+  {
+    "name": "offence",
+    "trans": [
+      "罪行, 犯罪, 违法行为, 冒犯 (noun.)"
+    ]
+  },
+  {
+    "name": "offer",
+    "trans": [
+      "提供, 给予 (verb.); 报价, 提议, 报盘, 要约 (noun.)"
+    ]
+  },
+  {
+    "name": "office",
+    "trans": [
+      "办公室, 办公, 办事处, 处 (noun.)"
+    ]
+  },
+  {
+    "name": "officer",
+    "trans": [
+      "军官, 警官, 官, 主任 (noun.)"
+    ]
+  },
+  {
+    "name": "official",
+    "trans": [
+      "官方, 正式, 官, 公务 (adj.); 官员, 负责人 (noun.)"
+    ]
+  },
+  {
+    "name": "often",
+    "trans": [
+      "经常, 常常, 往往, 常 (adv.)"
+    ]
+  },
+  {
+    "name": "oil",
+    "trans": [
+      "油, 石油, 机油, 原油 (noun.)"
+    ]
+  },
+  {
+    "name": "OK",
+    "trans": [
+      "好, 行, 还好 (noun.); 确定, 没事 (adj.)"
+    ]
+  },
+  {
+    "name": "OK",
+    "trans": [
+      "好, 行, 还好 (noun.); 确定, 没事 (adj.)"
+    ]
+  },
+  {
+    "name": "old",
+    "trans": [
+      "老, 旧, 古老, 陈旧 (adj.)"
+    ]
+  },
+  {
+    "name": "on",
+    "trans": [
+      "对, 上, 论, 在 (prep.)"
+    ]
+  },
+  {
+    "name": "once",
+    "trans": [
+      "一旦, 一次, 曾经, 曾 (adv.)"
+    ]
+  },
+  {
+    "name": "one",
+    "trans": [
+      "一个, 一, 之一, 一体 (adj.); 人 (noun.)"
+    ]
+  },
+  {
+    "name": "one another",
+    "trans": [
+      "彼此, 互相"
+    ]
+  },
+  {
+    "name": "onion",
+    "trans": [
+      "洋葱, 葱, 葱头, 大葱 (noun.)"
+    ]
+  },
+  {
+    "name": "only",
+    "trans": [
+      "只有, 只, 仅, 只是 (adv.); 唯一, 惟一 (adj.)"
+    ]
+  },
+  {
+    "name": "onto",
+    "trans": [
+      "到 (prep.)"
+    ]
+  },
+  {
+    "name": "open",
+    "trans": [
+      "开放, 开, 公开, 开放式 (adj.); 打开, 开启, 睁开 (verb.)"
+    ]
+  },
+  {
+    "name": "opening",
+    "trans": [
+      "开放, 打开, 开业, 开 (verb.); 开幕, 开口, 开幕式, 启用 (noun.)"
+    ]
+  },
+  {
+    "name": "operate",
+    "trans": [
+      "操作, 运作, 经营, 运营 (verb.)"
+    ]
+  },
+  {
+    "name": "operation",
+    "trans": [
+      "操作, 运行, 运作, 手术 (noun.)"
+    ]
+  },
+  {
+    "name": "operator",
+    "trans": [
+      "算子, 运算符, 操作员, 接线员 (noun.)"
+    ]
+  },
+  {
+    "name": "opinion",
+    "trans": [
+      "意见, 看来, 观点, 看法 (noun.)"
+    ]
+  },
+  {
+    "name": "opponent",
+    "trans": [
+      "对手, 敌手, 对方, 敌人 (noun.)"
+    ]
+  },
+  {
+    "name": "opportunity",
+    "trans": [
+      "机会, 机遇, 契机, 时机 (noun.)"
+    ]
+  },
+  {
+    "name": "oppose",
+    "trans": [
+      "反对, 作对 (verb.)"
+    ]
+  },
+  {
+    "name": "opposite",
+    "trans": [
+      "对面, 相反, 对立, 相对 (adj.); 对立面, 反面, 正好相反, 恰恰相反 (noun.)"
+    ]
+  },
+  {
+    "name": "opposition",
+    "trans": [
+      "反对派, 反对党, 反对, 对立 (noun.)"
+    ]
+  },
+  {
+    "name": "option",
+    "trans": [
+      "选项, 期权, 选择 (noun.)"
+    ]
+  },
+  {
+    "name": "or",
+    "trans": [
+      "或, 或者, 或是 (conj.)"
+    ]
+  },
+  {
+    "name": "orange",
+    "trans": [
+      "橙色, 橙, 橘子, 桔子 (noun.)"
+    ]
+  },
+  {
+    "name": "order",
+    "trans": [
+      "秩序, 订单, 顺序, 命令 (noun.); 点 (verb.)"
+    ]
+  },
+  {
+    "name": "ordinary",
+    "trans": [
+      "普通, 平凡, 一般, 平常 (adj.)"
+    ]
+  },
+  {
+    "name": "organ",
+    "trans": [
+      "器官, 脏器, 机关, 风琴 (noun.)"
+    ]
+  },
+  {
+    "name": "organic",
+    "trans": [
+      "有机, 有机物, 器质性, 有机质 (adj.)"
+    ]
+  },
+  {
+    "name": "organization",
+    "trans": [
+      "组织, 机构, 组织形式, 团体 (noun.)"
+    ]
+  },
+  {
+    "name": "organize",
+    "trans": [
+      "组织, 整理, 举办, 筹办 (verb.)"
+    ]
+  },
+  {
+    "name": "organized",
+    "trans": [
+      "组织, 举办, 井井有条, 筹办 (verb.)"
+    ]
+  },
+  {
+    "name": "origin",
+    "trans": [
+      "起源, 原产地, 渊源, 由来 (noun.)"
+    ]
+  },
+  {
+    "name": "original",
+    "trans": [
+      "原始, 原, 原来, 原有 (adj.)"
+    ]
+  },
+  {
+    "name": "originally",
+    "trans": [
+      "原来, 原本, 最初, 本来 (adv.)"
+    ]
+  },
+  {
+    "name": "other",
+    "trans": [
+      "其他, 其它, 另, 别的 (adj.)"
+    ]
+  },
+  {
+    "name": "otherwise",
+    "trans": [
+      "否则, 不然, 要不然, 不然的话 (adv.)"
+    ]
+  },
+  {
+    "name": "ought to",
+    "trans": [
+      "应该, 应当"
+    ]
+  },
+  {
+    "name": "ounce",
+    "trans": [
+      "盎司, 盎斯 (noun.)"
+    ]
+  },
+  {
+    "name": "our",
+    "trans": [
+      "我们 (pron.)"
+    ]
+  },
+  {
+    "name": "ours",
+    "trans": [
+      "我们 (pron.)"
+    ]
+  },
+  {
+    "name": "ourselves",
+    "trans": [
+      "自己 (pron.)"
+    ]
+  },
+  {
+    "name": "out",
+    "trans": [
+      "出去, 出来, 出, 了 (prep.)"
+    ]
+  },
+  {
+    "name": "outcome",
+    "trans": [
+      "结果, 结局, 产物, 成果 (noun.)"
+    ]
+  },
+  {
+    "name": "output",
+    "trans": [
+      "输出, 产出, 产量, 产值 (noun.)"
+    ]
+  },
+  {
+    "name": "outside",
+    "trans": [
+      "外面, 外边, 户外, 出去 (adv.); 外, 以外, 之外, 境外 (prep.); 外部, 外界 (adj.)"
+    ]
+  },
+  {
+    "name": "outstanding",
+    "trans": [
+      "优秀, 杰出, 突出, 未偿还 (adj.)"
+    ]
+  },
+  {
+    "name": "oven",
+    "trans": [
+      "烤箱, 烘箱, 烤炉, 烘炉 (adj.)"
+    ]
+  },
+  {
+    "name": "over",
+    "trans": [
+      "超过, 在 (prep.)"
+    ]
+  },
+  {
+    "name": "overall",
+    "trans": [
+      "整体, 总体, 全面, 总 (adj.); 总的来说, 总体而言 (adv.)"
+    ]
+  },
+  {
+    "name": "overcome",
+    "trans": [
+      "克服, 战胜, 克服困难, 攻克 (verb.)"
+    ]
+  },
+  {
+    "name": "overseas",
+    "trans": [
+      "海外, 国外, 外国, 外地 (adj.); 境外 (noun.); 出国 (adv.)"
+    ]
+  },
+  {
+    "name": "overtime",
+    "trans": [
+      "加班, 加班费, 加时赛, 超时 (noun.)"
+    ]
+  },
+  {
+    "name": "owe",
+    "trans": [
+      "欠, 亏欠, 归功于 (verb.)"
+    ]
+  },
+  {
+    "name": "own",
+    "trans": [
+      "自己, 自身, 个人, 本身 (adj.); 拥有 (verb.)"
+    ]
+  },
+  {
+    "name": "owner",
+    "trans": [
+      "所有者, 主人, 业主, 老板 (noun.)"
+    ]
+  },
+  {
+    "name": "ownership",
+    "trans": [
+      "所有权, 所有制, 股权, 归属 (noun.)"
+    ]
+  },
+  {
+    "name": "pace",
+    "trans": [
+      "步伐, 节奏, 速度, 步调 (noun.)"
+    ]
+  },
+  {
+    "name": "pack",
+    "trans": [
+      "包, 包装, 背包, 折 (noun.); 打包, 收拾, 收拾行李, 装 (verb.)"
+    ]
+  },
+  {
+    "name": "package",
+    "trans": [
+      "包, 包裹, 包装, 软件包 (noun.)"
+    ]
+  },
+  {
+    "name": "packet",
+    "trans": [
+      "包, 分组, 报文 (noun.)"
+    ]
+  },
+  {
+    "name": "pad",
+    "trans": [
+      "垫, 焊盘, 衬垫, 轧 (noun.)"
+    ]
+  },
+  {
+    "name": "page",
+    "trans": [
+      "网页, 页面, 页, 关于 (noun.)"
+    ]
+  },
+  {
+    "name": "pain",
+    "trans": [
+      "疼痛, 痛苦, 痛, 伤痛 (noun.)"
+    ]
+  },
+  {
+    "name": "paint",
+    "trans": [
+      "油漆, 漆, 涂料, 颜料 (noun.); 画, 画画, 粉刷, 涂 (verb.)"
+    ]
+  },
+  {
+    "name": "painting",
+    "trans": [
+      "绘画, 画, 幅画, 涂装 (noun.); 粉刷 (verb.)"
+    ]
+  },
+  {
+    "name": "pair",
+    "trans": [
+      "双, 副, 一对, 配对 (noun.)"
+    ]
+  },
+  {
+    "name": "palace",
+    "trans": [
+      "宫殿, 宫, 皇宫, 宫廷 (noun.)"
+    ]
+  },
+  {
+    "name": "pale",
+    "trans": [
+      "苍白, 脸色苍白, 淡, 面色苍白 (adj.); 苍 (verb.)"
+    ]
+  },
+  {
+    "name": "pan",
+    "trans": [
+      "泛, 潘, 锅, 盘 (noun.)"
+    ]
+  },
+  {
+    "name": "panel",
+    "trans": [
+      "面板, 事务委员会, 小组, 板 (noun.)"
+    ]
+  },
+  {
+    "name": "panic",
+    "trans": [
+      "恐慌, 惊慌, 惊恐, 慌张 (noun.)"
+    ]
+  },
+  {
+    "name": "pants",
+    "trans": [
+      "裤子, 裤, 条裤子, 长裤 (noun.)"
+    ]
+  },
+  {
+    "name": "paper",
+    "trans": [
+      "纸, 纸张, 论文, 造纸 (noun.)"
+    ]
+  },
+  {
+    "name": "parcel",
+    "trans": [
+      "包裹, 包裹寄, 邮包, 地块 (noun.)"
+    ]
+  },
+  {
+    "name": "pardon",
+    "trans": [
+      "赦免, 原谅, 特赦, 赦 (noun.); 请原谅 (verb.)"
+    ]
+  },
+  {
+    "name": "parent",
+    "trans": [
+      "父, 家长, 父母, 母 (noun.)"
+    ]
+  },
+  {
+    "name": "park",
+    "trans": [
+      "公园, 园区, 园, 朴 (noun.); 停车, 停 (verb.)"
+    ]
+  },
+  {
+    "name": "parking",
+    "trans": [
+      "停车, 泊车, 停车场, 停泊 (noun.)"
+    ]
+  },
+  {
+    "name": "parliament",
+    "trans": [
+      "议会, 国会, 议会大厦, 国会大厦 (noun.)"
+    ]
+  },
+  {
+    "name": "part",
+    "trans": [
+      "一部分, 部分, 组成部分, 部份 (noun.)"
+    ]
+  },
+  {
+    "name": "participate",
+    "trans": [
+      "参与, 参加, 参予, 参 (verb.)"
+    ]
+  },
+  {
+    "name": "particular",
+    "trans": [
+      "特定, 特别, 特殊, 特别是 (adj.)"
+    ]
+  },
+  {
+    "name": "particularly",
+    "trans": [
+      "特别是, 特别, 尤其是, 尤其 (adv.)"
+    ]
+  },
+  {
+    "name": "partly",
+    "trans": [
+      "部分, 一部分, 局部, 一方面 (adv.)"
+    ]
+  },
+  {
+    "name": "partner",
+    "trans": [
+      "合作伙伴, 伙伴, 搭档, 伴侣 (noun.)"
+    ]
+  },
+  {
+    "name": "partnership",
+    "trans": [
+      "伙伴关系, 合伙, 合作伙伴关系, 合伙企业 (noun.)"
+    ]
+  },
+  {
+    "name": "party",
+    "trans": [
+      "党, 派对, 聚会, 晚会 (noun.)"
+    ]
+  },
+  {
+    "name": "pass",
+    "trans": [
+      "通过, 传递, 递给, 及格 (verb.); 通, 通行证, 传球 (noun.)"
+    ]
+  },
+  {
+    "name": "passage",
+    "trans": [
+      "通道, 推移, 通过, 通行 (noun.)"
+    ]
+  },
+  {
+    "name": "passenger",
+    "trans": [
+      "客运, 乘客, 旅客, 载客 (noun.)"
+    ]
+  },
+  {
+    "name": "passion",
+    "trans": [
+      "激情, 热情, 热爱, 充满热情 (noun.)"
+    ]
+  },
+  {
+    "name": "past",
+    "trans": [
+      "过去, 过往, 近 (adj.); 以往, 往事, 以前, 过去了 (noun.)"
+    ]
+  },
+  {
+    "name": "path",
+    "trans": [
+      "路径, 道路, 小路, 路 (noun.)"
+    ]
+  },
+  {
+    "name": "patience",
+    "trans": [
+      "耐心, 耐性, 忍耐, 耐心等待 (noun.)"
+    ]
+  },
+  {
+    "name": "patient",
+    "trans": [
+      "病人, 患者, 病患, 患 (noun.); 耐心, 忍耐 (adj.)"
+    ]
+  },
+  {
+    "name": "pattern",
+    "trans": [
+      "模式, 格局, 图案, 花纹 (noun.)"
+    ]
+  },
+  {
+    "name": "pause",
+    "trans": [
+      "停顿, 暂停, 停下来, 迟疑 (noun.)"
+    ]
+  },
+  {
+    "name": "pay",
+    "trans": [
+      "支付, 付, 付出, 付钱 (verb.); 薪酬, 工资, 薪水 (noun.)"
+    ]
+  },
+  {
+    "name": "payment",
+    "trans": [
+      "付款, 支付, 缴付, 货款 (noun.)"
+    ]
+  },
+  {
+    "name": "peace",
+    "trans": [
+      "和平, 平安, 安宁, 平静 (noun.)"
+    ]
+  },
+  {
+    "name": "peaceful",
+    "trans": [
+      "和平, 平和, 平静, 宁静 (adj.)"
+    ]
+  },
+  {
+    "name": "peak",
+    "trans": [
+      "峰值, 峰, 高峰, 山顶 (noun.)"
+    ]
+  },
+  {
+    "name": "pen",
+    "trans": [
+      "笔, 钢笔, 支钢笔, 支笔 (noun.)"
+    ]
+  },
+  {
+    "name": "penalty",
+    "trans": [
+      "刑罚, 罚款, 点球, 罚 (noun.)"
+    ]
+  },
+  {
+    "name": "pencil",
+    "trans": [
+      "铅笔, 支铅笔, 枝铅笔, 铅笔盒 (noun.)"
+    ]
+  },
+  {
+    "name": "penny",
+    "trans": [
+      "佩妮, 潘妮, 便士, 彭妮 (noun.)"
+    ]
+  },
+  {
+    "name": "pension",
+    "trans": [
+      "养老金, 退休金, 养老, 长俸 (noun.)"
+    ]
+  },
+  {
+    "name": "people",
+    "trans": [
+      "人, 人们, 人民, 民众 (noun.)"
+    ]
+  },
+  {
+    "name": "pepper",
+    "trans": [
+      "胡椒, 辣椒, 胡椒粉, 花椒 (noun.)"
+    ]
+  },
+  {
+    "name": "per",
+    "trans": [
+      "每 (prep.)"
+    ]
+  },
+  {
+    "name": "perceive",
+    "trans": [
+      "感知, 察觉, 觉察到, 觉察 (verb.)"
+    ]
+  },
+  {
+    "name": "percent",
+    "trans": [
+      "百分之, 百分比, 个百分点 (noun.)"
+    ]
+  },
+  {
+    "name": "percentage",
+    "trans": [
+      "百分比, 百分率, 比例, 百分数 (noun.)"
+    ]
+  },
+  {
+    "name": "perception",
+    "trans": [
+      "感知, 知觉, 看法, 认知 (noun.)"
+    ]
+  },
+  {
+    "name": "perfect",
+    "trans": [
+      "完美, 完善, 十全十美, 健全 (adj.)"
+    ]
+  },
+  {
+    "name": "perfectly",
+    "trans": [
+      "完全, 完美, 绝对, 十分 (adv.)"
+    ]
+  },
+  {
+    "name": "perform",
+    "trans": [
+      "执行, 履行, 表演, 演出 (verb.)"
+    ]
+  },
+  {
+    "name": "performance",
+    "trans": [
+      "性能, 绩效, 表现, 业绩 (noun.)"
+    ]
+  },
+  {
+    "name": "perhaps",
+    "trans": [
+      "也许, 或许, 可能, 大概 (adv.)"
+    ]
+  },
+  {
+    "name": "period",
+    "trans": [
+      "时期, 期, 期间, 周期 (noun.)"
+    ]
+  },
+  {
+    "name": "permanent",
+    "trans": [
+      "永久, 永久性, 常任, 常设 (adj.)"
+    ]
+  },
+  {
+    "name": "permission",
+    "trans": [
+      "许可, 权限, 准许, 允许 (noun.)"
+    ]
+  },
+  {
+    "name": "permit",
+    "trans": [
+      "许可证, 许可, 证, 通行证 (noun.); 允许, 准许, 容许 (verb.)"
+    ]
+  },
+  {
+    "name": "person",
+    "trans": [
+      "人, 人士, 个人, 人称 (noun.)"
+    ]
+  },
+  {
+    "name": "personal",
+    "trans": [
+      "个人, 私人, 人身, 私 (adj.)"
+    ]
+  },
+  {
+    "name": "personality",
+    "trans": [
+      "人格, 个性, 性格, 品格 (noun.)"
+    ]
+  },
+  {
+    "name": "personally",
+    "trans": [
+      "亲自, 个人, 亲手, 亲身 (adv.)"
+    ]
+  },
+  {
+    "name": "personnel",
+    "trans": [
+      "人员, 人事, 人才, 人事部 (noun.)"
+    ]
+  },
+  {
+    "name": "perspective",
+    "trans": [
+      "视角, 透视, 角度, 角度来看 (noun.)"
+    ]
+  },
+  {
+    "name": "persuade",
+    "trans": [
+      "说服, 劝说, 劝, 劝服 (verb.)"
+    ]
+  },
+  {
+    "name": "petrol",
+    "trans": [
+      "汽油, 石油 (noun.)"
+    ]
+  },
+  {
+    "name": "phase",
+    "trans": [
+      "相, 相位, 阶段, 期 (noun.)"
+    ]
+  },
+  {
+    "name": "philosophy",
+    "trans": [
+      "哲学, 理念, 哲理, 人生观 (noun.)"
+    ]
+  },
+  {
+    "name": "phone",
+    "trans": [
+      "电话, 手机, 打电话, 通话 (noun.); 打电话给 (verb.)"
+    ]
+  },
+  {
+    "name": "photo",
+    "trans": [
+      "照片, 张照片, 相片, 图片 (noun.)"
+    ]
+  },
+  {
+    "name": "photocopy",
+    "trans": [
+      "影印本, 影印件, 复印件, 影印 (noun.); 复印 (verb.)"
+    ]
+  },
+  {
+    "name": "photograph",
+    "trans": [
+      "照片, 张照片, 摄影, 相片 (noun.); 拍摄 (verb.)"
+    ]
+  },
+  {
+    "name": "phrase",
+    "trans": [
+      "短语, 词组, 句话, 词 (noun.)"
+    ]
+  },
+  {
+    "name": "physical",
+    "trans": [
+      "物理, 身体, 体育, 体力 (adj.)"
+    ]
+  },
+  {
+    "name": "physically",
+    "trans": [
+      "身体, 物理, 体力, 肉体 (adv.)"
+    ]
+  },
+  {
+    "name": "physics",
+    "trans": [
+      "物理, 物理学 (noun.)"
+    ]
+  },
+  {
+    "name": "piano",
+    "trans": [
+      "钢琴, 弹钢琴, 架钢琴, 钢琴演奏 (noun.)"
+    ]
+  },
+  {
+    "name": "pick",
+    "trans": [
+      "挑, 挑选, 摘, 选 (verb.)"
+    ]
+  },
+  {
+    "name": "picture",
+    "trans": [
+      "图片, 照片, 张照片, 画面 (noun.)"
+    ]
+  },
+  {
+    "name": "pie",
+    "trans": [
+      "馅饼, 派, 饼, 扇形 (noun.)"
+    ]
+  },
+  {
+    "name": "piece",
+    "trans": [
+      "一块, 片, 件, 块 (noun.)"
+    ]
+  },
+  {
+    "name": "pig",
+    "trans": [
+      "猪, 小猪, 养猪, 生猪 (noun.)"
+    ]
+  },
+  {
+    "name": "pile",
+    "trans": [
+      "桩, 堆, 桩桩, 叠 (noun.)"
+    ]
+  },
+  {
+    "name": "pill",
+    "trans": [
+      "丸, 药丸, 药片, 避孕药 (noun.)"
+    ]
+  },
+  {
+    "name": "pilot",
+    "trans": [
+      "飞行员, 试点, 驾驶员, 导频 (noun.)"
+    ]
+  },
+  {
+    "name": "pin",
+    "trans": [
+      "销, 引脚, 针, 别针 (noun.)"
+    ]
+  },
+  {
+    "name": "pink",
+    "trans": [
+      "粉红色, 粉色, 粉红, 桃红色 (adj.)"
+    ]
+  },
+  {
+    "name": "pint",
+    "trans": [
+      "品脱 (noun.)"
+    ]
+  },
+  {
+    "name": "pipe",
+    "trans": [
+      "管, 管道, 烟斗, 管子 (noun.)"
+    ]
+  },
+  {
+    "name": "pitch",
+    "trans": [
+      "音高, 螺距, 球场, 沥青 (noun.)"
+    ]
+  },
+  {
+    "name": "pity",
+    "trans": [
+      "可惜, 怜悯, 遗憾, 怜 (noun.)"
+    ]
+  },
+  {
+    "name": "pizza",
+    "trans": [
+      "披萨, 比萨, 比萨饼, 匹萨 (noun.)"
+    ]
+  },
+  {
+    "name": "place",
+    "trans": [
+      "地方, 地点, 场所, 位置 (noun.); 放置 (verb.)"
+    ]
+  },
+  {
+    "name": "plain",
+    "trans": [
+      "平原 (noun.); 纯, 平淡, 普通, 朴素 (adj.)"
+    ]
+  },
+  {
+    "name": "plan",
+    "trans": [
+      "计划, 规划, 方案, 策划 (noun.)"
+    ]
+  },
+  {
+    "name": "plane",
+    "trans": [
+      "飞机, 平面, 架飞机, 面 (noun.)"
+    ]
+  },
+  {
+    "name": "planet",
+    "trans": [
+      "星球, 行星, 地球, 颗行星 (noun.)"
+    ]
+  },
+  {
+    "name": "plant",
+    "trans": [
+      "植物, 厂, 工厂, 厂房 (noun.); 种 (verb.)"
+    ]
+  },
+  {
+    "name": "plastic",
+    "trans": [
+      "塑料, 塑胶, 塑性, 塑 (noun.)"
+    ]
+  },
+  {
+    "name": "plate",
+    "trans": [
+      "板, 板块, 盘子, 钢板 (noun.)"
+    ]
+  },
+  {
+    "name": "platform",
+    "trans": [
+      "平台, 站台, 月台, 台 (noun.)"
+    ]
+  },
+  {
+    "name": "play",
+    "trans": [
+      "玩, 发挥, 打, 扮演 (verb.); 游戏 (noun.)"
+    ]
+  },
+  {
+    "name": "player",
+    "trans": [
+      "球员, 玩家, 播放器, 运动员 (noun.)"
+    ]
+  },
+  {
+    "name": "pleasant",
+    "trans": [
+      "愉快, 宜人, 令人愉快, 惬意 (adj.)"
+    ]
+  },
+  {
+    "name": "please",
+    "trans": [
+      "请, 拜托, 求, 取悦 (noun.)"
+    ]
+  },
+  {
+    "name": "please",
+    "trans": [
+      "请, 拜托, 求, 取悦 (noun.)"
+    ]
+  },
+  {
+    "name": "pleased",
+    "trans": [
+      "高兴, 欣慰, 满意, 开心 (adj.)"
+    ]
+  },
+  {
+    "name": "pleasure",
+    "trans": [
+      "乐趣, 快感, 快乐, 荣幸 (noun.)"
+    ]
+  },
+  {
+    "name": "plenty",
+    "trans": [
+      "大量, 充足, 很多, 足够 (noun.)"
+    ]
+  },
+  {
+    "name": "plot",
+    "trans": [
+      "情节, 阴谋, 剧情, 故事情节 (noun.); 绘制 (verb.)"
+    ]
+  },
+  {
+    "name": "plug",
+    "trans": [
+      "插头, 塞, 插, 塞子 (noun.); 堵塞, 插入, 填补 (verb.)"
+    ]
+  },
+  {
+    "name": "plus",
+    "trans": [
+      "加上, 加, 再加上 (conj.)"
+    ]
+  },
+  {
+    "name": "pocket",
+    "trans": [
+      "口袋里, 口袋, 袖珍, 兜里 (noun.)"
+    ]
+  },
+  {
+    "name": "poem",
+    "trans": [
+      "首诗, 诗, 诗歌, 首诗歌 (noun.)"
+    ]
+  },
+  {
+    "name": "poet",
+    "trans": [
+      "诗人 (noun.)"
+    ]
+  },
+  {
+    "name": "poetry",
+    "trans": [
+      "诗歌, 诗, 诗词, 诗意 (noun.)"
+    ]
+  },
+  {
+    "name": "point",
+    "trans": [
+      "点, 一点, 观点, 角度 (noun.); 指 (verb.)"
+    ]
+  },
+  {
+    "name": "pole",
+    "trans": [
+      "极点, 极, 杆, 磁极 (noun.)"
+    ]
+  },
+  {
+    "name": "police",
+    "trans": [
+      "警方, 警察, 警, 公安 (noun.)"
+    ]
+  },
+  {
+    "name": "policeman",
+    "trans": [
+      "警察, 警员 (noun.)"
+    ]
+  },
+  {
+    "name": "policy",
+    "trans": [
+      "政策, 策略, 施政, 方针 (noun.)"
+    ]
+  },
+  {
+    "name": "polite",
+    "trans": [
+      "礼貌, 客气, 彬彬有礼, 懂礼貌 (adj.)"
+    ]
+  },
+  {
+    "name": "political",
+    "trans": [
+      "政治, 政界, 政制, 政局 (adj.)"
+    ]
+  },
+  {
+    "name": "politician",
+    "trans": [
+      "政治家, 政客, 政界人士 (noun.)"
+    ]
+  },
+  {
+    "name": "politics",
+    "trans": [
+      "政治, 政治学, 政坛, 政治课 (noun.)"
+    ]
+  },
+  {
+    "name": "poll",
+    "trans": [
+      "民意调查, 民调, 民意测验, 轮询 (noun.)"
+    ]
+  },
+  {
+    "name": "pollution",
+    "trans": [
+      "污染, 环境污染, 污, 污染物 (noun.)"
+    ]
+  },
+  {
+    "name": "pond",
+    "trans": [
+      "池塘, 池塘边, 池, 塘 (noun.)"
+    ]
+  },
+  {
+    "name": "pool",
+    "trans": [
+      "池, 游泳池, 泳池, 水池 (noun.)"
+    ]
+  },
+  {
+    "name": "poor",
+    "trans": [
+      "可怜, 穷人, 穷, 贫穷 (adj.)"
+    ]
+  },
+  {
+    "name": "pop",
+    "trans": [
+      "流行, 弹出, 流行乐, 通俗 (noun.)"
+    ]
+  },
+  {
+    "name": "popular",
+    "trans": [
+      "流行, 受欢迎, 通俗, 热门 (adj.)"
+    ]
+  },
+  {
+    "name": "population",
+    "trans": [
+      "人口, 种群, 人群, 群体 (noun.)"
+    ]
+  },
+  {
+    "name": "port",
+    "trans": [
+      "港口, 端口, 港, 口岸 (noun.)"
+    ]
+  },
+  {
+    "name": "pose",
+    "trans": [
+      "姿势, 位姿, 体式, 姿态 (noun.); 构成, 摆姿势 (verb.)"
+    ]
+  },
+  {
+    "name": "position",
+    "trans": [
+      "位置, 地位, 立场, 职位 (noun.)"
+    ]
+  },
+  {
+    "name": "positive",
+    "trans": [
+      "积极, 正面, 阳性, 正 (adj.)"
+    ]
+  },
+  {
+    "name": "possess",
+    "trans": [
+      "拥有, 具备, 具有, 占有 (verb.)"
+    ]
+  },
+  {
+    "name": "possession",
+    "trans": [
+      "占有, 藏, 拥有, 附身 (noun.)"
+    ]
+  },
+  {
+    "name": "possibility",
+    "trans": [
+      "可能性, 可能, 可行性, 可否 (noun.)"
+    ]
+  },
+  {
+    "name": "possible",
+    "trans": [
+      "可能, 尽可能, 可行, 可能性 (adj.)"
+    ]
+  },
+  {
+    "name": "possibly",
+    "trans": [
+      "可能 (adv.)"
+    ]
+  },
+  {
+    "name": "post",
+    "trans": [
+      "后, 邮政, 岗位, 帖子 (noun.); 张贴, 发布 (verb.)"
+    ]
+  },
+  {
+    "name": "post office",
+    "trans": [
+      "邮局 (noun.)"
+    ]
+  },
+  {
+    "name": "poster",
+    "trans": [
+      "海报, 张海报, 招贴, 招贴画 (noun.)"
+    ]
+  },
+  {
+    "name": "pot",
+    "trans": [
+      "锅, 壶, 大麻, 罐 (noun.)"
+    ]
+  },
+  {
+    "name": "potato",
+    "trans": [
+      "马铃薯, 土豆, 薯, 山芋 (noun.)"
+    ]
+  },
+  {
+    "name": "potential",
+    "trans": [
+      "潜在, 可能 (adj.); 潜力, 电位, 潜能, 势 (noun.)"
+    ]
+  },
+  {
+    "name": "pound",
+    "trans": [
+      "磅, 英镑, 镑, 磅重 (noun.)"
+    ]
+  },
+  {
+    "name": "pour",
+    "trans": [
+      "倒, 倒入, 倾吐, 倾泻 (verb.); 倾 (noun.)"
+    ]
+  },
+  {
+    "name": "poverty",
+    "trans": [
+      "贫困, 贫穷, 贫, 贫困人口 (noun.)"
+    ]
+  },
+  {
+    "name": "power",
+    "trans": [
+      "权力, 功率, 电力, 力量 (noun.)"
+    ]
+  },
+  {
+    "name": "powerful",
+    "trans": [
+      "强大, 有力, 强有力, 强力 (adj.)"
+    ]
+  },
+  {
+    "name": "practical",
+    "trans": [
+      "实用, 实际, 实践, 切实可行 (adj.)"
+    ]
+  },
+  {
+    "name": "practically",
+    "trans": [
+      "几乎, 实际上, 切实, 差不多 (adv.)"
+    ]
+  },
+  {
+    "name": "practice",
+    "trans": [
+      "实践, 练习, 做法, 实习 (noun.)"
+    ]
+  },
+  {
+    "name": "practise",
+    "trans": [
+      "练习, 执业, 练 (verb.); 实践, 实习 (noun.)"
+    ]
+  },
+  {
+    "name": "praise",
+    "trans": [
+      "赞美, 好评, 赞誉, 赞扬 (noun.)"
+    ]
+  },
+  {
+    "name": "pray",
+    "trans": [
+      "祈祷, 祷告, 祈求, 求 (verb.)"
+    ]
+  },
+  {
+    "name": "prayer",
+    "trans": [
+      "祈祷, 祷告, 祷文, 祷 (noun.)"
+    ]
+  },
+  {
+    "name": "precise",
+    "trans": [
+      "精确, 精密, 准确, 确切 (adj.)"
+    ]
+  },
+  {
+    "name": "precisely",
+    "trans": [
+      "恰恰, 精确, 正是, 准确 (adv.)"
+    ]
+  },
+  {
+    "name": "predict",
+    "trans": [
+      "预测, 预知, 预言, 预计 (verb.)"
+    ]
+  },
+  {
+    "name": "prefer",
+    "trans": [
+      "宁愿, 喜欢, 偏爱, 宁可 (verb.)"
+    ]
+  },
+  {
+    "name": "preference",
+    "trans": [
+      "偏好, 偏爱, 首选项, 喜好 (noun.)"
+    ]
+  },
+  {
+    "name": "pregnant",
+    "trans": [
+      "怀孕, 孕, 身孕, 孕妇 (adj.)"
+    ]
+  },
+  {
+    "name": "premise",
+    "trans": [
+      "前提, 前提下, 大前提下, 大前提 (noun.)"
+    ]
+  },
+  {
+    "name": "preparation",
+    "trans": [
+      "制备, 准备, 制剂, 研制 (noun.)"
+    ]
+  },
+  {
+    "name": "prepare",
+    "trans": [
+      "准备, 预备, 做好准备, 制备 (verb.)"
+    ]
+  },
+  {
+    "name": "prepared",
+    "trans": [
+      "准备, 制备, 拟备, 做好准备 (verb.)"
+    ]
+  },
+  {
+    "name": "presence",
+    "trans": [
+      "存在, 在场, 面前, 光临 (noun.)"
+    ]
+  },
+  {
+    "name": "present",
+    "trans": [
+      "礼物 (noun.); 目前, 当前, 现行, 现在 (adj.); 呈现, 提出 (verb.)"
+    ]
+  },
+  {
+    "name": "presentation",
+    "trans": [
+      "演示文稿, 演示, 演讲, 陈述 (noun.)"
+    ]
+  },
+  {
+    "name": "preserve",
+    "trans": [
+      "保存, 保留, 保持, 保护 (verb.); 保护区 (noun.)"
+    ]
+  },
+  {
+    "name": "president",
+    "trans": [
+      "总统, 主席, 总裁, 国家主席 (noun.)"
+    ]
+  },
+  {
+    "name": "press",
+    "trans": [
+      "按 (verb.); 出版社, 新闻, 新闻界, 媒体 (noun.)"
+    ]
+  },
+  {
+    "name": "pressure",
+    "trans": [
+      "压力, 压, 气压, 压强 (noun.)"
+    ]
+  },
+  {
+    "name": "presumably",
+    "trans": [
+      "想必, 据推测, 大概, 推测 (adv.)"
+    ]
+  },
+  {
+    "name": "presume",
+    "trans": [
+      "推定, 冒昧, 相信, 推测 (verb.)"
+    ]
+  },
+  {
+    "name": "pretend",
+    "trans": [
+      "假装, 装作, 装, 伪装 (verb.); 假扮 (adj.)"
+    ]
+  },
+  {
+    "name": "pretty",
+    "trans": [
+      "漂亮, 相当, 很, 非常 (adv.)"
+    ]
+  },
+  {
+    "name": "prevent",
+    "trans": [
+      "防止, 预防, 阻止, 避免 (verb.)"
+    ]
+  },
+  {
+    "name": "previous",
+    "trans": [
+      "先前, 以前, 以往, 前面 (adj.)"
+    ]
+  },
+  {
+    "name": "previously",
+    "trans": [
+      "先前, 以前, 此前, 之前 (adv.)"
+    ]
+  },
+  {
+    "name": "price",
+    "trans": [
+      "价格, 价, 代价, 价钱 (noun.)"
+    ]
+  },
+  {
+    "name": "pride",
+    "trans": [
+      "骄傲, 自豪感, 自豪, 自尊心 (noun.)"
+    ]
+  },
+  {
+    "name": "priest",
+    "trans": [
+      "牧师, 神父, 祭司, 教士 (noun.)"
+    ]
+  },
+  {
+    "name": "primarily",
+    "trans": [
+      "主要, 为主, 初步, 基本上 (adv.)"
+    ]
+  },
+  {
+    "name": "primary",
+    "trans": [
+      "原发性, 初级, 主要, 首要 (adj.)"
+    ]
+  },
+  {
+    "name": "prince",
+    "trans": [
+      "王子, 亲王, 太子, 普林斯 (noun.)"
+    ]
+  },
+  {
+    "name": "princess",
+    "trans": [
+      "公主, 王妃, 妃 (noun.)"
+    ]
+  },
+  {
+    "name": "principal",
+    "trans": [
+      "校长, 本金, 委托, 委托人 (noun.); 主, 主要, 主体, 首席 (adj.)"
+    ]
+  },
+  {
+    "name": "principle",
+    "trans": [
+      "原理, 原则, 原则上, 基本原理 (noun.)"
+    ]
+  },
+  {
+    "name": "print",
+    "trans": [
+      "打印, 印刷, 印刷品, 版画 (noun.); 列印, 印, 印制 (verb.)"
+    ]
+  },
+  {
+    "name": "printer",
+    "trans": [
+      "打印机, 台打印机, 承印, 印刷机 (noun.)"
+    ]
+  },
+  {
+    "name": "prior",
+    "trans": [
+      "事先, 先验, 先前, 预先 (adj.); 之前, 前, 在此之前 (adv.)"
+    ]
+  },
+  {
+    "name": "priority",
+    "trans": [
+      "优先, 优先级, 优先权, 优先考虑 (noun.)"
+    ]
+  },
+  {
+    "name": "prison",
+    "trans": [
+      "监狱, 狱, 坐牢, 监禁 (noun.)"
+    ]
+  },
+  {
+    "name": "prisoner",
+    "trans": [
+      "囚犯, 犯人, 囚徒, 战俘 (noun.)"
+    ]
+  },
+  {
+    "name": "private",
+    "trans": [
+      "私人, 私营, 民营, 私有 (adj.)"
+    ]
+  },
+  {
+    "name": "privilege",
+    "trans": [
+      "特权, 权限, 荣幸, 殊荣 (noun.)"
+    ]
+  },
+  {
+    "name": "prize",
+    "trans": [
+      "奖, 奖品, 奖金, 奖项 (noun.); 珍视 (verb.)"
+    ]
+  },
+  {
+    "name": "probably",
+    "trans": [
+      "可能, 大概, 也许, 或许 (adv.)"
+    ]
+  },
+  {
+    "name": "problem",
+    "trans": [
+      "问题, 难题, 题, 麻烦 (noun.)"
+    ]
+  },
+  {
+    "name": "procedure",
+    "trans": [
+      "程序, 过程, 议事, 流程 (noun.)"
+    ]
+  },
+  {
+    "name": "proceed",
+    "trans": [
+      "进行, 继续, 着手 (verb.)"
+    ]
+  },
+  {
+    "name": "proceeding",
+    "trans": [
+      "此案, 跟进, 出发, 进行 (verb.); 诉讼 (noun.)"
+    ]
+  },
+  {
+    "name": "process",
+    "trans": [
+      "过程, 工艺, 流程, 进程 (noun.)"
+    ]
+  },
+  {
+    "name": "produce",
+    "trans": [
+      "产生, 生产, 出示, 生成 (verb.); 农产品 (noun.)"
+    ]
+  },
+  {
+    "name": "producer",
+    "trans": [
+      "生产者, 制片人, 制作人, 生产国 (noun.)"
+    ]
+  },
+  {
+    "name": "product",
+    "trans": [
+      "产品, 产物, 品, 制品 (noun.)"
+    ]
+  },
+  {
+    "name": "production",
+    "trans": [
+      "生产, 制作, 产量, 产 (noun.)"
+    ]
+  },
+  {
+    "name": "profession",
+    "trans": [
+      "职业, 行业, 专业, 界 (noun.)"
+    ]
+  },
+  {
+    "name": "professional",
+    "trans": [
+      "专业, 职业, 专业化, 专业人士 (adj.)"
+    ]
+  },
+  {
+    "name": "professor",
+    "trans": [
+      "教授 (noun.)"
+    ]
+  },
+  {
+    "name": "profile",
+    "trans": [
+      "配置文件, 剖面, 概要文件, 轮廓 (noun.)"
+    ]
+  },
+  {
+    "name": "profit",
+    "trans": [
+      "利润, 营利, 盈利, 营利性 (noun.)"
+    ]
+  },
+  {
+    "name": "program",
+    "trans": [
+      "程序, 节目, 计划, 方案 (noun.)"
+    ]
+  },
+  {
+    "name": "programme",
+    "trans": [
+      "计划, 方案, 节目, 纲领 (noun.)"
+    ]
+  },
+  {
+    "name": "progress",
+    "trans": [
+      "进展, 进步, 进度, 进程 (noun.)"
+    ]
+  },
+  {
+    "name": "project",
+    "trans": [
+      "项目, 工程, 工程项目, 专案 (noun.)"
+    ]
+  },
+  {
+    "name": "promise",
+    "trans": [
+      "承诺, 诺言, 许诺, 应许 (noun.); 答应, 保证, 发誓 (verb.)"
+    ]
+  },
+  {
+    "name": "promote",
+    "trans": [
+      "促进, 推动, 推广, 推进 (verb.)"
+    ]
+  },
+  {
+    "name": "promotion",
+    "trans": [
+      "推广, 晋升, 促进, 促销 (noun.)"
+    ]
+  },
+  {
+    "name": "prompt",
+    "trans": [
+      "提示, 提示符, 提示符下, 及时 (adj.); 促使 (verb.)"
+    ]
+  },
+  {
+    "name": "proof",
+    "trans": [
+      "证明, 证据, 举证, 论证 (noun.)"
+    ]
+  },
+  {
+    "name": "proper",
+    "trans": [
+      "适当, 正确, 恰当, 合适 (adj.)"
+    ]
+  },
+  {
+    "name": "properly",
+    "trans": [
+      "妥善, 正确, 适当, 得当 (adv.)"
+    ]
+  },
+  {
+    "name": "property",
+    "trans": [
+      "财产, 属性, 物业, 性能 (noun.)"
+    ]
+  },
+  {
+    "name": "proportion",
+    "trans": [
+      "比例, 比重, 所占比例, 配比 (noun.)"
+    ]
+  },
+  {
+    "name": "proposal",
+    "trans": [
+      "建议, 提案, 提议, 方案 (noun.)"
+    ]
+  },
+  {
+    "name": "propose",
+    "trans": [
+      "提出, 求婚, 建议, 提议 (verb.)"
+    ]
+  },
+  {
+    "name": "proposed",
+    "trans": [
+      "提出, 拟议, 建议, 提议 (verb.)"
+    ]
+  },
+  {
+    "name": "prosecution",
+    "trans": [
+      "检控, 起诉, 检察机关, 提出检控 (noun.)"
+    ]
+  },
+  {
+    "name": "prospect",
+    "trans": [
+      "前景, 展望, 前景展望, 前瞻 (noun.)"
+    ]
+  },
+  {
+    "name": "protect",
+    "trans": [
+      "保护, 保障, 保卫, 守护 (verb.)"
+    ]
+  },
+  {
+    "name": "protection",
+    "trans": [
+      "保护, 防护, 保障 (noun.)"
+    ]
+  },
+  {
+    "name": "protest",
+    "trans": [
+      "抗议, 抗议活动, 抗诉, 示威 (noun.)"
+    ]
+  },
+  {
+    "name": "proud",
+    "trans": [
+      "自豪, 骄傲, 引以为傲, 值得骄傲 (adj.)"
+    ]
+  },
+  {
+    "name": "prove",
+    "trans": [
+      "证明, 证实, 验证, 论证 (verb.)"
+    ]
+  },
+  {
+    "name": "provide",
+    "trans": [
+      "提供, 为 (verb.)"
+    ]
+  },
+  {
+    "name": "provided",
+    "trans": [
+      "提供, 规定, 只要, 设置 (verb.)"
+    ]
+  },
+  {
+    "name": "providing",
+    "trans": [
+      "提供 (verb.)"
+    ]
+  },
+  {
+    "name": "provision",
+    "trans": [
+      "条文, 提供, 规定, 条款 (noun.)"
+    ]
+  },
+  {
+    "name": "psychological",
+    "trans": [
+      "心理, 心理学 (adj.)"
+    ]
+  },
+  {
+    "name": "psychology",
+    "trans": [
+      "心理学, 心理, 心态 (noun.)"
+    ]
+  },
+  {
+    "name": "pub",
+    "trans": [
+      "酒吧, 酒馆, 小酒馆, 客栈 (noun.)"
+    ]
+  },
+  {
+    "name": "public",
+    "trans": [
+      "公共, 公众, 公开, 公营 (adj.); 市民, 大众, 民众 (noun.)"
+    ]
+  },
+  {
+    "name": "publication",
+    "trans": [
+      "出版, 出版物, 刊物, 发布 (noun.)"
+    ]
+  },
+  {
+    "name": "publicity",
+    "trans": [
+      "宣传, 张扬, 公示, 公开 (noun.)"
+    ]
+  },
+  {
+    "name": "publish",
+    "trans": [
+      "发布, 出版, 发表, 公布 (verb.)"
+    ]
+  },
+  {
+    "name": "publisher",
+    "trans": [
+      "出版商, 发行商, 出版社, 出版 (noun.)"
+    ]
+  },
+  {
+    "name": "pudding",
+    "trans": [
+      "布丁, 糕, 年糕 (noun.)"
+    ]
+  },
+  {
+    "name": "pull",
+    "trans": [
+      "拉, 拔, 拉动, 拉扯 (verb.); 拉力 (noun.)"
+    ]
+  },
+  {
+    "name": "punch",
+    "trans": [
+      "冲床, 拳, 凸模, 冲孔 (noun.); 揍 (verb.)"
+    ]
+  },
+  {
+    "name": "punishment",
+    "trans": [
+      "惩罚, 处罚, 刑, 刑罚 (noun.)"
+    ]
+  },
+  {
+    "name": "pupil",
+    "trans": [
+      "瞳孔, 小学生, 瞳, 学生 (noun.)"
+    ]
+  },
+  {
+    "name": "purchase",
+    "trans": [
+      "购买, 采购, 购, 购置 (noun.); 买 (verb.)"
+    ]
+  },
+  {
+    "name": "pure",
+    "trans": [
+      "纯, 纯净, 纯粹, 纯洁 (adj.)"
+    ]
+  },
+  {
+    "name": "purely",
+    "trans": [
+      "纯粹, 纯, 纯属, 单纯 (adv.)"
+    ]
+  },
+  {
+    "name": "purple",
+    "trans": [
+      "紫色, 紫, 紫砂, 紫红色 (adj.)"
+    ]
+  },
+  {
+    "name": "purpose",
+    "trans": [
+      "宗旨, 目的, 用途, 目标 (noun.)"
+    ]
+  },
+  {
+    "name": "purse",
+    "trans": [
+      "钱包, 皮包, 包, 手提包 (noun.)"
+    ]
+  },
+  {
+    "name": "pursue",
+    "trans": [
+      "追求, 奉行, 追寻, 追逐 (verb.)"
+    ]
+  },
+  {
+    "name": "push",
+    "trans": [
+      "推, 推动, 推进, 逼 (verb.)"
+    ]
+  },
+  {
+    "name": "put",
+    "trans": [
+      "把, 放, 穿, 投入 (verb.)"
+    ]
+  },
+  {
+    "name": "qualification",
+    "trans": [
+      "资格, 资质, 资格证书, 资历 (noun.)"
+    ]
+  },
+  {
+    "name": "qualify",
+    "trans": [
+      "资格, 限定, 晋级, 符合资格 (verb.)"
+    ]
+  },
+  {
+    "name": "quality",
+    "trans": [
+      "质量, 品质, 素质, 优质 (noun.)"
+    ]
+  },
+  {
+    "name": "quantity",
+    "trans": [
+      "数量, 量, 水量, 用量 (noun.)"
+    ]
+  },
+  {
+    "name": "quarter",
+    "trans": [
+      "季度, 季, 四分之一, 财季 (noun.)"
+    ]
+  },
+  {
+    "name": "queen",
+    "trans": [
+      "女王, 皇后, 王后, 女皇 (noun.)"
+    ]
+  },
+  {
+    "name": "question",
+    "trans": [
+      "问题, 质询, 项质询, 提问 (noun.); 质疑, 怀疑 (verb.)"
+    ]
+  },
+  {
+    "name": "queue",
+    "trans": [
+      "队列, 排队 (noun.)"
+    ]
+  },
+  {
+    "name": "quick",
+    "trans": [
+      "快速, 快, 快捷, 迅速 (adj.)"
+    ]
+  },
+  {
+    "name": "quickly",
+    "trans": [
+      "迅速, 很快, 快速, 快 (adv.)"
+    ]
+  },
+  {
+    "name": "quid",
+    "trans": [
+      "镑, 尼·柯德, 英镑 (noun.)"
+    ]
+  },
+  {
+    "name": "quiet",
+    "trans": [
+      "安静, 宁静, 平静, 文静 (adj.)"
+    ]
+  },
+  {
+    "name": "quietly",
+    "trans": [
+      "悄悄地, 静静地, 悄然, 悄悄 (adv.)"
+    ]
+  },
+  {
+    "name": "quit",
+    "trans": [
+      "退出, 辞职, 辞掉, 放弃 (verb.)"
+    ]
+  },
+  {
+    "name": "quite",
+    "trans": [
+      "相当, 很, 颇, 非常 (adv.)"
+    ]
+  },
+  {
+    "name": "quote",
+    "trans": [
+      "报价, 引号, 报价单, 名言 (noun.); 引述, 引用, 报 (verb.)"
+    ]
+  },
+  {
+    "name": "race",
+    "trans": [
+      "种族, 比赛, 赛跑, 竞赛 (noun.)"
+    ]
+  },
+  {
+    "name": "racing",
+    "trans": [
+      "赛车, 赛跑, 竞速, 比赛 (noun.); 竞相 (verb.)"
+    ]
+  },
+  {
+    "name": "radical",
+    "trans": [
+      "激进, 根治, 基, 彻底 (adj.)"
+    ]
+  },
+  {
+    "name": "radio",
+    "trans": [
+      "无线电, 收音机, 电台, 广播 (noun.)"
+    ]
+  },
+  {
+    "name": "rail",
+    "trans": [
+      "轨, 轨道, 钢轨, 铁路 (noun.)"
+    ]
+  },
+  {
+    "name": "railway",
+    "trans": [
+      "铁路, 铁道, 轨道, 铁 (noun.)"
+    ]
+  },
+  {
+    "name": "rain",
+    "trans": [
+      "雨, 下雨, 雨水, 降雨 (noun.)"
+    ]
+  },
+  {
+    "name": "raise",
+    "trans": [
+      "提高, 筹集, 筹, 抚养 (verb.)"
+    ]
+  },
+  {
+    "name": "range",
+    "trans": [
+      "范围, 范围内, 射程, 距离 (noun.)"
+    ]
+  },
+  {
+    "name": "rank",
+    "trans": [
+      "排名, 秩, 职级, 军衔 (noun.)"
+    ]
+  },
+  {
+    "name": "rapid",
+    "trans": [
+      "快速, 迅速, 飞速, 迅猛 (adj.)"
+    ]
+  },
+  {
+    "name": "rapidly",
+    "trans": [
+      "迅速, 快速, 迅猛, 急速 (adv.)"
+    ]
+  },
+  {
+    "name": "rare",
+    "trans": [
+      "罕见, 稀有, 难得, 少见 (adj.)"
+    ]
+  },
+  {
+    "name": "rarely",
+    "trans": [
+      "很少, 极少, 鲜有, 难得 (adv.)"
+    ]
+  },
+  {
+    "name": "rate",
+    "trans": [
+      "率, 速率, 速度, 利率 (noun.)"
+    ]
+  },
+  {
+    "name": "rather",
+    "trans": [
+      "而, 相当, 更确切地说, 宁可 (adv.)"
+    ]
+  },
+  {
+    "name": "ratio",
+    "trans": [
+      "比率, 比例, 比, 比值 (noun.)"
+    ]
+  },
+  {
+    "name": "raw",
+    "trans": [
+      "原始, 生, 原料, 生吃 (adj.)"
+    ]
+  },
+  {
+    "name": "reach",
+    "trans": [
+      "达到, 到达, 达成, 达 (verb.)"
+    ]
+  },
+  {
+    "name": "react",
+    "trans": [
+      "反应, 作何反应, 回应 (verb.)"
+    ]
+  },
+  {
+    "name": "reaction",
+    "trans": [
+      "反应, 反作用, 化学反应 (noun.)"
+    ]
+  },
+  {
+    "name": "read",
+    "trans": [
+      "读, 阅读, 读取, 看 (verb.)"
+    ]
+  },
+  {
+    "name": "reader",
+    "trans": [
+      "读者, 读卡器 (noun.)"
+    ]
+  },
+  {
+    "name": "readily",
+    "trans": [
+      "欣然, 容易, 随手, 随时 (adv.)"
+    ]
+  },
+  {
+    "name": "reading",
+    "trans": [
+      "阅读, 读, 读书, 读数 (noun.); 看书, 读取, 看 (verb.)"
+    ]
+  },
+  {
+    "name": "ready",
+    "trans": [
+      "准备, 准备就绪, 就绪, 做好准备 (adj.)"
+    ]
+  },
+  {
+    "name": "real",
+    "trans": [
+      "真正, 真实, 现实, 真 (adj.)"
+    ]
+  },
+  {
+    "name": "realistic",
+    "trans": [
+      "现实, 逼真, 求实, 写实 (adj.)"
+    ]
+  },
+  {
+    "name": "reality",
+    "trans": [
+      "现实, 实相, 真人, 现实性 (noun.)"
+    ]
+  },
+  {
+    "name": "realize",
+    "trans": [
+      "实现, 意识到, 认识, 体会 (verb.)"
+    ]
+  },
+  {
+    "name": "really",
+    "trans": [
+      "真, 真正, 确实, 很 (adv.)"
+    ]
+  },
+  {
+    "name": "reason",
+    "trans": [
+      "原因, 理由, 理性, 缘由 (noun.)"
+    ]
+  },
+  {
+    "name": "reasonable",
+    "trans": [
+      "合理, 合情合理, 合理性, 公道 (adj.)"
+    ]
+  },
+  {
+    "name": "reasonably",
+    "trans": [
+      "合理, 相当 (adv.)"
+    ]
+  },
+  {
+    "name": "recall",
+    "trans": [
+      "召回, 回收 (noun.); 记得, 回忆, 回想一下, 回忆起 (verb.)"
+    ]
+  },
+  {
+    "name": "receipt",
+    "trans": [
+      "收据, 收到, 张收据, 收条 (noun.)"
+    ]
+  },
+  {
+    "name": "receive",
+    "trans": [
+      "收到, 接收, 接受, 获得 (verb.)"
+    ]
+  },
+  {
+    "name": "recent",
+    "trans": [
+      "最近, 近期, 近, 近来 (adj.)"
+    ]
+  },
+  {
+    "name": "recently",
+    "trans": [
+      "最近, 近日, 近来, 近年来 (adv.)"
+    ]
+  },
+  {
+    "name": "reception",
+    "trans": [
+      "接待, 招待会, 接待处, 接收 (noun.)"
+    ]
+  },
+  {
+    "name": "recipe",
+    "trans": [
+      "食谱, 配方, 菜谱, 秘方 (noun.)"
+    ]
+  },
+  {
+    "name": "reckon",
+    "trans": [
+      "估计 (verb.)"
+    ]
+  },
+  {
+    "name": "recognition",
+    "trans": [
+      "识别, 认可, 承认, 认同 (noun.)"
+    ]
+  },
+  {
+    "name": "recognize",
+    "trans": [
+      "认出, 认识, 认得, 承认 (verb.)"
+    ]
+  },
+  {
+    "name": "recommend",
+    "trans": [
+      "推荐, 建议 (verb.)"
+    ]
+  },
+  {
+    "name": "recommendation",
+    "trans": [
+      "推荐, 推荐信, 建议, 推介 (noun.)"
+    ]
+  },
+  {
+    "name": "record",
+    "trans": [
+      "记录, 纪录, 创纪录, 唱片 (noun.)"
+    ]
+  },
+  {
+    "name": "recording",
+    "trans": [
+      "录音, 记录, 唱片, 录像 (noun.); 录制, 录 (verb.)"
+    ]
+  },
+  {
+    "name": "recover",
+    "trans": [
+      "恢复, 收回, 复苏, 复原 (verb.)"
+    ]
+  },
+  {
+    "name": "recovery",
+    "trans": [
+      "恢复, 复苏, 回收, 经济复苏 (noun.)"
+    ]
+  },
+  {
+    "name": "red",
+    "trans": [
+      "红色, 红, 赤, 红灯 (adj.); 瑞德 (noun.)"
+    ]
+  },
+  {
+    "name": "reduce",
+    "trans": [
+      "减少, 降低, 减轻, 减低 (verb.)"
+    ]
+  },
+  {
+    "name": "reduction",
+    "trans": [
+      "还原, 约简, 减少, 复位 (noun.)"
+    ]
+  },
+  {
+    "name": "refer",
+    "trans": [
+      "指, 参考, 引用, 请参阅 (verb.)"
+    ]
+  },
+  {
+    "name": "reference",
+    "trans": [
+      "参考, 引用, 参考咨询, 参照 (noun.)"
+    ]
+  },
+  {
+    "name": "reflect",
+    "trans": [
+      "反映, 反映出, 体现, 反射 (verb.)"
+    ]
+  },
+  {
+    "name": "reflection",
+    "trans": [
+      "反射, 反思, 反映, 倒影 (noun.)"
+    ]
+  },
+  {
+    "name": "reform",
+    "trans": [
+      "改革, 变革, 体制改革, 改造 (noun.)"
+    ]
+  },
+  {
+    "name": "refrigerator",
+    "trans": [
+      "冰箱, 电冰箱, 制冷机, 冰箱里 (noun.)"
+    ]
+  },
+  {
+    "name": "refuse",
+    "trans": [
+      "拒绝, 拒, 不肯 (verb.); 垃圾 (noun.)"
+    ]
+  },
+  {
+    "name": "regard",
+    "trans": [
+      "方面, 至于 (noun.)"
+    ]
+  },
+  {
+    "name": "regime",
+    "trans": [
+      "政权, 政体, 制度, 体制 (noun.)"
+    ]
+  },
+  {
+    "name": "region",
+    "trans": [
+      "地区, 区域, 区, 地域 (noun.)"
+    ]
+  },
+  {
+    "name": "regional",
+    "trans": [
+      "区域, 区域性, 地区, 地域 (adj.); 区域市政 (noun.)"
+    ]
+  },
+  {
+    "name": "register",
+    "trans": [
+      "注册, 登记, 报名, 挂号 (verb.); 寄存器, 登记册, 注册纪录册, 选民登记册 (noun.)"
+    ]
+  },
+  {
+    "name": "registration",
+    "trans": [
+      "登记, 注册, 配准, 人事登记 (noun.)"
+    ]
+  },
+  {
+    "name": "regret",
+    "trans": [
+      "后悔, 感到遗憾, 後悔 (verb.); 遗憾, 悔恨, 懊悔, 悔 (noun.)"
+    ]
+  },
+  {
+    "name": "regular",
+    "trans": [
+      "定期, 常规, 正规, 普通 (adj.)"
+    ]
+  },
+  {
+    "name": "regularly",
+    "trans": [
+      "定期, 经常, 定时, 规律 (adv.)"
+    ]
+  },
+  {
+    "name": "regulation",
+    "trans": [
+      "调节, 规例, 调控, 监管 (noun.)"
+    ]
+  },
+  {
+    "name": "reinforce",
+    "trans": [
+      "加强, 加固, 强化, 巩固 (verb.)"
+    ]
+  },
+  {
+    "name": "reject",
+    "trans": [
+      "拒绝, 拒收, 否决, 排斥 (verb.); 废弃物 (noun.)"
+    ]
+  },
+  {
+    "name": "relate",
+    "trans": [
+      "涉及到, 涉及, 关系到, 与 (verb.)"
+    ]
+  },
+  {
+    "name": "related",
+    "trans": [
+      "相关, 关联 (adj.); 有关, 关系到, 涉及, 关系 (verb.)"
+    ]
+  },
+  {
+    "name": "relation",
+    "trans": [
+      "关系, 关联, 联系, 而言 (noun.)"
+    ]
+  },
+  {
+    "name": "relationship",
+    "trans": [
+      "关系, 感情, 恋情, 人际关系 (noun.)"
+    ]
+  },
+  {
+    "name": "relative",
+    "trans": [
+      "相对, 相关, 亲戚, 亲属 (adj.)"
+    ]
+  },
+  {
+    "name": "relatively",
+    "trans": [
+      "相对, 相对较, 比较, 较为 (adv.)"
+    ]
+  },
+  {
+    "name": "relax",
+    "trans": [
+      "放松, 放松一下, 放轻松, 放宽 (verb.)"
+    ]
+  },
+  {
+    "name": "release",
+    "trans": [
+      "释放, 发布, 释, 放行 (noun.); 公布, 放开, 放, 解除 (verb.)"
+    ]
+  },
+  {
+    "name": "relevant",
+    "trans": [
+      "相关, 有关, 相应 (adj.)"
+    ]
+  },
+  {
+    "name": "relief",
+    "trans": [
+      "救济, 救灾, 浮雕, 救援 (noun.)"
+    ]
+  },
+  {
+    "name": "relieve",
+    "trans": [
+      "缓解, 减轻, 纾缓, 解除 (verb.)"
+    ]
+  },
+  {
+    "name": "religion",
+    "trans": [
+      "宗教, 宗教信仰, 信仰 (noun.)"
+    ]
+  },
+  {
+    "name": "religious",
+    "trans": [
+      "宗教, 信教, 宗教信仰, 虔诚 (adj.)"
+    ]
+  },
+  {
+    "name": "rely",
+    "trans": [
+      "依赖, 依靠, 倚赖 (verb.)"
+    ]
+  },
+  {
+    "name": "remain",
+    "trans": [
+      "保持, 仍然, 留, 仍 (verb.)"
+    ]
+  },
+  {
+    "name": "remaining",
+    "trans": [
+      "剩余, 其余, 余下, 剩下 (verb.)"
+    ]
+  },
+  {
+    "name": "remains",
+    "trans": [
+      "仍是, 仍然, 仍, 依然 (verb.); 遗骸, 遗体 (noun.)"
+    ]
+  },
+  {
+    "name": "remark",
+    "trans": [
+      "备注, 句话, 一句话, 言论 (noun.)"
+    ]
+  },
+  {
+    "name": "remarkable",
+    "trans": [
+      "显着, 显著, 非凡, 了不起 (adj.)"
+    ]
+  },
+  {
+    "name": "remember",
+    "trans": [
+      "记得, 记住, 请记住, 记 (verb.)"
+    ]
+  },
+  {
+    "name": "remind",
+    "trans": [
+      "提醒, 想起 (verb.)"
+    ]
+  },
+  {
+    "name": "remote",
+    "trans": [
+      "远程, 偏远, 偏僻, 遥控 (adj.)"
+    ]
+  },
+  {
+    "name": "remove",
+    "trans": [
+      "删除, 移除, 去除, 消除 (verb.)"
+    ]
+  },
+  {
+    "name": "rent",
+    "trans": [
+      "租金, 房租, 寻租, 地租 (noun.); 租, 出租, 租房, 租用 (verb.)"
+    ]
+  },
+  {
+    "name": "repair",
+    "trans": [
+      "修复, 修理, 维修, 修补 (noun.); 修好 (verb.)"
+    ]
+  },
+  {
+    "name": "repeat",
+    "trans": [
+      "重复, 重复一遍, 再重复一遍, 复述 (verb.); 重演 (noun.)"
+    ]
+  },
+  {
+    "name": "replace",
+    "trans": [
+      "取代, 替换, 代替, 更换 (verb.)"
+    ]
+  },
+  {
+    "name": "replacement",
+    "trans": [
+      "更换, 置换术, 置换, 替代 (noun.)"
+    ]
+  },
+  {
+    "name": "reply",
+    "trans": [
+      "答复, 答覆, 回复, 回答 (noun.); 发言答辩, 答辩 (verb.)"
+    ]
+  },
+  {
+    "name": "report",
+    "trans": [
+      "报告, 报表, 报道, 汇报 (noun.); 举报 (verb.)"
+    ]
+  },
+  {
+    "name": "reporter",
+    "trans": [
+      "记者 (noun.)"
+    ]
+  },
+  {
+    "name": "represent",
+    "trans": [
+      "代表, 表示, 占 (verb.)"
+    ]
+  },
+  {
+    "name": "representation",
+    "trans": [
+      "表示, 代表性, 表征, 代表 (noun.)"
+    ]
+  },
+  {
+    "name": "representative",
+    "trans": [
+      "代表, 代表作, 代理人 (noun.); 代表性, 具有代表性, 具代表性, 代议制 (adj.)"
+    ]
+  },
+  {
+    "name": "republic",
+    "trans": [
+      "共和国, 共和, 民国, 共和政体 (noun.)"
+    ]
+  },
+  {
+    "name": "reputation",
+    "trans": [
+      "声誉, 信誉, 名声, 口碑 (noun.)"
+    ]
+  },
+  {
+    "name": "request",
+    "trans": [
+      "请求, 要求, 申请 (noun.)"
+    ]
+  },
+  {
+    "name": "require",
+    "trans": [
+      "需要, 要求, 规定, 需 (verb.)"
+    ]
+  },
+  {
+    "name": "requirement",
+    "trans": [
+      "要求, 需求, 规定, 需 (noun.)"
+    ]
+  },
+  {
+    "name": "rescue",
+    "trans": [
+      "救援, 营救, 抢救, 拯救 (noun.); 救, 挽救 (verb.)"
+    ]
+  },
+  {
+    "name": "research",
+    "trans": [
+      "研究, 科研, 调研, 研制 (noun.)"
+    ]
+  },
+  {
+    "name": "reserve",
+    "trans": [
+      "储备, 后备, 准备金, 预备役 (noun.); 保留, 预订, 预留, 预定 (verb.)"
+    ]
+  },
+  {
+    "name": "resident",
+    "trans": [
+      "居民, 常驻, 驻地, 住院医生 (noun.); 常住, 驻 (adj.)"
+    ]
+  },
+  {
+    "name": "residential",
+    "trans": [
+      "住宅, 居住, 住宿, 住宅区 (adj.)"
+    ]
+  },
+  {
+    "name": "resign",
+    "trans": [
+      "辞职, 辞去, 引咎辞职, 下台 (verb.); 辞去职务 (noun.)"
+    ]
+  },
+  {
+    "name": "resignation",
+    "trans": [
+      "辞职, 辞职信, 辞呈, 辞职书 (noun.)"
+    ]
+  },
+  {
+    "name": "resist",
+    "trans": [
+      "抗拒, 抵制, 抵抗, 抵御 (verb.)"
+    ]
+  },
+  {
+    "name": "resistance",
+    "trans": [
+      "电阻, 阻力, 抵抗, 抗 (noun.)"
+    ]
+  },
+  {
+    "name": "resolution",
+    "trans": [
+      "分辨率, 决议, 决议案, 分辨 (noun.)"
+    ]
+  },
+  {
+    "name": "resolve",
+    "trans": [
+      "解决, 化解, 解析 (verb.); 决心 (noun.)"
+    ]
+  },
+  {
+    "name": "resort",
+    "trans": [
+      "度假村, 胜地, 度假胜地, 度假区 (noun.); 诉诸 (verb.)"
+    ]
+  },
+  {
+    "name": "resource",
+    "trans": [
+      "资源 (noun.)"
+    ]
+  },
+  {
+    "name": "respect",
+    "trans": [
+      "尊重, 尊敬, 方面, 敬意 (noun.)"
+    ]
+  },
+  {
+    "name": "respectively",
+    "trans": [
+      "分别, 各自 (adv.)"
+    ]
+  },
+  {
+    "name": "respond",
+    "trans": [
+      "回应, 响应, 作出回应, 作出响应 (verb.)"
+    ]
+  },
+  {
+    "name": "response",
+    "trans": [
+      "响应, 反应, 回应, 应答 (noun.)"
+    ]
+  },
+  {
+    "name": "responsibility",
+    "trans": [
+      "责任, 责任感, 职责, 责任心 (noun.)"
+    ]
+  },
+  {
+    "name": "responsible",
+    "trans": [
+      "负责任, 负责, 责任心, 责任感 (adj.)"
+    ]
+  },
+  {
+    "name": "rest",
+    "trans": [
+      "休息, 其余, 剩下, 休息一下 (noun.)"
+    ]
+  },
+  {
+    "name": "restaurant",
+    "trans": [
+      "餐厅, 餐馆, 饭馆, 饭店 (noun.)"
+    ]
+  },
+  {
+    "name": "restore",
+    "trans": [
+      "恢复, 还原, 挽回, 重建 (verb.)"
+    ]
+  },
+  {
+    "name": "restrict",
+    "trans": [
+      "限制, 制约, 限定 (verb.)"
+    ]
+  },
+  {
+    "name": "restriction",
+    "trans": [
+      "限制, 制约, 约束, 限制性 (noun.)"
+    ]
+  },
+  {
+    "name": "result",
+    "trans": [
+      "结果, 效果, 因此, 成绩 (noun.); 导致, 造成 (verb.)"
+    ]
+  },
+  {
+    "name": "retain",
+    "trans": [
+      "保留, 留住, 挽留, 保持 (verb.)"
+    ]
+  },
+  {
+    "name": "retire",
+    "trans": [
+      "退休, 退役, 隐退, 退 (verb.)"
+    ]
+  },
+  {
+    "name": "retirement",
+    "trans": [
+      "退休, 退休金, 退役, 养老 (noun.)"
+    ]
+  },
+  {
+    "name": "return",
+    "trans": [
+      "返回, 回来, 归还, 回 (verb.); 回报, 回归, 退货, 归来 (noun.)"
+    ]
+  },
+  {
+    "name": "reveal",
+    "trans": [
+      "揭示, 透露, 揭露, 露出 (verb.)"
+    ]
+  },
+  {
+    "name": "revenue",
+    "trans": [
+      "收入, 收益, 营收, 税收 (noun.)"
+    ]
+  },
+  {
+    "name": "reverse",
+    "trans": [
+      "逆向, 反求 (adj.); 反向, 扭转, 逆转, 反 (verb.); 相反, 倒 (noun.)"
+    ]
+  },
+  {
+    "name": "review",
+    "trans": [
+      "检讨, 回顾, 审查, 复习 (noun.)"
+    ]
+  },
+  {
+    "name": "revolution",
+    "trans": [
+      "革命, 大革命, 变革, 辛亥革命 (noun.)"
+    ]
+  },
+  {
+    "name": "reward",
+    "trans": [
+      "奖励, 奖赏, 报酬, 回报 (noun.)"
+    ]
+  },
+  {
+    "name": "rhythm",
+    "trans": [
+      "节奏, 节律, 韵律, 节奏感 (noun.)"
+    ]
+  },
+  {
+    "name": "rice",
+    "trans": [
+      "水稻, 大米, 米饭, 稻 (noun.)"
+    ]
+  },
+  {
+    "name": "rich",
+    "trans": [
+      "丰富, 富有, 富, 有钱 (adj.)"
+    ]
+  },
+  {
+    "name": "rid",
+    "trans": [
+      "摆脱, 除去, 除掉, 去除 (verb.); 赶走 (adj.)"
+    ]
+  },
+  {
+    "name": "ride",
+    "trans": [
+      "骑, 骑马, 骑车, 坐 (verb.); 乘坐, 程, 乘车, 旅程 (noun.)"
+    ]
+  },
+  {
+    "name": "ridiculous",
+    "trans": [
+      "荒谬, 可笑, 荒唐, 荒谬可笑 (adj.)"
+    ]
+  },
+  {
+    "name": "right",
+    "trans": [
+      "正确, 右, 合适 (adj.); 权利, 权, 右边 (noun.); 对, 吧, 就, 好 (adv.)"
+    ]
+  },
+  {
+    "name": "right",
+    "trans": [
+      "正确, 右, 合适 (adj.); 权利, 权, 右边 (noun.); 对, 吧, 就, 好 (adv.)"
+    ]
+  },
+  {
+    "name": "ring",
+    "trans": [
+      "戒指, 环, 环形, 枚戒指 (noun.); 响, 打电话 (verb.)"
+    ]
+  },
+  {
+    "name": "rip",
+    "trans": [
+      "撕烂, 撕, 撕开, 扯 (verb.); 撕裂, 翻录, 裂口, 扯裂 (noun.)"
+    ]
+  },
+  {
+    "name": "rise",
+    "trans": [
+      "上升, 崛起, 兴起, 上涨 (noun.); 升起 (verb.)"
+    ]
+  },
+  {
+    "name": "risk",
+    "trans": [
+      "风险, 危险, 冒险, 危险性 (noun.); 冒 (verb.)"
+    ]
+  },
+  {
+    "name": "rival",
+    "trans": [
+      "对手, 竞争对手, 情敌, 劲敌 (noun.); 敌对, 对立 (adj.); 媲美 (verb.)"
+    ]
+  },
+  {
+    "name": "river",
+    "trans": [
+      "河, 河流, 条河, 河边 (noun.)"
+    ]
+  },
+  {
+    "name": "road",
+    "trans": [
+      "道路, 路, 道, 公路 (noun.)"
+    ]
+  },
+  {
+    "name": "rob",
+    "trans": [
+      "抢, 抢劫, 打劫, 剥夺 (verb.); 罗布, 罗伯, 罗勃, 抢夺 (noun.)"
+    ]
+  },
+  {
+    "name": "rock",
+    "trans": [
+      "岩石, 岩, 摇滚, 摇滚乐 (noun.)"
+    ]
+  },
+  {
+    "name": "role",
+    "trans": [
+      "作用, 角色, 地位, 职责 (noun.)"
+    ]
+  },
+  {
+    "name": "roll",
+    "trans": [
+      "辊, 轧辊, 卷, 滚 (noun.); 摇, 推出 (verb.)"
+    ]
+  },
+  {
+    "name": "roof",
+    "trans": [
+      "屋顶, 顶板, 屋面, 房顶 (noun.)"
+    ]
+  },
+  {
+    "name": "room",
+    "trans": [
+      "房间, 室, 房, 客房 (noun.)"
+    ]
+  },
+  {
+    "name": "root",
+    "trans": [
+      "根, 根系, 根源, 根目录 (noun.)"
+    ]
+  },
+  {
+    "name": "rope",
+    "trans": [
+      "绳, 绳子, 绳索, 根绳子 (noun.)"
+    ]
+  },
+  {
+    "name": "rough",
+    "trans": [
+      "粗糙, 粗, 粗略, 粗暴 (adj.)"
+    ]
+  },
+  {
+    "name": "roughly",
+    "trans": [
+      "大致, 大约, 粗略, 约 (adv.)"
+    ]
+  },
+  {
+    "name": "round",
+    "trans": [
+      "圆, 轮, 回合, 圆形 (noun.); 圆圆, 全面 (adj.); 周围, 绕, 围着 (prep.); 四周 (adv.)"
+    ]
+  },
+  {
+    "name": "route",
+    "trans": [
+      "路线, 路由, 路径, 号干线 (noun.)"
+    ]
+  },
+  {
+    "name": "routine",
+    "trans": [
+      "常规, 例行, 日常, 套路 (adj.); 例程, 例行程序, 日常工作, 惯例 (noun.)"
+    ]
+  },
+  {
+    "name": "row",
+    "trans": [
+      "排, 行, 一行, 连续 (noun.); 划船 (verb.)"
+    ]
+  },
+  {
+    "name": "royal",
+    "trans": [
+      "皇家, 皇室, 王室, 英国皇家 (noun.); 皇族, 高贵 (adj.)"
+    ]
+  },
+  {
+    "name": "rub",
+    "trans": [
+      "擦, 搓, 揉, 揉搓 (verb.); 碰摩, 磨擦 (noun.)"
+    ]
+  },
+  {
+    "name": "rubber",
+    "trans": [
+      "橡胶, 橡皮, 胶, 橡塑 (noun.)"
+    ]
+  },
+  {
+    "name": "rubbish",
+    "trans": [
+      "垃圾, 废话, 垃圾堆, 胡说八道 (noun.)"
+    ]
+  },
+  {
+    "name": "rude",
+    "trans": [
+      "粗鲁, 无礼, 粗鲁无礼, 失礼 (adj.)"
+    ]
+  },
+  {
+    "name": "ruin",
+    "trans": [
+      "毁掉, 毁, 破坏, 断送 (verb.); 废墟, 毁灭, 破产 (noun.)"
+    ]
+  },
+  {
+    "name": "rule",
+    "trans": [
+      "规则, 统治, 规律, 法则 (noun.); 排除 (verb.)"
+    ]
+  },
+  {
+    "name": "run",
+    "trans": [
+      "运行, 跑, 奔跑, 快跑 (verb.); 来看 (noun.)"
+    ]
+  },
+  {
+    "name": "rural",
+    "trans": [
+      "农村, 乡村, 农, 乡郊 (adj.)"
+    ]
+  },
+  {
+    "name": "rush",
+    "trans": [
+      "拉什, 急于, 匆忙, 仓促 (noun.); 冲, 催, 赶 (verb.)"
+    ]
+  },
+  {
+    "name": "sack",
+    "trans": [
+      "麻袋, 袋, 袋子, 沙克 (noun.); 解雇, 开除 (verb.)"
+    ]
+  },
+  {
+    "name": "sad",
+    "trans": [
+      "伤心, 悲伤, 难过, 悲哀 (adj.)"
+    ]
+  },
+  {
+    "name": "safe",
+    "trans": [
+      "安全, 保险箱, 保险柜, 平安 (adj.)"
+    ]
+  },
+  {
+    "name": "safety",
+    "trans": [
+      "安全, 安全性, 安全生产 (noun.)"
+    ]
+  },
+  {
+    "name": "sail",
+    "trans": [
+      "帆, 船帆, 风帆, 赛欧 (noun.); 航行, 启航, 扬帆, 起航 (verb.)"
+    ]
+  },
+  {
+    "name": "sake",
+    "trans": [
+      "缘故, 着想, 清酒, 为了 (noun.)"
+    ]
+  },
+  {
+    "name": "salad",
+    "trans": [
+      "沙拉, 色拉, 沙律, 丁沙拉 (noun.)"
+    ]
+  },
+  {
+    "name": "salary",
+    "trans": [
+      "薪水, 工资, 薪酬, 薪金 (noun.)"
+    ]
+  },
+  {
+    "name": "sale",
+    "trans": [
+      "销售, 出售, 售, 售卖 (noun.)"
+    ]
+  },
+  {
+    "name": "salt",
+    "trans": [
+      "盐, 食盐, 咸, 鹹 (noun.)"
+    ]
+  },
+  {
+    "name": "same",
+    "trans": [
+      "相同, 同样, 同一, 一样 (adj.)"
+    ]
+  },
+  {
+    "name": "sample",
+    "trans": [
+      "样本, 样品, 示例, 样例 (noun.)"
+    ]
+  },
+  {
+    "name": "sand",
+    "trans": [
+      "砂, 沙子, 沙, 砂土 (noun.)"
+    ]
+  },
+  {
+    "name": "sandwich",
+    "trans": [
+      "三明治, 夹心, 夹芯, 夹层 (noun.)"
+    ]
+  },
+  {
+    "name": "satellite",
+    "trans": [
+      "卫星, 颗卫星, 人造卫星, 星载 (noun.)"
+    ]
+  },
+  {
+    "name": "satisfaction",
+    "trans": [
+      "满意, 满意度, 满足感, 满足 (noun.)"
+    ]
+  },
+  {
+    "name": "satisfied",
+    "trans": [
+      "满意, 满足, 信纳, 心满意足 (adj.)"
+    ]
+  },
+  {
+    "name": "satisfy",
+    "trans": [
+      "满足, 满意 (verb.)"
+    ]
+  },
+  {
+    "name": "sauce",
+    "trans": [
+      "酱, 酱汁, 汁, 沙司 (noun.)"
+    ]
+  },
+  {
+    "name": "sausage",
+    "trans": [
+      "香肠, 腊肠, 火腿肠, 肠 (noun.)"
+    ]
+  },
+  {
+    "name": "save",
+    "trans": [
+      "拯救, 救, 保存, 节省 (verb.)"
+    ]
+  },
+  {
+    "name": "saving",
+    "trans": [
+      "储蓄, 节约, 节省, 拯救 (verb.)"
+    ]
+  },
+  {
+    "name": "say",
+    "trans": [
+      "说, 说出, 称, 表示 (verb.)"
+    ]
+  },
+  {
+    "name": "scale",
+    "trans": [
+      "规模, 尺度, 秤, 刻度 (noun.); 扩展 (verb.)"
+    ]
+  },
+  {
+    "name": "scared",
+    "trans": [
+      "害怕, 吓坏, 怕, 惊吓 (adj.); 吓, 吓死 (verb.)"
+    ]
+  },
+  {
+    "name": "scene",
+    "trans": [
+      "现场, 场景, 场面, 幕 (noun.)"
+    ]
+  },
+  {
+    "name": "schedule",
+    "trans": [
+      "附表, 时间表, 进度, 日程安排 (noun.)"
+    ]
+  },
+  {
+    "name": "scheme",
+    "trans": [
+      "方案, 计划, 格式 (noun.)"
+    ]
+  },
+  {
+    "name": "school",
+    "trans": [
+      "学校, 上学, 校, 放学 (noun.)"
+    ]
+  },
+  {
+    "name": "science",
+    "trans": [
+      "科学, 理科, 学, 自然科学 (noun.)"
+    ]
+  },
+  {
+    "name": "scientific",
+    "trans": [
+      "科学, 科学化, 科学性, 科技 (adj.)"
+    ]
+  },
+  {
+    "name": "scientist",
+    "trans": [
+      "科学家 (noun.)"
+    ]
+  },
+  {
+    "name": "scope",
+    "trans": [
+      "范围, 适用范围, 范围内, 范畴 (noun.)"
+    ]
+  },
+  {
+    "name": "score",
+    "trans": [
+      "得分, 评分, 分数, 比分 (noun.); 进球 (verb.)"
+    ]
+  },
+  {
+    "name": "scratch",
+    "trans": [
+      "划伤, 划痕, 刮, 刮伤 (noun.); 挠, 搔, 抓 (verb.)"
+    ]
+  },
+  {
+    "name": "scream",
+    "trans": [
+      "尖叫, 大声尖叫, 大叫, 叫喊 (verb.); 声尖叫, 尖叫声, 呐喊, 叫声 (noun.)"
+    ]
+  },
+  {
+    "name": "screen",
+    "trans": [
+      "屏幕, 屏, 丝网, 画面 (noun.)"
+    ]
+  },
+  {
+    "name": "screw",
+    "trans": [
+      "螺杆, 螺钉, 螺丝, 螺旋 (noun.); 搞砸 (verb.)"
+    ]
+  },
+  {
+    "name": "script",
+    "trans": [
+      "脚本, 剧本, 指令码 (noun.)"
+    ]
+  },
+  {
+    "name": "sea",
+    "trans": [
+      "海, 大海, 海上, 海洋 (noun.)"
+    ]
+  },
+  {
+    "name": "seal",
+    "trans": [
+      "密封, 印章, 封, 海豹 (noun.)"
+    ]
+  },
+  {
+    "name": "search",
+    "trans": [
+      "搜索, 搜寻, 搜查, 寻找 (noun.); 搜 (verb.)"
+    ]
+  },
+  {
+    "name": "season",
+    "trans": [
+      "赛季, 季节, 季, 旺季 (noun.)"
+    ]
+  },
+  {
+    "name": "seat",
+    "trans": [
+      "座位, 座椅, 座, 位子 (noun.)"
+    ]
+  },
+  {
+    "name": "second",
+    "trans": [
+      "第二, 二, 第二次, 其次 (adj.)"
+    ]
+  },
+  {
+    "name": "secondary",
+    "trans": [
+      "二次, 二级, 次生, 次要 (adj.)"
+    ]
+  },
+  {
+    "name": "secondly",
+    "trans": [
+      "其次, 第二, 其二, 二 (adv.)"
+    ]
+  },
+  {
+    "name": "secret",
+    "trans": [
+      "秘密, 秘诀, 机密, 奥秘 (noun.); 秘, 隐秘, 保密, 神秘 (adj.)"
+    ]
+  },
+  {
+    "name": "secretary",
+    "trans": [
+      "司, 秘书, 局长, 司司长 (noun.)"
+    ]
+  },
+  {
+    "name": "section",
+    "trans": [
+      "节, 部分, 截面, 第 (noun.)"
+    ]
+  },
+  {
+    "name": "sector",
+    "trans": [
+      "部门, 界, 扇区, 行业 (noun.)"
+    ]
+  },
+  {
+    "name": "secure",
+    "trans": [
+      "安全, 保密, 安心, 保障 (adj.); 确保, 保护 (verb.)"
+    ]
+  },
+  {
+    "name": "security",
+    "trans": [
+      "安全, 保安, 安全性, 安防 (noun.)"
+    ]
+  },
+  {
+    "name": "see",
+    "trans": [
+      "看到, 看, 看见, 见 (verb.)"
+    ]
+  },
+  {
+    "name": "seed",
+    "trans": [
+      "种子, 籽, 粒种子, 种 (noun.)"
+    ]
+  },
+  {
+    "name": "seek",
+    "trans": [
+      "寻求, 寻找, 谋求, 追求 (verb.)"
+    ]
+  },
+  {
+    "name": "seem",
+    "trans": [
+      "似乎, 看起来, 好像, 看上去 (verb.)"
+    ]
+  },
+  {
+    "name": "seize",
+    "trans": [
+      "抓住, 抢占, 检取, 把握 (verb.)"
+    ]
+  },
+  {
+    "name": "select",
+    "trans": [
+      "选择, 选取, 选中, 挑选 (verb.); 专责 (noun.)"
+    ]
+  },
+  {
+    "name": "selection",
+    "trans": [
+      "选择, 选型, 选用, 选取 (noun.)"
+    ]
+  },
+  {
+    "name": "self",
+    "trans": [
+      "自我, 自, 赛尔夫, 自身 (noun.)"
+    ]
+  },
+  {
+    "name": "sell",
+    "trans": [
+      "卖, 出售, 卖掉, 卖出 (verb.)"
+    ]
+  },
+  {
+    "name": "send",
+    "trans": [
+      "发送, 送, 派, 寄 (verb.)"
+    ]
+  },
+  {
+    "name": "senior",
+    "trans": [
+      "高级, 资深, 高层, 中高级 (adj.)"
+    ]
+  },
+  {
+    "name": "sense",
+    "trans": [
+      "感, 意识, 感觉, 意义 (noun.)"
+    ]
+  },
+  {
+    "name": "sensible",
+    "trans": [
+      "明智, 懂事, 理智, 合理 (adj.)"
+    ]
+  },
+  {
+    "name": "sensitive",
+    "trans": [
+      "敏感, 灵敏, 敏, 敏感性 (adj.)"
+    ]
+  },
+  {
+    "name": "sentence",
+    "trans": [
+      "句子, 句, 句话, 刑期 (noun.)"
+    ]
+  },
+  {
+    "name": "separate",
+    "trans": [
+      "单独, 分开, 独立, 分离 (adj.); 分隔 (verb.)"
+    ]
+  },
+  {
+    "name": "sequence",
+    "trans": [
+      "序列, 顺序, 层序, 序 (noun.)"
+    ]
+  },
+  {
+    "name": "series",
+    "trans": [
+      "系列, 一系列, 序列, 串联 (noun.)"
+    ]
+  },
+  {
+    "name": "serious",
+    "trans": [
+      "严重, 严肃, 认真, 严峻 (adj.)"
+    ]
+  },
+  {
+    "name": "seriously",
+    "trans": [
+      "认真, 严重, 认真对待, 当真 (adv.)"
+    ]
+  },
+  {
+    "name": "servant",
+    "trans": [
+      "仆人, 佣人, 仆, 奴仆 (noun.)"
+    ]
+  },
+  {
+    "name": "serve",
+    "trans": [
+      "服务, 服侍, 侍奉, 事奉 (verb.); 发球 (noun.)"
+    ]
+  },
+  {
+    "name": "service",
+    "trans": [
+      "服务, 业务, 服务业, 使用 (noun.)"
+    ]
+  },
+  {
+    "name": "session",
+    "trans": [
+      "会话, 会期, 会议, 届 (noun.)"
+    ]
+  },
+  {
+    "name": "set",
+    "trans": [
+      "设置, 集, 设定, 定 (verb.); 组, 集合, 一套, 套 (noun.)"
+    ]
+  },
+  {
+    "name": "setting",
+    "trans": [
+      "设置, 设定, 整定, 制定 (verb.); 背景 (noun.)"
+    ]
+  },
+  {
+    "name": "settle",
+    "trans": [
+      "定居, 解决, 安顿, 和解 (verb.)"
+    ]
+  },
+  {
+    "name": "settlement",
+    "trans": [
+      "沉降, 结算, 交收, 聚落 (noun.)"
+    ]
+  },
+  {
+    "name": "several",
+    "trans": [
+      "几个, 几种, 几, 若干 (adj.)"
+    ]
+  },
+  {
+    "name": "severe",
+    "trans": [
+      "严重, 重症, 重型, 严峻 (adj.)"
+    ]
+  },
+  {
+    "name": "sew",
+    "trans": [
+      "缝, 缝制, 缝纫, 缝合 (verb.)"
+    ]
+  },
+  {
+    "name": "sex",
+    "trans": [
+      "性别, 性, 性爱, 性行为 (noun.)"
+    ]
+  },
+  {
+    "name": "sexual",
+    "trans": [
+      "性, 有性, 性别, 性爱 (adj.)"
+    ]
+  },
+  {
+    "name": "shadow",
+    "trans": [
+      "影子, 阴影, 影, 暗影 (noun.)"
+    ]
+  },
+  {
+    "name": "shake",
+    "trans": [
+      "动摇, 摇, 摇动, 撼动 (verb.)"
+    ]
+  },
+  {
+    "name": "shall",
+    "trans": [
+      "须, 应当, 应 (modal.)"
+    ]
+  },
+  {
+    "name": "shame",
+    "trans": [
+      "耻辱, 羞耻, 羞愧, 羞耻感 (noun.)"
+    ]
+  },
+  {
+    "name": "shape",
+    "trans": [
+      "形状, 形, 外形, 形态 (noun.); 塑造 (verb.)"
+    ]
+  },
+  {
+    "name": "share",
+    "trans": [
+      "分享, 共享, 分担, 大家分享 (verb.); 份额, 占有率, 股, 股份 (noun.)"
+    ]
+  },
+  {
+    "name": "sharp",
+    "trans": [
+      "锋利, 尖锐, 夏普, 锐利 (adj.)"
+    ]
+  },
+  {
+    "name": "sharply",
+    "trans": [
+      "大幅, 急剧, 一针见血, 锐 (adv.)"
+    ]
+  },
+  {
+    "name": "shave",
+    "trans": [
+      "刮胡子, 刮脸, 剃, 刮 (verb.); 剃须 (noun.)"
+    ]
+  },
+  {
+    "name": "she",
+    "trans": [
+      "她 (pron.)"
+    ]
+  },
+  {
+    "name": "shed",
+    "trans": [
+      "棚, 棚子, 大棚, 舍 (noun.); 流下, 摆脱, 脱落, 洒 (verb.)"
+    ]
+  },
+  {
+    "name": "sheep",
+    "trans": [
+      "羊, 绵羊, 羊群, 肥羊 (noun.)"
+    ]
+  },
+  {
+    "name": "sheet",
+    "trans": [
+      "钣, 薄板, 板材, 片材 (noun.)"
+    ]
+  },
+  {
+    "name": "shelf",
+    "trans": [
+      "货架, 架子, 陆架, 书架 (noun.)"
+    ]
+  },
+  {
+    "name": "shell",
+    "trans": [
+      "壳, 外壳, 壳牌, 壳体 (noun.)"
+    ]
+  },
+  {
+    "name": "shelter",
+    "trans": [
+      "庇护所, 避难所, 庇护, 收容所 (noun.)"
+    ]
+  },
+  {
+    "name": "shift",
+    "trans": [
+      "转变, 移, 转移, 轮班 (noun.); 改变 (verb.)"
+    ]
+  },
+  {
+    "name": "shine",
+    "trans": [
+      "闪耀, 照耀, 发光, 发亮 (verb.); 光泽, 光芒 (noun.)"
+    ]
+  },
+  {
+    "name": "ship",
+    "trans": [
+      "船, 船舶, 艘船, 舰 (noun.); 出货, 运送 (verb.)"
+    ]
+  },
+  {
+    "name": "shirt",
+    "trans": [
+      "衬衫, 衬衣, 件衬衫, 衫 (noun.)"
+    ]
+  },
+  {
+    "name": "shock",
+    "trans": [
+      "休克, 冲击, 震惊, 激波 (noun.)"
+    ]
+  },
+  {
+    "name": "shocked",
+    "trans": [
+      "震惊, 震撼, 惊呆, 吃惊 (adj.); 感到震惊, 吓, 电击, 惊吓 (verb.)"
+    ]
+  },
+  {
+    "name": "shocking",
+    "trans": [
+      "令人震惊, 触目惊心, 震撼, 震惊 (adj.)"
+    ]
+  },
+  {
+    "name": "shoe",
+    "trans": [
+      "鞋, 鞋子, 制鞋, 擦鞋 (noun.)"
+    ]
+  },
+  {
+    "name": "shoot",
+    "trans": [
+      "开枪, 射, 拍摄, 开枪打 (verb.); 茎 (noun.)"
+    ]
+  },
+  {
+    "name": "shop",
+    "trans": [
+      "店, 商店, 店铺, 车间 (noun.); 购物 (verb.)"
+    ]
+  },
+  {
+    "name": "shopping",
+    "trans": [
+      "购物, 逛街, 购, 买 (noun.)"
+    ]
+  },
+  {
+    "name": "short",
+    "trans": [
+      "短, 短暂, 简短, 短期 (adj.)"
+    ]
+  },
+  {
+    "name": "shortly",
+    "trans": [
+      "不久, 短, 很快, 不久便 (adv.)"
+    ]
+  },
+  {
+    "name": "shot",
+    "trans": [
+      "枪杀, 杀 (verb.); 拍摄, 开枪, 射, 镜头 (noun.)"
+    ]
+  },
+  {
+    "name": "should",
+    "trans": [
+      "应该, 应, 应当 (modal.)"
+    ]
+  },
+  {
+    "name": "shoulder",
+    "trans": [
+      "肩膀, 肩, 肩部, 肩关节 (noun.); 肩负, 承担 (verb.)"
+    ]
+  },
+  {
+    "name": "shout",
+    "trans": [
+      "喊, 呼喊, 大声喊, 大喊 (verb.)"
+    ]
+  },
+  {
+    "name": "shove",
+    "trans": [
+      "推 (verb.)"
+    ]
+  },
+  {
+    "name": "show",
+    "trans": [
+      "显示, 表明, 展示, 告诉 (verb.); 秀, 节目, 表演, 演出 (noun.)"
+    ]
+  },
+  {
+    "name": "shower",
+    "trans": [
+      "淋浴, 澡, 洗澡, 阵雨 (noun.)"
+    ]
+  },
+  {
+    "name": "shrug",
+    "trans": [
+      "耸肩, 耸耸肩 (noun.)"
+    ]
+  },
+  {
+    "name": "shut",
+    "trans": [
+      "关上, 关闭, 关, 闭 (verb.)"
+    ]
+  },
+  {
+    "name": "sick",
+    "trans": [
+      "生病, 病, 有病, 恶心 (adj.)"
+    ]
+  },
+  {
+    "name": "side",
+    "trans": [
+      "一边, 侧, 身边, 一面 (noun.)"
+    ]
+  },
+  {
+    "name": "sight",
+    "trans": [
+      "视线, 景象, 视力, 眼前 (noun.)"
+    ]
+  },
+  {
+    "name": "sign",
+    "trans": [
+      "标志, 迹象, 符号, 征兆 (noun.); 签, 签署, 签字, 签名 (verb.)"
+    ]
+  },
+  {
+    "name": "signal",
+    "trans": [
+      "信号, 讯号, 电信号 (noun.)"
+    ]
+  },
+  {
+    "name": "signature",
+    "trans": [
+      "签名, 签字, 签章, 署名 (noun.)"
+    ]
+  },
+  {
+    "name": "significance",
+    "trans": [
+      "意义, 重要性, 现实意义 (noun.)"
+    ]
+  },
+  {
+    "name": "significant",
+    "trans": [
+      "显著, 重大, 重要, 显着 (adj.)"
+    ]
+  },
+  {
+    "name": "significantly",
+    "trans": [
+      "显著, 明显, 大大, 显着 (adv.)"
+    ]
+  },
+  {
+    "name": "silence",
+    "trans": [
+      "沉默, 寂静, 沉寂, 静默 (noun.)"
+    ]
+  },
+  {
+    "name": "silent",
+    "trans": [
+      "沉默, 无声, 寂静, 静默 (adj.)"
+    ]
+  },
+  {
+    "name": "silly",
+    "trans": [
+      "傻, 愚蠢, 傻傻, 蠢 (adj.)"
+    ]
+  },
+  {
+    "name": "silver",
+    "trans": [
+      "银, 银币, 银制品, 银器(noun.) 银制的, 像银的 (adj.) (在某物上)镀银 (vt.)"
+    ]
+  },
+  {
+    "name": "similar",
+    "trans": [
+      "类似, 相似, 同类, 相近 (adj.)"
+    ]
+  },
+  {
+    "name": "similarly",
+    "trans": [
+      "同样, 类似, 同理, 相似 (adv.)"
+    ]
+  },
+  {
+    "name": "simple",
+    "trans": [
+      "简单, 简易, 单纯, 简便 (adj.)"
+    ]
+  },
+  {
+    "name": "simply",
+    "trans": [
+      "简单, 仅仅, 只是, 只需 (adv.)"
+    ]
+  },
+  {
+    "name": "sin",
+    "trans": [
+      "罪, 罪恶, 罪过, 罪孽 (noun.)"
+    ]
+  },
+  {
+    "name": "since",
+    "trans": [
+      "自从, 以来, 自, 既然 (prep.)"
+    ]
+  },
+  {
+    "name": "sing",
+    "trans": [
+      "唱, 唱歌, 歌唱, 唱出 (verb.)"
+    ]
+  },
+  {
+    "name": "singer",
+    "trans": [
+      "歌手, 歌唱家, 歌星, 辛格 (noun.)"
+    ]
+  },
+  {
+    "name": "single",
+    "trans": [
+      "单, 单一, 单身, 单个 (adj.)"
+    ]
+  },
+  {
+    "name": "sink",
+    "trans": [
+      "水槽, 洗涤槽, 水池, 汇 (noun.); 下沉, 沉, 沉下去, 沉沦 (verb.)"
+    ]
+  },
+  {
+    "name": "sir",
+    "trans": [
+      "先生, 主席先生, 长官, 爵士 (noun.)"
+    ]
+  },
+  {
+    "name": "sister",
+    "trans": [
+      "妹妹, 姐姐, 姐妹, 妹 (noun.)"
+    ]
+  },
+  {
+    "name": "sit",
+    "trans": [
+      "坐, 坐下, 静坐 (verb.)"
+    ]
+  },
+  {
+    "name": "site",
+    "trans": [
+      "网站, 站点, 现场, 工地 (noun.)"
+    ]
+  },
+  {
+    "name": "situation",
+    "trans": [
+      "情况, 形势, 状况, 局面 (noun.)"
+    ]
+  },
+  {
+    "name": "size",
+    "trans": [
+      "大小, 尺寸, 规模, 尺码 (noun.)"
+    ]
+  },
+  {
+    "name": "skill",
+    "trans": [
+      "技能, 技巧, 能力, 技艺 (noun.)"
+    ]
+  },
+  {
+    "name": "skin",
+    "trans": [
+      "皮肤, 肌肤, 皮, 肤 (noun.)"
+    ]
+  },
+  {
+    "name": "skirt",
+    "trans": [
+      "裙子, 裙, 条裙子, 短裙 (noun.)"
+    ]
+  },
+  {
+    "name": "sky",
+    "trans": [
+      "天空, 天上, 空中, 天际 (noun.)"
+    ]
+  },
+  {
+    "name": "sleep",
+    "trans": [
+      "睡眠, 眠, 觉, 沉睡 (noun.); 睡, 睡觉, 入睡, 睡着 (verb.)"
+    ]
+  },
+  {
+    "name": "slice",
+    "trans": [
+      "切片, 片, 薄片, 一片 (noun.); 切 (verb.)"
+    ]
+  },
+  {
+    "name": "slide",
+    "trans": [
+      "幻灯片, 滑, 滑动, 张幻灯片 (noun.)"
+    ]
+  },
+  {
+    "name": "slight",
+    "trans": [
+      "轻微, 细微, 微微, 稍有 (adj.)"
+    ]
+  },
+  {
+    "name": "slightly",
+    "trans": [
+      "稍, 略, 稍微, 略微 (adv.)"
+    ]
+  },
+  {
+    "name": "slim",
+    "trans": [
+      "苗条, 渺茫, 超薄, 身材苗条 (adj.); 斯利姆 (noun.)"
+    ]
+  },
+  {
+    "name": "slip",
+    "trans": [
+      "滑, 滑移, 滑动, 支路 (noun.); 溜, 滑倒, 打滑, 溜走 (verb.)"
+    ]
+  },
+  {
+    "name": "slope",
+    "trans": [
+      "边坡, 斜坡, 坡, 斜率 (noun.)"
+    ]
+  },
+  {
+    "name": "slow",
+    "trans": [
+      "慢, 缓慢, 慢速, 缓 (adj.); 减缓, 放缓, 减慢, 放慢 (verb.)"
+    ]
+  },
+  {
+    "name": "slowly",
+    "trans": [
+      "慢慢, 慢慢地, 缓慢, 慢 (adv.)"
+    ]
+  },
+  {
+    "name": "small",
+    "trans": [
+      "小, 小型, 小小, 较小 (adj.)"
+    ]
+  },
+  {
+    "name": "smart",
+    "trans": [
+      "聪明, 智能, 精明, 史马特 (adj.)"
+    ]
+  },
+  {
+    "name": "smell",
+    "trans": [
+      "气味, 味道, 嗅觉, 异味 (noun.); 闻, 闻起来, 闻闻, 嗅 (verb.)"
+    ]
+  },
+  {
+    "name": "smile",
+    "trans": [
+      "微笑, 笑容, 笑, 面带微笑 (noun.)"
+    ]
+  },
+  {
+    "name": "smoke",
+    "trans": [
+      "烟雾, 烟, 浓烟, 烟气 (noun.); 抽烟, 吸烟, 抽, 吸 (verb.)"
+    ]
+  },
+  {
+    "name": "smoking",
+    "trans": [
+      "吸烟, 抽烟, 禁烟, 冒烟 (noun.); 抽, 吸 (verb.)"
+    ]
+  },
+  {
+    "name": "smooth",
+    "trans": [
+      "光滑, 顺利, 平滑, 平稳 (adj.)"
+    ]
+  },
+  {
+    "name": "snap",
+    "trans": [
+      "抓拍, 捕捉, 折断 (verb.); 单元, 齐, 快照 (noun.)"
+    ]
+  },
+  {
+    "name": "snow",
+    "trans": [
+      "雪, 下雪, 积雪, 雪地 (noun.)"
+    ]
+  },
+  {
+    "name": "so",
+    "trans": [
+      "所以, 如此, 这么, 因此 (adv.)"
+    ]
+  },
+  {
+    "name": "soap",
+    "trans": [
+      "肥皂, 香皂, 皂, 肥皂洗手 (noun.)"
+    ]
+  },
+  {
+    "name": "so-called",
+    "trans": [
+      "所谓 (adj.)"
+    ]
+  },
+  {
+    "name": "social",
+    "trans": [
+      "社会, 社交, 社会性, 社 (adj.)"
+    ]
+  },
+  {
+    "name": "society",
+    "trans": [
+      "社会, 学会, 协会, 社会上 (noun.)"
+    ]
+  },
+  {
+    "name": "sock",
+    "trans": [
+      "袜子, 索克, 袜, 短袜 (noun.)"
+    ]
+  },
+  {
+    "name": "soft",
+    "trans": [
+      "软, 柔软, 柔和, 软弱 (adj.)"
+    ]
+  },
+  {
+    "name": "software",
+    "trans": [
+      "软件, 软 (noun.)"
+    ]
+  },
+  {
+    "name": "soil",
+    "trans": [
+      "土壤, 土, 土体, 泥土 (noun.)"
+    ]
+  },
+  {
+    "name": "soldier",
+    "trans": [
+      "士兵, 战士, 军人, 兵 (noun.)"
+    ]
+  },
+  {
+    "name": "sole",
+    "trans": [
+      "唯一, 独家, 鞋底, 独资 (adj.)"
+    ]
+  },
+  {
+    "name": "solicitor",
+    "trans": [
+      "律师, 执业律师 (noun.)"
+    ]
+  },
+  {
+    "name": "solid",
+    "trans": [
+      "固体, 坚实, 固, 固态 (adj.)"
+    ]
+  },
+  {
+    "name": "solution",
+    "trans": [
+      "解决方案, 溶液, 解, 解决办法 (noun.)"
+    ]
+  },
+  {
+    "name": "solve",
+    "trans": [
+      "解决, 求解, 解, 解答 (verb.)"
+    ]
+  },
+  {
+    "name": "some",
+    "trans": [
+      "一些, 有些, 某些 (det.)"
+    ]
+  },
+  {
+    "name": "somebody",
+    "trans": [
+      "有人, 某人, 别人, 来人 (noun.)"
+    ]
+  },
+  {
+    "name": "somehow",
+    "trans": [
+      "不知何故, 不知怎的, 不知为何, 莫名其妙地 (adv.)"
+    ]
+  },
+  {
+    "name": "someone",
+    "trans": [
+      "有人, 某人, 别人, 人 (noun.)"
+    ]
+  },
+  {
+    "name": "something",
+    "trans": [
+      "东西, 一些, 什么, 些 (noun.)"
+    ]
+  },
+  {
+    "name": "sometimes",
+    "trans": [
+      "有时, 有时候, 时而, 偶尔 (adv.)"
+    ]
+  },
+  {
+    "name": "somewhat",
+    "trans": [
+      "有点, 有些, 有所, 稍微 (adv.)"
+    ]
+  },
+  {
+    "name": "somewhere",
+    "trans": [
+      "某个地方, 某地, 地方, 某 (adv.)"
+    ]
+  },
+  {
+    "name": "son",
+    "trans": [
+      "儿子, 子, 儿, 孩子 (noun.)"
+    ]
+  },
+  {
+    "name": "song",
+    "trans": [
+      "首歌, 歌, 歌曲, 宋 (noun.)"
+    ]
+  },
+  {
+    "name": "soon",
+    "trans": [
+      "很快, 不久, 尽快, 快 (adv.)"
+    ]
+  },
+  {
+    "name": "sore",
+    "trans": [
+      "疮, 酸痛, 痛, 疼 (adj.)"
+    ]
+  },
+  {
+    "name": "sorry",
+    "trans": [
+      "抱歉, 对不起, 遗憾, 不好意思 (adj.)"
+    ]
+  },
+  {
+    "name": "sort",
+    "trans": [
+      "排序, 那种, 类, 分类 (noun.); 整理 (verb.)"
+    ]
+  },
+  {
+    "name": "soul",
+    "trans": [
+      "灵魂, 心灵, 魂, 灵魂深处 (noun.)"
+    ]
+  },
+  {
+    "name": "sound",
+    "trans": [
+      "声音, 声, 音响, 音 (noun.); 健全, 完善, 稳健, 良好 (adj.); 听起来, 听上去 (verb.)"
+    ]
+  },
+  {
+    "name": "soup",
+    "trans": [
+      "汤, 喝汤, 羹, 碗汤 (noun.)"
+    ]
+  },
+  {
+    "name": "source",
+    "trans": [
+      "源, 来源, 源泉, 源头 (noun.)"
+    ]
+  },
+  {
+    "name": "south",
+    "trans": [
+      "南, 南方, 南部, 南面 (noun.); 以南, 南边, 南下 (adv.)"
+    ]
+  },
+  {
+    "name": "southern",
+    "trans": [
+      "南部, 南方, 南, 华南 (adj.); 南区 (noun.)"
+    ]
+  },
+  {
+    "name": "space",
+    "trans": [
+      "空间, 太空, 航天, 空格 (noun.)"
+    ]
+  },
+  {
+    "name": "spare",
+    "trans": [
+      "备用, 业余, 空余, 空闲 (adj.); 饶, 抽出 (verb.)"
+    ]
+  },
+  {
+    "name": "speak",
+    "trans": [
+      "说话, 发言, 讲, 说 (verb.)"
+    ]
+  },
+  {
+    "name": "speaker",
+    "trans": [
+      "扬声器, 议长, 音箱, 演说家 (noun.)"
+    ]
+  },
+  {
+    "name": "special",
+    "trans": [
+      "特殊, 特别, 特种, 专用 (adj.)"
+    ]
+  },
+  {
+    "name": "specialist",
+    "trans": [
+      "专家, 专科, 专科医生, 专业公司 (noun.)"
+    ]
+  },
+  {
+    "name": "species",
+    "trans": [
+      "物种, 种, 种类, 品种 (noun.)"
+    ]
+  },
+  {
+    "name": "specific",
+    "trans": [
+      "特定, 具体, 特异性, 特殊 (adj.)"
+    ]
+  },
+  {
+    "name": "specifically",
+    "trans": [
+      "专门, 具体, 特别, 具体地说 (adv.)"
+    ]
+  },
+  {
+    "name": "specify",
+    "trans": [
+      "指定, 指明, 注明, 订明 (verb.)"
+    ]
+  },
+  {
+    "name": "speech",
+    "trans": [
+      "演讲, 语音, 讲话, 演说 (noun.)"
+    ]
+  },
+  {
+    "name": "speed",
+    "trans": [
+      "速度, 速, 转速, 车速 (noun.); 加速, 加快 (verb.)"
+    ]
+  },
+  {
+    "name": "spell",
+    "trans": [
+      "拼写, 拼, 拼读 (verb.); 法术, 咒语, 魔咒, 符咒 (noun.)"
+    ]
+  },
+  {
+    "name": "spelling",
+    "trans": [
+      "拼写, 拼字, 单词拼写, 拼 (noun.)"
+    ]
+  },
+  {
+    "name": "spend",
+    "trans": [
+      "花, 花费, 度过, 共度 (verb.)"
+    ]
+  },
+  {
+    "name": "spill",
+    "trans": [
+      "泄漏, 漏油事件, 溢, 泄漏事故 (noun.); 洒, 溅, 泼 (verb.)"
+    ]
+  },
+  {
+    "name": "spin",
+    "trans": [
+      "自旋, 旋转, 旋, 自转 (noun.); 转动, 剥离 (verb.)"
+    ]
+  },
+  {
+    "name": "spirit",
+    "trans": [
+      "精神, 灵, 灵魂, 圣灵 (noun.)"
+    ]
+  },
+  {
+    "name": "spiritual",
+    "trans": [
+      "精神, 灵性, 属灵, 心灵 (adj.)"
+    ]
+  },
+  {
+    "name": "spite",
+    "trans": [
+      "尽管, 不顾, 尽管如此, 不管 (noun.)"
+    ]
+  },
+  {
+    "name": "split",
+    "trans": [
+      "分裂, 拆分, 分割, 劈裂 (noun.); 分手, 分开, 分解 (verb.)"
+    ]
+  },
+  {
+    "name": "spoil",
+    "trans": [
+      "破坏, 宠坏, 宠, 溺爱 (verb.)"
+    ]
+  },
+  {
+    "name": "spokesman",
+    "trans": [
+      "发言人, 一位发言人, 代言人, 新闻发言人 (noun.)"
+    ]
+  },
+  {
+    "name": "spoon",
+    "trans": [
+      "勺子, 勺, 汤匙, 匙 (noun.)"
+    ]
+  },
+  {
+    "name": "sport",
+    "trans": [
+      "体育, 运动, 体育运动, 竞技 (noun.)"
+    ]
+  },
+  {
+    "name": "spot",
+    "trans": [
+      "现货, 当场, 斑, 现场 (noun.)"
+    ]
+  },
+  {
+    "name": "spray",
+    "trans": [
+      "喷雾, 喷, 喷涂, 喷淋 (noun.)"
+    ]
+  },
+  {
+    "name": "spread",
+    "trans": [
+      "传播, 蔓延, 扩散, 扩 (noun.); 散布, 散播, 分散, 展开 (verb.)"
+    ]
+  },
+  {
+    "name": "spring",
+    "trans": [
+      "春天, 弹簧, 春, 春季 (noun.)"
+    ]
+  },
+  {
+    "name": "squad",
+    "trans": [
+      "小队, 阵容, 队, 球队 (noun.)"
+    ]
+  },
+  {
+    "name": "square",
+    "trans": [
+      "广场, 平方, 正方形, 坊 (noun.); 方形, 方, 二乘, 二乘法 (adj.)"
+    ]
+  },
+  {
+    "name": "squeeze",
+    "trans": [
+      "挤, 挤出, 榨, 榨取 (verb.); 挤压, 紧缩, 压榨 (noun.)"
+    ]
+  },
+  {
+    "name": "stable",
+    "trans": [
+      "稳定, 平稳, 稳, 安定 (adj.)"
+    ]
+  },
+  {
+    "name": "staff",
+    "trans": [
+      "员工, 工作人员, 人员, 职员 (noun.)"
+    ]
+  },
+  {
+    "name": "stage",
+    "trans": [
+      "阶段, 舞台, 期, 台上 (noun.)"
+    ]
+  },
+  {
+    "name": "stair",
+    "trans": [
+      "楼梯, 台阶, 阶梯, 座椅 (noun.)"
+    ]
+  },
+  {
+    "name": "stake",
+    "trans": [
+      "股份, 股权, 木桩, 持股比例 (noun.)"
+    ]
+  },
+  {
+    "name": "stall",
+    "trans": [
+      "失速, 摊位, 摊档, 档位 (noun.); 拖住, 拖延, 停滞 (verb.)"
+    ]
+  },
+  {
+    "name": "stamp",
+    "trans": [
+      "邮票, 张邮票, 印章, 印花税 (noun.)"
+    ]
+  },
+  {
+    "name": "stand",
+    "trans": [
+      "站, 忍受, 站立, 受不了 (verb.); 立场, 架, 台 (noun.)"
+    ]
+  },
+  {
+    "name": "standard",
+    "trans": [
+      "标准, 标, 规范, 标准化 (adj.); 本位, 水准, 准则, 水平 (noun.)"
+    ]
+  },
+  {
+    "name": "star",
+    "trans": [
+      "明星, 星, 星级, 恒星 (noun.)"
+    ]
+  },
+  {
+    "name": "stare",
+    "trans": [
+      "凝视, 瞪眼, 瞪, 盯 (noun.)"
+    ]
+  },
+  {
+    "name": "start",
+    "trans": [
+      "开始, 启动, 出发, 展开 (verb.); 开端, 起步, 起动 (noun.)"
+    ]
+  },
+  {
+    "name": "starve",
+    "trans": [
+      "饿死, 挨饿, 饿肚子, 饿 (verb.)"
+    ]
+  },
+  {
+    "name": "state",
+    "trans": [
+      "状态, 国家, 州, 国有 (noun.)"
+    ]
+  },
+  {
+    "name": "statement",
+    "trans": [
+      "语句, 声明, 份声明, 陈述 (noun.)"
+    ]
+  },
+  {
+    "name": "station",
+    "trans": [
+      "站, 车站, 火车站, 电台 (noun.)"
+    ]
+  },
+  {
+    "name": "statistic",
+    "trans": [
+      "统计, 统计学, 统计数字 (noun.)"
+    ]
+  },
+  {
+    "name": "status",
+    "trans": [
+      "地位, 状态, 现状, 状况 (noun.)"
+    ]
+  },
+  {
+    "name": "stay",
+    "trans": [
+      "呆, 留, 待, 留下 (verb.); 逗留 (noun.)"
+    ]
+  },
+  {
+    "name": "steady",
+    "trans": [
+      "稳定, 稳步, 稳态, 稳 (adj.)"
+    ]
+  },
+  {
+    "name": "steak",
+    "trans": [
+      "牛排, 份牛排, 牛扒, 肉排 (noun.)"
+    ]
+  },
+  {
+    "name": "steal",
+    "trans": [
+      "偷, 偷走, 窃取, 偷窃 (verb.)"
+    ]
+  },
+  {
+    "name": "steam",
+    "trans": [
+      "蒸汽, 汽, 蒸气, 蒸 (noun.)"
+    ]
+  },
+  {
+    "name": "steel",
+    "trans": [
+      "钢, 钢铁, 钢材, 钢制 (noun.)"
+    ]
+  },
+  {
+    "name": "steep",
+    "trans": [
+      "陡峭, 陡, 险峻, 急倾斜 (adj.)"
+    ]
+  },
+  {
+    "name": "step",
+    "trans": [
+      "步, 步骤, 步进, 台阶 (noun.); 踩, 加强 (verb.)"
+    ]
+  },
+  {
+    "name": "stick",
+    "trans": [
+      "坚持, 粘, 棍, 贴 (verb.); 棍子, 根棍子, 棒, 杆 (noun.)"
+    ]
+  },
+  {
+    "name": "stiff",
+    "trans": [
+      "僵硬, 僵, 硬, 呆板 (adj.)"
+    ]
+  },
+  {
+    "name": "still",
+    "trans": [
+      "仍然, 还, 仍, 依然 (adv.)"
+    ]
+  },
+  {
+    "name": "stir",
+    "trans": [
+      "搅拌, 轰动, 骚动, 炒 (noun.); 挑起, 搅, 搅动, 激起 (verb.)"
+    ]
+  },
+  {
+    "name": "stock",
+    "trans": [
+      "股票, 库存, 证券, 存量 (noun.)"
+    ]
+  },
+  {
+    "name": "stomach",
+    "trans": [
+      "胃, 肚子, 肠胃, 腹部 (noun.)"
+    ]
+  },
+  {
+    "name": "stone",
+    "trans": [
+      "石头, 石, 石材, 块石头 (noun.)"
+    ]
+  },
+  {
+    "name": "stop",
+    "trans": [
+      "停止, 阻止, 停下来, 停下 (verb.); 站 (noun.)"
+    ]
+  },
+  {
+    "name": "storage",
+    "trans": [
+      "存储, 储存, 贮存, 贮藏 (noun.)"
+    ]
+  },
+  {
+    "name": "store",
+    "trans": [
+      "商店, 店, 存储, 店铺 (noun.); 储存, 存放, 保存 (verb.)"
+    ]
+  },
+  {
+    "name": "storm",
+    "trans": [
+      "风暴, 暴风雨, 暴风, 暴雨 (noun.)"
+    ]
+  },
+  {
+    "name": "story",
+    "trans": [
+      "故事, 报道, 层, 小说 (noun.)"
+    ]
+  },
+  {
+    "name": "straight",
+    "trans": [
+      "直, 直接, 笔直, 直线 (adv.); 异性恋, 平直, 连续 (adj.)"
+    ]
+  },
+  {
+    "name": "straightforward",
+    "trans": [
+      "直截了当, 简单明了, 简单, 直白 (adj.)"
+    ]
+  },
+  {
+    "name": "strain",
+    "trans": [
+      "应变, 菌株, 株, 菌种 (noun.)"
+    ]
+  },
+  {
+    "name": "strange",
+    "trans": [
+      "奇怪, 陌生, 怪, 奇特 (adj.)"
+    ]
+  },
+  {
+    "name": "stranger",
+    "trans": [
+      "陌生人, 陌生, 生人, 陌路 (noun.)"
+    ]
+  },
+  {
+    "name": "strategic",
+    "trans": [
+      "战略, 战略性, 地理位置, 策略 (adj.)"
+    ]
+  },
+  {
+    "name": "strategy",
+    "trans": [
+      "策略, 战略, 对策 (noun.)"
+    ]
+  },
+  {
+    "name": "straw",
+    "trans": [
+      "秸秆, 稻草, 秸杆, 吸管 (noun.)"
+    ]
+  },
+  {
+    "name": "strawberry",
+    "trans": [
+      "草莓, 草莓味 (noun.)"
+    ]
+  },
+  {
+    "name": "stream",
+    "trans": [
+      "流, 小溪, 溪流, 条小溪 (noun.)"
+    ]
+  },
+  {
+    "name": "street",
+    "trans": [
+      "街, 街道, 街上, 街头 (noun.)"
+    ]
+  },
+  {
+    "name": "strength",
+    "trans": [
+      "强度, 实力, 力量, 实力雄厚 (noun.)"
+    ]
+  },
+  {
+    "name": "strengthen",
+    "trans": [
+      "加强, 强化, 增强, 巩固 (verb.)"
+    ]
+  },
+  {
+    "name": "stress",
+    "trans": [
+      "应力, 压力, 应激, 胁迫 (noun.); 强调 (verb.)"
+    ]
+  },
+  {
+    "name": "stretch",
+    "trans": [
+      "舒展, 伸展, 拉伸, 弹力 (noun.); 伸出 (verb.)"
+    ]
+  },
+  {
+    "name": "strict",
+    "trans": [
+      "严格, 严, 严谨, 严密 (adj.)"
+    ]
+  },
+  {
+    "name": "strike",
+    "trans": [
+      "罢工, 打击, 击, 攻击 (noun.)"
+    ]
+  },
+  {
+    "name": "string",
+    "trans": [
+      "字符串, 弦, 字串, 串 (noun.)"
+    ]
+  },
+  {
+    "name": "strip",
+    "trans": [
+      "带钢, 脱衣舞, 脱衣, 条形 (noun.); 剥夺 (verb.)"
+    ]
+  },
+  {
+    "name": "stroke",
+    "trans": [
+      "中风, 脑卒中, 卒中, 冲程 (noun.); 抚摸 (verb.)"
+    ]
+  },
+  {
+    "name": "strong",
+    "trans": [
+      "强, 强烈, 强大, 坚强 (adj.)"
+    ]
+  },
+  {
+    "name": "strongly",
+    "trans": [
+      "强烈, 强, 大力, 极力 (adv.)"
+    ]
+  },
+  {
+    "name": "structure",
+    "trans": [
+      "结构, 构造, 架构, 构成 (noun.)"
+    ]
+  },
+  {
+    "name": "struggle",
+    "trans": [
+      "斗争, 奋斗, 挣扎, 拼搏 (noun.)"
+    ]
+  },
+  {
+    "name": "student",
+    "trans": [
+      "学生, 助学, 学员, 留学生 (noun.)"
+    ]
+  },
+  {
+    "name": "studio",
+    "trans": [
+      "演播室, 画室, 录音室, 制片厂 (noun.)"
+    ]
+  },
+  {
+    "name": "study",
+    "trans": [
+      "研究, 学习, 学, 观察 (noun.); 探讨 (verb.)"
+    ]
+  },
+  {
+    "name": "stuff",
+    "trans": [
+      "东西, 玩意, 玩意儿, 事情 (noun.)"
+    ]
+  },
+  {
+    "name": "stupid",
+    "trans": [
+      "愚蠢, 蠢, 笨, 傻 (adj.)"
+    ]
+  },
+  {
+    "name": "style",
+    "trans": [
+      "风格, 样式, 作风, 款式 (noun.)"
+    ]
+  },
+  {
+    "name": "subject",
+    "trans": [
+      "主体, 主题, 学科, 课题 (noun.); 受, 受到 (adj.)"
+    ]
+  },
+  {
+    "name": "submit",
+    "trans": [
+      "提交, 递交, 呈交, 报送 (verb.)"
+    ]
+  },
+  {
+    "name": "subsequent",
+    "trans": [
+      "后续, 随后, 其后, 后继 (adj.)"
+    ]
+  },
+  {
+    "name": "subsequently",
+    "trans": [
+      "随后, 其后, 后来, 随之 (adv.)"
+    ]
+  },
+  {
+    "name": "substance",
+    "trans": [
+      "物质, 实质, 物, 实体 (noun.)"
+    ]
+  },
+  {
+    "name": "substantial",
+    "trans": [
+      "实质性, 大量, 可观, 大幅 (adj.)"
+    ]
+  },
+  {
+    "name": "succeed",
+    "trans": [
+      "成功, 取得成功, 得逞, 接替 (verb.)"
+    ]
+  },
+  {
+    "name": "success",
+    "trans": [
+      "成功, 取得成功, 成功与否, 成就 (noun.)"
+    ]
+  },
+  {
+    "name": "successful",
+    "trans": [
+      "成功, 取得成功, 顺利 (adj.)"
+    ]
+  },
+  {
+    "name": "successfully",
+    "trans": [
+      "成功, 顺利, 圆满 (adv.)"
+    ]
+  },
+  {
+    "name": "such",
+    "trans": [
+      "这样, 这种, 如此, 这么 (adj.)"
+    ]
+  },
+  {
+    "name": "suck",
+    "trans": [
+      "吸, 吮吸, 吮, 吸吮 (verb.)"
+    ]
+  },
+  {
+    "name": "sudden",
+    "trans": [
+      "突然, 突如其来, 突发, 突发性 (adj.)"
+    ]
+  },
+  {
+    "name": "suddenly",
+    "trans": [
+      "突然, 忽然, 突然间, 顿时 (adv.)"
+    ]
+  },
+  {
+    "name": "suffer",
+    "trans": [
+      "受苦, 遭受, 受罪, 受害 (verb.)"
+    ]
+  },
+  {
+    "name": "sufficient",
+    "trans": [
+      "足够, 充足, 充分, 足以 (adj.)"
+    ]
+  },
+  {
+    "name": "sugar",
+    "trans": [
+      "糖, 食糖, 白糖, 砂糖 (noun.)"
+    ]
+  },
+  {
+    "name": "suggest",
+    "trans": [
+      "建议, 表明, 暗示, 显示 (verb.)"
+    ]
+  },
+  {
+    "name": "suggestion",
+    "trans": [
+      "建议, 提议, 暗示, 意见 (noun.)"
+    ]
+  },
+  {
+    "name": "suit",
+    "trans": [
+      "西装, 西服, 套装, 衣服 (noun.); 适合, 适应, 满足, 合适 (verb.)"
+    ]
+  },
+  {
+    "name": "suitable",
+    "trans": [
+      "合适, 适合, 适用, 适宜 (adj.)"
+    ]
+  },
+  {
+    "name": "sum",
+    "trans": [
+      "总和, 求和, 笔款项, 款项 (noun.)"
+    ]
+  },
+  {
+    "name": "summer",
+    "trans": [
+      "夏天, 夏季, 夏, 夏日 (noun.)"
+    ]
+  },
+  {
+    "name": "sun",
+    "trans": [
+      "太阳, 阳光, 孙, 太阳底下 (noun.)"
+    ]
+  },
+  {
+    "name": "super",
+    "trans": [
+      "超级, 超, 特 (adv.)"
+    ]
+  },
+  {
+    "name": "supermarket",
+    "trans": [
+      "超市, 超级市场 (noun.)"
+    ]
+  },
+  {
+    "name": "supper",
+    "trans": [
+      "晚饭, 晚餐, 夜宵, 吃完晚饭 (noun.)"
+    ]
+  },
+  {
+    "name": "supply",
+    "trans": [
+      "供应, 供给, 供货, 补给 (noun.); 提供 (verb.)"
+    ]
+  },
+  {
+    "name": "support",
+    "trans": [
+      "支持, 支援, 支撑, 支护 (noun.)"
+    ]
+  },
+  {
+    "name": "supporter",
+    "trans": [
+      "支持者, 拥护者 (noun.)"
+    ]
+  },
+  {
+    "name": "suppose",
+    "trans": [
+      "假设, 想, 猜, 猜想 (verb.)"
+    ]
+  },
+  {
+    "name": "sure",
+    "trans": [
+      "确定, 肯定, 当然, 确信 (adj.)"
+    ]
+  },
+  {
+    "name": "surely",
+    "trans": [
+      "肯定, 当然, 一定, 无疑 (adv.)"
+    ]
+  },
+  {
+    "name": "surface",
+    "trans": [
+      "表面, 面, 地表, 曲面 (noun.)"
+    ]
+  },
+  {
+    "name": "surgery",
+    "trans": [
+      "手术, 外科, 外科手术, 术 (noun.)"
+    ]
+  },
+  {
+    "name": "surprise",
+    "trans": [
+      "惊喜, 惊讶, 惊奇, 吃惊 (noun.)"
+    ]
+  },
+  {
+    "name": "surprised",
+    "trans": [
+      "惊讶, 吃惊, 诧异, 惊 (adj.); 感到惊讶, 惊奇, 感到意外, 大吃一惊 (verb.)"
+    ]
+  },
+  {
+    "name": "surprising",
+    "trans": [
+      "令人惊讶, 令人吃惊, 令人惊奇, 惊人 (adj.)"
+    ]
+  },
+  {
+    "name": "surprisingly",
+    "trans": [
+      "出奇, 令人惊讶, 出人意料, 出乎意料 (adv.)"
+    ]
+  },
+  {
+    "name": "surround",
+    "trans": [
+      "环绕, 围 (noun.); 包围, 围绕, 周围, 围拢 (verb.)"
+    ]
+  },
+  {
+    "name": "survey",
+    "trans": [
+      "调查, 测量, 概况, 综述 (noun.)"
+    ]
+  },
+  {
+    "name": "survival",
+    "trans": [
+      "生存, 存活, 求生存, 求生 (noun.)"
+    ]
+  },
+  {
+    "name": "survive",
+    "trans": [
+      "生存, 求生存, 生存下去, 存活 (verb.)"
+    ]
+  },
+  {
+    "name": "suspect",
+    "trans": [
+      "怀疑, 疑心, 猜想, 猜 (verb.); 嫌疑犯, 嫌犯, 疑犯, 嫌疑人 (noun.); 可疑 (adj.)"
+    ]
+  },
+  {
+    "name": "suspicion",
+    "trans": [
+      "怀疑, 猜疑, 嫌疑, 疑心 (noun.)"
+    ]
+  },
+  {
+    "name": "suspicious",
+    "trans": [
+      "可疑, 疑心, 怀疑, 多疑 (adj.)"
+    ]
+  },
+  {
+    "name": "sustain",
+    "trans": [
+      "维持, 维系, 支撑, 承受 (verb.)"
+    ]
+  },
+  {
+    "name": "swap",
+    "trans": [
+      "交换, 互换, 插拔, 调剂 (noun.)"
+    ]
+  },
+  {
+    "name": "swear",
+    "trans": [
+      "发誓, 起誓, 宣誓 (verb.); 赌咒 (noun.)"
+    ]
+  },
+  {
+    "name": "sweep",
+    "trans": [
+      "扫, 扫描, 扫频, 波及 (noun.); 打扫, 扫地, 横扫, 清扫 (verb.)"
+    ]
+  },
+  {
+    "name": "sweet",
+    "trans": [
+      "甜, 甜蜜, 甜美, 甜甜 (adj.)"
+    ]
+  },
+  {
+    "name": "swim",
+    "trans": [
+      "游泳, 游, 畅游 (verb.); 泳 (noun.)"
+    ]
+  },
+  {
+    "name": "swimming",
+    "trans": [
+      "游泳, 泳, 游动 (noun.); 游 (verb.)"
+    ]
+  },
+  {
+    "name": "swing",
+    "trans": [
+      "摆动, 秋千, 挥杆, 摇摆 (noun.); 荡, 挥棒, 摇 (verb.)"
+    ]
+  },
+  {
+    "name": "switch",
+    "trans": [
+      "开关, 交换机, 交换, 转换 (noun.); 切换, 换, 转 (verb.)"
+    ]
+  },
+  {
+    "name": "symbol",
+    "trans": [
+      "象征, 符号, 标志 (noun.)"
+    ]
+  },
+  {
+    "name": "sympathy",
+    "trans": [
+      "同情, 同情心, 慰问, 共鸣 (noun.)"
+    ]
+  },
+  {
+    "name": "system",
+    "trans": [
+      "系统, 体系, 制度, 体制 (noun.)"
+    ]
+  },
+  {
+    "name": "table",
+    "trans": [
+      "表, 桌子, 桌, 张桌子 (noun.)"
+    ]
+  },
+  {
+    "name": "tablet",
+    "trans": [
+      "平板电脑, 片, 片剂, 碑 (noun.)"
+    ]
+  },
+  {
+    "name": "tackle",
+    "trans": [
+      "解决, 对付, 应对, 应付 (verb.); 铲球, 钓具 (noun.)"
+    ]
+  },
+  {
+    "name": "tail",
+    "trans": [
+      "尾巴, 尾, 尾部, 尾翼 (noun.)"
+    ]
+  },
+  {
+    "name": "take",
+    "trans": [
+      "采取, 带, 拿, 把 (verb.)"
+    ]
+  },
+  {
+    "name": "tale",
+    "trans": [
+      "故事, 传说, 童话 (noun.)"
+    ]
+  },
+  {
+    "name": "talent",
+    "trans": [
+      "人才, 天赋, 才华, 才艺 (noun.)"
+    ]
+  },
+  {
+    "name": "talk",
+    "trans": [
+      "说话, 谈, 交谈, 谈谈 (verb.); 谈话 (noun.)"
+    ]
+  },
+  {
+    "name": "tall",
+    "trans": [
+      "高大, 高, 高个子, 身材高大 (adj.)"
+    ]
+  },
+  {
+    "name": "tank",
+    "trans": [
+      "坦克, 罐, 储罐, 水箱 (noun.)"
+    ]
+  },
+  {
+    "name": "tap",
+    "trans": [
+      "水龙头, 丝锥, 自来水, 抽头 (noun.); 点击, 挖掘, 轻拍 (verb.)"
+    ]
+  },
+  {
+    "name": "tape",
+    "trans": [
+      "磁带, 胶带, 带子, 录像带 (noun.)"
+    ]
+  },
+  {
+    "name": "target",
+    "trans": [
+      "目标, 靶, 靶子, 指标 (noun.); 瞄准, 针对 (verb.)"
+    ]
+  },
+  {
+    "name": "task",
+    "trans": [
+      "任务, 课题, 工作 (noun.)"
+    ]
+  },
+  {
+    "name": "taste",
+    "trans": [
+      "味道, 品味, 口味, 滋味 (noun.); 品尝, 尝, 尝尝 (verb.)"
+    ]
+  },
+  {
+    "name": "tax",
+    "trans": [
+      "税, 税收, 税务, 纳税 (noun.)"
+    ]
+  },
+  {
+    "name": "taxi",
+    "trans": [
+      "出租车, 的士, 辆出租车, 出租汽车 (noun.)"
+    ]
+  },
+  {
+    "name": "tea",
+    "trans": [
+      "茶, 茶叶, 喝茶, 茶树 (noun.)"
+    ]
+  },
+  {
+    "name": "teach",
+    "trans": [
+      "教, 教导, 教给, 教会 (verb.)"
+    ]
+  },
+  {
+    "name": "teacher",
+    "trans": [
+      "老师, 教师, 教员, 师资 (noun.)"
+    ]
+  },
+  {
+    "name": "teaching",
+    "trans": [
+      "教学, 教, 教书, 教育 (noun.)"
+    ]
+  },
+  {
+    "name": "team",
+    "trans": [
+      "团队, 队, 队伍, 球队 (noun.)"
+    ]
+  },
+  {
+    "name": "tear",
+    "trans": [
+      "撕裂, 滴眼泪, 滴泪, 泪 (noun.); 撕, 撕破, 扯 (verb.)"
+    ]
+  },
+  {
+    "name": "technical",
+    "trans": [
+      "技术, 技术性, 科技, 工艺 (adj.)"
+    ]
+  },
+  {
+    "name": "technique",
+    "trans": [
+      "技术, 工艺, 技巧, 方法 (noun.)"
+    ]
+  },
+  {
+    "name": "technology",
+    "trans": [
+      "技术, 科技, 工艺, 新技术 (noun.)"
+    ]
+  },
+  {
+    "name": "telephone",
+    "trans": [
+      "电话, 电话机, 打电话, 电话号码 (noun.)"
+    ]
+  },
+  {
+    "name": "television",
+    "trans": [
+      "电视, 电视台, 电视机, 电视节目 (noun.)"
+    ]
+  },
+  {
+    "name": "tell",
+    "trans": [
+      "告诉, 跟, 说, 讲 (verb.)"
+    ]
+  },
+  {
+    "name": "telly",
+    "trans": [
+      "电视, 电视机 (noun.); 泰莉 (adv.)"
+    ]
+  },
+  {
+    "name": "temperature",
+    "trans": [
+      "温度, 温, 气温, 体温 (noun.)"
+    ]
+  },
+  {
+    "name": "temporary",
+    "trans": [
+      "临时, 暂时, 临时性, 暂 (adj.)"
+    ]
+  },
+  {
+    "name": "tend",
+    "trans": [
+      "往往, 倾向, 趋向, 常常 (verb.)"
+    ]
+  },
+  {
+    "name": "tendency",
+    "trans": [
+      "趋势, 倾向, 趋向, 倾向性 (noun.)"
+    ]
+  },
+  {
+    "name": "tennis",
+    "trans": [
+      "网球 (noun.)"
+    ]
+  },
+  {
+    "name": "tension",
+    "trans": [
+      "张力, 紧张, 紧张局势, 拉伸 (noun.)"
+    ]
+  },
+  {
+    "name": "tent",
+    "trans": [
+      "帐篷, 帐蓬, 帐棚, 顶帐篷 (noun.)"
+    ]
+  },
+  {
+    "name": "term",
+    "trans": [
+      "学期, 术语, 任期, 期限 (noun.)"
+    ]
+  },
+  {
+    "name": "terrible",
+    "trans": [
+      "可怕, 糟糕, 糟透, 恐怖 (adj.)"
+    ]
+  },
+  {
+    "name": "terribly",
+    "trans": [
+      "可怕, 非常, 极度 (adv.)"
+    ]
+  },
+  {
+    "name": "territory",
+    "trans": [
+      "领土, 领地, 境内, 地盘 (noun.)"
+    ]
+  },
+  {
+    "name": "terror",
+    "trans": [
+      "恐怖, 恐惧, 恐怖活动, 反恐 (noun.)"
+    ]
+  },
+  {
+    "name": "terrorist",
+    "trans": [
+      "恐怖, 恐怖主义, 恐怖份子, 恐怖主义分子 (adj.); 恐怖分子 (noun.)"
+    ]
+  },
+  {
+    "name": "test",
+    "trans": [
+      "测试, 试验, 考验, 考试 (noun.)"
+    ]
+  },
+  {
+    "name": "text",
+    "trans": [
+      "文本, 文字, 课文, 正文 (noun.)"
+    ]
+  },
+  {
+    "name": "than",
+    "trans": [
+      "比 (prep.)"
+    ]
+  },
+  {
+    "name": "thank",
+    "trans": [
+      "谢谢, 感谢, 多谢, 谢 (verb.)"
+    ]
+  },
+  {
+    "name": "thanks",
+    "trans": [
+      "谢谢, 感谢, 谢, 多谢 (noun.)"
+    ]
+  },
+  {
+    "name": "thanks",
+    "trans": [
+      "谢谢, 感谢, 谢, 多谢 (noun.)"
+    ]
+  },
+  {
+    "name": "that",
+    "trans": [
+      "那 (det.)"
+    ]
+  },
+  {
+    "name": "the",
+    "trans": [
+      "的 (det.)"
+    ]
+  },
+  {
+    "name": "theatre",
+    "trans": [
+      "剧院, 剧场, 戏剧, 戏院 (noun.)"
+    ]
+  },
+  {
+    "name": "their",
+    "trans": [
+      "他们 (pron.)"
+    ]
+  },
+  {
+    "name": "theirs",
+    "trans": [
+      "他们 (pron.)"
+    ]
+  },
+  {
+    "name": "them",
+    "trans": [
+      "他们, 它们 (pron.)"
+    ]
+  },
+  {
+    "name": "theme",
+    "trans": [
+      "主题, 题材, 主位, 主旋律 (noun.)"
+    ]
+  },
+  {
+    "name": "themselves",
+    "trans": [
+      "自己 (pron.)"
+    ]
+  },
+  {
+    "name": "then",
+    "trans": [
+      "然后, 那么, 接着, 那 (adv.)"
+    ]
+  },
+  {
+    "name": "theoretical",
+    "trans": [
+      "理论, 理论上, 理论性 (adj.)"
+    ]
+  },
+  {
+    "name": "theory",
+    "trans": [
+      "理论, 论, 理论上, 学说 (noun.)"
+    ]
+  },
+  {
+    "name": "there",
+    "trans": [
+      "那里, 那儿, 那 (adv.); 有, 存在, 这里, 还 (noun.)"
+    ]
+  },
+  {
+    "name": "therefore",
+    "trans": [
+      "因此, 所以, 因而, 为此 (adv.)"
+    ]
+  },
+  {
+    "name": "they",
+    "trans": [
+      "他们, 它们 (pron.)"
+    ]
+  },
+  {
+    "name": "thick",
+    "trans": [
+      "厚, 厚厚, 浓, 浓浓 (adj.)"
+    ]
+  },
+  {
+    "name": "thin",
+    "trans": [
+      "薄, 瘦, 薄薄, 稀薄 (adj.)"
+    ]
+  },
+  {
+    "name": "thing",
+    "trans": [
+      "事情, 东西, 事, 一件事 (noun.)"
+    ]
+  },
+  {
+    "name": "think",
+    "trans": [
+      "认为, 觉得, 想, 以为 (verb.)"
+    ]
+  },
+  {
+    "name": "this",
+    "trans": [
+      "这, 这个, 这种, 此 (det.)"
+    ]
+  },
+  {
+    "name": "though",
+    "trans": [
+      "虽然, 尽管 (prep.)"
+    ]
+  },
+  {
+    "name": "thought",
+    "trans": [
+      "以为, 想, 认为, 想到 (verb.); 思想, 思维, 思考, 想法 (noun.)"
+    ]
+  },
+  {
+    "name": "threat",
+    "trans": [
+      "威胁, 构成威胁, 恐吓 (noun.)"
+    ]
+  },
+  {
+    "name": "threaten",
+    "trans": [
+      "威胁, 恐吓, 危及, 构成威胁 (verb.)"
+    ]
+  },
+  {
+    "name": "three",
+    "trans": [
+      "三, 三个, 第三 (adj.)"
+    ]
+  },
+  {
+    "name": "throat",
+    "trans": [
+      "喉咙, 咽喉, 喉, 喉部 (noun.)"
+    ]
+  },
+  {
+    "name": "through",
+    "trans": [
+      "通过, 透过 (prep.)"
+    ]
+  },
+  {
+    "name": "throughout",
+    "trans": [
+      "遍及, 整个 (prep.)"
+    ]
+  },
+  {
+    "name": "throw",
+    "trans": [
+      "扔, 抛出, 丢, 投掷 (verb.)"
+    ]
+  },
+  {
+    "name": "thus",
+    "trans": [
+      "因此, 从而, 因而, 由此 (adv.)"
+    ]
+  },
+  {
+    "name": "ticket",
+    "trans": [
+      "票, 机票, 张票, 车票 (noun.)"
+    ]
+  },
+  {
+    "name": "tidy",
+    "trans": [
+      "整洁, 整齐, 干净整洁, 条理 (adj.); 整理 (verb.)"
+    ]
+  },
+  {
+    "name": "tie",
+    "trans": [
+      "领带, 条领带, 打领带, 铁 (noun.); 绑, 配合, 系 (verb.)"
+    ]
+  },
+  {
+    "name": "tight",
+    "trans": [
+      "紧, 紧身, 严密, 紧张 (adj.)"
+    ]
+  },
+  {
+    "name": "tile",
+    "trans": [
+      "瓷砖, 瓦, 平铺, 瓦片 (noun.)"
+    ]
+  },
+  {
+    "name": "till",
+    "trans": [
+      "直到 (prep.)"
+    ]
+  },
+  {
+    "name": "time",
+    "trans": [
+      "时间, 时候, 时光, 一次 (noun.)"
+    ]
+  },
+  {
+    "name": "tin",
+    "trans": [
+      "锡, 田, 铁皮, 锡矿 (noun.)"
+    ]
+  },
+  {
+    "name": "tiny",
+    "trans": [
+      "微小, 小, 小小, 细小 (adj.)"
+    ]
+  },
+  {
+    "name": "tip",
+    "trans": [
+      "小费, 提示, 尖端, 尖 (noun.)"
+    ]
+  },
+  {
+    "name": "tired",
+    "trans": [
+      "累, 疲倦, 疲惫, 厌倦 (adj.)"
+    ]
+  },
+  {
+    "name": "title",
+    "trans": [
+      "标题, 称号, 头衔, 职称 (noun.)"
+    ]
+  },
+  {
+    "name": "to",
+    "trans": [
+      "到 (prep.)"
+    ]
+  },
+  {
+    "name": "toast",
+    "trans": [
+      "吐司, 烤面包, 土司, 敬酒 (noun.)"
+    ]
+  },
+  {
+    "name": "today",
+    "trans": [
+      "今天, 今日, 如今, 当今 (noun.)"
+    ]
+  },
+  {
+    "name": "toe",
+    "trans": [
+      "脚趾, 趾, 足趾, 脚尖 (noun.)"
+    ]
+  },
+  {
+    "name": "together",
+    "trans": [
+      "一起, 一同, 共同, 起来 (adv.)"
+    ]
+  },
+  {
+    "name": "toilet",
+    "trans": [
+      "厕所, 马桶, 卫生间, 洗手间 (noun.)"
+    ]
+  },
+  {
+    "name": "tomato",
+    "trans": [
+      "番茄, 西红柿, 蕃茄, 茄 (noun.)"
+    ]
+  },
+  {
+    "name": "tomorrow",
+    "trans": [
+      "明天, 明日, 明早 (noun.)"
+    ]
+  },
+  {
+    "name": "ton",
+    "trans": [
+      "吨, 吨左右, 成堆, 顿 (noun.)"
+    ]
+  },
+  {
+    "name": "tone",
+    "trans": [
+      "语气, 基调, 语调, 音 (noun.)"
+    ]
+  },
+  {
+    "name": "tongue",
+    "trans": [
+      "舌头, 舌, 舌尖, 舌头伸 (noun.)"
+    ]
+  },
+  {
+    "name": "tonight",
+    "trans": [
+      "今晚, 今夜, 晚上 (noun.)"
+    ]
+  },
+  {
+    "name": "too",
+    "trans": [
+      "太, 也, 过于, 也是 (adv.)"
+    ]
+  },
+  {
+    "name": "tool",
+    "trans": [
+      "工具, 刀具, 刀, 手段 (noun.)"
+    ]
+  },
+  {
+    "name": "tooth",
+    "trans": [
+      "齿, 牙, 牙齿, 颗牙 (noun.)"
+    ]
+  },
+  {
+    "name": "top",
+    "trans": [
+      "顶部, 顶端, 上面 (noun.); 顶, 顶级, 顶尖, 最高 (adj.)"
+    ]
+  },
+  {
+    "name": "topic",
+    "trans": [
+      "话题, 主题, 课题, 题目 (noun.)"
+    ]
+  },
+  {
+    "name": "total",
+    "trans": [
+      "总, 总额, 全, 总量 (adj.); 共有, 总数, 共 (noun.)"
+    ]
+  },
+  {
+    "name": "totally",
+    "trans": [
+      "完全, 彻底, 绝对, 全 (adv.)"
+    ]
+  },
+  {
+    "name": "touch",
+    "trans": [
+      "触摸, 接触, 联系, 触 (noun.); 碰, 摸, 触碰, 抚摸 (verb.)"
+    ]
+  },
+  {
+    "name": "tough",
+    "trans": [
+      "艰难, 强硬, 坚韧, 艰苦 (adj.)"
+    ]
+  },
+  {
+    "name": "tour",
+    "trans": [
+      "旅游, 巡演, 游览, 之旅 (noun.)"
+    ]
+  },
+  {
+    "name": "tourist",
+    "trans": [
+      "旅游, 游客, 旅游者, 观光 (noun.)"
+    ]
+  },
+  {
+    "name": "towards",
+    "trans": [
+      "对 (prep.)"
+    ]
+  },
+  {
+    "name": "towel",
+    "trans": [
+      "毛巾, 条毛巾, 巾, 浴巾 (noun.)"
+    ]
+  },
+  {
+    "name": "tower",
+    "trans": [
+      "塔, 铁塔, 塔楼, 塔台 (noun.)"
+    ]
+  },
+  {
+    "name": "town",
+    "trans": [
+      "镇, 城镇, 城里, 镇子 (noun.)"
+    ]
+  },
+  {
+    "name": "toy",
+    "trans": [
+      "玩具 (noun.)"
+    ]
+  },
+  {
+    "name": "track",
+    "trans": [
+      "轨道, 赛道, 轨迹, 航迹 (noun.); 跟踪, 追踪 (verb.)"
+    ]
+  },
+  {
+    "name": "trade",
+    "trans": [
+      "贸易, 交易, 贸, 行业 (noun.)"
+    ]
+  },
+  {
+    "name": "tradition",
+    "trans": [
+      "传统, 传承, 习俗, 惯例 (noun.)"
+    ]
+  },
+  {
+    "name": "traditional",
+    "trans": [
+      "传统, 繁体 (adj.)"
+    ]
+  },
+  {
+    "name": "traffic",
+    "trans": [
+      "交通, 流量, 宗交通, 行车 (noun.)"
+    ]
+  },
+  {
+    "name": "trailer",
+    "trans": [
+      "拖车, 挂车, 预告片, 辆拖车 (noun.)"
+    ]
+  },
+  {
+    "name": "train",
+    "trans": [
+      "火车, 列车, 列火车, 班火车 (noun.); 训练, 培养, 培训 (verb.)"
+    ]
+  },
+  {
+    "name": "trainer",
+    "trans": [
+      "教练, 教练机, 驯兽师, 教练员 (noun.)"
+    ]
+  },
+  {
+    "name": "training",
+    "trans": [
+      "培训, 训练, 培养, 训 (noun.)"
+    ]
+  },
+  {
+    "name": "transaction",
+    "trans": [
+      "事务, 交易, 笔交易, 成交 (noun.)"
+    ]
+  },
+  {
+    "name": "transfer",
+    "trans": [
+      "转移, 转让, 传递, 传输 (noun.); 转 (verb.)"
+    ]
+  },
+  {
+    "name": "transform",
+    "trans": [
+      "变换, 转换, 变革 (noun.); 转化, 转变, 改造, 改变 (verb.)"
+    ]
+  },
+  {
+    "name": "transition",
+    "trans": [
+      "过渡, 转型, 转变, 转轨 (noun.)"
+    ]
+  },
+  {
+    "name": "translate",
+    "trans": [
+      "翻译, 转化, 译 (verb.)"
+    ]
+  },
+  {
+    "name": "transport",
+    "trans": [
+      "运输, 交通, 传输, 交通工具 (noun.)"
+    ]
+  },
+  {
+    "name": "transportation",
+    "trans": [
+      "运输, 交通, 交通运输, 输送 (noun.)"
+    ]
+  },
+  {
+    "name": "trash",
+    "trans": [
+      "垃圾, 垃圾桶, 垃圾桶里, 垃圾箱 (noun.)"
+    ]
+  },
+  {
+    "name": "travel",
+    "trans": [
+      "旅行, 旅游, 出行, 行程 (noun.); 出差 (verb.)"
+    ]
+  },
+  {
+    "name": "tray",
+    "trans": [
+      "托盘, 盘, 盘子, 纸盒 (noun.)"
+    ]
+  },
+  {
+    "name": "treat",
+    "trans": [
+      "对待, 治疗, 善待, 看待 (verb.); 请客 (noun.)"
+    ]
+  },
+  {
+    "name": "treatment",
+    "trans": [
+      "治疗, 处理, 待遇, 治理 (noun.)"
+    ]
+  },
+  {
+    "name": "treaty",
+    "trans": [
+      "条约, 协约, 公约, 协定 (noun.)"
+    ]
+  },
+  {
+    "name": "tree",
+    "trans": [
+      "树, 棵树, 大树, 树木 (noun.)"
+    ]
+  },
+  {
+    "name": "tremendous",
+    "trans": [
+      "巨大, 极大 (adj.)"
+    ]
+  },
+  {
+    "name": "trend",
+    "trans": [
+      "趋势, 潮流, 走势, 趋向 (noun.)"
+    ]
+  },
+  {
+    "name": "trial",
+    "trans": [
+      "审判, 审讯, 试验, 试用 (noun.)"
+    ]
+  },
+  {
+    "name": "trick",
+    "trans": [
+      "把戏, 伎俩, 诀窍, 戏法 (noun.); 欺骗, 骗 (verb.)"
+    ]
+  },
+  {
+    "name": "tricky",
+    "trans": [
+      "棘手, 狡猾, 微妙, 巧妙 (adj.)"
+    ]
+  },
+  {
+    "name": "trip",
+    "trans": [
+      "旅行, 之旅, 行程, 旅程 (noun.)"
+    ]
+  },
+  {
+    "name": "troop",
+    "trans": [
+      "部队, 队伍, 军队, 军旅 (noun.)"
+    ]
+  },
+  {
+    "name": "trouble",
+    "trans": [
+      "麻烦, 烦恼, 故障, 困难 (noun.)"
+    ]
+  },
+  {
+    "name": "trousers",
+    "trans": [
+      "裤子, 长裤, 西裤, 条裤子 (noun.)"
+    ]
+  },
+  {
+    "name": "truck",
+    "trans": [
+      "卡车, 辆卡车, 货车, 车 (noun.)"
+    ]
+  },
+  {
+    "name": "true",
+    "trans": [
+      "真实, 真, 真正, 事实 (adj.)"
+    ]
+  },
+  {
+    "name": "truly",
+    "trans": [
+      "真正, 真, 真心, 确实 (adv.)"
+    ]
+  },
+  {
+    "name": "trust",
+    "trans": [
+      "信任, 信托, 信赖, 信得过 (noun.); 相信, 信, 放心 (verb.)"
+    ]
+  },
+  {
+    "name": "truth",
+    "trans": [
+      "真理, 真相, 实话, 事实 (noun.)"
+    ]
+  },
+  {
+    "name": "try",
+    "trans": [
+      "尝试, 试试, 试, 尽量 (verb.)"
+    ]
+  },
+  {
+    "name": "tube",
+    "trans": [
+      "管, 筒, 管内, 管子 (noun.)"
+    ]
+  },
+  {
+    "name": "tune",
+    "trans": [
+      "曲调, 调子, 调, 曲子 (noun.); 调优 (verb.)"
+    ]
+  },
+  {
+    "name": "tunnel",
+    "trans": [
+      "隧道, 隧洞, 巷道, 地道 (noun.)"
+    ]
+  },
+  {
+    "name": "turn",
+    "trans": [
+      "转, 把, 打开, 转动 (verb.); 轮, 转向 (noun.)"
+    ]
+  },
+  {
+    "name": "twice",
+    "trans": [
+      "两次, 过两次, 二次, 次 (adv.)"
+    ]
+  },
+  {
+    "name": "twist",
+    "trans": [
+      "捻, 麻花, 扭曲, 捻度 (noun.); 曲解 (verb.)"
+    ]
+  },
+  {
+    "name": "type",
+    "trans": [
+      "类型, 型, 式, 类 (noun.); 键入, 输入 (verb.)"
+    ]
+  },
+  {
+    "name": "typical",
+    "trans": [
+      "典型, 代表性 (adj.)"
+    ]
+  },
+  {
+    "name": "tyre",
+    "trans": [
+      "轮胎, 轮箍, 车胎, 胎 (noun.)"
+    ]
+  },
+  {
+    "name": "ugly",
+    "trans": [
+      "丑, 丑陋, 难看, 丑恶 (adj.)"
+    ]
+  },
+  {
+    "name": "ultimate",
+    "trans": [
+      "终极, 最终, 极限, 极致 (adj.)"
+    ]
+  },
+  {
+    "name": "ultimately",
+    "trans": [
+      "最终, 归根结底, 说到底, 归根到底 (adv.)"
+    ]
+  },
+  {
+    "name": "unable",
+    "trans": [
+      "无法, 不能, 无力 (adj.)"
+    ]
+  },
+  {
+    "name": "unbelievable",
+    "trans": [
+      "难以置信, 令人难以置信, 不可思议, 不可理喻 (adj.)"
+    ]
+  },
+  {
+    "name": "uncle",
+    "trans": [
+      "叔叔, 舅舅, 伯父, 叔 (noun.)"
+    ]
+  },
+  {
+    "name": "under",
+    "trans": [
+      "下, 根据 (prep.)"
+    ]
+  },
+  {
+    "name": "underneath",
+    "trans": [
+      "下面, 底下 (prep.)"
+    ]
+  },
+  {
+    "name": "understand",
+    "trans": [
+      "理解, 明白, 了解, 懂 (verb.)"
+    ]
+  },
+  {
+    "name": "understanding",
+    "trans": [
+      "理解, 了解, 认识, 谅解 (noun.)"
+    ]
+  },
+  {
+    "name": "undertake",
+    "trans": [
+      "承接, 承担, 承办, 从事 (verb.)"
+    ]
+  },
+  {
+    "name": "unemployed",
+    "trans": [
+      "失业, 失业人士, 无业, 待业 (adj.)"
+    ]
+  },
+  {
+    "name": "unemployment",
+    "trans": [
+      "失业, 失业率, 失业人数 (noun.)"
+    ]
+  },
+  {
+    "name": "unfair",
+    "trans": [
+      "不公, 公平, 不公平, 不公平地 (adj.)"
+    ]
+  },
+  {
+    "name": "unfortunate",
+    "trans": [
+      "不幸, 令人遗憾, 倒霉, 可惜 (adj.)"
+    ]
+  },
+  {
+    "name": "unfortunately",
+    "trans": [
+      "不幸, 可惜, 不巧, 遗憾 (adv.)"
+    ]
+  },
+  {
+    "name": "unhappy",
+    "trans": [
+      "不满, 怏怏不乐, 不幸, 不快 (adj.)"
+    ]
+  },
+  {
+    "name": "uniform",
+    "trans": [
+      "均匀, 统一, 一致, 匀 (adj.); 制服, 军装, 校服, 军服 (noun.)"
+    ]
+  },
+  {
+    "name": "union",
+    "trans": [
+      "工会, 联盟, 联合, 联合会 (noun.)"
+    ]
+  },
+  {
+    "name": "unique",
+    "trans": [
+      "独特, 独一无二, 独有, 唯一 (adj.)"
+    ]
+  },
+  {
+    "name": "unit",
+    "trans": [
+      "单位, 单元, 机组, 装置 (noun.)"
+    ]
+  },
+  {
+    "name": "united",
+    "trans": [
+      "曼联, 团结, 联合, 统一 (noun.)"
+    ]
+  },
+  {
+    "name": "unity",
+    "trans": [
+      "团结, 统一, 统一性, 统一体 (noun.)"
+    ]
+  },
+  {
+    "name": "universal",
+    "trans": [
+      "通用, 普遍, 万能, 普世 (adj.); 环球 (noun.)"
+    ]
+  },
+  {
+    "name": "universe",
+    "trans": [
+      "宇宙 (noun.)"
+    ]
+  },
+  {
+    "name": "university",
+    "trans": [
+      "大学, 高校, 大学生, 校 (noun.)"
+    ]
+  },
+  {
+    "name": "unknown",
+    "trans": [
+      "未知, 不明, 未知数, 不详 (adj.)"
+    ]
+  },
+  {
+    "name": "unless",
+    "trans": [
+      "除非 (prep.)"
+    ]
+  },
+  {
+    "name": "unlike",
+    "trans": [
+      "与 (prep.)"
+    ]
+  },
+  {
+    "name": "unlikely",
+    "trans": [
+      "不可能, 可能性不大, 未必, 不大 (adj.)"
+    ]
+  },
+  {
+    "name": "until",
+    "trans": [
+      "直到, 直至 (prep.)"
+    ]
+  },
+  {
+    "name": "unusual",
+    "trans": [
+      "不同寻常, 异常, 寻常, 非同寻常 (adj.)"
+    ]
+  },
+  {
+    "name": "up",
+    "trans": [
+      "起来, 了 (prep.)"
+    ]
+  },
+  {
+    "name": "upon",
+    "trans": [
+      "后 (prep.)"
+    ]
+  },
+  {
+    "name": "upper",
+    "trans": [
+      "上部, 上层, 上, 鞋面 (adj.)"
+    ]
+  },
+  {
+    "name": "upset",
+    "trans": [
+      "心烦, 心烦意乱, 沮丧, 难过 (adj.); 打乱 (verb.)"
+    ]
+  },
+  {
+    "name": "upstairs",
+    "trans": [
+      "楼上, 上楼, 到楼上去, 楼上去 (adv.)"
+    ]
+  },
+  {
+    "name": "urban",
+    "trans": [
+      "城市, 市区, 都市, 城镇 (adj.); 市政 (noun.)"
+    ]
+  },
+  {
+    "name": "urge",
+    "trans": [
+      "促请, 敦促, 恳请, 督促 (verb.); 呼吁, 冲动, 欲望 (noun.)"
+    ]
+  },
+  {
+    "name": "urgent",
+    "trans": [
+      "紧急, 迫切, 紧迫, 急 (adj.)"
+    ]
+  },
+  {
+    "name": "us",
+    "trans": [
+      "我们 (pron.); 美国 (noun.)"
+    ]
+  },
+  {
+    "name": "use",
+    "trans": [
+      "使用, 用 (verb.); 利用, 运用, 用途, 采用 (noun.)"
+    ]
+  },
+  {
+    "name": "used",
+    "trans": [
+      "使用, 用于, 用, 习惯 (verb.)"
+    ]
+  },
+  {
+    "name": "used to",
+    "trans": [
+      "过去常常"
+    ]
+  },
+  {
+    "name": "useful",
+    "trans": [
+      "有用, 有益, 实用, 用处 (adj.)"
+    ]
+  },
+  {
+    "name": "user",
+    "trans": [
+      "用户 (noun.)"
+    ]
+  },
+  {
+    "name": "usual",
+    "trans": [
+      "往常一样, 平常, 平时, 往常 (adj.)"
+    ]
+  },
+  {
+    "name": "usually",
+    "trans": [
+      "通常, 平时, 一般, 经常 (adv.)"
+    ]
+  },
+  {
+    "name": "vacation",
+    "trans": [
+      "假期, 度假, 休假, 放假 (noun.)"
+    ]
+  },
+  {
+    "name": "vague",
+    "trans": [
+      "含糊, 模糊, 空泛, 含糊其词 (adj.)"
+    ]
+  },
+  {
+    "name": "valley",
+    "trans": [
+      "山谷, 谷, 河谷, 流域 (noun.)"
+    ]
+  },
+  {
+    "name": "valuable",
+    "trans": [
+      "宝贵, 珍贵, 可贵, 值钱 (adj.)"
+    ]
+  },
+  {
+    "name": "value",
+    "trans": [
+      "价值, 值, 价值观, 重视 (noun.)"
+    ]
+  },
+  {
+    "name": "van",
+    "trans": [
+      "面包车, 货车, 辆货车, 辆面包车 (noun.)"
+    ]
+  },
+  {
+    "name": "variation",
+    "trans": [
+      "变异, 变化, 变体, 变动 (noun.)"
+    ]
+  },
+  {
+    "name": "variety",
+    "trans": [
+      "品种, 多种, 各种, 各种各样 (noun.)"
+    ]
+  },
+  {
+    "name": "various",
+    "trans": [
+      "各种, 各, 各个, 各类 (adj.)"
+    ]
+  },
+  {
+    "name": "vary",
+    "trans": [
+      "有所不同, 更改, 不同, 不尽相同 (verb.)"
+    ]
+  },
+  {
+    "name": "vast",
+    "trans": [
+      "广阔, 辽阔, 广大, 广袤 (adj.)"
+    ]
+  },
+  {
+    "name": "vegetable",
+    "trans": [
+      "蔬菜, 菜, 植物人, 菜地 (noun.)"
+    ]
+  },
+  {
+    "name": "vehicle",
+    "trans": [
+      "车辆, 车, 汽车, 车载 (noun.)"
+    ]
+  },
+  {
+    "name": "version",
+    "trans": [
+      "版本, 版 (noun.)"
+    ]
+  },
+  {
+    "name": "very",
+    "trans": [
+      "非常, 很, 十分, 极 (adv.)"
+    ]
+  },
+  {
+    "name": "vet",
+    "trans": [
+      "兽医, 老兵, 职业教育, 职教 (noun.)"
+    ]
+  },
+  {
+    "name": "via",
+    "trans": [
+      "通过 (prep.)"
+    ]
+  },
+  {
+    "name": "victim",
+    "trans": [
+      "受害者, 受害人, 被害人, 牺牲品 (noun.)"
+    ]
+  },
+  {
+    "name": "victory",
+    "trans": [
+      "胜利, 获胜, 取得胜利, 得胜 (noun.)"
+    ]
+  },
+  {
+    "name": "video",
+    "trans": [
+      "视频, 录像, 影片, 录影 (noun.)"
+    ]
+  },
+  {
+    "name": "view",
+    "trans": [
+      "视图, 观, 观点, 看法 (noun.); 查看 (verb.)"
+    ]
+  },
+  {
+    "name": "village",
+    "trans": [
+      "村庄, 村子, 村, 村里 (noun.)"
+    ]
+  },
+  {
+    "name": "violence",
+    "trans": [
+      "暴力, 暴力事件, 暴力行为, 暴力冲突 (noun.)"
+    ]
+  },
+  {
+    "name": "violent",
+    "trans": [
+      "暴力, 猛烈, 暴力倾向, 剧烈 (adj.)"
+    ]
+  },
+  {
+    "name": "virtually",
+    "trans": [
+      "几乎, 实际上, 无形中, 事实上 (adv.)"
+    ]
+  },
+  {
+    "name": "virtue",
+    "trans": [
+      "美德, 德行, 德治, 德 (noun.)"
+    ]
+  },
+  {
+    "name": "virus",
+    "trans": [
+      "病毒, 毒 (noun.)"
+    ]
+  },
+  {
+    "name": "visible",
+    "trans": [
+      "可见, 可见光, 有形, 可视 (adj.)"
+    ]
+  },
+  {
+    "name": "vision",
+    "trans": [
+      "视觉, 愿景, 视力, 视野 (noun.)"
+    ]
+  },
+  {
+    "name": "visit",
+    "trans": [
+      "访问, 访, 来访 (noun.); 参观, 拜访, 探望, 看望 (verb.)"
+    ]
+  },
+  {
+    "name": "visitor",
+    "trans": [
+      "访客, 访问者, 游客, 客人 (noun.)"
+    ]
+  },
+  {
+    "name": "visual",
+    "trans": [
+      "视觉, 可视化, 可视, 目视 (adj.)"
+    ]
+  },
+  {
+    "name": "vital",
+    "trans": [
+      "至关重要, 重要, 切身, 关键 (adj.)"
+    ]
+  },
+  {
+    "name": "voice",
+    "trans": [
+      "声音, 语音, 嗓音, 话音 (noun.)"
+    ]
+  },
+  {
+    "name": "volume",
+    "trans": [
+      "体积, 卷, 音量, 容积 (noun.)"
+    ]
+  },
+  {
+    "name": "voluntary",
+    "trans": [
+      "自愿, 志愿, 自发, 义务 (adj.)"
+    ]
+  },
+  {
+    "name": "vote",
+    "trans": [
+      "投票, 投, 选举权 (verb.); 表决, 选票, 票, 投票权 (noun.)"
+    ]
+  },
+  {
+    "name": "vulnerable",
+    "trans": [
+      "脆弱, 弱势, 易受伤害, 易受攻击 (adj.)"
+    ]
+  },
+  {
+    "name": "wage",
+    "trans": [
+      "工资, 薪资, 发动, 薪 (noun.)"
+    ]
+  },
+  {
+    "name": "wait",
+    "trans": [
+      "等待, 等, 等等, 等一等 (verb.)"
+    ]
+  },
+  {
+    "name": "wake",
+    "trans": [
+      "叫醒, 吵醒, 唤醒, 醒来 (verb.); 尾迹, 醒, 尾 (noun.)"
+    ]
+  },
+  {
+    "name": "walk",
+    "trans": [
+      "步行, 走路, 走, 行走 (verb.)"
+    ]
+  },
+  {
+    "name": "wall",
+    "trans": [
+      "墙, 壁, 墙体, 墙壁 (noun.)"
+    ]
+  },
+  {
+    "name": "wander",
+    "trans": [
+      "徘徊, 漫步, 徜徉, 游荡 (verb.)"
+    ]
+  },
+  {
+    "name": "want",
+    "trans": [
+      "想要, 想, 希望, 要 (verb.)"
+    ]
+  },
+  {
+    "name": "war",
+    "trans": [
+      "战争, 场战争, 战, 打仗 (noun.)"
+    ]
+  },
+  {
+    "name": "ward",
+    "trans": [
+      "病房, 沃德, 病区, 养女 (noun.)"
+    ]
+  },
+  {
+    "name": "wardrobe",
+    "trans": [
+      "衣柜, 衣橱, 衣柜里, 衣橱里 (noun.)"
+    ]
+  },
+  {
+    "name": "warm",
+    "trans": [
+      "温暖, 暖和, 暖, 温馨 (adj.)"
+    ]
+  },
+  {
+    "name": "warn",
+    "trans": [
+      "警告, 正告, 提醒, 发出警告 (verb.)"
+    ]
+  },
+  {
+    "name": "warning",
+    "trans": [
+      "警告, 警示, 预警, 警报 (noun.); 提醒 (verb.)"
+    ]
+  },
+  {
+    "name": "wash",
+    "trans": [
+      "洗, 洗洗, 清洗, 洗脸 (verb.); 洗净, 洗涤 (noun.)"
+    ]
+  },
+  {
+    "name": "washing",
+    "trans": [
+      "洗涤, 洗, 清洗, 水洗 (verb.)"
+    ]
+  },
+  {
+    "name": "waste",
+    "trans": [
+      "浪费, 废, 废弃物, 废料 (noun.)"
+    ]
+  },
+  {
+    "name": "watch",
+    "trans": [
+      "手表, 表 (noun.); 看, 观看, 观赏, 观察 (verb.)"
+    ]
+  },
+  {
+    "name": "water",
+    "trans": [
+      "水, 水分, 用水, 水量 (noun.)"
+    ]
+  },
+  {
+    "name": "wave",
+    "trans": [
+      "波, 波浪, 浪潮, 波动 (noun.)"
+    ]
+  },
+  {
+    "name": "way",
+    "trans": [
+      "方式, 办法, 方法, 途径 (noun.)"
+    ]
+  },
+  {
+    "name": "we",
+    "trans": [
+      "我们 (pron.)"
+    ]
+  },
+  {
+    "name": "weak",
+    "trans": [
+      "弱, 薄弱, 软弱, 虚弱 (adj.)"
+    ]
+  },
+  {
+    "name": "weakness",
+    "trans": [
+      "弱点, 软弱, 疲软, 虚弱 (noun.)"
+    ]
+  },
+  {
+    "name": "wealth",
+    "trans": [
+      "财富, 丰富, 贫富, 财 (noun.)"
+    ]
+  },
+  {
+    "name": "weapon",
+    "trans": [
+      "武器, 兵器, 凶器, 利器 (noun.)"
+    ]
+  },
+  {
+    "name": "wear",
+    "trans": [
+      "穿, 戴, 戴上, 穿着 (verb.); 磨损, 耐磨 (noun.)"
+    ]
+  },
+  {
+    "name": "weather",
+    "trans": [
+      "天气, 气象, 气候, 天气预报 (noun.)"
+    ]
+  },
+  {
+    "name": "web",
+    "trans": [
+      "Web, 网络, 网页, 网站 (noun.)"
+    ]
+  },
+  {
+    "name": "website",
+    "trans": [
+      "网站, 网址, 网页, 站点 (noun.)"
+    ]
+  },
+  {
+    "name": "wedding",
+    "trans": [
+      "婚礼, 结婚, 婚庆, 婚宴 (noun.)"
+    ]
+  },
+  {
+    "name": "week",
+    "trans": [
+      "周, 星期, 礼拜, 本周 (noun.)"
+    ]
+  },
+  {
+    "name": "weekend",
+    "trans": [
+      "周末, 周 (noun.)"
+    ]
+  },
+  {
+    "name": "weekly",
+    "trans": [
+      "每周, 周刊, 周报, 周 (adj.)"
+    ]
+  },
+  {
+    "name": "weigh",
+    "trans": [
+      "权衡, 衡量, 重, 重量 (verb.)"
+    ]
+  },
+  {
+    "name": "weight",
+    "trans": [
+      "重量, 体重, 权重, 重 (noun.)"
+    ]
+  },
+  {
+    "name": "weird",
+    "trans": [
+      "奇怪, 怪异, 怪, 古怪 (adj.)"
+    ]
+  },
+  {
+    "name": "welcome",
+    "trans": [
+      "欢迎, 迎接 (verb.); 欢迎广大, 欢迎各界, 受欢迎 (adj.)"
+    ]
+  },
+  {
+    "name": "welfare",
+    "trans": [
+      "福利, 福利局, 福祉, 公益 (noun.)"
+    ]
+  },
+  {
+    "name": "well",
+    "trans": [
+      "嗯, 呃, 哦, 那么 (noun.); 好, 井, 良好, 以及 (adv.)"
+    ]
+  },
+  {
+    "name": "well",
+    "trans": [
+      "嗯, 呃, 哦, 那么 (noun.); 好, 井, 良好, 以及 (adv.)"
+    ]
+  },
+  {
+    "name": "west",
+    "trans": [
+      "西, 西方, 西部, 西边 (noun.)"
+    ]
+  },
+  {
+    "name": "western",
+    "trans": [
+      "西方, 西部, 西式, 西 (adj.); 西区 (noun.)"
+    ]
+  },
+  {
+    "name": "wet",
+    "trans": [
+      "湿, 湿法, 潮湿, 弄湿 (adj.)"
+    ]
+  },
+  {
+    "name": "what",
+    "trans": [
+      "什么 (pron.)"
+    ]
+  },
+  {
+    "name": "whatever",
+    "trans": [
+      "不管, 无论, 任何, 不论 (verb.)"
+    ]
+  },
+  {
+    "name": "whatsoever",
+    "trans": [
+      "任何, 无论如何 (adv.)"
+    ]
+  },
+  {
+    "name": "wheel",
+    "trans": [
+      "轮, 车轮, 轮子, 砂轮 (noun.)"
+    ]
+  },
+  {
+    "name": "when",
+    "trans": [
+      "当, 时, 时候 (prep.)"
+    ]
+  },
+  {
+    "name": "whenever",
+    "trans": [
+      "每当, 无论何时 (prep.)"
+    ]
+  },
+  {
+    "name": "where",
+    "trans": [
+      "哪里, 哪儿 (prep.)"
+    ]
+  },
+  {
+    "name": "whereas",
+    "trans": [
+      "而 (prep.)"
+    ]
+  },
+  {
+    "name": "wherever",
+    "trans": [
+      "无论 (prep.)"
+    ]
+  },
+  {
+    "name": "whether",
+    "trans": [
+      "是否, 无论 (prep.)"
+    ]
+  },
+  {
+    "name": "which",
+    "trans": [
+      "哪, 哪个, 其中, 这 (verb.)"
+    ]
+  },
+  {
+    "name": "while",
+    "trans": [
+      "而, 虽然 (prep.)"
+    ]
+  },
+  {
+    "name": "whisky",
+    "trans": [
+      "威士忌, 威士忌酒, 杯威士忌 (noun.)"
+    ]
+  },
+  {
+    "name": "whisper",
+    "trans": [
+      "耳语, 低语, 私语, 窃窃私语 (noun.)"
+    ]
+  },
+  {
+    "name": "white",
+    "trans": [
+      "白色, 白, 白人, 洁白 (adj.); 怀特 (noun.)"
+    ]
+  },
+  {
+    "name": "who",
+    "trans": [
+      "谁 (pron.)"
+    ]
+  },
+  {
+    "name": "whoever",
+    "trans": [
+      "谁 (pron.)"
+    ]
+  },
+  {
+    "name": "whole",
+    "trans": [
+      "整个, 整体, 整, 全 (adj.); 一体, 总体 (noun.)"
+    ]
+  },
+  {
+    "name": "whom",
+    "trans": [
+      "谁 (pron.)"
+    ]
+  },
+  {
+    "name": "whose",
+    "trans": [
+      "其 (pron.)"
+    ]
+  },
+  {
+    "name": "why",
+    "trans": [
+      "为什么, 为何 (prep.)"
+    ]
+  },
+  {
+    "name": "wicked",
+    "trans": [
+      "邪恶, 恶人, 缺德, 恶毒 (adj.)"
+    ]
+  },
+  {
+    "name": "wide",
+    "trans": [
+      "宽, 广泛, 广, 广阔 (adj.)"
+    ]
+  },
+  {
+    "name": "widely",
+    "trans": [
+      "广泛, 广为, 普遍, 广 (adv.)"
+    ]
+  },
+  {
+    "name": "widespread",
+    "trans": [
+      "广泛, 普遍, 广为流传, 普及 (adj.)"
+    ]
+  },
+  {
+    "name": "wife",
+    "trans": [
+      "妻子, 老婆, 太太, 妻 (noun.)"
+    ]
+  },
+  {
+    "name": "wild",
+    "trans": [
+      "野生, 野, 狂野, 野性 (adj.); 野外, 荒野 (noun.)"
+    ]
+  },
+  {
+    "name": "will",
+    "trans": [
+      "将, 会 (modal.)"
+    ]
+  },
+  {
+    "name": "will",
+    "trans": [
+      "将, 会 (modal.)"
+    ]
+  },
+  {
+    "name": "willing",
+    "trans": [
+      "愿意, 愿, 肯, 心甘情愿 (adj.)"
+    ]
+  },
+  {
+    "name": "win",
+    "trans": [
+      "赢, 赢得, 取胜, 获胜 (verb.)"
+    ]
+  },
+  {
+    "name": "wind",
+    "trans": [
+      "风, 风力, 风能, 风吹 (noun.)"
+    ]
+  },
+  {
+    "name": "window",
+    "trans": [
+      "窗口, 窗户, 窗, 窗外 (noun.)"
+    ]
+  },
+  {
+    "name": "windy",
+    "trans": [
+      "刮风, 大风, 风, 起风 (noun.)"
+    ]
+  },
+  {
+    "name": "wine",
+    "trans": [
+      "酒, 葡萄酒, 红酒, 美酒 (noun.)"
+    ]
+  },
+  {
+    "name": "wing",
+    "trans": [
+      "翼, 机翼, 翅膀, 翅 (noun.)"
+    ]
+  },
+  {
+    "name": "winner",
+    "trans": [
+      "赢家, 获胜者, 胜利者, 得主 (noun.)"
+    ]
+  },
+  {
+    "name": "winter",
+    "trans": [
+      "冬天, 冬季, 冬, 冬日 (noun.)"
+    ]
+  },
+  {
+    "name": "wipe",
+    "trans": [
+      "擦拭, 擦, 抹, 擦擦 (verb.); 擦除 (noun.)"
+    ]
+  },
+  {
+    "name": "wire",
+    "trans": [
+      "电线, 丝, 钢丝, 线 (noun.)"
+    ]
+  },
+  {
+    "name": "wise",
+    "trans": [
+      "明智, 聪明, 英明, 睿智 (adj.)"
+    ]
+  },
+  {
+    "name": "wish",
+    "trans": [
+      "希望, 祝, 祝愿, 愿 (verb.); 愿望, 心愿 (noun.)"
+    ]
+  },
+  {
+    "name": "with",
+    "trans": [
+      "与, 详细 (prep.)"
+    ]
+  },
+  {
+    "name": "withdraw",
+    "trans": [
+      "撤回, 撤出, 收回, 退出 (verb.)"
+    ]
+  },
+  {
+    "name": "within",
+    "trans": [
+      "内, 在 (prep.)"
+    ]
+  },
+  {
+    "name": "without",
+    "trans": [
+      "没有, 无 (prep.)"
+    ]
+  },
+  {
+    "name": "witness",
+    "trans": [
+      "证人, 见证, 目击者, 见证人 (noun.); 目睹, 目击, 亲眼目睹 (verb.)"
+    ]
+  },
+  {
+    "name": "woman",
+    "trans": [
+      "女人, 女子, 妇女, 妇人 (noun.)"
+    ]
+  },
+  {
+    "name": "wonder",
+    "trans": [
+      "奇迹, 难怪, 奇怪, 惊奇 (noun.); 怀疑, 纳闷, 想, 好奇 (verb.)"
+    ]
+  },
+  {
+    "name": "wonderful",
+    "trans": [
+      "美妙, 精彩, 奇妙, 美好 (adj.)"
+    ]
+  },
+  {
+    "name": "wood",
+    "trans": [
+      "木材, 木, 木头, 木质 (noun.)"
+    ]
+  },
+  {
+    "name": "wooden",
+    "trans": [
+      "木制, 木, 木质, 木头 (adj.)"
+    ]
+  },
+  {
+    "name": "wool",
+    "trans": [
+      "羊毛, 毛, 毛纺, 毛料 (noun.)"
+    ]
+  },
+  {
+    "name": "word",
+    "trans": [
+      "词, 字, 单词, 句话 (noun.)"
+    ]
+  },
+  {
+    "name": "work",
+    "trans": [
+      "工作, 作品, 作业, 劳动 (noun.); 上班, 干活, 努力, 合作 (verb.)"
+    ]
+  },
+  {
+    "name": "worker",
+    "trans": [
+      "工人, 工作者, 工, 职工 (noun.)"
+    ]
+  },
+  {
+    "name": "working",
+    "trans": [
+      "工作, 上班, 努力, 合作 (verb.)"
+    ]
+  },
+  {
+    "name": "workshop",
+    "trans": [
+      "车间, 厂房, 研讨会, 作坊 (noun.)"
+    ]
+  },
+  {
+    "name": "world",
+    "trans": [
+      "世界, 全世界, 世界各地, 全球 (noun.)"
+    ]
+  },
+  {
+    "name": "worried",
+    "trans": [
+      "担心, 着急, 担忧, 忧心忡忡 (adj.)"
+    ]
+  },
+  {
+    "name": "worry",
+    "trans": [
+      "担心, 着急, 操心, 急 (verb.); 担忧, 忧虑, 省心, 烦恼 (noun.)"
+    ]
+  },
+  {
+    "name": "worrying",
+    "trans": [
+      "令人担忧, 令人忧虑 (adj.); 担心, 堪忧, 担忧, 忧虑 (verb.)"
+    ]
+  },
+  {
+    "name": "worse",
+    "trans": [
+      "更糟, 变得更糟, 糟糕, 恶化 (adj.)"
+    ]
+  },
+  {
+    "name": "worth",
+    "trans": [
+      "值得, 价值, 值, 值钱 (adj.)"
+    ]
+  },
+  {
+    "name": "would",
+    "trans": [
+      "会, 将 (modal.)"
+    ]
+  },
+  {
+    "name": "wound",
+    "trans": [
+      "伤口, 伤, 创伤, 缠绕 (noun.); 创面, 切口 (adj.)"
+    ]
+  },
+  {
+    "name": "wrap",
+    "trans": [
+      "包裹, 包装, 包, 封装 (verb.); 裹, 缠绕 (noun.)"
+    ]
+  },
+  {
+    "name": "write",
+    "trans": [
+      "写, 编写, 写信, 写出 (verb.)"
+    ]
+  },
+  {
+    "name": "writer",
+    "trans": [
+      "作家, 作者, 文学家, 笔者 (noun.)"
+    ]
+  },
+  {
+    "name": "writing",
+    "trans": [
+      "写作, 书写, 书面, 书面形式 (noun.); 写, 编写, 撰写, 写信 (verb.)"
+    ]
+  },
+  {
+    "name": "wrong",
+    "trans": [
+      "错, 错误, 不对, 错事 (adj.)"
+    ]
+  },
+  {
+    "name": "yard",
+    "trans": [
+      "院子里, 院子, 围场, 堆场 (noun.)"
+    ]
+  },
+  {
+    "name": "yeah",
+    "trans": [
+      "对 (noun.)"
+    ]
+  },
+  {
+    "name": "year",
+    "trans": [
+      "年, 每年, 今年, 年度 (noun.)"
+    ]
+  },
+  {
+    "name": "yellow",
+    "trans": [
+      "黄色, 黄, 发黄, 黄河 (adj.)"
+    ]
+  },
+  {
+    "name": "yep",
+    "trans": [
+      "是的, 没错 (noun.)"
+    ]
+  },
+  {
+    "name": "yes",
+    "trans": [
+      "是的, 没错, 耶, 对 (noun.)"
+    ]
+  },
+  {
+    "name": "yesterday",
+    "trans": [
+      "昨天, 昨日, 昨 (noun.)"
+    ]
+  },
+  {
+    "name": "yet",
+    "trans": [
+      "然而, 尚未, 但, 还 (adv.)"
+    ]
+  },
+  {
+    "name": "you",
+    "trans": [
+      "你, 您, 你们 (pron.)"
+    ]
+  },
+  {
+    "name": "young",
+    "trans": [
+      "年轻, 青年, 年轻人, 年青 (adj.); 杨 (noun.)"
+    ]
+  },
+  {
+    "name": "youngster",
+    "trans": [
+      "年轻人, 童, 小将, 年青人 (noun.)"
+    ]
+  },
+  {
+    "name": "your",
+    "trans": [
+      "你, 您 (pron.)"
+    ]
+  },
+  {
+    "name": "yours",
+    "trans": [
+      "你 (pron.)"
+    ]
+  },
+  {
+    "name": "yourself",
+    "trans": [
+      "自己 (pron.)"
+    ]
+  },
+  {
+    "name": "youth",
+    "trans": [
+      "青年, 青春, 青少年, 年轻人 (noun.)"
+    ]
+  },
+  {
+    "name": "zone",
+    "trans": [
+      "区, 地带, 区域, 带 (noun.)"
+    ]
+  }
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -202,6 +202,17 @@ const chinaExam: DictionaryResource[] = [
     languageCategory: 'en',
   },
   {
+    id: 'longman_communication_3000_words',
+    name: 'Longman Communication 3000',
+    description: 'Most frequent words in both spoken and written English',
+    category: '中国考试',
+    tags: ['其他'],
+    url: '/dicts/Longman_Communication_3000.json',
+    length: 3168,
+    language: 'en',
+    languageCategory: 'en',
+  },
+  {
     id: 'top_2000_English_Words',
     name: 'Top 2000 words',
     description: 'with highest frequency',


### PR DESCRIPTION
## Why
The **Longman Communication 3000** is a list of the 3000 most frequent words in both spoken and written English, based on statistical analysis of the 390 million words contained in the Longman Corpus Network – a group of corpuses or databases of authentic English language. The Longman Communication 3000 represents the core of the English language and shows students of English which words are the most important for them to learn and study in order to communicate effectively in both speech and writing.

Analysis of the Longman Corpus Network shows that these 3000 most frequent words in spoken and written English account for 86% of the language. This means that by knowing this list of words, a learner of English is in a position to understand 86% or more of what he or she reads. Of course, “knowing”a word involves more than simply being able to recognise it and know a main meaning of it. Many of the most frequent words have a range of different meanings, a variety of different grammatical patterns, and numerous significant collocations.

Nonetheless, a basic understanding of the Longman Communication 3000 is a very powerful tool and will help students develop good comprehension and communication skills in English.

## Others
> **Note**
> The words come from https://github.com/sapbmw/Longman-Communication-3000/blob/master/Longman_Communication_3000.txt

> **Note**
> The dictionary data generated by Azure Translation Services.
