### PR TITLE
fix the problem of via browser unsupport SPEECH API causing black screen

### DIFF
--- a/src/pages/Typing/components/WordPanel/components/Translation/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Translation/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { SoundIcon } from '../SoundIcon'
 import Tooltip from '@/components/Tooltip'
 import useSpeech from '@/hooks/useSpeech'
@@ -11,6 +12,7 @@ export type TranslationProps = {
 export default function Translation({ trans }: TranslationProps) {
   const pronunciationConfig = useAtomValue(pronunciationConfigAtom)
   const isShowTransRead = window.speechSynthesis && pronunciationConfig.isTransRead
+  if (!isShowTransRead) return <></> // 防止部分浏览器因为不支持 useSpeech 中的 api 而无法运行
   const speechOptions = useMemo(() => ({ volume: pronunciationConfig.transVolume }), [pronunciationConfig.transVolume])
   const { speak, speaking } = useSpeech(trans, speechOptions)
 


### PR DESCRIPTION
我使用 via 浏览器打开的时候会因为 React HOOK throw ERROR 而终止渲染导致黑屏，我加了一个判断条件使其在检测到不支持这个api的时候退出执行