### PR TITLE
Improve mobile user interface

### DIFF
--- a/src/components/StarCard/index.tsx
+++ b/src/components/StarCard/index.tsx
@@ -86,9 +86,9 @@ export default function StarCard() {
       leave="transition ease-in duration-500 transform"
       leaveFrom="translate-x-0 translate-y-0"
       leaveTo="translate-x-full -translate-y-full"
-      className="fixed inset-0 z-30 flex h-0 justify-center md:block"
+      className="fixed inset-0 z-30 hidden h-0 justify-center md:flex"
     >
-      <div className="fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800 md:block">
+      <div className="fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800">
         <div className="absolute right-3 top-3">
           {isCounting && (
             <span className="m-1.5 dark:text-gray-100">

--- a/src/components/StarCard/index.tsx
+++ b/src/components/StarCard/index.tsx
@@ -86,9 +86,9 @@ export default function StarCard() {
       leave="transition ease-in duration-500 transform"
       leaveFrom="translate-x-0 translate-y-0"
       leaveTo="translate-x-full -translate-y-full"
-      className="fixed inset-0 z-30 flex h-0 justify-center"
+      className="fixed inset-0 z-30 flex h-0 justify-center sm:block"
     >
-      <div className="fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800">
+      <div className="fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800 sm:block">
         <div className="absolute right-3 top-3">
           {isCounting && (
             <span className="m-1.5 dark:text-gray-100">

--- a/src/components/StarCard/index.tsx
+++ b/src/components/StarCard/index.tsx
@@ -86,9 +86,9 @@ export default function StarCard() {
       leave="transition ease-in duration-500 transform"
       leaveFrom="translate-x-0 translate-y-0"
       leaveTo="translate-x-full -translate-y-full"
-      className="fixed inset-0 z-30 flex h-0 justify-center sm:block"
+      className="fixed inset-0 z-30 flex h-0 justify-center md:block"
     >
-      <div className="fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800 sm:block">
+      <div className="fixed right-1 top-4 flex w-150 flex-col items-center justify-evenly rounded-2xl bg-white p-12 shadow-2xl dark:bg-gray-800 md:block">
         <div className="absolute right-3 top-3">
           {isCounting && (
             <span className="m-1.5 dark:text-gray-100">


### PR DESCRIPTION
StarCard会使手机访问qwerty learner时的界面布局更加混乱，并且考虑到应该不会有用户在手机上无法使用的情况下收藏，也许可以hidden掉。
before:
![before](https://github.com/Kaiyiwing/qwerty-learner/assets/119289307/2dc21498-78ee-4745-8043-13644650a60b)
after:
![after](https://github.com/Kaiyiwing/qwerty-learner/assets/119289307/4d52cd43-1c39-44cc-80a6-6659f04426e1)
