### PR TITLE
Fix jpa dict

### DIFF
--- a/public/dicts/JapVocabList.N1.json
+++ b/public/dicts/JapVocabList.N1.json
@@ -525,11 +525,11 @@
         "notation": "苦(くる)しめる"
     },
     {
-        "name": "以te",
+        "name": "motte",
         "trans": [
             "with, by, by means of, because, in view of"
         ],
-        "notation": "以(以)て"
+        "notation": "以(もっ)て"
     },
     {
         "name": "janpaa",
@@ -812,11 +812,11 @@
         "notation": "前売(まえう)り"
     },
     {
-        "name": "凡yuru",
+        "name": "arayuru",
         "trans": [
             "all, every"
         ],
-        "notation": "凡(凡)ゆる"
+        "notation": "凡(あら)ゆる"
     },
     {
         "name": "kanryou",
@@ -966,11 +966,11 @@
         "notation": "恥(は)じる"
     },
     {
-        "name": "煌biyaka",
+        "name": "kirabiyaka",
         "trans": [
             "gorgeous, gaudy, dazzling, gay"
         ],
-        "notation": "煌(煌)びやか"
+        "notation": "煌(きら)びやか"
     },
     {
         "name": "seiken",
@@ -1785,11 +1785,11 @@
         "notation": "賭(か)ける"
     },
     {
-        "name": "嚏",
+        "name": "kushami",
         "trans": [
             "sneeze"
         ],
-        "notation": "嚏(嚏)"
+        "notation": "嚏(くしゃみ)"
     },
     {
         "name": "itsuka",
@@ -1820,7 +1820,7 @@
         "notation": "所定(しょてい)"
     },
     {
-        "name": "jo々",
+        "name": "jojo",
         "trans": [
             "gradually, steadily, quietly, slowly, soon"
         ],
@@ -1932,11 +1932,11 @@
         "notation": "行政(ぎょうせい)"
     },
     {
-        "name": "恰do",
+        "name": "choudo",
         "trans": [
             "just, right, exactly"
         ],
-        "notation": "恰(恰)度(ど)"
+        "notation": "恰(ちょう)度(ど)"
     },
     {
         "name": "muyou",
@@ -1981,11 +1981,11 @@
         "notation": "痛感(つうかん)"
     },
     {
-        "name": "其sho",
+        "name": "sonosho",
         "trans": [
             "that place, there"
         ],
-        "notation": "其(其)処(しょ)"
+        "notation": "其(その)処(しょ)"
     },
     {
         "name": "sai",
@@ -1995,11 +1995,11 @@
         "notation": "際(さい)"
     },
     {
-        "name": "其shode",
+        "name": "sonoshode",
         "trans": [
             "so (conj), accordingly, now, then, thereupon"
         ],
-        "notation": "其(其)処(しょ)で"
+        "notation": "其(その)処(しょ)で"
     },
     {
         "name": "kounetsuhi",
@@ -2100,11 +2100,11 @@
         "notation": "ポーズ"
     },
     {
-        "name": "屹do",
+        "name": "kiddo",
         "trans": [
             "1. (uk) surely, undoubtedly, certainly, without fail, 2. sternly, severely"
         ],
-        "notation": "屹(屹)度(ど)"
+        "notation": "屹(キッ)度(ど)"
     },
     {
         "name": "yoroshiku",
@@ -2758,11 +2758,11 @@
         "notation": "優位(ゆうい)"
     },
     {
-        "name": "其rekara",
+        "name": "sorekara",
         "trans": [
             "and then, after that"
         ],
-        "notation": "其(其)れから"
+        "notation": "其(そ)れから"
     },
     {
         "name": "chiratto",
@@ -2891,7 +2891,7 @@
         "notation": "辿(たど)り着(つ)く"
     },
     {
-        "name": "houtsupeta",
+        "name": "hooppeta",
         "trans": [
             "cheek"
         ],
@@ -3605,7 +3605,7 @@
         "notation": "朽(く)ちる"
     },
     {
-        "name": "kyouwa",
+        "name": "kyouha",
         "trans": [
             "hello, good day (daytime greeting id)"
         ],
@@ -3822,11 +3822,11 @@
         "notation": "優先(ゆうせん)"
     },
     {
-        "name": "鋏",
+        "name": "hasami",
         "trans": [
             "scissors"
         ],
-        "notation": "鋏(鋏)"
+        "notation": "鋏(はさみ)"
     },
     {
         "name": "megumi",
@@ -4242,11 +4242,11 @@
         "notation": "確信(かくしん)"
     },
     {
-        "name": "kanata此kata",
+        "name": "kanatakochira",
         "trans": [
             "here and there"
         ],
-        "notation": "彼方(かなた)此(此)方(かた)"
+        "notation": "彼方(かなた)此方(こちら)"
     },
     {
         "name": "sanka",
@@ -4256,11 +4256,11 @@
         "notation": "酸化(さんか)"
     },
     {
-        "name": "僅",
+        "name": "wazuka",
         "trans": [
             "a little, small quantity"
         ],
-        "notation": "僅(僅)"
+        "notation": "僅(わずか)"
     },
     {
         "name": "katai",
@@ -4312,7 +4312,7 @@
         "notation": "心細(こころぼそ)い"
     },
     {
-        "name": "yaritousu",
+        "name": "yaritoosu",
         "trans": [
             "to carry through, to achieve, to complete"
         ],
@@ -4767,11 +4767,11 @@
         "notation": "差(さ)し支(つか)える"
     },
     {
-        "name": "其rede",
+        "name": "sorede",
         "trans": [
             "and (conj), thereupon, because of that"
         ],
-        "notation": "其(其)れで"
+        "notation": "其(それ)で"
     },
     {
         "name": "kisei",
@@ -4779,10 +4779,6 @@
             "regulation"
         ],
         "notation": "規制(きせい)"
-    },
-    {
-        "name": "",
-        "trans": "#NAME?"
     },
     {
         "name": "iede",
@@ -5226,10 +5222,6 @@
         "notation": "ほっと"
     },
     {
-        "name": "",
-        "trans": "#NAME?"
-    },
-    {
         "name": "jiko",
         "trans": [
             "self, oneself"
@@ -5545,11 +5537,11 @@
         "notation": "上回(うわまわ)る"
     },
     {
-        "name": "巨",
+        "name": "kyo",
         "trans": [
             "big, large, great"
         ],
-        "notation": "巨(巨)"
+        "notation": "巨(きょ)"
     },
     {
         "name": "oseji",
@@ -5951,7 +5943,7 @@
         "notation": "肥料(ひりょう)"
     },
     {
-        "name": "nobeitewa",
+        "name": "nobeiteha",
         "trans": [
             "not only...but also, in addition to, consequently"
         ],
@@ -6217,11 +6209,11 @@
         "notation": "長閑(のどか)"
     },
     {
-        "name": "其shora",
+        "name": "sonoshora",
         "trans": [
             "everywhere, somewhere, approximately, that area, around there"
         ],
-        "notation": "其(其)処(しょ)ら"
+        "notation": "其(その)処(しょ)ら"
     },
     {
         "name": "tsupparu",
@@ -6693,11 +6685,11 @@
         "notation": "着目(ちゃくもく)"
     },
     {
-        "name": "其kata",
+        "name": "sonokata",
         "trans": [
             "over there, the other"
         ],
-        "notation": "其(其)方(かた)"
+        "notation": "其(その)方(かた)"
     },
     {
         "name": "hinkon",
@@ -7001,11 +6993,11 @@
         "notation": "ご無沙汰(ぶさた)"
     },
     {
-        "name": "其redemo",
+        "name": "soredemo",
         "trans": [
             "but (still), and yet, nevertheless, even so, notwithstanding"
         ],
-        "notation": "其(其)れでも"
+        "notation": "其(それ)でも"
     },
     {
         "name": "gairai",
@@ -7134,11 +7126,11 @@
         "notation": "可愛(かわい)い"
     },
     {
-        "name": "fuyama戯ru",
+        "name": "fuyamagiru",
         "trans": [
             "to romp, to gambol, to frolic, to joke, to make fun of, to flirt"
         ],
-        "notation": "不(ふ)山(やま)戯(戯)る"
+        "notation": "不(ふ)山(やま)戯(ぎ)る"
     },
     {
         "name": "chosho",
@@ -8324,11 +8316,11 @@
         "notation": "結核(けっかく)"
     },
     {
-        "name": "歎",
+        "name": "tan",
         "trans": [
             "grief, sigh, lamentation"
         ],
-        "notation": "歎(歎)"
+        "notation": "歎(たん)"
     },
     {
         "name": "kyuuji",
@@ -8513,7 +8505,7 @@
         "notation": "禅(ぜん)"
     },
     {
-        "name": "aruiwa",
+        "name": "aruiha",
         "trans": [
             "or, possibly"
         ],
@@ -8954,11 +8946,11 @@
         "notation": "桐(きり)"
     },
     {
-        "name": "yatsuhari",
+        "name": "yappari",
         "trans": [
             "also, as I thought, still, in spite of, absolutely"
         ],
-        "notation": "矢(や)っ張(は)り"
+        "notation": "矢(や)張(っぱ)り"
     },
     {
         "name": "tabou",
@@ -9143,11 +9135,11 @@
         "notation": "新入生(しんにゅうせい)"
     },
     {
-        "name": "偶ni",
+        "name": "tamani",
         "trans": [
             "occasionally, once in a while"
         ],
-        "notation": "偶(偶)に"
+        "notation": "偶(たま)に"
     },
     {
         "name": "kokoromiru",
@@ -9164,11 +9156,11 @@
         "notation": "キャリア"
     },
     {
-        "name": "齎rasu",
+        "name": "motarasu",
         "trans": [
             "to bring, to take, to bring about"
         ],
-        "notation": "齎(齎)らす"
+        "notation": "齎(もたら)す"
     },
     {
         "name": "harappa",
@@ -9612,7 +9604,7 @@
         "notation": "尽(つ)くす"
     },
     {
-        "name": "iya々",
+        "name": "iyadou",
         "trans": [
             "unwillingly, grudgingly, shaking head in refusal (to children)"
         ],
@@ -9850,7 +9842,7 @@
         "notation": "中腹(ちゅうふく)"
     },
     {
-        "name": "machidoushii",
+        "name": "machidooshii",
         "trans": [
             "looking forward to"
         ],
@@ -9927,11 +9919,11 @@
         "notation": "促(うなが)す"
     },
     {
-        "name": "其redewa",
+        "name": "soredeha",
         "trans": [
             "in that situation, well then ..."
         ],
-        "notation": "其(其)れでは"
+        "notation": "其(それ)では"
     },
     {
         "name": "tomi",
@@ -10032,7 +10024,7 @@
         "notation": "処置(しょち)"
     },
     {
-        "name": "todokouru",
+        "name": "todokooru",
         "trans": [
             "to stagnate, to be delayed"
         ],
@@ -10151,11 +10143,11 @@
         "notation": "腫(は)れる"
     },
     {
-        "name": "傲ru",
+        "name": "ogoru",
         "trans": [
             "to be proud"
         ],
-        "notation": "傲(傲)る"
+        "notation": "傲(おご)る"
     },
     {
         "name": "fuben",
@@ -10277,11 +10269,11 @@
         "notation": "字(じ)"
     },
     {
-        "name": "其rehodo",
+        "name": "sorehodo",
         "trans": [
             "to that degree, extent"
         ],
-        "notation": "其(其)れ程(ほど)"
+        "notation": "其(それ)程(ほど)"
     },
     {
         "name": "tate",
@@ -10291,11 +10283,11 @@
         "notation": "盾(たて)"
     },
     {
-        "name": "此no",
+        "name": "kono",
         "trans": [
             "this"
         ],
-        "notation": "此(此)の"
+        "notation": "此(こ)の"
     },
     {
         "name": "mikon",
@@ -10368,7 +10360,7 @@
         "notation": "雛(ひな)"
     },
     {
-        "name": "toumawari",
+        "name": "toomawari",
         "trans": [
             "detour, roundabout way"
         ],
@@ -10921,11 +10913,11 @@
         "notation": "不況(ふきょう)"
     },
     {
-        "name": "働",
+        "name": "dou",
         "trans": [
             "work, labor"
         ],
-        "notation": "働(働)"
+        "notation": "働(どう)"
     },
     {
         "name": "chanoyu",
@@ -10991,11 +10983,11 @@
         "notation": "無念(むねん)"
     },
     {
-        "name": "諄i",
+        "name": "kudoi",
         "trans": [
             "verbose, importunate, heavy (taste)"
         ],
-        "notation": "諄(諄)い"
+        "notation": "諄(くど)い"
     },
     {
         "name": "sumasu",
@@ -11131,10 +11123,6 @@
         "notation": "目覚(めざま)しい"
     },
     {
-        "name": "",
-        "trans": "#NAME?"
-    },
-    {
         "name": "azawarau",
         "trans": [
             "to sneer at, to ridicule"
@@ -11198,11 +11186,11 @@
         "notation": "辺(あた)り"
     },
     {
-        "name": "嫋ka",
+        "name": "taoyaka",
         "trans": [
             "supple, flexible, elastic"
         ],
-        "notation": "嫋(嫋)か"
+        "notation": "嫋(たおや)か"
     },
     {
         "name": "hairyo",
@@ -11289,18 +11277,18 @@
         "notation": "暴風(ぼうふう)"
     },
     {
-        "name": "osshasshiyaru",
+        "name": "osshassharu",
         "trans": [
             "to say, to speak, to tell, to talk"
         ],
         "notation": "仰(おっしゃ)っしゃる"
     },
     {
-        "name": "稍",
+        "name": "yaya",
         "trans": [
             "a little, partially, somewhat, a short time, a while"
         ],
-        "notation": "稍(稍)"
+        "notation": "稍(やや)"
     },
     {
         "name": "ore",
@@ -11471,11 +11459,11 @@
         "notation": "救援(きゅうえん)"
     },
     {
-        "name": "shimo吏",
+        "name": "shimotsukasa",
         "trans": [
             "lower official"
         ],
-        "notation": "下(しも)吏(吏)"
+        "notation": "下(しも)吏(つかさ)"
     },
     {
         "name": "sokkenai",
@@ -12381,7 +12369,7 @@
         "notation": "名高(なだか)い"
     },
     {
-        "name": "mitoushi",
+        "name": "mitooshi",
         "trans": [
             "perspective, unobstructed view, outlook, forecast, prospect, insight"
         ],
@@ -12444,11 +12432,11 @@
         "notation": "饂飩(うどん)"
     },
     {
-        "name": "傾",
+        "name": "katamuku",
         "trans": [
             "lean, incline"
         ],
-        "notation": "傾(傾)"
+        "notation": "傾(かたむ)く"
     },
     {
         "name": "matagu",
@@ -12563,11 +12551,11 @@
         "notation": "呉(く)れる"
     },
     {
-        "name": "泌mi泌mi",
+        "name": "himihimi",
         "trans": [
             "keenly, deeply, heartily"
         ],
-        "notation": "泌(泌)み泌(泌)み"
+        "notation": "泌(ひ)み泌(ひ)み"
     },
     {
         "name": "ikou",
@@ -12787,7 +12775,7 @@
         "notation": "すれ違(ちが)う"
     },
     {
-        "name": "omedetaa",
+        "name": "omedetau",
         "trans": [
             "(ateji) (int) (uk) Congratulations!, an auspicious occasion!"
         ],
@@ -12962,11 +12950,11 @@
         "notation": "単(たん)"
     },
     {
-        "name": "噛ru",
+        "name": "kajiru",
         "trans": [
             "to chew, to bite (at), to gnaw, to nibble, to munch, to crunch, to have a smattering of"
         ],
-        "notation": "噛(噛)る"
+        "notation": "噛(かじ)る"
     },
     {
         "name": "osaeru",
@@ -13004,11 +12992,11 @@
         "notation": "金槌(かなづち)"
     },
     {
-        "name": "其reyue",
+        "name": "soreyue",
         "trans": [
             "therefore, for that reason, so"
         ],
-        "notation": "其(其)れ故(ゆえ)"
+        "notation": "其(それ)故(ゆえ)"
     },
     {
         "name": "obitadashii",
@@ -13172,7 +13160,7 @@
         "notation": "理性(りせい)"
     },
     {
-        "name": "tourikakaru",
+        "name": "toorikakaru",
         "trans": [
             "to happen to pass by"
         ],
@@ -14551,11 +14539,11 @@
         "notation": "交(まじ)える"
     },
     {
-        "name": "tai々",
+        "name": "wazawaza",
         "trans": [
             "expressly, specially, doing something especially rather than incidentally"
         ],
-        "notation": "態(たい)々"
+        "notation": "態(わざ)々"
     },
     {
         "name": "ittei",
@@ -14712,11 +14700,11 @@
         "notation": "介護(かいご)"
     },
     {
-        "name": "此re",
+        "name": "kore",
         "trans": [
             "this"
         ],
-        "notation": "此(此)れ"
+        "notation": "此(こ)れ"
     },
     {
         "name": "sokuzani",
@@ -14803,7 +14791,7 @@
         "notation": "略奪(りゃくだつ)"
     },
     {
-        "name": "yamuoenai",
+        "name": "yamuwoenai",
         "trans": [
             "cannot be helped, unavoidable"
         ],
@@ -15321,11 +15309,11 @@
         "notation": "摘(つま)む"
     },
     {
-        "name": "其re",
+        "name": "sore",
         "trans": [
             "it, that"
         ],
-        "notation": "其(其)れ"
+        "notation": "其(そ)れ"
     },
     {
         "name": "dounyuu",
@@ -15440,11 +15428,11 @@
         "notation": "不動産(ふどうさん)"
     },
     {
-        "name": "ai褸",
+        "name": "ranru",
         "trans": [
             "rag, scrap, tattered clothes, fault (esp. in a pretense), defect, run-down or junky"
         ],
-        "notation": "藍(あい)褸(褸)"
+        "notation": "藍(らん)褸(る)"
     },
     {
         "name": "rei",
@@ -15706,11 +15694,11 @@
         "notation": "股(また)"
     },
     {
-        "name": "akira々gojitsu",
+        "name": "akaakagojitsu",
         "trans": [
             "two days after tomorrow"
         ],
-        "notation": "明(あきら)々後日(ごじつ)"
+        "notation": "明々(あかあか)後日(ごじつ)"
     },
     {
         "name": "geppu",
@@ -17001,11 +16989,11 @@
         "notation": "否決(ひけつ)"
     },
     {
-        "name": "哉",
+        "name": "kana",
         "trans": [
             "question mark"
         ],
-        "notation": "哉(哉)"
+        "notation": "哉(かな)"
     },
     {
         "name": "tenjou",
@@ -18408,11 +18396,11 @@
         "notation": "絶(た)える"
     },
     {
-        "name": "而mo",
+        "name": "shikamo",
         "trans": [
             "moreover, furthermore, nevertheless, and yet"
         ],
-        "notation": "而(而)も"
+        "notation": "而(しか)も"
     },
     {
         "name": "chinbotsu",
@@ -18450,11 +18438,11 @@
         "notation": "ご馳走(ちそう)"
     },
     {
-        "name": "迚mo",
+        "name": "totemo",
         "trans": [
             "very, awfully, exceedingly"
         ],
-        "notation": "迚(迚)も"
+        "notation": "迚(とて)も"
     },
     {
         "name": "kokorozuyoi",
@@ -18506,11 +18494,11 @@
         "notation": "跡(あと)切(き)れる"
     },
     {
-        "name": "苛々",
+        "name": "iraira",
         "trans": [
             "getting nervous, irritation"
         ],
-        "notation": "苛(苛)々"
+        "notation": "苛々(イライラ)"
     },
     {
         "name": "sukunakutomo",
@@ -18660,7 +18648,7 @@
         "notation": "新(しん)"
     },
     {
-        "name": "touzakaru",
+        "name": "toozakaru",
         "trans": [
             "to go far off"
         ],
@@ -20361,11 +20349,11 @@
         "notation": "気配(けはい)"
     },
     {
-        "name": "nani々",
+        "name": "naninani",
         "trans": [
             "which (emphatic)"
         ],
-        "notation": "何(なに)々"
+        "notation": "何々(なになに)"
     },
     {
         "name": "soboku",
@@ -20872,11 +20860,11 @@
         "notation": "垂(た)れる"
     },
     {
-        "name": "於",
+        "name": "o",
         "trans": [
             "at, in, on"
         ],
-        "notation": "於(於)"
+        "notation": "於(お)"
     },
     {
         "name": "jishin",
@@ -20977,11 +20965,11 @@
         "notation": "忠告(ちゅうこく)"
     },
     {
-        "name": "此retou",
+        "name": "koretou",
         "trans": [
             "these"
         ],
-        "notation": "此(此)れ等(とう)"
+        "notation": "此(こ)れ等(とう)"
     },
     {
         "name": "jisonshin",
@@ -21124,7 +21112,7 @@
         "notation": "強硬(きょうこう)"
     },
     {
-        "name": "konbanwa",
+        "name": "konbanha",
         "trans": [
             "good evening"
         ],
@@ -21348,11 +21336,11 @@
         "notation": "権威(けんい)"
     },
     {
-        "name": "kaku々",
+        "name": "onoono",
         "trans": [
             "each, every, either, respectively, severally"
         ],
-        "notation": "各(かく)々"
+        "notation": "各々(おのおの)"
     },
     {
         "name": "yanushi",
@@ -22328,11 +22316,11 @@
         "notation": "取(と)っ手(て)"
     },
     {
-        "name": "倣",
+        "name": "hou",
         "trans": [
             "imitate, follow, emulate"
         ],
-        "notation": "倣(倣)"
+        "notation": "倣(ほう)"
     },
     {
         "name": "sakisengetsu",
@@ -22580,11 +22568,11 @@
         "notation": "版(ばん)"
     },
     {
-        "name": "kanata此kata",
+        "name": "kanatakonokata",
         "trans": [
             "here and there"
         ],
-        "notation": "彼方(かなた)此(此)方(かた)"
+        "notation": "彼方(かなた)此(この)方(かた)"
     },
     {
         "name": "bengo",
@@ -22622,11 +22610,11 @@
         "notation": "方式(ほうしき)"
     },
     {
-        "name": "疾tsukuni",
+        "name": "hayakkuni",
         "trans": [
             "long ago, already, a long time ago"
         ],
-        "notation": "疾(疾)っくに"
+        "notation": "疾(はや)っくに"
     },
     {
         "name": "hinata",
@@ -22692,11 +22680,11 @@
         "notation": "濫用(らんよう)"
     },
     {
-        "name": "sono儘",
+        "name": "sonomama",
         "trans": [
             "without change, as it is (i.e. now)"
         ],
-        "notation": "其(そ)の儘(儘)"
+        "notation": "其(そ)の儘(まま)"
     },
     {
         "name": "genba",
@@ -22818,7 +22806,7 @@
         "notation": "教材(きょうざい)"
     },
     {
-        "name": "moshikuwa",
+        "name": "moshikuha",
         "trans": [
             "or, otherwise"
         ],
@@ -22972,11 +22960,11 @@
         "notation": "丸々(まるまる)"
     },
     {
-        "name": "些tomo",
+        "name": "sattomo",
         "trans": [
             "not at all (neg. verb)"
         ],
-        "notation": "些(些)とも"
+        "notation": "些(さ)っとも"
     },
     {
         "name": "miawaseru",
@@ -23441,11 +23429,11 @@
         "notation": "恐(おそ)れ入(い)る"
     },
     {
-        "name": "偖",
+        "name": "sate",
         "trans": [
             "well, now, then"
         ],
-        "notation": "偖(偖)"
+        "notation": "偖(さて)"
     },
     {
         "name": "muudo",
@@ -23574,11 +23562,11 @@
         "notation": "組(く)み合(あ)わせ"
     },
     {
-        "name": "iyoiyo々",
+        "name": "iyoiyo",
         "trans": [
             "more and more, all the more, increasingly, at last, beyond doubt"
         ],
-        "notation": "愈(いよいよ)々"
+        "notation": "愈々(いよいよ)"
     },
     {
         "name": "tomonau",
@@ -24001,11 +23989,11 @@
         "notation": "露骨(ろこつ)"
     },
     {
-        "name": "其reni",
+        "name": "soreni",
         "trans": [
             "besides, moreover"
         ],
-        "notation": "其(其)れに"
+        "notation": "其(そ)れに"
     },
     {
         "name": "kissa",
@@ -24169,11 +24157,11 @@
         "notation": "味覚(みかく)"
     },
     {
-        "name": "其retomo",
+        "name": "soretomo",
         "trans": [
             "or, or else"
         ],
-        "notation": "其(其)れ共(とも)"
+        "notation": "其(そ)れ共(とも)"
     },
     {
         "name": "shutsudai",

--- a/public/dicts/JapVocabList.N2.json
+++ b/public/dicts/JapVocabList.N2.json
@@ -49,7 +49,7 @@
         "notation": "停止(ていし)"
     },
     {
-        "name": "oodouri",
+        "name": "oodoori",
         "trans": [
             "main street"
         ],
@@ -1043,7 +1043,7 @@
         "notation": "安易(あんい)"
     },
     {
-        "name": "hitodouri",
+        "name": "hitodoori",
         "trans": [
             "pedestrian traffic"
         ],
@@ -1547,11 +1547,11 @@
         "notation": "将棋(しょうぎ)"
     },
     {
-        "name": "betsu々",
+        "name": "betsubetsu",
         "trans": [
             "separately,individually"
         ],
-        "notation": "別(べつ)々"
+        "notation": "別々(べつべつ)"
     },
     {
         "name": "kousa",
@@ -1932,7 +1932,7 @@
         "notation": "延長(えんちょう)"
     },
     {
-        "name": "moyoushi",
+        "name": "moyooshi",
         "trans": [
             "event,festivities,function"
         ],
@@ -2926,11 +2926,11 @@
         "notation": "ジャーナリスト"
     },
     {
-        "name": "kaku々",
+        "name": "onoono",
         "trans": [
             "each,every,either,respectively,severally"
         ],
-        "notation": "各(かく)々"
+        "notation": "各々(おのおの)"
     },
     {
         "name": "sakanoboru",
@@ -3332,11 +3332,11 @@
         "notation": "校庭(こうてい)"
     },
     {
-        "name": "咥eru",
+        "name": "kuwaeru",
         "trans": [
             ""
         ],
-        "notation": "咥(咥)える"
+        "notation": "咥(くわ)える"
     },
     {
         "name": "shokunin",
@@ -4291,7 +4291,7 @@
         "notation": "スケジュール"
     },
     {
-        "name": "yamuoenai",
+        "name": "yamuwoenai",
         "trans": [
             "cannot be helped,unavoidable"
         ],
@@ -5376,11 +5376,11 @@
         "notation": "為替(かわせ)"
     },
     {
-        "name": "佚",
+        "name": "itsu",
         "trans": [
             "be lost,peace,hide,mistake,beautiful,in turn"
         ],
-        "notation": "佚(佚)"
+        "notation": "佚(いつ)"
     },
     {
         "name": "roumaji",
@@ -6314,7 +6314,7 @@
         "notation": "索引(さくいん)"
     },
     {
-        "name": "tourikakaru",
+        "name": "toorikakaru",
         "trans": [
             "to happen to pass by"
         ],
@@ -6398,11 +6398,11 @@
         "notation": "捕(と)る"
     },
     {
-        "name": "nani々",
+        "name": "naninani",
         "trans": [
             "such and such,What?"
         ],
-        "notation": "何(なに)々"
+        "notation": "何々(なになに)"
     },
     {
         "name": "shousha",
@@ -7462,11 +7462,11 @@
         "notation": "期限(きげん)"
     },
     {
-        "name": "ichitouri",
+        "name": "hitotoori",
         "trans": [
             "ordinary,usual,in general,briefly"
         ],
-        "notation": "一(いち)通(とお)り"
+        "notation": "一通り(ひととおり"
     },
     {
         "name": "chimei",
@@ -7574,7 +7574,7 @@
         "notation": "溶(と)く"
     },
     {
-        "name": "konbanwa",
+        "name": "konbanha",
         "trans": [
             "good evening"
         ],
@@ -7840,11 +7840,11 @@
         "notation": "コース"
     },
     {
-        "name": "teki確",
+        "name": "tekikaku",
         "trans": [
             "precise,accurate"
         ],
-        "notation": "適(てき)確(確)"
+        "notation": "適(てき)確(かく)"
     },
     {
         "name": "suichoku",
@@ -8407,13 +8407,6 @@
         "notation": "カーブ"
     },
     {
-        "name": "×",
-        "trans": [
-            ""
-        ],
-        "notation": "×"
-    },
-    {
         "name": "rokkaa",
         "trans": [
             "locker"
@@ -8848,11 +8841,11 @@
         "notation": "叔父(おじ)さん"
     },
     {
-        "name": "Ͼtatsu",
+        "name": "tairitsu",
         "trans": [
             "confrontation,opposition,antagonism"
         ],
-        "notation": "Ͼ立(たつ)"
+        "notation": "対立(たつ)"
     },
     {
         "name": "sensu",
@@ -9660,11 +9653,11 @@
         "notation": "長方形(ちょうほうけい)"
     },
     {
-        "name": "傾raka",
+        "name": "katamukeraka",
         "trans": [
             ""
         ],
-        "notation": "傾(傾)らか"
+        "notation": "傾(かたむ)けらか"
     },
     {
         "name": "urouro",
@@ -9870,7 +9863,7 @@
         "notation": "領収(りょうしゅう)"
     },
     {
-        "name": "kiotsukeru",
+        "name": "kiwotsukeru",
         "trans": [
             "to be careful,to pay attention,to take care"
         ],
@@ -10213,7 +10206,7 @@
         "notation": "水曜(すいよう)"
     },
     {
-        "name": "matawa",
+        "name": "mataha",
         "trans": [
             "or,otherwise"
         ],
@@ -11487,7 +11480,7 @@
         "notation": "荒(あら)い"
     },
     {
-        "name": "sukitouru",
+        "name": "sukitooru",
         "trans": [
             "to be(come) transparent"
         ],

--- a/public/dicts/JapVocabList.N3.json
+++ b/public/dicts/JapVocabList.N3.json
@@ -1078,7 +1078,7 @@
         "notation": "移動(いどう)"
     },
     {
-        "name": "tousu",
+        "name": "toosu",
         "trans": [
             "to let pass,to overlook,to continue"
         ],
@@ -1491,7 +1491,7 @@
         "notation": "畑(はたけ)"
     },
     {
-        "name": "kouru",
+        "name": "kooru",
         "trans": [
             "to freeze,to be frozen over,to congeal"
         ],
@@ -3997,7 +3997,7 @@
         "notation": "少女(しょうじょ)"
     },
     {
-        "name": "konnichiwa",
+        "name": "konnichiha",
         "trans": [
             "hello,good day (daytime greeting, id)"
         ],
@@ -4788,11 +4788,11 @@
         "notation": "穀物(こくもつ)"
     },
     {
-        "name": "偶々",
+        "name": "tamatama",
         "trans": [
             "casually,unexpectedly,accidentally,by chance"
         ],
-        "notation": "偶(偶)々"
+        "notation": "偶々(たまたま)"
     },
     {
         "name": "renzoku",
@@ -4851,7 +4851,7 @@
         "notation": "批判(ひはん)"
     },
     {
-        "name": "dewa",
+        "name": "deha",
         "trans": [
             "chance of going out,opportunity (to succeed),moment of departure,beginning of work"
         ],
@@ -7714,7 +7714,7 @@
         "notation": "利口(りこう)"
     },
     {
-        "name": "tourisugiru",
+        "name": "toorisugiru",
         "trans": [
             "to pass,to pass through"
         ],
@@ -9303,7 +9303,7 @@
         "notation": "きちんと"
     },
     {
-        "name": "touri",
+        "name": "toori",
         "trans": [
             "in accordance with ~,following ~,~ Street,~ Avenue"
         ],
@@ -10472,11 +10472,11 @@
         "notation": "勿論(もちろん)"
     },
     {
-        "name": "kiyoshi々",
+        "name": "seizei",
         "trans": [
             "at the most,at best,to the utmost,as much (far) as possible"
         ],
-        "notation": "精(きよし)々"
+        "notation": "精々(せいぜい)"
     },
     {
         "name": "seikaku",
@@ -10969,11 +10969,11 @@
         "notation": "不満(ふまん)"
     },
     {
-        "name": "偶",
+        "name": "tama",
         "trans": [
             "even number,couple,man and wife,friend"
         ],
-        "notation": "偶(偶)"
+        "notation": "偶(たま)"
     },
     {
         "name": "iin",
@@ -11123,7 +11123,7 @@
         "notation": "害(がい)"
     },
     {
-        "name": "aruiwa",
+        "name": "aruiha",
         "trans": [
             "or,possibly"
         ],
@@ -11508,7 +11508,7 @@
         "notation": "何(なん)とか"
     },
     {
-        "name": "jitsuwa",
+        "name": "jitsuha",
         "trans": [
             "as a matter of fact,by the way"
         ],
@@ -12096,11 +12096,11 @@
         "notation": "者(もの)"
     },
     {
-        "name": "佩",
+        "name": "hai",
         "trans": [
             "wear,put on (sword)"
         ],
-        "notation": "佩(佩)"
+        "notation": "佩(はい)"
     },
     {
         "name": "tsukamu",

--- a/public/dicts/JapVocabList.N4.json
+++ b/public/dicts/JapVocabList.N4.json
@@ -28,7 +28,7 @@
         "notation": "彼(かれ)"
     },
     {
-        "name": "bikkuri･suru",
+        "name": "bikkuri/suru",
         "trans": [
             "to be surprised"
         ],
@@ -595,7 +595,7 @@
         "notation": "残念(ざんねん)"
     },
     {
-        "name": "chekku･suru",
+        "name": "chekku/suru",
         "trans": [
             "to check"
         ],
@@ -770,7 +770,7 @@
         "notation": "火(ひ)"
     },
     {
-        "name": "kenka･suru",
+        "name": "kenka/suru",
         "trans": [
             "to quarrel"
         ],
@@ -826,7 +826,7 @@
         "notation": "決(き)める"
     },
     {
-        "name": "touru",
+        "name": "tooru",
         "trans": [
             "to go through"
         ],
@@ -917,11 +917,11 @@
         "notation": "きっと"
     },
     {
-        "name": "落ru",
+        "name": "ochiru",
         "trans": [
             "to fall or drop"
         ],
-        "notation": "落(落)る"
+        "notation": "落(おち)る"
     },
     {
         "name": "okage",
@@ -1687,7 +1687,7 @@
         "notation": "必(かなら)ず"
     },
     {
-        "name": "matawa",
+        "name": "mataha",
         "trans": [
             "or,otherwise"
         ],
@@ -2688,7 +2688,7 @@
         "notation": "壁(かべ)"
     },
     {
-        "name": "touku",
+        "name": "tooku",
         "trans": [
             "distant"
         ],
@@ -3136,7 +3136,7 @@
         "notation": "慣(な)れる"
     },
     {
-        "name": "kega･suru",
+        "name": "kega/suru",
         "trans": [
             "to injure"
         ],
@@ -3738,11 +3738,11 @@
         "notation": "止(と)める"
     },
     {
-        "name": "naka々",
+        "name": "nakanaka",
         "trans": [
             "considerably"
         ],
-        "notation": "中(なか)々"
+        "notation": "中々(なかなか)"
     },
     {
         "name": "karera",
@@ -4004,7 +4004,7 @@
         "notation": "特急(とっきゅう)"
     },
     {
-        "name": "o･kanemochi",
+        "name": "o/kanemochi",
         "trans": [
             "rich man"
         ],

--- a/public/dicts/JapVocabList.N5.json
+++ b/public/dicts/JapVocabList.N5.json
@@ -910,11 +910,11 @@
         "notation": "温(ぬく)い"
     },
     {
-        "name": "miru miru",
+        "name": "miru/miru",
         "trans": [
             "to see, to watch"
         ],
-        "notation": "見(み)る 観(み)る"
+        "notation": "見(み)る/観(み)る"
     },
     {
         "name": "kiiroi",
@@ -1617,7 +1617,7 @@
         "notation": "四(よん)日(にち)"
     },
     {
-        "name": "toui",
+        "name": "tooi",
         "trans": [
             "far"
         ],
@@ -2324,7 +2324,7 @@
         "notation": "暖(あたた)かい"
     },
     {
-        "name": "soredewa",
+        "name": "soredeha",
         "trans": [
             "in that situation"
         ],
@@ -4228,7 +4228,7 @@
         "notation": "五(ご)"
     },
     {
-        "name": "dewa",
+        "name": "deha",
         "trans": [
             "with that..."
         ],

--- a/public/dicts/Jap_High-Frequency_N1.json
+++ b/public/dicts/Jap_High-Frequency_N1.json
@@ -56,7 +56,7 @@
         "notation": "重(おも)んじる"
     },
     {
-        "name": "special",
+        "name": "supesharu",
         "trans": [
             "② 名·ナ形  特别，特殊；专门"
         ],
@@ -147,7 +147,7 @@
         "notation": "藪(やぶ)"
     },
     {
-        "name": "panic",
+        "name": "panikku",
         "trans": [
             "① 名  恐慌，慌乱，混乱"
         ],
@@ -371,7 +371,7 @@
         "notation": "励(はげ)む"
     },
     {
-        "name": "timer",
+        "name": "taima-",
         "trans": [
             "① 名  秒表，定时器；计时员"
         ],
@@ -441,7 +441,7 @@
         "notation": "原点(げんてん)"
     },
     {
-        "name": "stadium",
+        "name": "sutajiamu",
         "trans": [
             "② 名  运动场，比赛场"
         ],
@@ -574,7 +574,7 @@
         "notation": "カテゴリー"
     },
     {
-        "name": "后接否定",
+        "name": "aete",
         "trans": [
             "① 副  敢于，硬要；（后接否定）并（不）"
         ],
@@ -595,14 +595,14 @@
         "notation": "器量(きりょう)"
     },
     {
-        "name": "液体",
+        "name": "dabudabu",
         "trans": [
             "① 副·自动3  肥大；肥胖；（液体）满，盈"
         ],
         "notation": "だぶだぶ"
     },
     {
-        "name": "idol",
+        "name": "aidoru",
         "trans": [
             "① 名  偶像"
         ],
@@ -735,7 +735,7 @@
         "notation": "治安(ちあん)"
     },
     {
-        "name": "hanger",
+        "name": "hanga-",
         "trans": [
             "① 名  衣架"
         ],
@@ -770,7 +770,7 @@
         "notation": "呆(ぼ)ける"
     },
     {
-        "name": "dubbing",
+        "name": "dabingu",
         "trans": [
             "⓪ 名·他动3  复制，拷贝（磁盘、唱片等）"
         ],
@@ -896,7 +896,7 @@
         "notation": "叶(かな)う"
     },
     {
-        "name": "filter",
+        "name": "firuta-",
         "trans": [
             "⓪ 名  过滤嘴，过滤器"
         ],
@@ -1001,7 +1001,7 @@
         "notation": "とことんまで"
     },
     {
-        "name": "socks",
+        "name": "sokkusu",
         "trans": [
             "① 名  短袜"
         ],
@@ -1127,7 +1127,7 @@
         "notation": "捲(めく)る"
     },
     {
-        "name": "loose",
+        "name": "ru-zu",
         "trans": [
             "① ナ形  松懈的；散漫的"
         ],
@@ -1281,7 +1281,7 @@
         "notation": "清清(すがすが)しい"
     },
     {
-        "name": "hijack",
+        "name": "haijakku",
         "trans": [
             "③ 名·他动3  劫持飞机"
         ],
@@ -1386,7 +1386,7 @@
         "notation": "勝(まさ)る"
     },
     {
-        "name": "fair",
+        "name": "fea",
         "trans": [
             "① ナ形  公平的"
         ],
@@ -1421,7 +1421,7 @@
         "notation": "貴族(きぞく)"
     },
     {
-        "name": "感情、欲望等",
+        "name": "sosoru",
         "trans": [
             "⓪ 他动1  引起，勾起（感情、欲望等）"
         ],
@@ -1449,7 +1449,7 @@
         "notation": "比(ひ)する"
     },
     {
-        "name": "hostess",
+        "name": "hosutesu",
         "trans": [
             "① 名  （宴会的）女主人；（酒吧的）女招待"
         ],
@@ -1519,7 +1519,7 @@
         "notation": "白髪(しらが)"
     },
     {
-        "name": "on line",
+        "name": "onrain",
         "trans": [
             "③ 名  联机，在线"
         ],
@@ -1617,7 +1617,7 @@
         "notation": "退(ど)かす"
     },
     {
-        "name": "gap",
+        "name": "gyappu",
         "trans": [
             "⓪ 名  裂缝；分歧，隔阂"
         ],
@@ -1701,7 +1701,7 @@
         "notation": "裁(さば)く"
     },
     {
-        "name": "counselor",
+        "name": "kaunsera-",
         "trans": [
             "② 名  （心理）咨询师；生活指导员"
         ],
@@ -1827,7 +1827,7 @@
         "notation": "慕(した)う"
     },
     {
-        "name": "missile",
+        "name": "misairu",
         "trans": [
             "② 名  导弹"
         ],
@@ -1911,7 +1911,7 @@
         "notation": "真(ま)ん丸(まる)い"
     },
     {
-        "name": "motel",
+        "name": "mo-teru",
         "trans": [
             "① 名  汽车旅馆"
         ],
@@ -1974,7 +1974,7 @@
         "notation": "似通(にかよ)う"
     },
     {
-        "name": "claim",
+        "name": "kure-mu",
         "trans": [
             "⓪ 名  不平，不满；索赔"
         ],
@@ -2079,7 +2079,7 @@
         "notation": "歪(ひず)む"
     },
     {
-        "name": "slacks",
+        "name": "surakkusu",
         "trans": [
             "② 名  裤子，女士西裤"
         ],
@@ -2121,7 +2121,7 @@
         "notation": "蘇(よみがえ)る"
     },
     {
-        "name": "inspiration",
+        "name": "insupire-shon",
         "trans": [
             "⑤ 名  灵感"
         ],
@@ -2317,7 +2317,7 @@
         "notation": "内幕(うちまく)"
     },
     {
-        "name": "studio",
+        "name": "sutajio",
         "trans": [
             "⓪ 名  摄影棚；工作室"
         ],
@@ -2590,7 +2590,7 @@
         "notation": "戯曲(ぎきょく)"
     },
     {
-        "name": "jumper",
+        "name": "janpa-",
         "trans": [
             "① 名  夹克衫，运动服"
         ],
@@ -2709,7 +2709,7 @@
         "notation": "回(まわ)りくどい"
     },
     {
-        "name": "terminal",
+        "name": "ta-minaru",
         "trans": [
             "① 名  终点站；航站楼"
         ],
@@ -2842,7 +2842,7 @@
         "notation": "伏(ふ)せる"
     },
     {
-        "name": "mineral water",
+        "name": "mineraruwho-ta-",
         "trans": [
             "⑤ 名  矿泉水"
         ],
@@ -2926,7 +2926,7 @@
         "notation": "野外(やがい)"
     },
     {
-        "name": "license",
+        "name": "raisensu",
         "trans": [
             "① 名  许可；执照，许可证"
         ],
@@ -3010,7 +3010,7 @@
         "notation": "軽快(けいかい)"
     },
     {
-        "name": "scale",
+        "name": "suke-ru",
         "trans": [
             "② 名  尺寸；规模；能力"
         ],
@@ -3052,7 +3052,7 @@
         "notation": "夜具(やぐ)"
     },
     {
-        "name": "request",
+        "name": "rikuesuto",
         "trans": [
             "③ 名·他动3  要求，希望；点播（节目）"
         ],
@@ -3255,7 +3255,7 @@
         "notation": "無論(むろん)"
     },
     {
-        "name": "fiction",
+        "name": "fikushon",
         "trans": [
             "① 名  小说；虚构，杜撰"
         ],
@@ -3325,7 +3325,7 @@
         "notation": "役場(やくば)"
     },
     {
-        "name": "lifestyle",
+        "name": "raifusutairu",
         "trans": [
             "⑤ 名  生活方式"
         ],
@@ -3367,7 +3367,7 @@
         "notation": "憎(にく)しみ"
     },
     {
-        "name": "peanuts",
+        "name": "pi-nattsu",
         "trans": [
             "① 名  花生"
         ],
@@ -3500,7 +3500,7 @@
         "notation": "冷害(れいがい)"
     },
     {
-        "name": "academic",
+        "name": "akademikku",
         "trans": [
             "④ ナ形  学术的；墨守成规的"
         ],
@@ -3584,7 +3584,7 @@
         "notation": "着飾(きかざ)る"
     },
     {
-        "name": "circus",
+        "name": "sa-kasu",
         "trans": [
             "① 名  杂技团，马戏团"
         ],
@@ -3633,7 +3633,7 @@
         "notation": "力士(りきし)"
     },
     {
-        "name": "wit",
+        "name": "uitto",
         "trans": [
             "② 名  机智；妙语，打趣的话"
         ],
@@ -3668,7 +3668,7 @@
         "notation": "抜(ぬ)け出(だ)す"
     },
     {
-        "name": "fight",
+        "name": "faito",
         "trans": [
             "① 名  战斗，斗争；斗志"
         ],
@@ -3745,7 +3745,7 @@
         "notation": "閉口(へいこう)"
     },
     {
-        "name": "能力、水平等",
+        "name": "mekimeki",
         "trans": [
             "① 副  （能力、水平等）显著提高"
         ],
@@ -3759,7 +3759,7 @@
         "notation": "容疑者(ようぎしゃ)"
     },
     {
-        "name": "laser",
+        "name": "re-za-",
         "trans": [
             "① 名  激光"
         ],
@@ -3857,7 +3857,7 @@
         "notation": "ちょくちょく"
     },
     {
-        "name": "napkin",
+        "name": "napukin",
         "trans": [
             "① 名  餐巾"
         ],
@@ -3948,7 +3948,7 @@
         "notation": "屋台(やたい)"
     },
     {
-        "name": "rough",
+        "name": "rafu",
         "trans": [
             "① ナ形  粗糙的；粗略的；不加修饰的"
         ],
@@ -3976,7 +3976,7 @@
         "notation": "しぶとい"
     },
     {
-        "name": "charming",
+        "name": "cha-mingu",
         "trans": [
             "① ナ形  有魅力的，迷人的"
         ],
@@ -4102,7 +4102,7 @@
         "notation": "出(で)くわす"
     },
     {
-        "name": "naming",
+        "name": "ne-mingu",
         "trans": [
             "⓪ 名  命名"
         ],
@@ -4172,7 +4172,7 @@
         "notation": "農耕(のうこう)"
     },
     {
-        "name": "boycott",
+        "name": "boikotto",
         "trans": [
             "③ 名·他动3  联合抵制"
         ],
@@ -4207,7 +4207,7 @@
         "notation": "上(あ)がり"
     },
     {
-        "name": "cursor",
+        "name": "ka-soru",
         "trans": [
             "⓪ 名  光标，指针"
         ],
@@ -4256,7 +4256,7 @@
         "notation": "屋敷(やしき)"
     },
     {
-        "name": "兴奋或期待时",
+        "name": "wakuwaku",
         "trans": [
             "① 副  （兴奋或期待时）心扑通扑通地跳"
         ],
@@ -4277,14 +4277,14 @@
         "notation": "義理(ぎり)"
     },
     {
-        "name": "不像话的事",
+        "name": "shidekasu",
         "trans": [
             "③ 他动1  做出，干出（不像话的事）"
         ],
         "notation": "しでかす"
     },
     {
-        "name": "chain",
+        "name": "che-n",
         "trans": [
             "① 名  链子，链条；连锁组织"
         ],
@@ -4354,7 +4354,7 @@
         "notation": "熱狂(ねっきょう)"
     },
     {
-        "name": "privacy",
+        "name": "puraibashi-",
         "trans": [
             "② 名  隐私，私生活"
         ],
@@ -4403,7 +4403,7 @@
         "notation": "制御(せいぎょ)"
     },
     {
-        "name": "其实并不",
+        "name": "tekkiri",
         "trans": [
             "③ 副  以为一定（其实并不）"
         ],
@@ -4438,7 +4438,7 @@
         "notation": "容赦(ようしゃ)"
     },
     {
-        "name": "regular",
+        "name": "regyura-",
         "trans": [
             "① 名  正式成员；正规"
         ],
@@ -4452,7 +4452,7 @@
         "notation": "商(あきな)う"
     },
     {
-        "name": "carpet",
+        "name": "ka-petto",
         "trans": [
             "① 名  地毯"
         ],
@@ -4529,7 +4529,7 @@
         "notation": "持病(じびょう)"
     },
     {
-        "name": "听到",
+        "name": "chiratto",
         "trans": [
             "② 副  一晃，一闪；隐约（听到）"
         ],
@@ -4634,7 +4634,7 @@
         "notation": "自粛(じしゅく)"
     },
     {
-        "name": "颜色",
+        "name": "akudoi",
         "trans": [
             "③ イ形  （颜色）过艳的；（味道）腻的；（手法）恶毒的"
         ],
@@ -4928,7 +4928,7 @@
         "notation": "情緒(じょうちょ/じょうしょ)"
     },
     {
-        "name": "timing",
+        "name": "taimingu",
         "trans": [
             "⓪ 名  时机"
         ],
@@ -4970,7 +4970,7 @@
         "notation": "外観(がいかん)"
     },
     {
-        "name": "survival",
+        "name": "sabaibaru",
         "trans": [
             "② 名  幸存，残存"
         ],
@@ -5019,7 +5019,7 @@
         "notation": "紛(まぐ)れ当(あ)たり"
     },
     {
-        "name": "出色地",
+        "name": "yattenokeru",
         "trans": [
             "⓪ 他动2  （出色地）做完"
         ],
@@ -5089,7 +5089,7 @@
         "notation": "紛(まぎ)らわしい"
     },
     {
-        "name": "recall",
+        "name": "riko-ru",
         "trans": [
             "② 名·他动3  罢免；召回（有缺陷产品）"
         ],
@@ -5173,7 +5173,7 @@
         "notation": "与(あずか)る"
     },
     {
-        "name": "option",
+        "name": "opushon",
         "trans": [
             "① 名  选择"
         ],
@@ -5411,7 +5411,7 @@
         "notation": "協定(きょうてい)"
     },
     {
-        "name": "jumbo",
+        "name": "janbo",
         "trans": [
             "① 名·ナ形  巨大，特大"
         ],
@@ -5467,7 +5467,7 @@
         "notation": "ばらまく"
     },
     {
-        "name": "maikuro～",
+        "name": "maikuro~",
         "trans": [
             " 接头  微；百万分之一"
         ],
@@ -5537,7 +5537,7 @@
         "notation": "返上(へんじょう)"
     },
     {
-        "name": "reception",
+        "name": "resepushon",
         "trans": [
             "② 名  招待会，欢迎会，宴会"
         ],
@@ -5656,7 +5656,7 @@
         "notation": "決(き)まり文句(もんく)"
     },
     {
-        "name": "tobokeru",
+        "name": "houkeru",
         "trans": [
             "③ 自动2  装傻，装糊涂；出洋相"
         ],
@@ -5691,7 +5691,7 @@
         "notation": "ひところ"
     },
     {
-        "name": "maternity",
+        "name": "matanithi-",
         "trans": [
             "② 名  孕妇；怀孕期间"
         ],
@@ -5775,7 +5775,7 @@
         "notation": "無邪気(むじゃき)"
     },
     {
-        "name": "wet",
+        "name": "uetto",
         "trans": [
             "② ナ形  湿的；多愁善感的"
         ],
@@ -5852,7 +5852,7 @@
         "notation": "遠(とお)ざかる"
     },
     {
-        "name": "butikku",
+        "name": "buthikku",
         "trans": [
             "① 名  精品店，时装店"
         ],
@@ -5957,7 +5957,7 @@
         "notation": "指差(ゆびさ)す"
     },
     {
-        "name": "access",
+        "name": "akusesu",
         "trans": [
             "① 名·自动3  计算机存取数据；连接机场等地的公路或铁路；网站登录"
         ],
@@ -6041,7 +6041,7 @@
         "notation": "しょっちゅう"
     },
     {
-        "name": "display",
+        "name": "dhisupure-",
         "trans": [
             "① 名·他动3  陈列，展示，展览"
         ],
@@ -6104,7 +6104,7 @@
         "notation": "立(た)て替(か)える"
     },
     {
-        "name": "工作",
+        "name": "batontacchi",
         "trans": [
             "④ 名·他动3  递交接力棒；交接（工作）"
         ],
@@ -6174,7 +6174,7 @@
         "notation": "融通(ゆうずう)"
     },
     {
-        "name": "rugby",
+        "name": "ragubi-",
         "trans": [
             "① 名  橄榄球"
         ],
@@ -6237,7 +6237,7 @@
         "notation": "内線(ないせん)"
     },
     {
-        "name": "pinch",
+        "name": "pinchi",
         "trans": [
             "① 名  紧急关头，危机"
         ],
@@ -6286,7 +6286,7 @@
         "notation": "素質(そしつ)"
     },
     {
-        "name": "大小",
+        "name": "kicchiri",
         "trans": [
             "③ 副  正好，恰好；（大小）正合适；严实，没有空隙"
         ],
@@ -6363,7 +6363,7 @@
         "notation": "生(い)かす"
     },
     {
-        "name": "character",
+        "name": "charakuta-",
         "trans": [
             "① 名  性格，个性；角色"
         ],
@@ -6412,7 +6412,7 @@
         "notation": "用心(ようじん)"
     },
     {
-        "name": "leader",
+        "name": "ri-da-",
         "trans": [
             "① 名  领导者，领导人"
         ],
@@ -6811,7 +6811,7 @@
         "notation": "下心(したごころ)"
     },
     {
-        "name": "slogan",
+        "name": "suro-gan",
         "trans": [
             "② 名  标语，口号"
         ],
@@ -6874,7 +6874,7 @@
         "notation": "加味(かみ)"
     },
     {
-        "name": "service area",
+        "name": "sa-bisueria",
         "trans": [
             "⑤ 名  （电波）可接收范围；服务区"
         ],
@@ -7042,7 +7042,7 @@
         "notation": "切(せつ)ない"
     },
     {
-        "name": "taboo",
+        "name": "tabu-",
         "trans": [
             "② 名  禁忌"
         ],
@@ -7105,7 +7105,7 @@
         "notation": "もつれる"
     },
     {
-        "name": "药和食物的",
+        "name": "ekisu",
         "trans": [
             "① 名  （药和食物的）提取物；精华"
         ],
@@ -7168,7 +7168,7 @@
         "notation": "解(ほど)ける"
     },
     {
-        "name": "mannerism",
+        "name": "manneri",
         "trans": [
             "⓪ 名  因循守旧，墨守成规，千篇一律，老一套"
         ],
@@ -7196,7 +7196,7 @@
         "notation": "垣根(かきね)"
     },
     {
-        "name": "simulation",
+        "name": "shimyure-shon",
         "trans": [
             "③ 名·他动3  模拟，仿真"
         ],
@@ -7280,7 +7280,7 @@
         "notation": "配給(はいきゅう)"
     },
     {
-        "name": "follow",
+        "name": "foro-",
         "trans": [
             "① 名·他动3  跟随；跟踪"
         ],
@@ -7315,7 +7315,7 @@
         "notation": "うっとうしい"
     },
     {
-        "name": "cool",
+        "name": "ku-ru",
         "trans": [
             "① ナ形  凉爽的，凉快的；冷静的，沉着的"
         ],
@@ -7385,7 +7385,7 @@
         "notation": "開業(かいぎょう)"
     },
     {
-        "name": "contact",
+        "name": "kontakuto",
         "trans": [
             "① 名  接触，联络；“コンタクトレンズ”（隐形眼镜）的缩略语"
         ],
@@ -7420,7 +7420,7 @@
         "notation": "馴染(なじ)む"
     },
     {
-        "name": "peak",
+        "name": "pi-ku",
         "trans": [
             "① 名  最高峰，顶点"
         ],
@@ -7434,7 +7434,7 @@
         "notation": "発足(ほっそく/はっそく)"
     },
     {
-        "name": "后接否定",
+        "name": "marukiri/marukkiri",
         "trans": [
             "⓪ 副  （后接否定）完全，根本"
         ],
@@ -7469,7 +7469,7 @@
         "notation": "一同(いちどう)"
     },
     {
-        "name": "strike",
+        "name": "sutoraiki",
         "trans": [
             "③ 名·自动3  罢工；罢市；罢课"
         ],
@@ -7574,7 +7574,7 @@
         "notation": "誘惑(ゆうわく)"
     },
     {
-        "name": "rail",
+        "name": "re-ru",
         "trans": [
             "⓪ 名  铁轨，轨道"
         ],
@@ -7630,7 +7630,7 @@
         "notation": "ぐっしょり"
     },
     {
-        "name": "elegant",
+        "name": "ereganto",
         "trans": [
             "① ナ形  优雅的，高雅的"
         ],
@@ -7665,7 +7665,7 @@
         "notation": "最寄(もよ)り"
     },
     {
-        "name": "后接否定",
+        "name": "nanra",
         "trans": [
             "① 副  （后接否定）任何；丝毫"
         ],
@@ -7749,7 +7749,7 @@
         "notation": "潜水(せんすい)"
     },
     {
-        "name": "global",
+        "name": "guro-baru",
         "trans": [
             "② ナ形  全球的，全世界的"
         ],
@@ -7791,7 +7791,7 @@
         "notation": "入手(にゅうしゅ)"
     },
     {
-        "name": "stainless",
+        "name": "sutenresu",
         "trans": [
             "② 名  不锈钢"
         ],
@@ -7854,7 +7854,7 @@
         "notation": "口述(こうじゅつ)"
     },
     {
-        "name": "show window",
+        "name": "sho-uindo-",
         "trans": [
             "④ 名  橱窗，陈列窗"
         ],
@@ -7931,7 +7931,7 @@
         "notation": "決(き)まり悪(わる)い"
     },
     {
-        "name": "technology",
+        "name": "tekunoroji-",
         "trans": [
             "③ 名  技术"
         ],
@@ -8001,7 +8001,7 @@
         "notation": "兼備(けんび)"
     },
     {
-        "name": "approach",
+        "name": "apuro-chi",
         "trans": [
             "③ 名·自动3  接近；研究"
         ],
@@ -8064,7 +8064,7 @@
         "notation": "思春期(ししゅんき)"
     },
     {
-        "name": "sense",
+        "name": "sensu",
         "trans": [
             "① 名  感觉；审美能力"
         ],
@@ -8183,7 +8183,7 @@
         "notation": "瞬(またた)く"
     },
     {
-        "name": "merit",
+        "name": "meritto",
         "trans": [
             "① 名  可取之处，优点"
         ],
@@ -8232,7 +8232,7 @@
         "notation": "七光(ななひか)り"
     },
     {
-        "name": "battery",
+        "name": "batteri-",
         "trans": [
             "① 名  电池"
         ],
@@ -8267,7 +8267,7 @@
         "notation": "覚束(おぼつか)ない"
     },
     {
-        "name": "interchange",
+        "name": "inta-chenji",
         "trans": [
             "⑤ 名  高速公路出入口"
         ],
@@ -8302,14 +8302,14 @@
         "notation": "提携(ていけい)"
     },
     {
-        "name": "眼睛",
+        "name": "donyori",
         "trans": [
             "③ 副·自动3  阴沉沉；（眼睛）浑浊"
         ],
         "notation": "どんより"
     },
     {
-        "name": "know-how",
+        "name": "nouhau/no-hau",
         "trans": [
             "① 名  技术知识；诀窍"
         ],
@@ -8449,7 +8449,7 @@
         "notation": "態勢(たいせい)"
     },
     {
-        "name": "stock",
+        "name": "sutokku",
         "trans": [
             "② 名·他动3  存货，库存"
         ],
@@ -8477,7 +8477,7 @@
         "notation": "走行(そうこう)"
     },
     {
-        "name": "时间上",
+        "name": "zuruzuru",
         "trans": [
             "① 副·自动3  拖拉着；滑溜溜；（时间上）拖拖拉拉"
         ],
@@ -8589,7 +8589,7 @@
         "notation": "責(せ)める"
     },
     {
-        "name": "accelerator",
+        "name": "akuseru",
         "trans": [
             "① 名  加速装置，油门"
         ],
@@ -8631,7 +8631,7 @@
         "notation": "妬(ねた)ましい"
     },
     {
-        "name": "backup",
+        "name": "bakkuappu",
         "trans": [
             "④ 名·他动3  做后盾，后援；备份"
         ],
@@ -8694,7 +8694,7 @@
         "notation": "冷(さ)ます"
     },
     {
-        "name": "cable",
+        "name": "ke-buru",
         "trans": [
             "① 名  缆绳；电缆"
         ],
@@ -8708,7 +8708,7 @@
         "notation": "先行(せんこう)"
     },
     {
-        "name": "液体",
+        "name": "daradara",
         "trans": [
             "① 副·自动3  （液体）滴滴答答；冗长，不简练"
         ],
@@ -8750,7 +8750,7 @@
         "notation": "如実(にょじつ)"
     },
     {
-        "name": "赃物",
+        "name": "barasu",
         "trans": [
             "② 他动1  拆卸；卖掉（赃物）；揭穿，泄露（秘密）"
         ],
@@ -8778,7 +8778,7 @@
         "notation": "和(やわ)らげる"
     },
     {
-        "name": "risk",
+        "name": "risuku",
         "trans": [
             "① 名  风险，危险"
         ],
@@ -8820,7 +8820,7 @@
         "notation": "ちょこちょこ"
     },
     {
-        "name": "棒球",
+        "name": "naita-",
         "trans": [
             "(棒球)  ① 名  （棒球）夜场比赛"
         ],
@@ -8890,7 +8890,7 @@
         "notation": "入浴(にゅうよく)"
     },
     {
-        "name": "form",
+        "name": "fo-mu",
         "trans": [
             "① 名  姿势；形式，样式"
         ],
@@ -8974,7 +8974,7 @@
         "notation": "迂回(うかい)"
     },
     {
-        "name": "question mark",
+        "name": "kuesuchonma-ku",
         "trans": [
             "⑥ 名  问号"
         ],
@@ -9002,7 +9002,7 @@
         "notation": "熱量(ねつりょう)"
     },
     {
-        "name": "意志",
+        "name": "furafura",
         "trans": [
             "① 副·自动3·ナ形  摇晃，蹒跚；（意志）不坚定；稀里糊涂"
         ],
@@ -9058,7 +9058,7 @@
         "notation": "納品(のうひん)"
     },
     {
-        "name": "base",
+        "name": "be-su",
         "trans": [
             "① 名  基础"
         ],
@@ -9149,7 +9149,7 @@
         "notation": "的(まと)"
     },
     {
-        "name": "uniform",
+        "name": "yunifo-mu",
         "trans": [
             "③ 名  制服"
         ],
@@ -9184,7 +9184,7 @@
         "notation": "乗(の)っ取(と)る"
     },
     {
-        "name": "total",
+        "name": "to-taru",
         "trans": [
             "① 名·他动3·ナ形  总计，合计，共计；整体，总体"
         ],
@@ -9233,7 +9233,7 @@
         "notation": "蛇足(だそく)"
     },
     {
-        "name": "tool",
+        "name": "tsu-ru",
         "trans": [
             "① 名  工具，道具"
         ],
@@ -9310,7 +9310,7 @@
         "notation": "媚(こ)びる"
     },
     {
-        "name": "extra",
+        "name": "ekisutora",
         "trans": [
             "③ 名  临时演员；临时，额外；增刊，号外"
         ],
@@ -9359,7 +9359,7 @@
         "notation": "並大抵(なみたいてい)"
     },
     {
-        "name": "billiard",
+        "name": "biriya-do",
         "trans": [
             "③ 名  台球"
         ],
@@ -9422,7 +9422,7 @@
         "notation": "内陸(ないりく)"
     },
     {
-        "name": "bubble",
+        "name": "baburu",
         "trans": [
             "① 名  泡沫"
         ],
@@ -9499,7 +9499,7 @@
         "notation": "訴(うった)える"
     },
     {
-        "name": "straw",
+        "name": "sutoro-",
         "trans": [
             "② 名  吸管；麦秆"
         ],
@@ -9583,7 +9583,7 @@
         "notation": "惜(お)しむ"
     },
     {
-        "name": "interphone",
+        "name": "inta-fon",
         "trans": [
             "③ 名  内线电话，对讲机"
         ],
@@ -9695,7 +9695,7 @@
         "notation": "肉体(にくたい)"
     },
     {
-        "name": "hit",
+        "name": "hitto",
         "trans": [
             "① 名·自动3  大受欢迎，巨大成功"
         ],
@@ -9709,7 +9709,7 @@
         "notation": "見逃(みのが)す"
     },
     {
-        "name": "exotic",
+        "name": "ekizochikku",
         "trans": [
             "④ ナ形  异国情调的"
         ],
@@ -9723,7 +9723,7 @@
         "notation": "区間(くかん)"
     },
     {
-        "name": "一刀",
+        "name": "zubari",
         "trans": [
             "② 副  （一刀）锋利切下；击中要害，一语道破"
         ],
@@ -9744,7 +9744,7 @@
         "notation": "捻出(ねんしゅつ)"
     },
     {
-        "name": "衣服等",
+        "name": "bukabuka",
         "trans": [
             "⓪ 副·ナ形  （衣服等）肥大"
         ],
@@ -9814,7 +9814,7 @@
         "notation": "介護(かいご)"
     },
     {
-        "name": "后接否定",
+        "name": "sahodo",
         "trans": [
             "⓪ 副  （后接否定）那么，那样"
         ],
@@ -9849,7 +9849,7 @@
         "notation": "辞退(じたい)"
     },
     {
-        "name": "costume",
+        "name": "kosuchu-mu",
         "trans": [
             "① 名  服装，装束；戏装"
         ],
@@ -9912,7 +9912,7 @@
         "notation": "喜劇(きげき)"
     },
     {
-        "name": "commercial",
+        "name": "koma-sharu",
         "trans": [
             "② 名  商业，商务；商业广告"
         ],
@@ -10073,7 +10073,7 @@
         "notation": "制(せい)する"
     },
     {
-        "name": "delicate",
+        "name": "derike-to",
         "trans": [
             "③ ナ形  精致的；微妙的；敏感的，脆弱的"
         ],
@@ -10185,7 +10185,7 @@
         "notation": "会合(かいごう)"
     },
     {
-        "name": "supplement",
+        "name": "sapurimento",
         "trans": [
             "① 名  营养补品；增刊；附录"
         ],
@@ -10227,14 +10227,14 @@
         "notation": "鳴(な)り物入(ものい)り"
     },
     {
-        "name": "variation",
+        "name": "barie-shon",
         "trans": [
             "③ 名  变化"
         ],
         "notation": "バリエーション"
     },
     {
-        "name": "意见",
+        "name": "matomaru",
         "trans": [
             "⓪ 自动1  谈妥，解决；凑齐；归纳起来；统一（意见）"
         ],
@@ -10304,7 +10304,7 @@
         "notation": "浸(ひた)す"
     },
     {
-        "name": "miss",
+        "name": "misu",
         "trans": [
             "① 名·自动3  错误；失败；失误"
         ],
@@ -10332,7 +10332,7 @@
         "notation": "鯨(くじら)"
     },
     {
-        "name": "scandal",
+        "name": "sukyandaru",
         "trans": [
             "② 名  丑闻；丑事"
         ],
@@ -10451,7 +10451,7 @@
         "notation": "ぼやく"
     },
     {
-        "name": "monitor",
+        "name": "monita-",
         "trans": [
             "① 名·他动3  评论员；监视器"
         ],
@@ -10528,7 +10528,7 @@
         "notation": "結晶(けっしょう)"
     },
     {
-        "name": "surfing",
+        "name": "sa-fin",
         "trans": [
             "① 名  冲浪运动；冲浪板"
         ],
@@ -10584,7 +10584,7 @@
         "notation": "名残惜(なごりお)しい"
     },
     {
-        "name": "vision",
+        "name": "bijon",
         "trans": [
             "① 名  想象，幻想；理想，前景"
         ],
@@ -10598,7 +10598,7 @@
         "notation": "満喫(まんきつ)"
     },
     {
-        "name": "事到如今",
+        "name": "mohaya",
         "trans": [
             "① 副  （事到如今）已经"
         ],
@@ -10766,14 +10766,14 @@
         "notation": "鞭(むち)"
     },
     {
-        "name": "后多接否定",
+        "name": "roku",
         "trans": [
             "⓪ ナ形  （后多接否定）令人满意的；正经的，正常的"
         ],
         "notation": "ろく"
     },
     {
-        "name": "alphabet",
+        "name": "arufabetto",
         "trans": [
             "④ 名  字母表，字母序列；基本知识，入门"
         ],
@@ -10906,7 +10906,7 @@
         "notation": "待(ま)ち明(あ)かす"
     },
     {
-        "name": "场所",
+        "name": "nakahodo",
         "trans": [
             "⓪ 名  （场所）中间，中央；中途；（程度）中等"
         ],
@@ -10955,7 +10955,7 @@
         "notation": "気心(きごころ)"
     },
     {
-        "name": "钟",
+        "name": "janjan",
         "trans": [
             "① 副  连续不断地，一个劲儿地；（钟）当当响"
         ],
@@ -10983,7 +10983,7 @@
         "notation": "捏造(ねつぞう)"
     },
     {
-        "name": "high-tech",
+        "name": "haiteku",
         "trans": [
             "⓪ 名  高新技术"
         ],
@@ -11046,7 +11046,7 @@
         "notation": "孕(はら)む"
     },
     {
-        "name": "escalate",
+        "name": "esukare-to",
         "trans": [
             "④ 名·自动3  （纷争）逐步升级"
         ],
@@ -11088,7 +11088,7 @@
         "notation": "未(いま)だに"
     },
     {
-        "name": "automatic",
+        "name": "o-tomachikku",
         "trans": [
             "⑤ 名·ナ形  自动装置；自动的，自动式的"
         ],
@@ -11228,7 +11228,7 @@
         "notation": "驚異(きょうい)"
     },
     {
-        "name": "support",
+        "name": "sapo-to",
         "trans": [
             "② 名·他动3  支持，支援"
         ],
@@ -11284,7 +11284,7 @@
         "notation": "手強(てごわ)い"
     },
     {
-        "name": "nonsense",
+        "name": "nansensu",
         "trans": [
             "① 名·ナ形  无意义，无聊，荒谬；废话"
         ],
@@ -11368,7 +11368,7 @@
         "notation": "腫(は)れる"
     },
     {
-        "name": "tone",
+        "name": "to-n",
         "trans": [
             "① 名  音调；色调；气氛"
         ],
@@ -11403,7 +11403,7 @@
         "notation": "同乗(どうじょう)"
     },
     {
-        "name": "后多接否定",
+        "name": "anagachi",
         "trans": [
             "⓪ 副  （后多接否定）未必，不见得"
         ],
@@ -11452,7 +11452,7 @@
         "notation": "日増(ひま)しに"
     },
     {
-        "name": "drive in",
+        "name": "doraibuin",
         "trans": [
             "④ 名  免下车服务设施"
         ],
@@ -11543,7 +11543,7 @@
         "notation": "横領(おうりょう)"
     },
     {
-        "name": "badge",
+        "name": "bajji",
         "trans": [
             "① 名  徽章"
         ],
@@ -11620,7 +11620,7 @@
         "notation": "ぎこちない"
     },
     {
-        "name": "aftercare",
+        "name": "afuta-kea",
         "trans": [
             "⑤ 名  病后疗养；售后服务"
         ],
@@ -11683,7 +11683,7 @@
         "notation": "取(と)り巻(ま)く"
     },
     {
-        "name": "orientation",
+        "name": "oriente-jon",
         "trans": [
             "⑤ 名  入学教育，新员工培训"
         ],
@@ -11774,7 +11774,7 @@
         "notation": "刑務所(けいむしょ)"
     },
     {
-        "name": "scenario",
+        "name": "shinario",
         "trans": [
             "⓪ 名  脚本，剧本"
         ],
@@ -11851,7 +11851,7 @@
         "notation": "放(ほう)り込(こ)む"
     },
     {
-        "name": "career",
+        "name": "kyaria",
         "trans": [
             "① 名  经验，履历；职业；比赛经历"
         ],
@@ -11963,7 +11963,7 @@
         "notation": "憚(はばか)る"
     },
     {
-        "name": "security",
+        "name": "sekyurithi-",
         "trans": [
             "② 名  安全，安保"
         ],
@@ -12026,7 +12026,7 @@
         "notation": "なにとぞ"
     },
     {
-        "name": "pioneer",
+        "name": "paionia",
         "trans": [
             "⓪ 名  先驱，开拓者"
         ],
@@ -12117,7 +12117,7 @@
         "notation": "忍耐(にんたい)"
     },
     {
-        "name": "package",
+        "name": "pakke-ji",
         "trans": [
             "① 名·他动3  包装；成套商品"
         ],
@@ -12208,7 +12208,7 @@
         "notation": "免除(めんじょ)"
     },
     {
-        "name": "后多接否定",
+        "name": "yomoya",
         "trans": [
             "① 副  （后多接否定）未必，不至于"
         ],
@@ -12236,7 +12236,7 @@
         "notation": "ぞくぞく"
     },
     {
-        "name": "decoration",
+        "name": "dekore-shon",
         "trans": [
             "③ 名  装饰，装潢"
         ],
@@ -12362,7 +12362,7 @@
         "notation": "心地(ここち)よい"
     },
     {
-        "name": "information",
+        "name": "infome-shon",
         "trans": [
             "④ 名  信息，通知，报告；问讯处"
         ],
@@ -12516,7 +12516,7 @@
         "notation": "国有(こくゆう)"
     },
     {
-        "name": "journalist",
+        "name": "ja-narisuto",
         "trans": [
             "④ 名  记者；编辑"
         ],
@@ -12642,7 +12642,7 @@
         "notation": "澄(す)ます"
     },
     {
-        "name": "share",
+        "name": "shea",
         "trans": [
             "① 名  市场占有率，份额"
         ],
@@ -12691,7 +12691,7 @@
         "notation": "任務(にんむ)"
     },
     {
-        "name": "dry",
+        "name": "dorai",
         "trans": [
             "② ナ形  干燥的；理智的，冷冰冰的"
         ],
@@ -12810,7 +12810,7 @@
         "notation": "見張(みは)る"
     },
     {
-        "name": "episode",
+        "name": "episo-do",
         "trans": [
             "① 名  插曲，小故事；轶事，趣闻 "
         ],
@@ -12894,7 +12894,7 @@
         "notation": "サボる"
     },
     {
-        "name": "container",
+        "name": "kontena-",
         "trans": [
             "① 名  集装箱，货柜"
         ],
@@ -12922,7 +12922,7 @@
         "notation": "年少(ねんしょう)"
     },
     {
-        "name": "homesick",
+        "name": "ho-mushikku",
         "trans": [
             "④ 名  想家，思乡"
         ],
@@ -12971,7 +12971,7 @@
         "notation": "趣旨(しゅし)"
     },
     {
-        "name": "搓、擦",
+        "name": "goshigoshi",
         "trans": [
             "① 副  使劲地（搓、擦）"
         ],
@@ -13013,7 +13013,7 @@
         "notation": "失調(しっちょう)"
     },
     {
-        "name": "attack",
+        "name": "atakku",
         "trans": [
             "② 名·自他动3  攻击，进攻；挑战"
         ],
@@ -13209,7 +13209,7 @@
         "notation": "晴(は)れ晴(ば)れしい"
     },
     {
-        "name": "pride",
+        "name": "puraido",
         "trans": [
             "⓪ 名  自尊心"
         ],
@@ -13293,7 +13293,7 @@
         "notation": "しかるべき"
     },
     {
-        "name": "performance",
+        "name": "pafo-mansu",
         "trans": [
             "② 名  表演；效果，性能"
         ],
@@ -13328,7 +13328,7 @@
         "notation": "落(お)ち度(ど)"
     },
     {
-        "name": "catch",
+        "name": "kyacchi",
         "trans": [
             "① 名·他动3  捕捉，接收；接球"
         ],
@@ -13405,7 +13405,7 @@
         "notation": "もじもじ"
     },
     {
-        "name": "young",
+        "name": "yangu",
         "trans": [
             "① 名  年轻人，年轻一代"
         ],
@@ -13447,7 +13447,7 @@
         "notation": "くっきり"
     },
     {
-        "name": "strobo",
+        "name": "sutorobo",
         "trans": [
             "⓪ 名  闪光灯"
         ],
@@ -13538,7 +13538,7 @@
         "notation": "棚卸(たなおろ)し"
     },
     {
-        "name": "sharp",
+        "name": "sha-pu",
         "trans": [
             "① ナ形  敏锐的；锋利的；清晰的"
         ],
@@ -13657,7 +13657,7 @@
         "notation": "今(いま)にして"
     },
     {
-        "name": "climax",
+        "name": "kuraimakkusu",
         "trans": [
             "④ 名  顶点，最高峰"
         ],
@@ -13713,7 +13713,7 @@
         "notation": "保温(ほおん)"
     },
     {
-        "name": "后接否定",
+        "name": "manzara",
         "trans": [
             "⓪ 副  （后接否定）并非完全，未必一定"
         ],
@@ -13741,7 +13741,7 @@
         "notation": "悟(さと)る"
     },
     {
-        "name": "contrast",
+        "name": "kontorasuto",
         "trans": [
             "① 名  对比，对照"
         ],
@@ -13811,14 +13811,14 @@
         "notation": "万引(まんび)き"
     },
     {
-        "name": "lead",
+        "name": "ri-do",
         "trans": [
             "① 自他动3  领导，带领；领先"
         ],
         "notation": "リード"
     },
     {
-        "name": "顺序、位置等",
+        "name": "abekobe",
         "trans": [
             "⓪ 名·ナ形  （顺序、位置等）相反，颠倒"
         ],
@@ -13951,7 +13951,7 @@
         "notation": "反(そ)る"
     },
     {
-        "name": "time service",
+        "name": "taimusa-bisu",
         "trans": [
             "④ 名  限时特卖"
         ],
@@ -14063,7 +14063,7 @@
         "notation": "連(つら)ねる"
     },
     {
-        "name": "tile",
+        "name": "tairu",
         "trans": [
             "① 名  瓷砖，花砖"
         ],
@@ -14154,7 +14154,7 @@
         "notation": "山腹(さんぷく)"
     },
     {
-        "name": "complex",
+        "name": "konpurekkusu",
         "trans": [
             "④ 名  情结；自卑感"
         ],
@@ -14315,7 +14315,7 @@
         "notation": "交(か)わす"
     },
     {
-        "name": "at home",
+        "name": "attoho-mu",
         "trans": [
             "④ ナ形  舒适的，无拘无束的"
         ],
@@ -14364,7 +14364,7 @@
         "notation": "出番(でばん)"
     },
     {
-        "name": "homeless",
+        "name": "ho-muresu",
         "trans": [
             "① 名  无家可归的人"
         ],
@@ -14448,7 +14448,7 @@
         "notation": "下調(したしら)べ"
     },
     {
-        "name": "tension",
+        "name": "tenshon",
         "trans": [
             "① 名  紧张，兴奋"
         ],
@@ -14504,7 +14504,7 @@
         "notation": "取(と)り混(ま)ぜる"
     },
     {
-        "name": "bar code",
+        "name": "ba-ko-do",
         "trans": [
             "③ 名  条形码"
         ],
@@ -14574,7 +14574,7 @@
         "notation": "自転(じてん)"
     },
     {
-        "name": "original",
+        "name": "orijinaru",
         "trans": [
             "② 名·ナ形  原创，独创"
         ],
@@ -14630,7 +14630,7 @@
         "notation": "綴(と)じる"
     },
     {
-        "name": "event",
+        "name": "ibento",
         "trans": [
             "⓪ 名  活动，节目；事件"
         ],
@@ -14742,7 +14742,7 @@
         "notation": "切(き)り開(ひら)く"
     },
     {
-        "name": "cycle",
+        "name": "saikuru",
         "trans": [
             "① 名  周期，循环"
         ],
@@ -14805,7 +14805,7 @@
         "notation": "濯(すす)ぐ"
     },
     {
-        "name": "PR",
+        "name": "pi-a-ru",
         "trans": [
             "③ 名  宣传活动，广告活动"
         ],
@@ -14854,7 +14854,7 @@
         "notation": "隈(くま)"
     },
     {
-        "name": "swing",
+        "name": "suingu",
         "trans": [
             "② 名·他动3  舞动，挥动，摇动"
         ],
@@ -14889,7 +14889,7 @@
         "notation": "久(ひさ)しい"
     },
     {
-        "name": "position",
+        "name": "pojishon",
         "trans": [
             "② 名  地位，职位"
         ],
@@ -14959,7 +14959,7 @@
         "notation": "上空(じょうくう)"
     },
     {
-        "name": "team work",
+        "name": "chi-muwa-ku",
         "trans": [
             "④ 名  团队合作"
         ],
@@ -15050,7 +15050,7 @@
         "notation": "創立(そうりつ)"
     },
     {
-        "name": "身体",
+        "name": "guzutsuku",
         "trans": [
             "⓪ 自动1  磨蹭，拖延；阴天；（身体）不舒服"
         ],
@@ -15085,7 +15085,7 @@
         "notation": "実費(じっぴ)"
     },
     {
-        "name": "time recorder",
+        "name": "taimureko-da-",
         "trans": [
             "⑤ 名  打卡器"
         ],
@@ -15120,7 +15120,7 @@
         "notation": "ねちねち"
     },
     {
-        "name": "frustration",
+        "name": "furasutore-shon",
         "trans": [
             "⑤ 名  失意，受挫，挫折，沮丧"
         ],
@@ -15176,7 +15176,7 @@
         "notation": "潜入(せんにゅう)"
     },
     {
-        "name": "appeal",
+        "name": "api-ru",
         "trans": [
             "② 自他动3  呼吁，要求；有魅力，有吸引力，打动人心"
         ],
@@ -15232,7 +15232,7 @@
         "notation": "対等(たいとう)"
     },
     {
-        "name": "try",
+        "name": "torai",
         "trans": [
             "② 名·自动3  尝试"
         ],
@@ -15344,7 +15344,7 @@
         "notation": "砂利(じゃり)"
     },
     {
-        "name": "期限",
+        "name": "motte",
         "trans": [
             "① 连语  以，用；因为，根据；到（期限）"
         ],
@@ -15379,7 +15379,7 @@
         "notation": "身元(みもと)"
     },
     {
-        "name": "refresh",
+        "name": "rifuresshu",
         "trans": [
             "③ 名·自他动3  重新振作，恢复精神"
         ],
@@ -15568,7 +15568,7 @@
         "notation": "選考(せんこう)"
     },
     {
-        "name": "patrol",
+        "name": "patoro-ru",
         "trans": [
             "③ 名·自动3  巡逻，巡视"
         ],
@@ -15666,7 +15666,7 @@
         "notation": "特集(とくしゅう)"
     },
     {
-        "name": "partner",
+        "name": "pa-tona-",
         "trans": [
             "① 名  伙伴，合伙人"
         ],
@@ -15729,7 +15729,7 @@
         "notation": "既成(きせい)"
     },
     {
-        "name": "siren",
+        "name": "sairen",
         "trans": [
             "① 名  汽笛，警笛"
         ],
@@ -15855,7 +15855,7 @@
         "notation": "燻(くすぶ)る"
     },
     {
-        "name": "symposium",
+        "name": "shinpojiumu",
         "trans": [
             "④ 名  研讨会，座谈会"
         ],
@@ -15953,7 +15953,7 @@
         "notation": "手近(てぢか)"
     },
     {
-        "name": "orthodox",
+        "name": "o-sodokkusu",
         "trans": [
             "④ ナ形  正统的"
         ],
@@ -16072,7 +16072,7 @@
         "notation": "本体(ほんたい)"
     },
     {
-        "name": "over",
+        "name": "o-ba-",
         "trans": [
             "① 自他动3·ナ形  超过；过分，夸张"
         ],
@@ -16205,7 +16205,7 @@
         "notation": "嘆(なげ)く"
     },
     {
-        "name": "section",
+        "name": "sekushon",
         "trans": [
             "① 名  部门；（报纸等的）版面，栏目"
         ],
@@ -16261,7 +16261,7 @@
         "notation": "貧血(ひんけつ)"
     },
     {
-        "name": "ropeway",
+        "name": "ro-puue-",
         "trans": [
             "⑤ 名  空中索道"
         ],
@@ -16380,7 +16380,7 @@
         "notation": "淑(しと)やか"
     },
     {
-        "name": "puncture",
+        "name": "panku",
         "trans": [
             "⓪ 名·自动3  爆胎；胀破；拥挤不堪；破产"
         ],
@@ -16457,7 +16457,7 @@
         "notation": "密接(みっせつ)"
     },
     {
-        "name": "化学用语",
+        "name": "arukari",
         "trans": [
             "⓪ 名  （化学用语）碱，强碱"
         ],
@@ -16534,7 +16534,7 @@
         "notation": "重宝(ちょうほう)"
     },
     {
-        "name": "back number",
+        "name": "bakkunanba-",
         "trans": [
             "④ 名  过期杂志；车牌号"
         ],
@@ -16576,7 +16576,7 @@
         "notation": "疾病(しっぺい)"
     },
     {
-        "name": "sponsor",
+        "name": "suponsa-",
         "trans": [
             "② 名  赞助者，广告主"
         ],
@@ -16667,7 +16667,7 @@
         "notation": "功名(こうみょう)"
     },
     {
-        "name": "spring",
+        "name": "supuringu",
         "trans": [
             "③ 名  春天；弹簧，弹力"
         ],
@@ -16702,7 +16702,7 @@
         "notation": "発病(はつびょう)"
     },
     {
-        "name": "brand",
+        "name": "burando",
         "trans": [
             "⓪ 名  品牌，商标"
         ],
@@ -16737,7 +16737,7 @@
         "notation": "大方(おおかた)"
     },
     {
-        "name": "code",
+        "name": "ko-do",
         "trans": [
             "① 名  规则；符号，代码；编码"
         ],
@@ -16849,7 +16849,7 @@
         "notation": "堪能(たんのう)"
     },
     {
-        "name": "parade",
+        "name": "pare-do",
         "trans": [
             "② 名·自动3  阅兵式；盛装游行"
         ],
@@ -16940,7 +16940,7 @@
         "notation": "もろに"
     },
     {
-        "name": "drill",
+        "name": "doriru",
         "trans": [
             "① 名  钢钻，钻孔器；训练，练习"
         ],
@@ -17052,7 +17052,7 @@
         "notation": "河川(かせん)"
     },
     {
-        "name": "control",
+        "name": "kontoro-ru",
         "trans": [
             "④ 名·他动3  控制，操纵，管理"
         ],
@@ -17115,7 +17115,7 @@
         "notation": "案(あん)ずる"
     },
     {
-        "name": "dilemma",
+        "name": "jirenma",
         "trans": [
             "② 名  进退维谷，困境"
         ],
@@ -17192,7 +17192,7 @@
         "notation": "窒息(ちっそく)"
     },
     {
-        "name": "neck",
+        "name": "nekku",
         "trans": [
             "① 名  颈部；衣领；障碍，瓶颈"
         ],
@@ -17262,7 +17262,7 @@
         "notation": "端的(たんてき)"
     },
     {
-        "name": "barometer",
+        "name": "barome-ta-",
         "trans": [
             "③ 名  气压计；标志，指标"
         ],
@@ -17304,7 +17304,7 @@
         "notation": "華奢(きゃしゃ)"
     },
     {
-        "name": "comma",
+        "name": "konma",
         "trans": [
             "① 名  逗号；小数点"
         ],
@@ -17395,7 +17395,7 @@
         "notation": "辛抱強(しんぼうづよ)い"
     },
     {
-        "name": "formal",
+        "name": "fo-maru",
         "trans": [
             "① ナ形  正式的"
         ],
@@ -17423,7 +17423,7 @@
         "notation": "吟味(ぎんみ)"
     },
     {
-        "name": "后接否定",
+        "name": "bikutomo",
         "trans": [
             "① 副  （后接否定）纹丝不动，毫不动摇"
         ],
@@ -17542,7 +17542,7 @@
         "notation": "染(し)み"
     },
     {
-        "name": "self service",
+        "name": "serufusa-bisu",
         "trans": [
             "④ 名  自助，自选"
         ],
@@ -17654,7 +17654,7 @@
         "notation": "人一倍(ひといちばい)"
     },
     {
-        "name": "break",
+        "name": "bure-ku",
         "trans": [
             "② 名·自动3  休息；受欢迎"
         ],
@@ -17675,7 +17675,7 @@
         "notation": "甚(はなは)だ"
     },
     {
-        "name": "relax",
+        "name": "rirakkusu",
         "trans": [
             "② 名·自动3  放松，轻松"
         ],
@@ -17794,7 +17794,7 @@
         "notation": "喪服(もふく)"
     },
     {
-        "name": "arrange",
+        "name": "arenji",
         "trans": [
             "② 名·他动3  布置；改编；安排"
         ],
@@ -17934,7 +17934,7 @@
         "notation": "とっさ"
     },
     {
-        "name": "freeze",
+        "name": "furi-zu",
         "trans": [
             "② 名·自动3  冷冻，冻结；死机"
         ],
@@ -18060,7 +18060,7 @@
         "notation": "興(きょう)じる"
     },
     {
-        "name": "owner",
+        "name": "o-na-",
         "trans": [
             "① 名  物主，所有者"
         ],
@@ -18242,7 +18242,7 @@
         "notation": "強気(つよき)"
     },
     {
-        "name": "timely",
+        "name": "taimuri-",
         "trans": [
             "① ナ形  适时的，正合时宜的"
         ],
@@ -18452,7 +18452,7 @@
         "notation": "振(ふ)り出(だ)し"
     },
     {
-        "name": "barrier free",
+        "name": "bariafuri-",
         "trans": [
             "⑤ 名  无障碍式"
         ],
@@ -18557,7 +18557,7 @@
         "notation": "柔軟(じゅうなん)"
     },
     {
-        "name": "relay",
+        "name": "rire-",
         "trans": [
             "⓪ 名  接力，传递"
         ],
@@ -18809,7 +18809,7 @@
         "notation": "突飛(とっぴ)"
     },
     {
-        "name": "ceremony",
+        "name": "seremoni-",
         "trans": [
             "① 名  仪式，典礼"
         ],
@@ -18991,7 +18991,7 @@
         "notation": "上役(うわやく)"
     },
     {
-        "name": "come back",
+        "name": "kamubakku",
         "trans": [
             "① 名·自动3  恢复（原位），东山再起"
         ],
@@ -19075,7 +19075,7 @@
         "notation": "ひっそり"
     },
     {
-        "name": "campaign",
+        "name": "kyanpe-n",
         "trans": [
             "③ 名  宣传活动，运动"
         ],
@@ -19096,7 +19096,7 @@
         "notation": "主(しゅ)として"
     },
     {
-        "name": "sponge",
+        "name": "suponji",
         "trans": [
             "⓪ 名  海绵，海绵状物体"
         ],
@@ -19418,7 +19418,7 @@
         "notation": "不信(ふしん)"
     },
     {
-        "name": "勒、关闭、拉、按等",
+        "name": "gyutto",
         "trans": [
             "⓪ 副  紧紧地（勒、关闭、拉、按等）"
         ],
@@ -19831,7 +19831,7 @@
         "notation": "億劫(おっくう)"
     },
     {
-        "name": "inflation",
+        "name": "infure",
         "trans": [
             "⓪ 名  通货膨胀"
         ],
@@ -20097,7 +20097,7 @@
         "notation": "露骨(ろこつ)"
     },
     {
-        "name": "houbou",
+        "name": "katagata",
         "trans": [
             "① 名  到处，各处"
         ],
@@ -20307,7 +20307,7 @@
         "notation": "本能(ほんのう)"
     },
     {
-        "name": "process",
+        "name": "purosesu",
         "trans": [
             "② 名  过程；程序，流程"
         ],
@@ -20524,7 +20524,7 @@
         "notation": "破裂(はれつ)"
     },
     {
-        "name": "full",
+        "name": "furu",
         "trans": [
             "① 名·ナ形  充分；全部"
         ],
@@ -20545,7 +20545,7 @@
         "notation": "嫌(いや)らしい"
     },
     {
-        "name": "loss",
+        "name": "rosu",
         "trans": [
             "① 名·他动3  浪费，损耗"
         ],
@@ -20678,7 +20678,7 @@
         "notation": "おっちょこちょい"
     },
     {
-        "name": "头疼、耳鸣",
+        "name": "gangan",
         "trans": [
             "① 副  （头疼、耳鸣）强烈；喋喋不休"
         ],
@@ -20853,7 +20853,7 @@
         "notation": "精力(せいりょく)"
     },
     {
-        "name": "阳光、火焰",
+        "name": "kankan",
         "trans": [
             "① 副  （阳光、火焰）强烈；大发雷霆"
         ],
@@ -20993,7 +20993,7 @@
         "notation": "着実(ちゃくじつ)"
     },
     {
-        "name": "想法",
+        "name": "guratsuku",
         "trans": [
             "⓪ 自动1  摇晃；（想法）动摇"
         ],

--- a/public/dicts/Jap_High-Frequency_N2.json
+++ b/public/dicts/Jap_High-Frequency_N2.json
@@ -196,7 +196,7 @@
         "notation": "決勝(けっしょう)"
     },
     {
-        "name": "dam",
+        "name": "damu",
         "trans": [
             "① 名  水坝；水库"
         ],
@@ -658,7 +658,7 @@
         "notation": "室温(しつおん)"
     },
     {
-        "name": "stereotype",
+        "name": "sutereotaipu",
         "trans": [
             "⑤ 名  （印刷用语）铅版；老一套，模式化观念"
         ],
@@ -672,14 +672,14 @@
         "notation": "攻撃(こうげき)"
     },
     {
-        "name": "prologue",
+        "name": "puroro-gu",
         "trans": [
             "③ 名  序言；开端，开头"
         ],
         "notation": "プロローグ"
     },
     {
-        "name": "segmentation",
+        "name": "segumente-shon",
         "trans": [
             "⑤ 名  区分市场"
         ],
@@ -756,7 +756,7 @@
         "notation": "酸性(さんせい)"
     },
     {
-        "name": "seal",
+        "name": "shi-ru",
         "trans": [
             "① 名  密封条；贴纸"
         ],
@@ -1148,7 +1148,7 @@
         "notation": "身柄(みがら)"
     },
     {
-        "name": "gender",
+        "name": "jenda-",
         "trans": [
             "① 名  性别，男女差异"
         ],
@@ -1218,7 +1218,7 @@
         "notation": "背伸(せの)び"
     },
     {
-        "name": "seminar",
+        "name": "semina-",
         "trans": [
             "① 名  研讨会，小组讨论"
         ],
@@ -1239,7 +1239,7 @@
         "notation": "庶民(しょみん)"
     },
     {
-        "name": "sensor",
+        "name": "sensa-",
         "trans": [
             "① 名  传感器，感应装置"
         ],
@@ -1267,14 +1267,14 @@
         "notation": "収賄(しゅうわい)"
     },
     {
-        "name": "initial",
+        "name": "inisharu",
         "trans": [
             "② 名  单词或名字的首字母"
         ],
         "notation": "イニシャル"
     },
     {
-        "name": "internship",
+        "name": "inta-nshippu",
         "trans": [
             "⑥ 名  实习"
         ],
@@ -1330,7 +1330,7 @@
         "notation": "穏和(おんわ)"
     },
     {
-        "name": "guardrail",
+        "name": "ga-dore-ru",
         "trans": [
             "④ 名  公路上的护栏"
         ],
@@ -1428,14 +1428,14 @@
         "notation": "ずきずき"
     },
     {
-        "name": "shopping center",
+        "name": "shoppingusenta-",
         "trans": [
             "⑥ 名  商业区，购物中心"
         ],
         "notation": "ショッピングセンター"
     },
     {
-        "name": "shopping mall",
+        "name": "shoppingumo-ru",
         "trans": [
             "⑥ 名  商场，大型购物中心"
         ],
@@ -1449,14 +1449,14 @@
         "notation": "新卒(しんそつ)"
     },
     {
-        "name": "stamina",
+        "name": "sutamina",
         "trans": [
             "⓪ 名  持久力，耐力；精力；体力"
         ],
         "notation": "スタミナ"
     },
     {
-        "name": "spice",
+        "name": "supaisu",
         "trans": [
             "② 名  调味品，香料"
         ],
@@ -1498,7 +1498,7 @@
         "notation": "生態(せいたい)"
     },
     {
-        "name": "stalker",
+        "name": "suto-ka-",
         "trans": [
             "⓪ 名  跟踪狂，骚扰者"
         ],
@@ -1526,7 +1526,7 @@
         "notation": "墨絵(すみえ)"
     },
     {
-        "name": "smooth",
+        "name": "suma-zu",
         "trans": [
             "② ナ形  平滑的，光滑的；顺利的，流畅的，顺畅的"
         ],
@@ -1540,7 +1540,7 @@
         "notation": "すり替(か)える"
     },
     {
-        "name": "thrill",
+        "name": "suriru",
         "trans": [
             "① 名  惊险，刺激性，紧张感"
         ],
@@ -1792,7 +1792,7 @@
         "notation": "家屋(かおく)"
     },
     {
-        "name": "drugstore",
+        "name": "doraggusutoa",
         "trans": [
             "⑥ 名  药妆店，杂货店"
         ],
@@ -1869,7 +1869,7 @@
         "notation": "地方(ちほう)"
     },
     {
-        "name": "severe",
+        "name": "shibia",
         "trans": [
             "① ナ形  严厉的，苛刻的，毫不留情的"
         ],
@@ -1904,7 +1904,7 @@
         "notation": "突(つ)き放(はな)す"
     },
     {
-        "name": "safe",
+        "name": "se-fu",
         "trans": [
             "① 名  安全；（棒球）安全进垒"
         ],
@@ -2037,14 +2037,14 @@
         "notation": "着替(きが)え"
     },
     {
-        "name": "dynamic",
+        "name": "dainamikku",
         "trans": [
             "④ ナ形  动态的，有生气的"
         ],
         "notation": "ダイナミック"
     },
     {
-        "name": "vitality",
+        "name": "baitarithi-",
         "trans": [
             "③ 名  活力，生气，生命力"
         ],
@@ -2086,14 +2086,14 @@
         "notation": "詰(つ)めかける"
     },
     {
-        "name": "display",
+        "name": "dhisupure-",
         "trans": [
             "① 名·他动3  陈列，展示 "
         ],
         "notation": "ディスプレー"
     },
     {
-        "name": "technique",
+        "name": "tekunikku",
         "trans": [
             "① 名  技巧，技艺；艺术上的手法"
         ],
@@ -2121,7 +2121,7 @@
         "notation": "大陸(たいりく)"
     },
     {
-        "name": "down",
+        "name": "daun",
         "trans": [
             "① 名·自他动3  降低，下降；倒下；病倒"
         ],
@@ -2170,7 +2170,7 @@
         "notation": "冒険(ぼうけん)"
     },
     {
-        "name": "terminal care",
+        "name": "ta-minarukea",
         "trans": [
             "⑥ 名  临终看护；临终关怀"
         ],
@@ -2233,7 +2233,7 @@
         "notation": "毒(どく)"
     },
     {
-        "name": "doctor",
+        "name": "dokuta-",
         "trans": [
             "① 名  医生；博士"
         ],
@@ -2338,7 +2338,7 @@
         "notation": "捻(ねじ)る"
     },
     {
-        "name": "network",
+        "name": "nettowa-ku",
         "trans": [
             "④ 名  网络"
         ],
@@ -2380,7 +2380,7 @@
         "notation": "覗(のぞ)く"
     },
     {
-        "name": "parking",
+        "name": "pa-kingu",
         "trans": [
             "① 名  停车；停车场"
         ],
@@ -2401,7 +2401,7 @@
         "notation": "敷居(しきい)"
     },
     {
-        "name": "parking area",
+        "name": "pa-kingueria",
         "trans": [
             "⑥ 名  停车区域，停车场"
         ],
@@ -2443,7 +2443,7 @@
         "notation": "罰(ばつ)"
     },
     {
-        "name": "hacker",
+        "name": "hakka-",
         "trans": [
             "① 名  黑客（秘密窥视或改变他人计算机系统信息）"
         ],
@@ -2457,7 +2457,7 @@
         "notation": "構想(こうそう)"
     },
     {
-        "name": "pack",
+        "name": "pakku",
         "trans": [
             "① 名·他动3  包装；做面膜"
         ],
@@ -2485,7 +2485,7 @@
         "notation": "連続(れんぞく)"
     },
     {
-        "name": "dry",
+        "name": "dorai",
         "trans": [
             "② ナ形  干燥的；理智的，冷冰冰的"
         ],
@@ -2520,7 +2520,7 @@
         "notation": "話(はな)しかける"
     },
     {
-        "name": "panel",
+        "name": "paneru",
         "trans": [
             "① 名  油画板；告示板"
         ],
@@ -2548,11 +2548,11 @@
         "notation": "猛烈(もうれつ)"
     },
     {
-        "name": "凭re掛karu",
+        "name": "motarekakaru",
         "trans": [
             " ⑤ 自动1  凭靠，靠；依靠，依赖"
         ],
-        "notation": "凭れ掛かる"
+        "notation": "凭(もた)れ掛(か)かる"
     },
     {
         "name": "yakuzai",
@@ -2604,7 +2604,7 @@
         "notation": "属(ぞく)する"
     },
     {
-        "name": "service station",
+        "name": "sa-bisusute-shon",
         "trans": [
             "⑥ 名  服务站，修理站"
         ],
@@ -2625,7 +2625,7 @@
         "notation": "晩年(ばんねん)"
     },
     {
-        "name": "healthy",
+        "name": "herushi-",
         "trans": [
             "① ナ形  健康的"
         ],
@@ -2653,7 +2653,7 @@
         "notation": "便秘(べんぴ)"
     },
     {
-        "name": "home center",
+        "name": "ho-musenta-",
         "trans": [
             "④ 名  大型家居建材商店"
         ],
@@ -2709,7 +2709,7 @@
         "notation": "食(は)み出(で)る"
     },
     {
-        "name": "variety",
+        "name": "baraethi-",
         "trans": [
             "② 名  多样性，变化"
         ],
@@ -2737,7 +2737,7 @@
         "notation": "めど"
     },
     {
-        "name": "popular",
+        "name": "popyura-",
         "trans": [
             "① ナ形  流行的，受欢迎的"
         ],
@@ -2779,7 +2779,7 @@
         "notation": "身体(しんたい)"
     },
     {
-        "name": "pose",
+        "name": "po-zu",
         "trans": [
             "① 名  姿势，形态，样子"
         ],
@@ -2807,21 +2807,21 @@
         "notation": "無造作(むぞうさ)"
     },
     {
-        "name": "mechanism",
+        "name": "mekanizumu",
         "trans": [
             "③ 名  结构，组织；（机械）装置"
         ],
         "notation": "メカニズム"
     },
     {
-        "name": "变化",
+        "name": "mekkiri",
         "trans": [
             "(变化)  ③ 副  （变化）显著，明显，急剧"
         ],
         "notation": "めっきり"
     },
     {
-        "name": "policy",
+        "name": "porishi-",
         "trans": [
             "① 名  方针，政策；策略"
         ],
@@ -2849,7 +2849,7 @@
         "notation": "要素(ようそ)"
     },
     {
-        "name": "meter",
+        "name": "me-ta-",
         "trans": [
             "⓪ 名  计量仪表，计量器"
         ],
@@ -3073,7 +3073,7 @@
         "notation": "概略(がいりゃく)"
     },
     {
-        "name": "calcium",
+        "name": "karushiumu",
         "trans": [
             "③ 名  钙"
         ],
@@ -3227,11 +3227,11 @@
         "notation": "小声(こごえ)"
     },
     {
-        "name": "凭reru",
+        "name": "motareru",
         "trans": [
             " ③ 自动2  倚靠，凭靠；积食，不消化"
         ],
-        "notation": "凭れる"
+        "notation": "凭(もた)れる"
     },
     {
         "name": "momu",
@@ -3290,7 +3290,7 @@
         "notation": "終焉(しゅうえん)"
     },
     {
-        "name": "topic",
+        "name": "topikku",
         "trans": [
             "① 名  话题，主题，题目"
         ],
@@ -3745,7 +3745,7 @@
         "notation": "瑕疵(かし)"
     },
     {
-        "name": "double",
+        "name": "daburu",
         "trans": [
             "① 名  成双；两倍，加倍"
         ],
@@ -3794,7 +3794,7 @@
         "notation": "通報(つうほう)"
     },
     {
-        "name": "World Cup",
+        "name": "wa-rudokappu",
         "trans": [
             "⑤ 名  世界杯"
         ],
@@ -3808,7 +3808,7 @@
         "notation": "地価(ちか)"
     },
     {
-        "name": "reform",
+        "name": "rifo-mu",
         "trans": [
             "② 名·他动3  改革，改良；翻新，改造"
         ],
@@ -3822,14 +3822,14 @@
         "notation": "親子(おやこ)"
     },
     {
-        "name": "originality",
+        "name": "orijinarithi-",
         "trans": [
             "④ 名  独创性，创意，创造力"
         ],
         "notation": "オリジナリティー"
     },
     {
-        "name": "organ",
+        "name": "orugan",
         "trans": [
             "⓪ 名  风琴"
         ],
@@ -3857,7 +3857,7 @@
         "notation": "海水浴(かいすいよく)"
     },
     {
-        "name": "counter",
+        "name": "kaunta-",
         "trans": [
             "⓪ 名  柜台；服务台"
         ],
@@ -3878,7 +3878,7 @@
         "notation": "隔日(かくじつ)"
     },
     {
-        "name": "cocktail",
+        "name": "kakuteru",
         "trans": [
             "① 名  鸡尾酒"
         ],
@@ -3899,7 +3899,7 @@
         "notation": "過激(かげき)"
     },
     {
-        "name": "儿童用语",
+        "name": "kakekko",
         "trans": [
             "(儿童用语)  ② 名·自动3  （儿童用语）赛跑"
         ],
@@ -3955,7 +3955,7 @@
         "notation": "うねうね"
     },
     {
-        "name": "shift",
+        "name": "shifuto",
         "trans": [
             "① 名  移动；改变；替换；换班"
         ],
@@ -3983,7 +3983,7 @@
         "notation": "外泊(がいはく)"
     },
     {
-        "name": "en'en",
+        "name": "nobenobe",
         "trans": [
             "⓪ 副·ナ形  没完没了，接连不断"
         ],
@@ -4102,7 +4102,7 @@
         "notation": "発言(はつげん)"
     },
     {
-        "name": "captain",
+        "name": "kyaputen",
         "trans": [
             "① 名  首领；队长；船长"
         ],
@@ -4536,7 +4536,7 @@
         "notation": "体調(たいちょう)"
     },
     {
-        "name": "title",
+        "name": "taitoru",
         "trans": [
             "① 名  标题；头衔；字幕"
         ],
@@ -5089,7 +5089,7 @@
         "notation": "偽物(にせもの)"
     },
     {
-        "name": "nickname",
+        "name": "nikkune-mu",
         "trans": [
             "④ 名  昵称；外号，绰号"
         ],
@@ -5236,7 +5236,7 @@
         "notation": "気安(きやす)い"
     },
     {
-        "name": "champion",
+        "name": "chanpion",
         "trans": [
             "① 名  优胜者，冠军"
         ],
@@ -5278,7 +5278,7 @@
         "notation": "力強(ちからづよ)い"
     },
     {
-        "name": "channel",
+        "name": "channeru",
         "trans": [
             "⓪ 名  频道，波段；航道"
         ],
@@ -5383,7 +5383,7 @@
         "notation": "費(つい)やす"
     },
     {
-        "name": "talent",
+        "name": "tarento",
         "trans": [
             "⓪ 名  技能；艺人，演员"
         ],
@@ -5691,7 +5691,7 @@
         "notation": "地位(ちい)"
     },
     {
-        "name": "challenge",
+        "name": "charenji",
         "trans": [
             "② 名·自动3  挑战"
         ],
@@ -5705,7 +5705,7 @@
         "notation": "均質(きんしつ)"
     },
     {
-        "name": "up",
+        "name": "appu",
         "trans": [
             "① 名·自他动3  增高，提高"
         ],
@@ -6412,7 +6412,7 @@
         "notation": "接点(せってん)"
     },
     {
-        "name": "guest house",
+        "name": "gesutobausu",
         "trans": [
             "④ 名  宾馆，招待所"
         ],
@@ -6482,7 +6482,7 @@
         "notation": "有頂天(うちょうてん)"
     },
     {
-        "name": "为小事",
+        "name": "akuseku",
         "trans": [
             "(为小事)  ① 副·自动3  辛辛苦苦，忙忙碌碌；（为小事）苦恼"
         ],
@@ -6566,7 +6566,7 @@
         "notation": "巣立(すだ)ち"
     },
     {
-        "name": "sentence",
+        "name": "sentensu",
         "trans": [
             "① 名  句子"
         ],
@@ -6748,7 +6748,7 @@
         "notation": "自動詞(じどうし)"
     },
     {
-        "name": "雨",
+        "name": "shitoshito",
         "trans": [
             "(雨)  ① 副  （雨）淅淅沥沥"
         ],
@@ -6972,7 +6972,7 @@
         "notation": "義務(ぎむ)"
     },
     {
-        "name": "动物",
+        "name": "shitsukeru",
         "trans": [
             "(动物)  ③ 他动2  教育，培养；训练（动物）"
         ],
@@ -7238,7 +7238,7 @@
         "notation": "野郎(やろう)"
     },
     {
-        "name": "amateur",
+        "name": "amachua",
         "trans": [
             "⓪ 名  业余爱好者"
         ],
@@ -7301,7 +7301,7 @@
         "notation": "助手(じょしゅ)"
     },
     {
-        "name": "shock",
+        "name": "shokku",
         "trans": [
             "① 名  打击，震惊，冲击"
         ],
@@ -7378,7 +7378,7 @@
         "notation": "稲妻(いなずま)"
     },
     {
-        "name": "international",
+        "name": "inta-nashonaru",
         "trans": [
             "⑤ 名·ナ形  国际；国际的"
         ],
@@ -7392,7 +7392,7 @@
         "notation": "陰陽(おんよう)"
     },
     {
-        "name": "weekday",
+        "name": "ui-kude-",
         "trans": [
             "② 名  工作日，平日"
         ],
@@ -7434,7 +7434,7 @@
         "notation": "円周(えんしゅう)"
     },
     {
-        "name": "entry",
+        "name": "entori-",
         "trans": [
             "① 名·自动3  报名参加"
         ],
@@ -7476,7 +7476,7 @@
         "notation": "小児科(しょうにか)"
     },
     {
-        "name": "airmail",
+        "name": "eame-ru",
         "trans": [
             "③ 名  航空信件"
         ],
@@ -7532,7 +7532,7 @@
         "notation": "隠居(いんきょ)"
     },
     {
-        "name": "essay",
+        "name": "essei",
         "trans": [
             "① 名  随笔，散文"
         ],
@@ -7644,7 +7644,7 @@
         "notation": "省略(しょうりゃく)"
     },
     {
-        "name": "喝",
+        "name": "guigui",
         "trans": [
             "(喝)  ① 副  连续用力；使劲（喝），大口大口地（喝）"
         ],
@@ -7882,7 +7882,7 @@
         "notation": "真空(しんくう)"
     },
     {
-        "name": "single",
+        "name": "shinguru",
         "trans": [
             "① 名  单个，单人；单身"
         ],
@@ -7896,7 +7896,7 @@
         "notation": "素早(すばや)い"
     },
     {
-        "name": "speaker",
+        "name": "supi-ka-",
         "trans": [
             "② 名  发言的人；扬声器，喇叭"
         ],
@@ -8078,14 +8078,14 @@
         "notation": "侵害(しんがい)"
     },
     {
-        "name": "stage",
+        "name": "sute-ji",
         "trans": [
             "② 名  舞台；讲坛；阶段，程度"
         ],
         "notation": "ステージ"
     },
     {
-        "name": "snack",
+        "name": "sunakku",
         "trans": [
             "② 名  零食，小点心；小吃店"
         ],
@@ -8120,7 +8120,7 @@
         "notation": "澄(す)む"
     },
     {
-        "name": "slide",
+        "name": "suraido",
         "trans": [
             "⓪ 名·自他动3  幻灯片；滑行，滑动"
         ],
@@ -8204,7 +8204,7 @@
         "notation": "適用(てきよう)"
     },
     {
-        "name": "designer",
+        "name": "dezaina-",
         "trans": [
             "② 名  设计师"
         ],
@@ -8232,7 +8232,7 @@
         "notation": "押(お)し通(とお)す"
     },
     {
-        "name": "office",
+        "name": "ofisu",
         "trans": [
             "① 名  办公室，事务所"
         ],
@@ -8337,7 +8337,7 @@
         "notation": "職務(しょくむ)"
     },
     {
-        "name": "symbol",
+        "name": "shinboru",
         "trans": [
             "① 名  象征；符号"
         ],
@@ -8967,7 +8967,7 @@
         "notation": "送別(そうべつ)"
     },
     {
-        "name": "sauce",
+        "name": "so-su",
         "trans": [
             "① 名  酱料，调味汁"
         ],
@@ -9079,7 +9079,7 @@
         "notation": "雨具(あまぐ)"
     },
     {
-        "name": "girl",
+        "name": "ga-ru",
         "trans": [
             "① 名  少女，女孩"
         ],
@@ -9247,7 +9247,7 @@
         "notation": "品切(しなぎ)れ"
     },
     {
-        "name": "shutter",
+        "name": "shatta-",
         "trans": [
             "① 名  快门；百叶窗"
         ],
@@ -9289,7 +9289,7 @@
         "notation": "長時間(ちょうじかん)"
     },
     {
-        "name": "bucket",
+        "name": "baketsu",
         "trans": [
             "⓪ 名  水桶"
         ],
@@ -9359,7 +9359,7 @@
         "notation": "吊(つ)る"
     },
     {
-        "name": "outlet",
+        "name": "autoretto",
         "trans": [
             "④ 名  工厂直销，（奥特莱斯 ）直销店"
         ],
@@ -9415,7 +9415,7 @@
         "notation": "教(おし)え込(こ)む"
     },
     {
-        "name": "collection",
+        "name": "korekushon",
         "trans": [
             "② 名  收集，收藏"
         ],
@@ -9457,7 +9457,7 @@
         "notation": "外壁(がいへき)"
     },
     {
-        "name": "counseling",
+        "name": "kaunseringu",
         "trans": [
             "② 名  心理咨询，咨询指导"
         ],
@@ -9779,7 +9779,7 @@
         "notation": "否定(ひてい)"
     },
     {
-        "name": "volunteer",
+        "name": "boranthia",
         "trans": [
             "② 名  志愿者"
         ],
@@ -9933,7 +9933,7 @@
         "notation": "すたすた"
     },
     {
-        "name": "断绝",
+        "name": "suppari",
         "trans": [
             "(断绝)  ③ 副  干脆利落地切断；彻底（断绝），干脆"
         ],
@@ -10276,7 +10276,7 @@
         "notation": "捉(とら)える"
     },
     {
-        "name": "trouble",
+        "name": "toraberu",
         "trans": [
             "② 名  纠纷，纷争；故障"
         ],
@@ -10500,7 +10500,7 @@
         "notation": "当選(とうせん)"
     },
     {
-        "name": "后接否定",
+        "name": "dounimo",
         "trans": [
             "(后接否定)  ① 副  （后接否定）无论如何也；实在，的确"
         ],
@@ -10605,7 +10605,7 @@
         "notation": "灰(はい)"
     },
     {
-        "name": "hiking",
+        "name": "haikingu",
         "trans": [
             "① 名·自动3  郊游，远足，徒步旅游"
         ],
@@ -10654,7 +10654,7 @@
         "notation": "梯子(はしご)"
     },
     {
-        "name": "pattern",
+        "name": "pata-n",
         "trans": [
             "② 名  类型，模式；图案"
         ],
@@ -10759,7 +10759,7 @@
         "notation": "破産(はさん)"
     },
     {
-        "name": "雨",
+        "name": "bishobisho",
         "trans": [
             "(雨)  ① ナ形·副  湿透的；（雨）连绵不断"
         ],
@@ -10836,7 +10836,7 @@
         "notation": "密(ひそ)か"
     },
     {
-        "name": "vitamin",
+        "name": "bitamin",
         "trans": [
             "② 名  维生素"
         ],
@@ -11242,7 +11242,7 @@
         "notation": "成熟(せいじゅく)"
     },
     {
-        "name": "best ",
+        "name": "besuto",
         "trans": [
             "① 名  最好，最上等，最优秀；全力"
         ],
@@ -11333,7 +11333,7 @@
         "notation": "繁殖(はんしょく)"
     },
     {
-        "name": "market",
+        "name": "ma-ketto",
         "trans": [
             "① 名  市场，商场；销售市场"
         ],
@@ -11347,7 +11347,7 @@
         "notation": "方程式(ほうていしき)"
     },
     {
-        "name": "sharp",
+        "name": "sha-pu",
         "trans": [
             "① ナ形  尖锐的；敏锐的；清晰的"
         ],
@@ -11396,7 +11396,7 @@
         "notation": "披露(ひろう)"
     },
     {
-        "name": "best seller",
+        "name": "besutosera-",
         "trans": [
             "④ 名  畅销书"
         ],
@@ -11515,7 +11515,7 @@
         "notation": "ピン"
     },
     {
-        "name": "boom",
+        "name": "bu-mu",
         "trans": [
             "① 名  热潮，潮流"
         ],
@@ -11641,7 +11641,7 @@
         "notation": "別人(べつじん)"
     },
     {
-        "name": "veteran",
+        "name": "beteran",
         "trans": [
             "⓪ 名  老手，经验丰富的人"
         ],
@@ -11914,7 +11914,7 @@
         "notation": "待(ま)ち望(のぞ)む"
     },
     {
-        "name": "massage",
+        "name": "massa-ji",
         "trans": [
             "③ 名·他动3  按摩，推拿"
         ],
@@ -11963,7 +11963,7 @@
         "notation": "身(み)"
     },
     {
-        "name": "meeting",
+        "name": "mi-thingu",
         "trans": [
             "⓪ 名  会，会议"
         ],
@@ -12040,7 +12040,7 @@
         "notation": "細(こま)やか"
     },
     {
-        "name": "home page",
+        "name": "ho-mupe-ji",
         "trans": [
             "④ 名  （网站）主页，首页"
         ],
@@ -12334,7 +12334,7 @@
         "notation": "目(め)つき"
     },
     {
-        "name": "后接否定",
+        "name": "mettani",
         "trans": [
             "(后接否定)  ① 副  （后接否定）极少，几乎"
         ],
@@ -12362,7 +12362,7 @@
         "notation": "名産(めいさん)"
     },
     {
-        "name": "maker",
+        "name": "me-ka-",
         "trans": [
             "① 名  制造商，制造者"
         ],
@@ -12537,7 +12537,7 @@
         "notation": "平野(へいや)"
     },
     {
-        "name": "bakery",
+        "name": "ba-kari-",
         "trans": [
             "① 名  面包店，面包房"
         ],
@@ -12551,7 +12551,7 @@
         "notation": "敏捷(びんしょう)"
     },
     {
-        "name": "feedback",
+        "name": "fi-dobakku",
         "trans": [
             "④ 名·他动3  反馈"
         ],
@@ -12607,7 +12607,7 @@
         "notation": "敬具(けいぐ)"
     },
     {
-        "name": "festival",
+        "name": "fesuthibaru",
         "trans": [
             "① 名  节日，庆典"
         ],
@@ -12796,7 +12796,7 @@
         "notation": "不眠症(ふみんしょう)"
     },
     {
-        "name": "flea market",
+        "name": "furi-ma-ketto",
         "trans": [
             "④ 名  跳蚤市场，自由市场"
         ],
@@ -12852,7 +12852,7 @@
         "notation": "休息(きゅうそく)"
     },
     {
-        "name": "profile",
+        "name": "purofi-ru",
         "trans": [
             "③ 名  侧面，侧面像；人物简介"
         ],
@@ -13069,7 +13069,7 @@
         "notation": "小数点(しょうすうてん)"
     },
     {
-        "name": "去",
+        "name": "motarasu",
         "trans": [
             "(去)  ③ 他动1  带来（去）；招致，造成（某种结果）"
         ],
@@ -13202,7 +13202,7 @@
         "notation": "優先的(ゆうせんてき)"
     },
     {
-        "name": "塞得",
+        "name": "kichikichi",
         "trans": [
             "(塞得)  ⓪ 副·ナ形  （塞得）满满的；（时间）恰好，刚好；准确无误"
         ],
@@ -13244,14 +13244,14 @@
         "notation": "行方(ゆくえ)"
     },
     {
-        "name": "line",
+        "name": "rain",
         "trans": [
             "① 名  线；路线；航线"
         ],
         "notation": "ライン"
     },
     {
-        "name": "medal",
+        "name": "medaru",
         "trans": [
             "⓪ 名  奖牌，奖章"
         ],
@@ -13286,7 +13286,7 @@
         "notation": "結(むす)び"
     },
     {
-        "name": "rival",
+        "name": "raibaru",
         "trans": [
             "① 名  竞争对手，竞争者"
         ],
@@ -13335,7 +13335,7 @@
         "notation": "落第(らくだい)"
     },
     {
-        "name": "label",
+        "name": "raberu",
         "trans": [
             "① 名  商品标签；商标"
         ],
@@ -13377,14 +13377,14 @@
         "notation": "容積(ようせき)"
     },
     {
-        "name": "leisure",
+        "name": "reja-",
         "trans": [
             "① 名  空闲，业余时间；休闲娱乐"
         ],
         "notation": "レジャー"
     },
     {
-        "name": "lettuce",
+        "name": "retasu",
         "trans": [
             "① 名  生菜，叶用莴苣"
         ],
@@ -13447,7 +13447,7 @@
         "notation": "浪費(ろうひ)"
     },
     {
-        "name": "loan",
+        "name": "ro-n",
         "trans": [
             "① 名  贷款"
         ],
@@ -13475,7 +13475,7 @@
         "notation": "預金(よきん)"
     },
     {
-        "name": "romantic",
+        "name": "romanchikku",
         "trans": [
             "④ ナ形  浪漫的，幻想的"
         ],
@@ -13594,7 +13594,7 @@
         "notation": "かき氷(ごおり)"
     },
     {
-        "name": "smog",
+        "name": "sumoggu",
         "trans": [
             "② 名  烟雾，烟尘"
         ],
@@ -13699,7 +13699,7 @@
         "notation": "相槌(あいづち)"
     },
     {
-        "name": "皮肤",
+        "name": "kimekomaka",
         "trans": [
             "(皮肤)  ③ ナ形  （皮肤）细腻的；（做法）细致的"
         ],
@@ -13734,7 +13734,7 @@
         "notation": "客観的(きゃっかんてき)"
     },
     {
-        "name": "camp",
+        "name": "kyanpu",
         "trans": [
             "① 名·自动3  帐篷；露营，野营"
         ],
@@ -13909,7 +13909,7 @@
         "notation": "区域(くいき)"
     },
     {
-        "name": "quiz",
+        "name": "kuizu",
         "trans": [
             "① 名  猜谜，智力问答"
         ],
@@ -14665,7 +14665,7 @@
         "notation": "学説(がくせつ)"
     },
     {
-        "name": "plan",
+        "name": "puran",
         "trans": [
             "① 名  计划，方案"
         ],
@@ -15190,7 +15190,7 @@
         "notation": "鶴(つる)"
     },
     {
-        "name": "data",
+        "name": "de-ta",
         "trans": [
             "① 名  数据，资料，材料"
         ],
@@ -15225,7 +15225,7 @@
         "notation": "女将(じょしょう)"
     },
     {
-        "name": "innovation",
+        "name": "inobe-shon",
         "trans": [
             "③ 名  改革，革新，变革"
         ],
@@ -15274,7 +15274,7 @@
         "notation": "見事(みごと)"
     },
     {
-        "name": "cash",
+        "name": "kyasshu",
         "trans": [
             "① 名  现金"
         ],
@@ -15288,7 +15288,7 @@
         "notation": "一致(いっち)"
     },
     {
-        "name": "clip",
+        "name": "kurippu",
         "trans": [
             "② 名  夹子；回形针"
         ],
@@ -15372,7 +15372,7 @@
         "notation": "成金(なりきん)"
     },
     {
-        "name": "antenna",
+        "name": "antena",
         "trans": [
             "⓪ 名  天线"
         ],
@@ -15386,7 +15386,7 @@
         "notation": "規律(きりつ)"
     },
     {
-        "name": "digital",
+        "name": "dejitaru",
         "trans": [
             "① 名  数字（的），数字化（的）"
         ],
@@ -15876,7 +15876,7 @@
         "notation": "売(う)り出(だ)す"
     },
     {
-        "name": "inflation",
+        "name": "infure",
         "trans": [
             "⓪ 名  通货膨胀"
         ],
@@ -16856,14 +16856,14 @@
         "notation": "読(よ)み返(かえ)す"
     },
     {
-        "name": "live",
+        "name": "raibu",
         "trans": [
             "① 名  直播，实况播出"
         ],
         "notation": "ライブ"
     },
     {
-        "name": "life science",
+        "name": "raifusaiensu",
         "trans": [
             "④ 名  生命科学"
         ],
@@ -16877,7 +16877,7 @@
         "notation": "裏口(うらぐち)"
     },
     {
-        "name": "last",
+        "name": "rasuto",
         "trans": [
             "① 名  最后，末尾"
         ],
@@ -16940,14 +16940,14 @@
         "notation": "見抜(みぬ)く"
     },
     {
-        "name": "rank",
+        "name": "ranke",
         "trans": [
             "① 名·他动3  顺序，名次；排序"
         ],
         "notation": "ランク"
     },
     {
-        "name": "resort",
+        "name": "rizo-to",
         "trans": [
             "② 名  休养地，度假地"
         ],
@@ -17017,7 +17017,7 @@
         "notation": "未満(みまん)"
     },
     {
-        "name": "recipe",
+        "name": "reshipi",
         "trans": [
             "① 名  食谱，烹饪法"
         ],
@@ -17031,7 +17031,7 @@
         "notation": "老眼(ろうがん)"
     },
     {
-        "name": "list",
+        "name": "risuto",
         "trans": [
             "① 名  名单；一览表"
         ],
@@ -17073,7 +17073,7 @@
         "notation": "考慮(こうりょ)"
     },
     {
-        "name": "后接否定",
+        "name": "rokuni",
         "trans": [
             "(后接否定)  ⓪ 副  （后接否定）很好地，令人满意地"
         ],
@@ -17087,7 +17087,7 @@
         "notation": "寸前(すんぜん)"
     },
     {
-        "name": "trial",
+        "name": "toraiaru",
         "trans": [
             "② 名  试行，试运行；预赛"
         ],
@@ -17108,14 +17108,14 @@
         "notation": "緩行(かんこう)"
     },
     {
-        "name": "renewal",
+        "name": "rinyu-aru",
         "trans": [
             "② 名·他动3  更新；重建 "
         ],
         "notation": "リニューアル"
     },
     {
-        "name": "finance",
+        "name": "fainansu",
         "trans": [
             "① 名  金融，财政"
         ],
@@ -17234,7 +17234,7 @@
         "notation": "強烈(きょうれつ)"
     },
     {
-        "name": "guest",
+        "name": "gesuto",
         "trans": [
             "① 名  客人；嘉宾"
         ],
@@ -17311,7 +17311,7 @@
         "notation": "支持(しじ)"
     },
     {
-        "name": "comment",
+        "name": "komento",
         "trans": [
             "⓪ 名·自动3  评论，说明；发表意见"
         ],
@@ -17465,7 +17465,7 @@
         "notation": "高等(こうとう)"
     },
     {
-        "name": "chorus",
+        "name": "ko-rasu",
         "trans": [
             "① 名  合唱；合唱团"
         ],

--- a/public/dicts/Jap_High-Frequency_N3.json
+++ b/public/dicts/Jap_High-Frequency_N3.json
@@ -77,7 +77,7 @@
         "notation": "水着(みずぎ)"
     },
     {
-        "name": "hint",
+        "name": "hinto",
         "trans": [
             "① 名  暗示，启发"
         ],
@@ -91,7 +91,7 @@
         "notation": "訪問(ほうもん)"
     },
     {
-        "name": "mask",
+        "name": "masuku",
         "trans": [
             "① 名  面具；口罩"
         ],
@@ -182,7 +182,7 @@
         "notation": "週刊誌(しゅうかんし)"
     },
     {
-        "name": "accelerator",
+        "name": "akuseru",
         "trans": [
             "① 名  油门，加速器"
         ],
@@ -196,7 +196,7 @@
         "notation": "半々(はんはん)"
     },
     {
-        "name": "wrap",
+        "name": "rappu",
         "trans": [
             "① 名  保鲜膜"
         ],
@@ -231,7 +231,7 @@
         "notation": "勝(か)ち"
     },
     {
-        "name": "后接否定",
+        "name": "marude",
         "trans": [
             "⓪ 副  好像，仿佛；（后接否定）完全（不）"
         ],
@@ -427,7 +427,7 @@
         "notation": "友(とも)"
     },
     {
-        "name": "curve",
+        "name": "ka-bu",
         "trans": [
             "① 名·自动3  弯曲，转弯"
         ],
@@ -490,7 +490,7 @@
         "notation": "普通(ふつう)"
     },
     {
-        "name": "～betsu",
+        "name": "~betsu",
         "trans": [
             " 接尾  区别，按⋯⋯的不同"
         ],
@@ -553,7 +553,7 @@
         "notation": "役立(やくだ)てる"
     },
     {
-        "name": "case",
+        "name": "ke-su",
         "trans": [
             "① 名  盒子；事例，案例"
         ],
@@ -602,14 +602,14 @@
         "notation": "引(ひ)っかける"
     },
     {
-        "name": "雨",
+        "name": "barabara",
         "trans": [
             "① 副  （雨）淅淅沥沥地降落；稀稀落落"
         ],
         "notation": "ぱらぱら"
     },
     {
-        "name": "fast food",
+        "name": "fa-sutofu-do",
         "trans": [
             "⑤ 名  快餐"
         ],
@@ -665,7 +665,7 @@
         "notation": "笑顔(えがお)"
     },
     {
-        "name": "cut",
+        "name": "katto",
         "trans": [
             "① 名·他动3  切，削，删去；剪发"
         ],
@@ -679,7 +679,7 @@
         "notation": "機械的(きかいてき)"
     },
     {
-        "name": "oven",
+        "name": "o-bun",
         "trans": [
             "① 名  烤箱，烤炉"
         ],
@@ -693,21 +693,21 @@
         "notation": "上品(じょうひん)"
     },
     {
-        "name": "out",
+        "name": "outo",
         "trans": [
             "① 名  外面；出局；出界"
         ],
         "notation": "アウト"
     },
     {
-        "name": "camera man",
+        "name": "kameraman",
         "trans": [
             "③ 名  摄影师"
         ],
         "notation": "カメラマン"
     },
     {
-        "name": "pianist",
+        "name": "pianisuto",
         "trans": [
             "③ 名  钢琴家，钢琴演奏者"
         ],
@@ -770,14 +770,14 @@
         "notation": "従(したが)う"
     },
     {
-        "name": "click",
+        "name": "kurikku",
         "trans": [
             "② 名·他动3  点击（鼠标）"
         ],
         "notation": "クリック"
     },
     {
-        "name": "idea",
+        "name": "aidelia/aidea",
         "trans": [
             "① 名  想法，主意"
         ],
@@ -805,7 +805,7 @@
         "notation": "注(そそ)ぐ"
     },
     {
-        "name": "dancer",
+        "name": "dansa-",
         "trans": [
             "① 名  舞蹈家；舞女"
         ],
@@ -896,7 +896,7 @@
         "notation": "頂戴(ちょうだい)"
     },
     {
-        "name": "大学的",
+        "name": "zemi/zemina-ru",
         "trans": [
             "① 名  （大学的）研讨会"
         ],
@@ -1029,7 +1029,7 @@
         "notation": "曖昧(あいまい)"
     },
     {
-        "name": "表演、作文等的",
+        "name": "konku-ru",
         "trans": [
             "③ 名  （表演、作文等的）竞赛，比赛"
         ],
@@ -1141,7 +1141,7 @@
         "notation": "矢(や)"
     },
     {
-        "name": "金钱上",
+        "name": "mazushii",
         "trans": [
             "③ イ形  （金钱上）贫穷的；（经验等）贫乏的，微薄的"
         ],
@@ -1225,14 +1225,14 @@
         "notation": "消極的(しょうきょくてき)"
     },
     {
-        "name": "心情",
+        "name": "sukkiri",
         "trans": [
             "③ 副·自动3  （心情）爽快，痛快；流畅"
         ],
         "notation": "すっきり"
     },
     {
-        "name": "series",
+        "name": "shiri-zu",
         "trans": [
             "① 名  系列"
         ],
@@ -1302,14 +1302,14 @@
         "notation": "奪(うば)う"
     },
     {
-        "name": "keyboard",
+        "name": "ki-bo-do",
         "trans": [
             "③ 名  键盘"
         ],
         "notation": "キーボード"
     },
     {
-        "name": "one piece",
+        "name": "wanpi-su",
         "trans": [
             "③ 名  连衣裙"
         ],
@@ -1379,7 +1379,7 @@
         "notation": "上(のぼ)り"
     },
     {
-        "name": "jeans",
+        "name": "ji-nsu",
         "trans": [
             "① 名  牛仔裤"
         ],
@@ -1435,7 +1435,7 @@
         "notation": "弱(よわ)み"
     },
     {
-        "name": "液体",
+        "name": "taratara",
         "trans": [
             "① 副  （液体）滴滴答答地"
         ],
@@ -1491,7 +1491,7 @@
         "notation": "しばしば"
     },
     {
-        "name": "training",
+        "name": "tore-ningu",
         "trans": [
             "② 名·自动3  练习，训练"
         ],
@@ -1596,7 +1596,7 @@
         "notation": "差(さ)"
     },
     {
-        "name": "violin",
+        "name": "buiorin",
         "trans": [
             "⓪ 名  小提琴"
         ],
@@ -1659,7 +1659,7 @@
         "notation": "残(のこ)らず"
     },
     {
-        "name": "color",
+        "name": "kara-",
         "trans": [
             "① 名  颜色，色彩；特色"
         ],
@@ -1743,7 +1743,7 @@
         "notation": "大抵(たいてい)"
     },
     {
-        "name": "album",
+        "name": "arubamu",
         "trans": [
             "⓪ 名  相册，影集，纪念册"
         ],
@@ -1785,7 +1785,7 @@
         "notation": "贅沢(ぜいたく)"
     },
     {
-        "name": "music",
+        "name": "myu-jikku",
         "trans": [
             "① 名  音乐"
         ],
@@ -1799,14 +1799,14 @@
         "notation": "浮(う)かべる"
     },
     {
-        "name": "raincoat",
+        "name": "reinko-to",
         "trans": [
             "④ 名  雨衣"
         ],
         "notation": "レインコート"
     },
     {
-        "name": "牙或肚子",
+        "name": "shikushiku",
         "trans": [
             "① 副·自动3  抽抽搭搭地哭泣；（牙或肚子）不剧烈的疼痛"
         ],
@@ -1883,7 +1883,7 @@
         "notation": "これまで"
     },
     {
-        "name": "contest",
+        "name": "kontesuto",
         "trans": [
             "① 名  竞赛，比赛；（文艺）会演"
         ],
@@ -1925,7 +1925,7 @@
         "notation": "満点(まんてん)"
     },
     {
-        "name": "～kagiri",
+        "name": "~kagiri",
         "trans": [
             " 接尾  限于⋯⋯"
         ],
@@ -1988,7 +1988,7 @@
         "notation": "カロリー"
     },
     {
-        "name": "campus",
+        "name": "kyanpasu",
         "trans": [
             "① 名  校园"
         ],
@@ -2114,7 +2114,7 @@
         "notation": "市場(いちば)"
     },
     {
-        "name": "iron",
+        "name": "airon",
         "trans": [
             "⓪ 名  熨斗"
         ],
@@ -2149,7 +2149,7 @@
         "notation": "きっかけ"
     },
     {
-        "name": "running",
+        "name": "ranningu",
         "trans": [
             "⓪ 名  跑步"
         ],
@@ -2170,7 +2170,7 @@
         "notation": "休憩(きゅうけい)"
     },
     {
-        "name": "classic",
+        "name": "kurashikku",
         "trans": [
             "③ 名·ナ形  古典音乐；古典的"
         ],
@@ -2289,7 +2289,7 @@
         "notation": "削除(さくじょ)"
     },
     {
-        "name": "marathon",
+        "name": "marason",
         "trans": [
             "⓪ 名  马拉松"
         ],
@@ -2366,7 +2366,7 @@
         "notation": "蛇口(じゃぐち)"
     },
     {
-        "name": "shop",
+        "name": "shoppu",
         "trans": [
             "① 名  商店，店铺"
         ],
@@ -2450,7 +2450,7 @@
         "notation": "演説(えんぜつ)"
     },
     {
-        "name": "equal",
+        "name": "iko-ru",
         "trans": [
             "② 名  等于；等号"
         ],
@@ -2506,7 +2506,7 @@
         "notation": "迷惑(めいわく)"
     },
     {
-        "name": "手续",
+        "name": "yakamashii",
         "trans": [
             "④ イ形  吵闹的，嘈杂的；（手续）麻烦的"
         ],
@@ -2534,7 +2534,7 @@
         "notation": "意義(いぎ)"
     },
     {
-        "name": "symposium",
+        "name": "shinpojiwamu",
         "trans": [
             "④ 名  讨论会，座谈会"
         ],
@@ -2576,7 +2576,7 @@
         "notation": "ばたばた"
     },
     {
-        "name": "bargainsale",
+        "name": "ba-gen/ba-gense-ru",
         "trans": [
             "① 名  大减价"
         ],
@@ -2660,7 +2660,7 @@
         "notation": "暗証番号(あんしょうばんごう)"
     },
     {
-        "name": "物体",
+        "name": "hossori",
         "trans": [
             "③ 副·自动3  （物体）细长，（人）纤细苗条"
         ],
@@ -2807,14 +2807,14 @@
         "notation": "散(ち)る"
     },
     {
-        "name": "soup",
+        "name": "su-pu",
         "trans": [
             "① 名  汤"
         ],
         "notation": "スープ"
     },
     {
-        "name": "living room",
+        "name": "ribinguru-mu",
         "trans": [
             "⑤ 名  起居室"
         ],
@@ -2891,7 +2891,7 @@
         "notation": "通(とお)す"
     },
     {
-        "name": "stand",
+        "name": "sutando",
         "trans": [
             "⓪ 名  看台；（放置物品）台，座"
         ],
@@ -2919,7 +2919,7 @@
         "notation": "或(ある)いは"
     },
     {
-        "name": "cover",
+        "name": "kaba-",
         "trans": [
             "① 名·他动3  外皮，套子；弥补"
         ],
@@ -2996,7 +2996,7 @@
         "notation": "秘書(ひしょ)"
     },
     {
-        "name": "earring",
+        "name": "iyaringu",
         "trans": [
             "① 名  耳环，耳饰"
         ],
@@ -3073,7 +3073,7 @@
         "notation": "うらやましい"
     },
     {
-        "name": "download",
+        "name": "daunro-do",
         "trans": [
             "④ 名·他动3  下载"
         ],
@@ -3122,7 +3122,7 @@
         "notation": "宛名(あてな)"
     },
     {
-        "name": "后接否定",
+        "name": "taishita",
         "trans": [
             "① 连体  了不起的；（后接否定）不值一提的"
         ],
@@ -3150,7 +3150,7 @@
         "notation": "間違(まちが)える"
     },
     {
-        "name": "advice",
+        "name": "adobaisu",
         "trans": [
             "① 名·他动3  建议，忠告"
         ],
@@ -3164,7 +3164,7 @@
         "notation": "招致(しょうち)"
     },
     {
-        "name": "influenza",
+        "name": "infuruenza",
         "trans": [
             "⑤ 名  流行性感冒"
         ],
@@ -3220,7 +3220,7 @@
         "notation": "外(はず)れる"
     },
     {
-        "name": "waiter",
+        "name": "ule-ta-",
         "trans": [
             "⓪ 名  男服务员"
         ],
@@ -3255,7 +3255,7 @@
         "notation": "頷(うなず)く"
     },
     {
-        "name": "tip",
+        "name": "chippi",
         "trans": [
             "① 名  小费"
         ],
@@ -3283,7 +3283,7 @@
         "notation": "衝突(しょうとつ)"
     },
     {
-        "name": "尊他语",
+        "name": "oide",
         "trans": [
             "⓪ 名  （尊他语）来；去；在"
         ],
@@ -3388,7 +3388,7 @@
         "notation": "頂上(ちょうじょう)"
     },
     {
-        "name": "announce",
+        "name": "anaunsu",
         "trans": [
             "③ 名·他动3  广播"
         ],
@@ -3402,14 +3402,14 @@
         "notation": "定員(ていいん)"
     },
     {
-        "name": "～doori",
+        "name": "~doori",
         "trans": [
             " 接尾  按照⋯⋯；⋯⋯大街"
         ],
         "notation": "～通(どお)り"
     },
     {
-        "name": "group",
+        "name": "guru-pu",
         "trans": [
             "② 名  团体，小组"
         ],
@@ -3437,14 +3437,14 @@
         "notation": "途端(とたん)"
     },
     {
-        "name": "design",
+        "name": "dezain",
         "trans": [
             "② 名·他动3  设计"
         ],
         "notation": "デザイン"
     },
     {
-        "name": "guide",
+        "name": "gaido",
         "trans": [
             "① 名·他动3  向导；指南；引导"
         ],
@@ -3493,7 +3493,7 @@
         "notation": "慎重(しんちょう)"
     },
     {
-        "name": "professional",
+        "name": "purofesshonaru",
         "trans": [
             "③ ナ形  职业的，专业的"
         ],
@@ -3528,7 +3528,7 @@
         "notation": "表通(おもてどお)り"
     },
     {
-        "name": "minus",
+        "name": "mainasu",
         "trans": [
             "⓪ 名·他动3  负面，不利；减号，负数；减去"
         ],
@@ -3605,7 +3605,7 @@
         "notation": "隠(かく)れる"
     },
     {
-        "name": "top",
+        "name": "toppu",
         "trans": [
             "① 名  最高级；第一位；（报纸）头条"
         ],
@@ -3668,7 +3668,7 @@
         "notation": "価格(かかく)"
     },
     {
-        "name": "waitress",
+        "name": "ule-toresu",
         "trans": [
             "② 名  女服务员"
         ],
@@ -3703,7 +3703,7 @@
         "notation": "繋(つな)ぐ"
     },
     {
-        "name": "interview",
+        "name": "intabyu-",
         "trans": [
             "① 名·自动3  采访，访问"
         ],
@@ -3801,7 +3801,7 @@
         "notation": "異(こと)なる"
     },
     {
-        "name": "coach",
+        "name": "ko-chi",
         "trans": [
             "① 名  教练，技术指导"
         ],
@@ -3829,7 +3829,7 @@
         "notation": "謙虚(けんきょ)"
     },
     {
-        "name": "cleaning",
+        "name": "kuri-ningu",
         "trans": [
             "② 名  洗衣服，干洗"
         ],
@@ -3969,7 +3969,7 @@
         "notation": "挟(はさ)まる"
     },
     {
-        "name": "platform",
+        "name": "purattoho-mu",
         "trans": [
             "⑤ 名  站台，月台"
         ],
@@ -4025,7 +4025,7 @@
         "notation": "温(ぬる)い"
     },
     {
-        "name": "sales",
+        "name": "se-rusu",
         "trans": [
             "① 名  推销，销售"
         ],
@@ -4137,14 +4137,14 @@
         "notation": "洗濯機(せんたくき)"
     },
     {
-        "name": "drive",
+        "name": "doraibu",
         "trans": [
             "② 名·自动3  开车兜风"
         ],
         "notation": "ドライブ"
     },
     {
-        "name": "driver",
+        "name": "doraiba-",
         "trans": [
             "⓪ 名  司机"
         ],
@@ -4193,7 +4193,7 @@
         "notation": "実験(じっけん)"
     },
     {
-        "name": "气味",
+        "name": "shitsukoi",
         "trans": [
             "③ イ形  （气味）浓厚的，腻人的；执拗的，纠缠不休的"
         ],
@@ -4207,7 +4207,7 @@
         "notation": "暴(あば)れる"
     },
     {
-        "name": "听、看等",
+        "name": "jitto",
         "trans": [
             "⓪ 副·自动3  一动不动；聚精会神地（听、看等）"
         ],
@@ -4221,7 +4221,7 @@
         "notation": "縛(しば)る"
     },
     {
-        "name": "communication",
+        "name": "komyunike-shon",
         "trans": [
             "④ 名  交流，沟通"
         ],
@@ -4291,7 +4291,7 @@
         "notation": "売(う)り上(あ)げ"
     },
     {
-        "name": "姐妹",
+        "name": "itoko",
         "trans": [
             "② 名  堂兄弟（姐妹）；表兄弟（姐妹）"
         ],
@@ -4445,7 +4445,7 @@
         "notation": "製作(せいさく)"
     },
     {
-        "name": "handbook",
+        "name": "handobukke",
         "trans": [
             "④ 名  手册，指南"
         ],
@@ -4620,7 +4620,7 @@
         "notation": "散(ち)らかす"
     },
     {
-        "name": "时间、距离",
+        "name": "tsui",
         "trans": [
             "① 副  无意中，不由得；（时间、距离）相隔不远"
         ],
@@ -4683,7 +4683,7 @@
         "notation": "対(たい)する"
     },
     {
-        "name": "bike",
+        "name": "baiku",
         "trans": [
             "① 名  摩托车"
         ],
@@ -4760,7 +4760,7 @@
         "notation": "支度(したく)"
     },
     {
-        "name": "contact lens",
+        "name": "kontakutorenzu",
         "trans": [
             "⑥ 名  隐形眼镜"
         ],
@@ -4795,7 +4795,7 @@
         "notation": "程度(ていど)"
     },
     {
-        "name": "语气蔑视",
+        "name": "doitsu",
         "trans": [
             "① 代  （语气蔑视）哪个家伙"
         ],
@@ -4816,7 +4816,7 @@
         "notation": "増(ふ)やす"
     },
     {
-        "name": "plus",
+        "name": "purasu",
         "trans": [
             "① 名·他动3  正面，有利；加号，正数；加上"
         ],
@@ -4830,7 +4830,7 @@
         "notation": "見事(みごと)"
     },
     {
-        "name": "motor",
+        "name": "mo-ta-",
         "trans": [
             "① 名  发动机"
         ],
@@ -4935,7 +4935,7 @@
         "notation": "掬(すく)う"
     },
     {
-        "name": "engineer",
+        "name": "enjinia",
         "trans": [
             "③ 名  工程师"
         ],
@@ -4949,7 +4949,7 @@
         "notation": "座布団(ざぶとん)"
     },
     {
-        "name": "sunglasses",
+        "name": "sangurasu",
         "trans": [
             "③ 名  墨镜，太阳镜"
         ],
@@ -4984,7 +4984,7 @@
         "notation": "取(と)り入(い)れる"
     },
     {
-        "name": "number",
+        "name": "nanba-",
         "trans": [
             "① 名  数字，号码；号码牌"
         ],
@@ -5138,7 +5138,7 @@
         "notation": "言(い)い直(なお)す"
     },
     {
-        "name": "off",
+        "name": "ofu",
         "trans": [
             "① 名  关掉，停止"
         ],
@@ -5292,7 +5292,7 @@
         "notation": "通過(つうか)"
     },
     {
-        "name": "ticket",
+        "name": "chiketto",
         "trans": [
             "② 名  票，券"
         ],
@@ -5334,7 +5334,7 @@
         "notation": "放(はな)す"
     },
     {
-        "name": "balance",
+        "name": "baransu",
         "trans": [
             "⓪ 名  平衡"
         ],
@@ -5439,14 +5439,14 @@
         "notation": "染(そ)める"
     },
     {
-        "name": "software",
+        "name": "sofutowea",
         "trans": [
             "④ 名  软件"
         ],
         "notation": "ソフトウェア"
     },
     {
-        "name": "diet",
+        "name": "geietto",
         "trans": [
             "① 名·自动3  节食，减肥"
         ],
@@ -5614,7 +5614,7 @@
         "notation": "御中(おんちゅう)"
     },
     {
-        "name": "pants",
+        "name": "pantsu",
         "trans": [
             "① 名  短裤，内裤"
         ],
@@ -5817,7 +5817,7 @@
         "notation": "定期券(ていきけん)"
     },
     {
-        "name": "automation",
+        "name": "o-tome-shon",
         "trans": [
             "④ 名  自动化"
         ],
@@ -5915,7 +5915,7 @@
         "notation": "出来上(できあ)がり"
     },
     {
-        "name": "salaried man",
+        "name": "sarari-man",
         "trans": [
             "③ 名  工薪阶层，公司职员"
         ],
@@ -5964,14 +5964,14 @@
         "notation": "守(まも)る"
     },
     {
-        "name": "rush hour",
+        "name": "rasshuawa-",
         "trans": [
             "④ 名  交通拥挤时段"
         ],
         "notation": "ラッシュアワー"
     },
     {
-        "name": "rhythm",
+        "name": "rizumu",
         "trans": [
             "① 名  节奏，韵律"
         ],
@@ -6055,7 +6055,7 @@
         "notation": "日付(ひづけ)"
     },
     {
-        "name": "wine",
+        "name": "wain",
         "trans": [
             "① 名  葡萄酒"
         ],
@@ -6083,7 +6083,7 @@
         "notation": "予想(よそう)"
     },
     {
-        "name": "位置",
+        "name": "zurasu",
         "trans": [
             "② 他动1  挪动（位置）；错开（时间）"
         ],
@@ -6174,7 +6174,7 @@
         "notation": "お札(さつ)"
     },
     {
-        "name": "pass",
+        "name": "pasu",
         "trans": [
             "① 名·自动3  票，券；合格，通过"
         ],
@@ -6314,7 +6314,7 @@
         "notation": "動詞(どうし)"
     },
     {
-        "name": "～nareru",
+        "name": "~nareru",
         "trans": [
             " 接尾  ⋯⋯惯了"
         ],
@@ -6671,7 +6671,7 @@
         "notation": "そうしたら"
     },
     {
-        "name": "smart",
+        "name": "suma-to",
         "trans": [
             "② ナ形  漂亮的；苗条的；潇洒的"
         ],
@@ -6692,7 +6692,7 @@
         "notation": "尊重(そんちょう)"
     },
     {
-        "name": "dryer",
+        "name": "doraiya-",
         "trans": [
             "⓪ 名  吹风机；干燥剂"
         ],
@@ -6713,7 +6713,7 @@
         "notation": "迷子(まいご)"
     },
     {
-        "name": "drama",
+        "name": "dorama",
         "trans": [
             "① 名  电视剧；戏剧"
         ],
@@ -6783,7 +6783,7 @@
         "notation": "仲直(なかなお)り"
     },
     {
-        "name": "window",
+        "name": "windo-",
         "trans": [
             "① 名  窗户；（电脑）窗口"
         ],
@@ -6860,7 +6860,7 @@
         "notation": "地元(じもと)"
     },
     {
-        "name": "woman",
+        "name": "u-man",
         "trans": [
             "① 名  妇女，女性"
         ],
@@ -7021,7 +7021,7 @@
         "notation": "本人(ほんにん)"
     },
     {
-        "name": "microphone",
+        "name": "maikorohon",
         "trans": [
             "④ 名  麦克风"
         ],
@@ -7063,14 +7063,14 @@
         "notation": "正直(しょうじき)"
     },
     {
-        "name": "internet",
+        "name": "inta-netto",
         "trans": [
             "⑤ 名  互联网"
         ],
         "notation": "インターネット"
     },
     {
-        "name": "guard",
+        "name": "ga-do",
         "trans": [
             "① 名  警卫；防卫"
         ],
@@ -7098,14 +7098,14 @@
         "notation": "勤務(きんむ)"
     },
     {
-        "name": "cashmere",
+        "name": "kashimiya",
         "trans": [
             "⓪ 名  山羊绒"
         ],
         "notation": "カシミヤ"
     },
     {
-        "name": "truck",
+        "name": "torakku",
         "trans": [
             "② 名  卡车"
         ],
@@ -7147,7 +7147,7 @@
         "notation": "順延(じゅんえん)"
     },
     {
-        "name": "Christmas",
+        "name": "kurisumasu",
         "trans": [
             "③ 名  圣诞节"
         ],
@@ -7224,7 +7224,7 @@
         "notation": "力強(ちからづよ)い"
     },
     {
-        "name": "chime",
+        "name": "chaimu",
         "trans": [
             "① 名  门铃；编钟"
         ],
@@ -7238,7 +7238,7 @@
         "notation": "ふざける"
     },
     {
-        "name": "instant",
+        "name": "insutanto",
         "trans": [
             " 接头  速成，速食"
         ],
@@ -7343,7 +7343,7 @@
         "notation": "何(なん)とか"
     },
     {
-        "name": "dessert",
+        "name": "deza-to",
         "trans": [
             "② 名  甜点"
         ],
@@ -7378,14 +7378,14 @@
         "notation": "長所(ちょうしょ)"
     },
     {
-        "name": "树木、建筑物",
+        "name": "yusayusa",
         "trans": [
             "① 副·自动3  （树木、建筑物）大幅度摇晃"
         ],
         "notation": "ゆさゆさ"
     },
     {
-        "name": "cement",
+        "name": "semento",
         "trans": [
             "⓪ 名  水泥"
         ],
@@ -7483,7 +7483,7 @@
         "notation": "平気(へいき)"
     },
     {
-        "name": "program",
+        "name": "puroguramu",
         "trans": [
             "③ 名  计划，进程；程序"
         ],
@@ -7504,7 +7504,7 @@
         "notation": "描(えが)く"
     },
     {
-        "name": "ping-pong",
+        "name": "pinpon",
         "trans": [
             "① 名  乒乓球"
         ],
@@ -7588,7 +7588,7 @@
         "notation": "日本酒(にほんしゅ)"
     },
     {
-        "name": "情况",
+        "name": "nadaraka",
         "trans": [
             "② ナ形  坡度小的，平稳的；（情况）顺利的"
         ],
@@ -7679,14 +7679,14 @@
         "notation": "絞(しぼ)る"
     },
     {
-        "name": "gray",
+        "name": "gure-",
         "trans": [
             "② 名  灰色"
         ],
         "notation": "グレー"
     },
     {
-        "name": "chalk",
+        "name": "cho-ku",
         "trans": [
             "① 名  粉笔"
         ],
@@ -7770,21 +7770,21 @@
         "notation": "お盆(ぼん)"
     },
     {
-        "name": "mouse",
+        "name": "mausu",
         "trans": [
             "① 名  老鼠；鼠标"
         ],
         "notation": "マウス"
     },
     {
-        "name": "～tarazu",
+        "name": "~tarazu",
         "trans": [
             " 接尾  ⋯⋯不足"
         ],
         "notation": "～足(た)らず"
     },
     {
-        "name": "control",
+        "name": "kontoro-ru",
         "trans": [
             "④ 名·他动3  控制，管理"
         ],
@@ -7798,7 +7798,7 @@
         "notation": "快適(かいてき)"
     },
     {
-        "name": "style",
+        "name": "sutairu",
         "trans": [
             "② 名  样式，形式；（人的）姿势，风采"
         ],
@@ -7819,7 +7819,7 @@
         "notation": "年代(ねんだい)"
     },
     {
-        "name": "～kaeru",
+        "name": "~kaeru",
         "trans": [
             " 接尾  改⋯⋯，换⋯⋯"
         ],
@@ -7910,7 +7910,7 @@
         "notation": "日差(ひざ)し"
     },
     {
-        "name": "ferry",
+        "name": "feri-",
         "trans": [
             "① 名  渡口；渡船"
         ],
@@ -8008,7 +8008,7 @@
         "notation": "何(なに)しろ"
     },
     {
-        "name": "volleyball",
+        "name": "bare-bo-ru",
         "trans": [
             "④ 名  排球"
         ],
@@ -8036,7 +8036,7 @@
         "notation": "かっこいい"
     },
     {
-        "name": "pipe",
+        "name": "piipu",
         "trans": [
             "⓪ 名  管子，管道"
         ],
@@ -8106,7 +8106,7 @@
         "notation": "発明(はつめい)"
     },
     {
-        "name": "coin",
+        "name": "koin",
         "trans": [
             "① 名  硬币"
         ],
@@ -8267,7 +8267,7 @@
         "notation": "秤(はかり)"
     },
     {
-        "name": "bag",
+        "name": "baggu",
         "trans": [
             "① 名  手提包"
         ],
@@ -8330,7 +8330,7 @@
         "notation": "思(おも)える"
     },
     {
-        "name": "cook",
+        "name": "kokke",
         "trans": [
             "① 名  厨师"
         ],
@@ -8351,14 +8351,14 @@
         "notation": "むずむず"
     },
     {
-        "name": "cotton",
+        "name": "kotton",
         "trans": [
             "① 名  棉花，棉布"
         ],
         "notation": "コットン"
     },
     {
-        "name": "后接否定",
+        "name": "doushitemo",
         "trans": [
             "④ 副  （后接否定）怎么也（不）⋯⋯；务必，一定"
         ],
@@ -8372,7 +8372,7 @@
         "notation": "早寝早起(はやねはやお)き"
     },
     {
-        "name": "dress",
+        "name": "doresu",
         "trans": [
             "① 名  女士礼服"
         ],
@@ -8547,7 +8547,7 @@
         "notation": "反抗(はんこう)"
     },
     {
-        "name": "science",
+        "name": "saiensu",
         "trans": [
             "① 名  科学"
         ],
@@ -8603,7 +8603,7 @@
         "notation": "犯罪(はんざい)"
     },
     {
-        "name": "star",
+        "name": "suta-",
         "trans": [
             "② 名  星星；明星"
         ],
@@ -8631,7 +8631,7 @@
         "notation": "地域(ちいき)"
     },
     {
-        "name": "brake",
+        "name": "bure-ki",
         "trans": [
             "② 名  刹车，制动器；阻碍"
         ],
@@ -8652,7 +8652,7 @@
         "notation": "破(やぶ)く"
     },
     {
-        "name": "handbag",
+        "name": "handobaggu",
         "trans": [
             "④ 名  （女用）手提包"
         ],
@@ -8680,7 +8680,7 @@
         "notation": "少年(しょうねん)"
     },
     {
-        "name": "烤得",
+        "name": "kongari",
         "trans": [
             "③ 副·自动3  （烤得）恰到好处"
         ],
@@ -8722,14 +8722,14 @@
         "notation": "吊(つる)す"
     },
     {
-        "name": "handle",
+        "name": "handoru",
         "trans": [
             "⓪ 名  方向盘"
         ],
         "notation": "ハンドル"
     },
     {
-        "name": "earphone",
+        "name": "iyahon",
         "trans": [
             "② 名  耳机"
         ],
@@ -8834,7 +8834,7 @@
         "notation": "足音(あしおと)"
     },
     {
-        "name": "speaker",
+        "name": "subi-ka-",
         "trans": [
             "② 名  扩音器"
         ],
@@ -8883,7 +8883,7 @@
         "notation": "夢中(むちゅう)"
     },
     {
-        "name": "tent",
+        "name": "tento",
         "trans": [
             "① 名  帐篷"
         ],
@@ -8911,14 +8911,14 @@
         "notation": "終点(しゅうてん)"
     },
     {
-        "name": "sample",
+        "name": "sanpiru",
         "trans": [
             "① 名  样品，样本"
         ],
         "notation": "サンプル"
     },
     {
-        "name": "concrete",
+        "name": "konkuri-to",
         "trans": [
             "④ 名  混凝土"
         ],
@@ -8946,7 +8946,7 @@
         "notation": "一言(ひとこと)"
     },
     {
-        "name": "Spain",
+        "name": "supein",
         "trans": [
             "③ 名  西班牙"
         ],
@@ -8981,7 +8981,7 @@
         "notation": "一休(ひとやす)み"
     },
     {
-        "name": "bar",
+        "name": "ba-",
         "trans": [
             "① 名  酒吧，（西式）酒馆"
         ],
@@ -9023,14 +9023,14 @@
         "notation": "組(く)み立(た)てる"
     },
     {
-        "name": "space",
+        "name": "sube-su",
         "trans": [
             "② 名  空间；空白"
         ],
         "notation": "スペース"
     },
     {
-        "name": "～gurashi",
+        "name": "~gurashi",
         "trans": [
             " 接尾  ⋯⋯生活"
         ],
@@ -9156,7 +9156,7 @@
         "notation": "明(あき)らか"
     },
     {
-        "name": "down",
+        "name": "daun",
         "trans": [
             "① 名·自动3  下降，落下；倒下"
         ],
@@ -9212,7 +9212,7 @@
         "notation": "一人息子(ひとりむすこ)"
     },
     {
-        "name": "sheet",
+        "name": "shi-tsu",
         "trans": [
             "① 名  床单，被单"
         ],
@@ -9303,7 +9303,7 @@
         "notation": "語(かた)る"
     },
     {
-        "name": "time",
+        "name": "taimu",
         "trans": [
             "① 名  时间"
         ],
@@ -9331,7 +9331,7 @@
         "notation": "筆(ふで)"
     },
     {
-        "name": "talk",
+        "name": "to-ku",
         "trans": [
             "① 名  谈话，闲谈"
         ],
@@ -9345,7 +9345,7 @@
         "notation": "ようやく"
     },
     {
-        "name": "lion",
+        "name": "raion",
         "trans": [
             "⓪ 名  狮子"
         ],
@@ -9380,7 +9380,7 @@
         "notation": "トン"
     },
     {
-        "name": "scarf",
+        "name": "suka-fu",
         "trans": [
             "② 名  围巾，披肩"
         ],
@@ -9415,7 +9415,7 @@
         "notation": "代表(だいひょう)"
     },
     {
-        "name": "night",
+        "name": "naito",
         "trans": [
             "① 名  夜晚，晚上"
         ],
@@ -9471,7 +9471,7 @@
         "notation": "儲(もう)ける"
     },
     {
-        "name": "message",
+        "name": "messe-ji",
         "trans": [
             "① 名  消息，信息"
         ],
@@ -9660,7 +9660,7 @@
         "notation": "自家用車(じかようしゃ)"
     },
     {
-        "name": "accent",
+        "name": "akusento",
         "trans": [
             "① 名  语调，口音；重音；重点"
         ],
@@ -9681,7 +9681,7 @@
         "notation": "小数(しょうすう)"
     },
     {
-        "name": "nylon",
+        "name": "nairon",
         "trans": [
             "① 名  尼龙"
         ],
@@ -9702,7 +9702,7 @@
         "notation": "なぜならば"
     },
     {
-        "name": "knock",
+        "name": "nokku",
         "trans": [
             "① 名·自动3  敲门；敲打"
         ],
@@ -9786,7 +9786,7 @@
         "notation": "走(はし)り回(まわ)る"
     },
     {
-        "name": "file",
+        "name": "fairu",
         "trans": [
             "① 名  文件夹"
         ],
@@ -9884,7 +9884,7 @@
         "notation": "先(さき)ほど"
     },
     {
-        "name": "wool",
+        "name": "u-ru",
         "trans": [
             "① 名  羊毛，毛织品"
         ],
@@ -10038,14 +10038,14 @@
         "notation": "得意先(とくいさき)"
     },
     {
-        "name": "market",
+        "name": "ma-ketto",
         "trans": [
             "① 名  商场；（经济学）市场"
         ],
         "notation": "マーケット"
     },
     {
-        "name": "veranda",
+        "name": "beranda",
         "trans": [
             "⓪ 名  阳台"
         ],
@@ -10059,7 +10059,7 @@
         "notation": "結(むす)ぶ"
     },
     {
-        "name": "boy",
+        "name": "bo-i",
         "trans": [
             "⓪ 名  男孩；男服务员"
         ],
@@ -10094,7 +10094,7 @@
         "notation": "省(はぶ)く"
     },
     {
-        "name": "fashion",
+        "name": "fasshon",
         "trans": [
             "① 名  流行，时尚"
         ],
@@ -10150,7 +10150,7 @@
         "notation": "被害(ひがい)"
     },
     {
-        "name": "home",
+        "name": "ho-mu",
         "trans": [
             "① 名  家，家庭；疗养院"
         ],
@@ -10192,7 +10192,7 @@
         "notation": "パート"
     },
     {
-        "name": "station",
+        "name": "sute-shon",
         "trans": [
             "② 名  车站，火车站"
         ],
@@ -10360,7 +10360,7 @@
         "notation": "額(ひたい)"
     },
     {
-        "name": "apron",
+        "name": "epuron",
         "trans": [
             "① 名  围裙"
         ],
@@ -10388,7 +10388,7 @@
         "notation": "絵画(かいが)"
     },
     {
-        "name": "Hawaii",
+        "name": "hawai",
         "trans": [
             "① 名  夏威夷"
         ],
@@ -10402,7 +10402,7 @@
         "notation": "作製(さくせい)"
     },
     {
-        "name": "～sho",
+        "name": "~sho",
         "trans": [
             " 接尾  ⋯⋯书"
         ],
@@ -10444,7 +10444,7 @@
         "notation": "都内(とない)"
     },
     {
-        "name": "stress",
+        "name": "sutoresu",
         "trans": [
             "② 名  紧张，精神压力"
         ],
@@ -10504,7 +10504,7 @@
         "trans": [
             " 接尾  ⋯⋯同伴，⋯⋯伙伴"
         ],
-        "notation": "～同士(どうし)"
+        "notation": "～どうし(どうし)"
     },
     {
         "name": "kaori",
@@ -10549,7 +10549,7 @@
         "notation": "気温(きおん)"
     },
     {
-        "name": "master",
+        "name": "masuta-",
         "trans": [
             "① 名·他动3  老板；掌握，精通"
         ],
@@ -10598,7 +10598,7 @@
         "notation": "その代(か)わり"
     },
     {
-        "name": "start",
+        "name": "suta-to",
         "trans": [
             "② 名·自动3  出发点，起点；开始"
         ],
@@ -10675,7 +10675,7 @@
         "notation": "見(み)つめる"
     },
     {
-        "name": "information",
+        "name": "infome-shon",
         "trans": [
             "④ 名  信息，消息；问讯处"
         ],
@@ -10766,7 +10766,7 @@
         "notation": "飯(めし)"
     },
     {
-        "name": "pink",
+        "name": "pinku",
         "trans": [
             "① 名  粉红色"
         ],
@@ -10843,14 +10843,14 @@
         "notation": "手前(てまえ)"
     },
     {
-        "name": "film",
+        "name": "firumu",
         "trans": [
             "① 名  （相机）胶卷；影片；薄膜"
         ],
         "notation": "フィルム"
     },
     {
-        "name": "～kasho",
+        "name": "~kasho",
         "trans": [
             " 接尾  ⋯⋯处，⋯⋯的地方"
         ],
@@ -10913,7 +10913,7 @@
         "notation": "雑巾(ぞうきん)"
     },
     {
-        "name": "set",
+        "name": "setto",
         "trans": [
             "① 名·他动3  一组，一套；组装"
         ],
@@ -10934,7 +10934,7 @@
         "notation": "自習(じしゅう)"
     },
     {
-        "name": "boots",
+        "name": "bu-tsu",
         "trans": [
             "① 名  长筒靴"
         ],
@@ -10983,7 +10983,7 @@
         "notation": "不安定(ふあんてい)"
     },
     {
-        "name": "Brazil",
+        "name": "burajiru",
         "trans": [
             "⓪ 名  巴西"
         ],
@@ -11039,7 +11039,7 @@
         "notation": "三角形(さんかくけい/さんかっけい)"
     },
     {
-        "name": "seat belt",
+        "name": "shi-toberuto",
         "trans": [
             "④ 名  安全带"
         ],
@@ -11074,7 +11074,7 @@
         "notation": "頼(たの)み"
     },
     {
-        "name": "open",
+        "name": "o-pun",
         "trans": [
             "① 名·自动3  开业；开放"
         ],
@@ -11214,7 +11214,7 @@
         "notation": "中身(なかみ)"
     },
     {
-        "name": "net",
+        "name": "netto",
         "trans": [
             "① 名  网；球网"
         ],
@@ -11263,7 +11263,7 @@
         "notation": "申込者(もうしこみしゃ)"
     },
     {
-        "name": "France",
+        "name": "furansu",
         "trans": [
             "⓪ 名  法国"
         ],
@@ -11326,7 +11326,7 @@
         "notation": "形式(けいしき)"
     },
     {
-        "name": "～gou",
+        "name": "~gou",
         "trans": [
             " 接尾  （车、飞机等）号；（杂志等）号，期"
         ],
@@ -11347,7 +11347,7 @@
         "notation": "酒場(さかば)"
     },
     {
-        "name": "～saki",
+        "name": "~saki",
         "trans": [
             " 接尾  ⋯⋯地点，⋯⋯目的地"
         ],
@@ -11431,7 +11431,7 @@
         "notation": "強調(きょうちょう)"
     },
     {
-        "name": "install",
+        "name": "insuto-ru",
         "trans": [
             "④ 名·他动3  安装（计算机软件）"
         ],
@@ -11543,7 +11543,7 @@
         "notation": "宇宙(うちゅう)"
     },
     {
-        "name": "school",
+        "name": "suku-ru",
         "trans": [
             "② 名  学校"
         ],
@@ -11578,7 +11578,7 @@
         "notation": "得(う)る"
     },
     {
-        "name": "green",
+        "name": "guri-n",
         "trans": [
             "② 名  绿色；草地"
         ],
@@ -11690,7 +11690,7 @@
         "notation": "夫妻(ふさい)"
     },
     {
-        "name": "fryingpan",
+        "name": "furaipan",
         "trans": [
             "⓪ 名  平底锅，煎锅"
         ],
@@ -11718,7 +11718,7 @@
         "notation": "両方(りょうほう)"
     },
     {
-        "name": "free",
+        "name": "furi-",
         "trans": [
             "② 名·ナ形  自由；免费"
         ],
@@ -11977,7 +11977,7 @@
         "notation": "刈(か)る"
     },
     {
-        "name": "juice",
+        "name": "ju-su",
         "trans": [
             "① 名  果汁，蔬菜汁"
         ],
@@ -12110,7 +12110,7 @@
         "notation": "これほど"
     },
     {
-        "name": "sidemirror",
+        "name": "saidomira-",
         "trans": [
             "④ 名  （汽车两侧）后视镜"
         ],
@@ -12152,7 +12152,7 @@
         "notation": "満席(まんせき)"
     },
     {
-        "name": "brooch",
+        "name": "buro-chi",
         "trans": [
             "② 名  别针，胸针"
         ],
@@ -12173,7 +12173,7 @@
         "notation": "白髪(しらが)"
     },
     {
-        "name": "～jou",
+        "name": "~jou",
         "trans": [
             " 接尾  （计算榻榻米的单位）⋯⋯张"
         ],
@@ -12250,14 +12250,14 @@
         "notation": "熱(ねっ)する"
     },
     {
-        "name": "fastener",
+        "name": "fasuna-",
         "trans": [
             "① 名  拉链，拉锁"
         ],
         "notation": "ファスナー"
     },
     {
-        "name": "hall",
+        "name": "ho-ru",
         "trans": [
             "① 名  大厅，礼堂"
         ],
@@ -12432,7 +12432,7 @@
         "notation": "生地(きじ)"
     },
     {
-        "name": "cunning",
+        "name": "kanningu",
         "trans": [
             "⓪ 名·自动3  （考试）作弊"
         ],
@@ -12446,7 +12446,7 @@
         "notation": "彼氏(かれし)"
     },
     {
-        "name": "baby",
+        "name": "bebi-",
         "trans": [
             "① 名  婴儿"
         ],
@@ -12460,7 +12460,7 @@
         "notation": "餅(もち)"
     },
     {
-        "name": "humor",
+        "name": "yu-moa",
         "trans": [
             "① 名  幽默，滑稽"
         ],
@@ -12544,7 +12544,7 @@
         "notation": "便(たよ)り"
     },
     {
-        "name": "stop",
+        "name": "sutoppu",
         "trans": [
             "② 名·自他动3  停止，终止；停下"
         ],
@@ -12558,7 +12558,7 @@
         "notation": "日当(ひあ)たり"
     },
     {
-        "name": "blue",
+        "name": "buru-",
         "trans": [
             "② 名  蓝色"
         ],
@@ -12586,7 +12586,7 @@
         "notation": "礼儀(れいぎ)"
     },
     {
-        "name": "white shirt",
+        "name": "waishatsu",
         "trans": [
             "⓪ 名  男士衬衫"
         ],
@@ -12656,7 +12656,7 @@
         "notation": "くだらない"
     },
     {
-        "name": "baby car",
+        "name": "bebi-ka-",
         "trans": [
             "② 名  婴儿车"
         ],
@@ -12698,7 +12698,7 @@
         "notation": "無(な)し"
     },
     {
-        "name": "～dukai",
+        "name": "~dukai",
         "trans": [
             " 接尾  ⋯⋯用；⋯⋯用法；用⋯⋯的人"
         ],
@@ -12719,7 +12719,7 @@
         "notation": "無効(むこう)"
     },
     {
-        "name": "homestay",
+        "name": "ho-musutei",
         "trans": [
             "⑤ 名  （留学）寄宿家庭"
         ],
@@ -12831,7 +12831,7 @@
         "notation": "苦(くる)しむ"
     },
     {
-        "name": "auction",
+        "name": "o-kushon",
         "trans": [
             "① 名  拍卖"
         ],
@@ -12866,7 +12866,7 @@
         "notation": "振(ふ)る舞(ま)う"
     },
     {
-        "name": "modern",
+        "name": "moden",
         "trans": [
             "⓪ ナ形  现代的；流行的"
         ],
@@ -12887,7 +12887,7 @@
         "notation": "わざわざ"
     },
     {
-        "name": "level",
+        "name": "reburu",
         "trans": [
             "① 名  水平，水准"
         ],
@@ -12915,7 +12915,7 @@
         "notation": "返信(へんしん)"
     },
     {
-        "name": "～houdai",
+        "name": "~houdai",
         "trans": [
             " 接尾  自由地⋯⋯，随便地⋯⋯"
         ],
@@ -12943,7 +12943,7 @@
         "notation": "裸(はだか)"
     },
     {
-        "name": "light",
+        "name": "raito",
         "trans": [
             "① 名  灯光；轻的"
         ],
@@ -12978,7 +12978,7 @@
         "notation": "方々(かたがた)"
     },
     {
-        "name": "yacht",
+        "name": "yotto",
         "trans": [
             "① 名  游艇；帆船"
         ],
@@ -12992,7 +12992,7 @@
         "notation": "課長(かちょう)"
     },
     {
-        "name": "life",
+        "name": "raifu",
         "trans": [
             "① 名  生活，生命，人生"
         ],
@@ -13041,7 +13041,7 @@
         "notation": "入(はい)り込(こ)む"
     },
     {
-        "name": "helicopter",
+        "name": "herikoputa-",
         "trans": [
             "③ 名  直升机"
         ],
@@ -13055,7 +13055,7 @@
         "notation": "まったく"
     },
     {
-        "name": "Miss",
+        "name": "misu",
         "trans": [
             "① 名  （对未婚女性的称呼）小姐"
         ],
@@ -13090,7 +13090,7 @@
         "notation": "四(よ)つ角(かど)"
     },
     {
-        "name": "rent-a-car",
+        "name": "rentaka-",
         "trans": [
             "③ 名  租赁汽车"
         ],
@@ -13125,7 +13125,7 @@
         "notation": "変換(へんかん)"
     },
     {
-        "name": "list",
+        "name": "risuto",
         "trans": [
             "① 名  目录；名单；一览表"
         ],
@@ -13181,7 +13181,7 @@
         "notation": "現代(げんだい)"
     },
     {
-        "name": "credit card",
+        "name": "kurejittoka-do",
         "trans": [
             "⑥ 名  信用卡"
         ],
@@ -13202,21 +13202,21 @@
         "notation": "針(はり)"
     },
     {
-        "name": "ribbon",
+        "name": "ribon",
         "trans": [
             "① 名  丝带，缎带"
         ],
         "notation": "リボン"
     },
     {
-        "name": "robot",
+        "name": "robotto",
         "trans": [
             "① 名  机器人"
         ],
         "notation": "ロボット"
     },
     {
-        "name": "rule",
+        "name": "ru-ru",
         "trans": [
             "① 名  规则，章程"
         ],
@@ -13230,7 +13230,7 @@
         "notation": "横切(よこぎ)る"
     },
     {
-        "name": "～muke",
+        "name": "~muke",
         "trans": [
             " 接尾  面向，以⋯⋯为对象"
         ],
@@ -13251,7 +13251,7 @@
         "notation": "補講(ほこう)"
     },
     {
-        "name": "reporter",
+        "name": "repo-ta-",
         "trans": [
             "⓪ 名  报告人；记者"
         ],
@@ -13265,7 +13265,7 @@
         "notation": "距離(きょり)"
     },
     {
-        "name": "lemon",
+        "name": "remon",
         "trans": [
             "① 名  柠檬"
         ],
@@ -13433,14 +13433,14 @@
         "notation": "勘定(かんじょう)"
     },
     {
-        "name": "racket",
+        "name": "raketto",
         "trans": [
             "② 名  球拍"
         ],
         "notation": "ラケット"
     },
     {
-        "name": "table",
+        "name": "te-buru",
         "trans": [
             "⓪ 名  饭桌，桌子"
         ],
@@ -13524,7 +13524,7 @@
         "notation": "急速(きゅうそく)"
     },
     {
-        "name": "颜色",
+        "name": "ussuri",
         "trans": [
             "③ 副  （颜色）淡淡地；（厚度）薄薄地"
         ],
@@ -13552,7 +13552,7 @@
         "notation": "踏(ふ)み切(き)り"
     },
     {
-        "name": "催促或安慰",
+        "name": "maamaa",
         "trans": [
             "③ 叹·副  （催促或安慰）好了好了，行了；大致，还算"
         ],
@@ -13594,7 +13594,7 @@
         "notation": "取(と)り出(だ)す"
     },
     {
-        "name": "咕噜咕噜响",
+        "name": "gabugabu",
         "trans": [
             "① 副·自动3  咕咚咕咚地喝水；胃里液体多（咕噜咕噜响）"
         ],
@@ -13615,7 +13615,7 @@
         "notation": "ごそごそ"
     },
     {
-        "name": "lunch",
+        "name": "ranchi",
         "trans": [
             "① 名  午餐"
         ],
@@ -13629,7 +13629,7 @@
         "notation": "予算(よさん)"
     },
     {
-        "name": "rocket",
+        "name": "roketto",
         "trans": [
             "② 名  火箭"
         ],
@@ -13657,7 +13657,7 @@
         "notation": "真(ま)っ暗(くら)"
     },
     {
-        "name": "～busoku",
+        "name": "~busoku",
         "trans": [
             " 接尾  ⋯⋯不足，⋯⋯不够"
         ],
@@ -13685,7 +13685,7 @@
         "notation": "保存(ほぞん)"
     },
     {
-        "name": "save",
+        "name": "sa-bu",
         "trans": [
             "① 名·他动3  救，搭救；保留（力量）；储蓄，节约"
         ],
@@ -13713,7 +13713,7 @@
         "notation": "引(ひ)き分(わ)け"
     },
     {
-        "name": "～naosu",
+        "name": "~naosu",
         "trans": [
             " 接尾  重新⋯⋯"
         ],

--- a/public/dicts/Jap_High-Frequency_N4N5.json
+++ b/public/dicts/Jap_High-Frequency_N4N5.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "ice cream",
+        "name": "aisukuri-mu",
         "trans": [
             "⑤ 名  冰激凌"
         ],
@@ -56,7 +56,7 @@
         "notation": "病気(びょうき)"
     },
     {
-        "name": "mail",
+        "name": "me-ru",
         "trans": [
             "① 名  邮件"
         ],
@@ -84,14 +84,14 @@
         "notation": "楽(たの)しい"
     },
     {
-        "name": "不",
+        "name": "amari",
         "trans": [
             "⓪ 副·ナ形  （不）太，（不）怎么样；过分"
         ],
         "notation": "あまり"
     },
     {
-        "name": "report",
+        "name": "repo-to",
         "trans": [
             "② 名·他动3  报告；报道"
         ],
@@ -154,7 +154,7 @@
         "notation": "似(に)る"
     },
     {
-        "name": "skirt",
+        "name": "suka-to",
         "trans": [
             "② 名  裙子"
         ],
@@ -196,7 +196,7 @@
         "notation": "留学(りゅうがく)"
     },
     {
-        "name": "action",
+        "name": "akujon",
         "trans": [
             "① 名  动作"
         ],
@@ -273,7 +273,7 @@
         "notation": "無事(ぶじ)"
     },
     {
-        "name": "project",
+        "name": "purojekuto",
         "trans": [
             "② 名  课题，项目"
         ],
@@ -532,7 +532,7 @@
         "notation": "売(う)り場(ば)"
     },
     {
-        "name": "儿",
+        "name": "chotto",
         "trans": [
             "① 副  稍微，一点（儿）"
         ],
@@ -560,7 +560,7 @@
         "notation": "旅行(りょこう)"
     },
     {
-        "name": "elevator",
+        "name": "erebe-ta-",
         "trans": [
             "③ 名  升降电梯，直梯"
         ],
@@ -581,7 +581,7 @@
         "notation": "丈夫(じょうぶ)"
     },
     {
-        "name": "internet",
+        "name": "inta-netto",
         "trans": [
             "⑤ 名  因特网"
         ],
@@ -679,7 +679,7 @@
         "notation": "エアコン"
     },
     {
-        "name": "simple",
+        "name": "shinpuru",
         "trans": [
             "① ナ形  简单的，单纯的；质朴的"
         ],
@@ -812,7 +812,7 @@
         "notation": "止(と)まる"
     },
     {
-        "name": "cake",
+        "name": "ke-ki",
         "trans": [
             "① 名  蛋糕"
         ],
@@ -987,7 +987,7 @@
         "notation": "押(お)す"
     },
     {
-        "name": "towel",
+        "name": "taoru",
         "trans": [
             "① 名  毛巾"
         ],
@@ -1036,7 +1036,7 @@
         "notation": "中学校(ちゅうがっこう)"
     },
     {
-        "name": "skate",
+        "name": "suke-to",
         "trans": [
             "⓪ 名·自动3  滑冰"
         ],
@@ -1050,7 +1050,7 @@
         "notation": "重(おも)い"
     },
     {
-        "name": "sneaker",
+        "name": "suni-ka-",
         "trans": [
             "⓪ 名  运动鞋"
         ],
@@ -1344,7 +1344,7 @@
         "notation": "同(おな)じ"
     },
     {
-        "name": "knife",
+        "name": "naifu",
         "trans": [
             "① 名  小刀，餐刀"
         ],
@@ -1386,7 +1386,7 @@
         "notation": "待(ま)つ"
     },
     {
-        "name": "cola",
+        "name": "ko-ra",
         "trans": [
             "① 名  可乐"
         ],
@@ -1400,7 +1400,7 @@
         "notation": "喫茶店(きっさてん)"
     },
     {
-        "name": "sports",
+        "name": "supo-tsu",
         "trans": [
             "② 名  运动"
         ],
@@ -1561,7 +1561,7 @@
         "notation": "習(なら)う"
     },
     {
-        "name": "sale",
+        "name": "se-ru",
         "trans": [
             "① 名  促销，大减价"
         ],
@@ -1624,7 +1624,7 @@
         "notation": "被(かぶ)る"
     },
     {
-        "name": "yes",
+        "name": "iesu",
         "trans": [
             "② 叹  是，对"
         ],
@@ -1659,7 +1659,7 @@
         "notation": "外国(がいこく)"
     },
     {
-        "name": "memory",
+        "name": "memori-",
         "trans": [
             "① 名  记忆；存储（卡）"
         ],
@@ -1701,7 +1701,7 @@
         "notation": "駅前(えきまえ)"
     },
     {
-        "name": "text",
+        "name": "tekisuto",
         "trans": [
             "① 名  课本，教科书"
         ],
@@ -1764,7 +1764,7 @@
         "notation": "取引(とりひき)"
     },
     {
-        "name": "camera",
+        "name": "kamera",
         "trans": [
             "① 名  照相机"
         ],
@@ -1806,7 +1806,7 @@
         "notation": "秘密(ひみつ)"
     },
     {
-        "name": "barbecue",
+        "name": "ba-bekyu-",
         "trans": [
             "③ 名  烧烤"
         ],
@@ -1855,7 +1855,7 @@
         "notation": "企画(きかく)"
     },
     {
-        "name": "pocket",
+        "name": "poketto",
         "trans": [
             "② 名  口袋"
         ],
@@ -1904,7 +1904,7 @@
         "notation": "だから"
     },
     {
-        "name": "test",
+        "name": "tesuto",
         "trans": [
             "① 名  测验，考试"
         ],
@@ -1918,7 +1918,7 @@
         "notation": "期限(きげん)"
     },
     {
-        "name": "handsome",
+        "name": "hansamu",
         "trans": [
             "① ナ形  英俊的，潇洒的"
         ],
@@ -1953,7 +1953,7 @@
         "notation": "観客(かんきゃく)"
     },
     {
-        "name": "～hiki",
+        "name": "~hiki",
         "trans": [
             " 接尾  （鸟、鱼、虫等小动物）只，条"
         ],
@@ -1988,7 +1988,7 @@
         "notation": "聞(き)く"
     },
     {
-        "name": "tennis",
+        "name": "tenisu",
         "trans": [
             "① 名  网球"
         ],
@@ -2037,14 +2037,14 @@
         "notation": "切符(きっぷ)"
     },
     {
-        "name": "chuu",
+        "name": "~chuu",
         "trans": [
             " 接尾  正在……"
         ],
         "notation": "～中(ちゅう)"
     },
     {
-        "name": "band",
+        "name": "bando",
         "trans": [
             "⓪ 名  乐队；腰带，皮带"
         ],
@@ -2177,7 +2177,7 @@
         "notation": "八百屋(やおや)"
     },
     {
-        "name": "necktie",
+        "name": "nekutai",
         "trans": [
             "① 名  领带"
         ],
@@ -2247,7 +2247,7 @@
         "notation": "七(なな)つ"
     },
     {
-        "name": "kitchen",
+        "name": "kicchin",
         "trans": [
             "① 名  厨房"
         ],
@@ -2352,7 +2352,7 @@
         "notation": "曇(くも)る"
     },
     {
-        "name": "guitar",
+        "name": "gita-",
         "trans": [
             "① 名  吉他"
         ],
@@ -2394,7 +2394,7 @@
         "notation": "教師(きょうし)"
     },
     {
-        "name": "butter",
+        "name": "bata-",
         "trans": [
             "① 名  黄油"
         ],
@@ -2548,7 +2548,7 @@
         "notation": "毎週(まいしゅう)"
     },
     {
-        "name": "pilot",
+        "name": "pairotto",
         "trans": [
             "③ 名  飞行员"
         ],
@@ -2569,7 +2569,7 @@
         "notation": "話(はな)す"
     },
     {
-        "name": "植物、没有生命的物体",
+        "name": "aru",
         "trans": [
             "① 自动1  （植物、没有生命的物体）有；存在"
         ],
@@ -2590,7 +2590,7 @@
         "notation": "高校生(こうこうせい)"
     },
     {
-        "name": "corner",
+        "name": "ko-na-",
         "trans": [
             "① 名  角落；柜台"
         ],
@@ -2681,7 +2681,7 @@
         "notation": "警察(けいさつ)"
     },
     {
-        "name": "speech",
+        "name": "supe-chi",
         "trans": [
             "② 名  演讲，致辞"
         ],
@@ -2716,7 +2716,7 @@
         "notation": "地図(ちず)"
     },
     {
-        "name": "jogging",
+        "name": "jogingu",
         "trans": [
             "⓪ 名·自动3  慢跑"
         ],
@@ -2765,7 +2765,7 @@
         "notation": "仲間(なかま)"
     },
     {
-        "name": "passport",
+        "name": "pasupo-to",
         "trans": [
             "③ 名  护照"
         ],
@@ -2786,14 +2786,14 @@
         "notation": "登(のぼ)る"
     },
     {
-        "name": "register",
+        "name": "reji/rejisuta-",
         "trans": [
             "① 名  收款台；收银员"
         ],
         "notation": "レジ/レジスター"
     },
     {
-        "name": "page",
+        "name": "pe-ji",
         "trans": [
             "⓪ 名  页，页数"
         ],
@@ -2807,7 +2807,7 @@
         "notation": "生徒(せいと)"
     },
     {
-        "name": "pamphlet",
+        "name": "panfuretto",
         "trans": [
             "① 名  小册子"
         ],
@@ -2905,7 +2905,7 @@
         "notation": "半分(はんぶん)"
     },
     {
-        "name": "season",
+        "name": "shi-zun",
         "trans": [
             "① 名  季节；旺季"
         ],
@@ -2933,7 +2933,7 @@
         "notation": "金(きん)"
     },
     {
-        "name": "course",
+        "name": "ko-su",
         "trans": [
             "① 名  路线；课程"
         ],
@@ -2968,7 +2968,7 @@
         "notation": "畳(たたみ)"
     },
     {
-        "name": "poster",
+        "name": "posuta-",
         "trans": [
             "① 名  海报，宣传画"
         ],
@@ -2996,7 +2996,7 @@
         "notation": "国(くに)"
     },
     {
-        "name": "bonus",
+        "name": "bo-nasu",
         "trans": [
             "① 名  奖金，额外津贴"
         ],
@@ -3038,7 +3038,7 @@
         "notation": "結婚(けっこん)"
     },
     {
-        "name": "badminton",
+        "name": "badominton",
         "trans": [
             "③ 名  羽毛球"
         ],
@@ -3073,7 +3073,7 @@
         "notation": "車(くるま)"
     },
     {
-        "name": "sandwich",
+        "name": "sandoicchi",
         "trans": [
             "④ 名  三明治"
         ],
@@ -3108,7 +3108,7 @@
         "notation": "航空便(こうくうびん)"
     },
     {
-        "name": "fax",
+        "name": "fakkusu",
         "trans": [
             "① 名  传真"
         ],
@@ -3129,7 +3129,7 @@
         "notation": "今度(こんど)"
     },
     {
-        "name": "tape",
+        "name": "te-pu",
         "trans": [
             "① 名  磁带，录音带"
         ],
@@ -3213,7 +3213,7 @@
         "notation": "晴(は)れる"
     },
     {
-        "name": "satsu",
+        "name": "~satsu",
         "trans": [
             " 接尾  （书、本等）册，本"
         ],
@@ -3227,14 +3227,14 @@
         "notation": "塩(しお)"
     },
     {
-        "name": "class",
+        "name": "kurasu",
         "trans": [
             "① 名  班级；等级"
         ],
         "notation": "クラス"
     },
     {
-        "name": "match",
+        "name": "macchi",
         "trans": [
             "① 名·自动3  火柴；相称"
         ],
@@ -3255,7 +3255,7 @@
         "notation": "全部(ぜんぶ)"
     },
     {
-        "name": "hotel",
+        "name": "hoteru",
         "trans": [
             "① 名  （西式）宾馆，酒店"
         ],
@@ -3276,7 +3276,7 @@
         "notation": "神社(じんじゃ)"
     },
     {
-        "name": "brand",
+        "name": "burando",
         "trans": [
             "⓪ 名  商标，品牌"
         ],
@@ -3297,7 +3297,7 @@
         "notation": "前(まえ)"
     },
     {
-        "name": "coat",
+        "name": "ko-to",
         "trans": [
             "① 名  大衣，外套"
         ],
@@ -3353,7 +3353,7 @@
         "notation": "紅葉(もみじ)"
     },
     {
-        "name": "copy",
+        "name": "kopi-",
         "trans": [
             "① 名·他动3  复印"
         ],
@@ -3381,7 +3381,7 @@
         "notation": "二人(ふたり)"
     },
     {
-        "name": "manner",
+        "name": "mana-",
         "trans": [
             "① 名  礼节，规矩；礼貌"
         ],
@@ -3402,7 +3402,7 @@
         "notation": "荷物(にもつ)"
     },
     {
-        "name": "goal",
+        "name": "go-ru",
         "trans": [
             "① 名  终点；目标"
         ],
@@ -3423,7 +3423,7 @@
         "notation": "交番(こうばん)"
     },
     {
-        "name": "pet",
+        "name": "petto",
         "trans": [
             "① 名  宠物"
         ],
@@ -3465,7 +3465,7 @@
         "notation": "原稿(げんこう)"
     },
     {
-        "name": "boat",
+        "name": "bo-to",
         "trans": [
             "① 名  小船，船"
         ],
@@ -3493,7 +3493,7 @@
         "notation": "火曜日(かようび)"
     },
     {
-        "name": "radio",
+        "name": "rajio",
         "trans": [
             "① 名  收音机，广播"
         ],
@@ -3507,7 +3507,7 @@
         "notation": "切手(きって)"
     },
     {
-        "name": "level",
+        "name": "reberu",
         "trans": [
             "① 名  水准，水平"
         ],
@@ -3542,7 +3542,7 @@
         "notation": "電話(でんわ)"
     },
     {
-        "name": "computer",
+        "name": "konpyu-ta-",
         "trans": [
             "③ 名  电脑，计算机"
         ],
@@ -3556,7 +3556,7 @@
         "notation": "論文(ろんぶん)"
     },
     {
-        "name": "sai",
+        "name": "~toshi",
         "trans": [
             " 接尾  ……岁"
         ],
@@ -3598,7 +3598,7 @@
         "notation": "声(こえ)"
     },
     {
-        "name": "member",
+        "name": "menba-",
         "trans": [
             "① 名  成员"
         ],
@@ -3626,7 +3626,7 @@
         "notation": "玄関(げんかん)"
     },
     {
-        "name": "diving",
+        "name": "daibingu",
         "trans": [
             "① 名·自动3  潜水"
         ],
@@ -3654,7 +3654,7 @@
         "notation": "美容院(びよういん)"
     },
     {
-        "name": "button",
+        "name": "botan",
         "trans": [
             "⓪ 名  纽扣；按钮"
         ],
@@ -3682,7 +3682,7 @@
         "notation": "最後(さいご)"
     },
     {
-        "name": "mark",
+        "name": "ma-ku",
         "trans": [
             "① 名·他动3  标记；做标记"
         ],
@@ -3707,10 +3707,10 @@
         "trans": [
             "⓪ 名  其他"
         ],
-        "notation": "他(た)"
+        "notation": "他(ほか)"
     },
     {
-        "name": "point",
+        "name": "pointo",
         "trans": [
             "⓪ 名  积分；要点"
         ],
@@ -3745,7 +3745,7 @@
         "notation": "今月(こんげつ)"
     },
     {
-        "name": "bed",
+        "name": "beddo",
         "trans": [
             "① 名  床"
         ],
@@ -3766,7 +3766,7 @@
         "notation": "雑誌(ざっし)"
     },
     {
-        "name": "chance",
+        "name": "chansu",
         "trans": [
             "① 名  机会"
         ],
@@ -3787,7 +3787,7 @@
         "notation": "洗濯(せんたく)"
     },
     {
-        "name": "silk",
+        "name": "shiruku",
         "trans": [
             "① 名  丝绸"
         ],
@@ -3815,7 +3815,7 @@
         "notation": "見送(みおく)り"
     },
     {
-        "name": "set",
+        "name": "setto",
         "trans": [
             "① 名  一套，一组"
         ],
@@ -3836,7 +3836,7 @@
         "notation": "鳥(とり)"
     },
     {
-        "name": "～ya",
+        "name": "~ya",
         "trans": [
             " 接尾  ……店；容易……的人"
         ],
@@ -3850,7 +3850,7 @@
         "notation": "大使(たいし)"
     },
     {
-        "name": "homesick",
+        "name": "ho-mushikku",
         "trans": [
             "④ 名  思乡"
         ],
@@ -3871,7 +3871,7 @@
         "notation": "窓(まど)"
     },
     {
-        "name": "spoon",
+        "name": "supu-n",
         "trans": [
             "② 名  汤匙，勺子"
         ],
@@ -3906,7 +3906,7 @@
         "notation": "新幹線(しんかんせん)"
     },
     {
-        "name": "horror",
+        "name": "hora-",
         "trans": [
             "① 名  恐怖"
         ],
@@ -3948,7 +3948,7 @@
         "notation": "石(せっ)けん"
     },
     {
-        "name": "～mai",
+        "name": "~mai",
         "trans": [
             " 接尾  （薄片状物体）片，枚，张"
         ],
@@ -4270,7 +4270,7 @@
         "notation": "ごみ"
     },
     {
-        "name": "ka",
+        "name": "~ka",
         "trans": [
             " 接尾  （某种职业）……家"
         ],
@@ -4291,7 +4291,7 @@
         "notation": "品質(ひんしつ)"
     },
     {
-        "name": "wine",
+        "name": "wain",
         "trans": [
             "① 名  葡萄酒"
         ],
@@ -4375,7 +4375,7 @@
         "notation": "帽子(ぼうし)"
     },
     {
-        "name": "curtain",
+        "name": "ka-ten",
         "trans": [
             "① 名  窗帘"
         ],
@@ -4613,7 +4613,7 @@
         "notation": "水曜日(すいようび)"
     },
     {
-        "name": "club",
+        "name": "kurabu",
         "trans": [
             "① 名  俱乐部"
         ],
@@ -4669,7 +4669,7 @@
         "notation": "復習(ふくしゅう)"
     },
     {
-        "name": "cream",
+        "name": "kuri-mu",
         "trans": [
             "② 名  奶油；乳，霜"
         ],
@@ -4767,7 +4767,7 @@
         "notation": "移(うつ)る"
     },
     {
-        "name": "cabbage",
+        "name": "kyabetsu",
         "trans": [
             "① 名  圆白菜，卷心菜"
         ],
@@ -4809,7 +4809,7 @@
         "notation": "超(こ)える"
     },
     {
-        "name": "curry",
+        "name": "kare-",
         "trans": [
             "⓪ 名  咖喱"
         ],
@@ -4830,14 +4830,14 @@
         "notation": "どうやって"
     },
     {
-        "name": "gas",
+        "name": "gasu",
         "trans": [
             "① 名  气体；煤气"
         ],
         "notation": "ガス"
     },
     {
-        "name": "image",
+        "name": "ime-ji",
         "trans": [
             "② 名  印象，形象"
         ],
@@ -4872,14 +4872,14 @@
         "notation": "たまに"
     },
     {
-        "name": "～go",
+        "name": "~go",
         "trans": [
             " 接尾  ……之后"
         ],
         "notation": "～後(ご)"
     },
     {
-        "name": "address",
+        "name": "adoresu",
         "trans": [
             "① 名  地址，住址"
         ],
@@ -4921,7 +4921,7 @@
         "notation": "感(かん)じる"
     },
     {
-        "name": "Olympic",
+        "name": "orinpikku",
         "trans": [
             "④ 名  奥运会，奥林匹克"
         ],
@@ -4963,7 +4963,7 @@
         "notation": "台風(たいふう)"
     },
     {
-        "name": "ball",
+        "name": "bo-ru",
         "trans": [
             "⓪ 名  球"
         ],
@@ -5026,7 +5026,7 @@
         "notation": "そこで"
     },
     {
-        "name": "catalog",
+        "name": "katarogu",
         "trans": [
             "⓪ 名  商品目录"
         ],
@@ -5040,7 +5040,7 @@
         "notation": "或(あ)る"
     },
     {
-        "name": "cup",
+        "name": "kappu",
         "trans": [
             "① 名  杯子"
         ],
@@ -5054,7 +5054,7 @@
         "notation": "梨(なし)"
     },
     {
-        "name": "date",
+        "name": "de-to",
         "trans": [
             "① 名·自动3  约会"
         ],
@@ -5082,7 +5082,7 @@
         "notation": "金曜日(きんようび)"
     },
     {
-        "name": "alarm",
+        "name": "ara-mu",
         "trans": [
             "② 名  闹钟；警报"
         ],
@@ -5096,7 +5096,7 @@
         "notation": "載(の)せる"
     },
     {
-        "name": "twin room",
+        "name": "tsuinru-mu",
         "trans": [
             "④ 名  双人间"
         ],
@@ -5173,7 +5173,7 @@
         "notation": "専門(せんもん)"
     },
     {
-        "name": "bargain",
+        "name": "ba-gen",
         "trans": [
             "① 名  特价品；大减价"
         ],
@@ -5208,7 +5208,7 @@
         "notation": "恥(は)ずかしい"
     },
     {
-        "name": "gasoline",
+        "name": "gasorin",
         "trans": [
             "⓪ 名  汽油"
         ],
@@ -5222,7 +5222,7 @@
         "notation": "医学(いがく)"
     },
     {
-        "name": "～sei",
+        "name": "~sei",
         "trans": [
             "⓪ 接尾  （表示产地）……制造"
         ],
@@ -5243,7 +5243,7 @@
         "notation": "指(さ)す"
     },
     {
-        "name": "cookie",
+        "name": "kukki-",
         "trans": [
             "① 名  曲奇饼干"
         ],
@@ -5271,7 +5271,7 @@
         "notation": "竹(たけ)"
     },
     {
-        "name": "bell",
+        "name": "beru",
         "trans": [
             "① 名  铃，电铃"
         ],
@@ -5313,7 +5313,7 @@
         "notation": "贈(おく)る"
     },
     {
-        "name": "violin",
+        "name": "baiorin",
         "trans": [
             "⓪ 名  小提琴"
         ],
@@ -5341,7 +5341,7 @@
         "notation": "政治(せいじ)"
     },
     {
-        "name": "salad",
+        "name": "saragu",
         "trans": [
             "① 名  沙拉"
         ],
@@ -5411,7 +5411,7 @@
         "notation": "主任(しゅにん)"
     },
     {
-        "name": "soccer",
+        "name": "sakka-",
         "trans": [
             "① 名  足球"
         ],
@@ -5453,7 +5453,7 @@
         "notation": "増(ふ)える"
     },
     {
-        "name": "tire",
+        "name": "taiya",
         "trans": [
             "⓪ 名  轮胎"
         ],
@@ -5509,7 +5509,7 @@
         "notation": "安全(あんぜん)"
     },
     {
-        "name": "转换话题",
+        "name": "tokorode",
         "trans": [
             "③ 接续  （转换话题）话说，不过"
         ],
@@ -5530,7 +5530,7 @@
         "notation": "単位(たんい)"
     },
     {
-        "name": "～shiki",
+        "name": "~shiki",
         "trans": [
             " 接尾  ……仪式；……类型"
         ],
@@ -5551,7 +5551,7 @@
         "notation": "講堂(こうどう)"
     },
     {
-        "name": "dressing",
+        "name": "doresshingu",
         "trans": [
             "② 名  调味汁，调味酱"
         ],
@@ -5572,7 +5572,7 @@
         "notation": "菊(きく)"
     },
     {
-        "name": "oil",
+        "name": "oiru",
         "trans": [
             "① 名  油；石油"
         ],
@@ -5621,7 +5621,7 @@
         "notation": "決(き)まる"
     },
     {
-        "name": "chocolate",
+        "name": "chokore-to",
         "trans": [
             "③ 名  巧克力"
         ],
@@ -5656,7 +5656,7 @@
         "notation": "水道(すいどう)"
     },
     {
-        "name": "circle",
+        "name": "sa-kuru",
         "trans": [
             "① 名  圆；小组，社团"
         ],
@@ -5691,21 +5691,21 @@
         "notation": "髪(かみ)の毛(け)"
     },
     {
-        "name": "restaurant",
+        "name": "resutoran",
         "trans": [
             "① 名  饭店"
         ],
         "notation": "レストラン"
     },
     {
-        "name": "coffee",
+        "name": "ko-hi-",
         "trans": [
             "③ 名  咖啡"
         ],
         "notation": "コーヒー"
     },
     {
-        "name": "ground",
+        "name": "guraundo",
         "trans": [
             "⓪ 名  运动场，操场"
         ],
@@ -5824,7 +5824,7 @@
         "notation": "工事(こうじ)"
     },
     {
-        "name": "couple",
+        "name": "kappuru",
         "trans": [
             "① 名  情侣，恋人"
         ],
@@ -5852,7 +5852,7 @@
         "notation": "完成(かんせい)"
     },
     {
-        "name": "提起话题",
+        "name": "touieba",
         "trans": [
             "④ 接续  （提起话题）说起来，对了"
         ],
@@ -5922,7 +5922,7 @@
         "notation": "語彙(ごい)"
     },
     {
-        "name": "suit",
+        "name": "su-tsu",
         "trans": [
             "① 名  西装"
         ],
@@ -6013,7 +6013,7 @@
         "notation": "腕(うで)"
     },
     {
-        "name": "announcer",
+        "name": "anaunsa-",
         "trans": [
             "③ 名  播音员"
         ],
@@ -6076,7 +6076,7 @@
         "notation": "変(へん)"
     },
     {
-        "name": "switch",
+        "name": "suicchi",
         "trans": [
             "② 名  电源开关"
         ],
@@ -6125,7 +6125,7 @@
         "notation": "立場(たちば)"
     },
     {
-        "name": "staff",
+        "name": "sutaffu",
         "trans": [
             "② 名  职员，工作人员"
         ],
@@ -6188,7 +6188,7 @@
         "notation": "小(ちい)さな"
     },
     {
-        "name": "office",
+        "name": "ofisu",
         "trans": [
             "① 名  办公室"
         ],
@@ -6251,7 +6251,7 @@
         "notation": "遭(あ)う"
     },
     {
-        "name": "～kai",
+        "name": "~kai",
         "trans": [
             " 接尾  （组织或活动）……会"
         ],
@@ -6335,7 +6335,7 @@
         "notation": "開始(かいし)"
     },
     {
-        "name": "OK",
+        "name": "o-ke-",
         "trans": [
             "① 叹  好"
         ],
@@ -6412,7 +6412,7 @@
         "notation": "計画(けいかく)"
     },
     {
-        "name": "accessory",
+        "name": "akusesari-",
         "trans": [
             "① 名  饰品；零件"
         ],
@@ -6426,7 +6426,7 @@
         "notation": "興味(きょうみ)"
     },
     {
-        "name": "七（shichi/nana）②/",
+        "name": "shichi/nana",
         "trans": [
             "① 数  七"
         ],
@@ -6454,7 +6454,7 @@
         "notation": "用紙(ようし)"
     },
     {
-        "name": "No",
+        "name": "no-",
         "trans": [
             "① 叹  不"
         ],
@@ -6643,7 +6643,7 @@
         "notation": "在庫(ざいこ)"
     },
     {
-        "name": "不确定的",
+        "name": "dokoka",
         "trans": [
             "① 连语·副  （不确定的）某处；总觉得"
         ],
@@ -6727,7 +6727,7 @@
         "notation": "辺(あた)り"
     },
     {
-        "name": "schedule",
+        "name": "sukeju-ru",
         "trans": [
             "② 名  日程；日程表"
         ],
@@ -6762,7 +6762,7 @@
         "notation": "倒(たお)れる"
     },
     {
-        "name": "speed",
+        "name": "supi-do",
         "trans": [
             "⓪ 名  速度"
         ],
@@ -7091,7 +7091,7 @@
         "notation": "まずい"
     },
     {
-        "name": "engine",
+        "name": "enjin",
         "trans": [
             "① 名  引擎，发动机"
         ],
@@ -7154,7 +7154,7 @@
         "notation": "相談(そうだん)"
     },
     {
-        "name": "menu",
+        "name": "menyu-",
         "trans": [
             "① 名  菜单"
         ],
@@ -7238,7 +7238,7 @@
         "notation": "研究(けんきゅう)"
     },
     {
-        "name": "over",
+        "name": "o-ba-",
         "trans": [
             "① 名·自动3  超出，超过"
         ],
@@ -7301,7 +7301,7 @@
         "notation": "集(あつ)まる"
     },
     {
-        "name": "size",
+        "name": "saizu",
         "trans": [
             "① 名  尺寸"
         ],
@@ -7539,7 +7539,7 @@
         "notation": "ずらりと"
     },
     {
-        "name": "sandal",
+        "name": "sandaru",
         "trans": [
             "⓪ 名  凉鞋"
         ],
@@ -7588,7 +7588,7 @@
         "notation": "幅広(はばひろ)い"
     },
     {
-        "name": "taxi",
+        "name": "takushi-",
         "trans": [
             "① 名  出租车"
         ],
@@ -7602,7 +7602,7 @@
         "notation": "大会(たいかい)"
     },
     {
-        "name": "necklace",
+        "name": "nekkuresu",
         "trans": [
             "① 名  项链"
         ],
@@ -7665,7 +7665,7 @@
         "notation": "土地(とち)"
     },
     {
-        "name": "tissue",
+        "name": "telisshu",
         "trans": [
             "① 名  餐巾纸，面巾纸"
         ],
@@ -7686,7 +7686,7 @@
         "notation": "特長(とくちょう)"
     },
     {
-        "name": "shower",
+        "name": "shawa-",
         "trans": [
             "① 名  淋浴"
         ],
@@ -7721,7 +7721,7 @@
         "notation": "濃(こ)い"
     },
     {
-        "name": "toilet",
+        "name": "toire",
         "trans": [
             "① 名  洗手间"
         ],
@@ -7735,7 +7735,7 @@
         "notation": "五(ご)"
     },
     {
-        "name": "gram",
+        "name": "guramu",
         "trans": [
             "① 量  （重量单位）克"
         ],
@@ -7749,7 +7749,7 @@
         "notation": "経済(けいざい)"
     },
     {
-        "name": "mansion",
+        "name": "manshon",
         "trans": [
             "① 名  高级公寓"
         ],
@@ -7798,14 +7798,14 @@
         "notation": "事務(じむ)"
     },
     {
-        "name": "别人",
+        "name": "kureru",
         "trans": [
             "⓪ 他动2  （别人）给我或我方的人……"
         ],
         "notation": "くれる"
     },
     {
-        "name": "guide book",
+        "name": "gaidobukku",
         "trans": [
             "④ 名  导游手册，旅行指南"
         ],
@@ -7938,7 +7938,7 @@
         "notation": "両手(りょうて)"
     },
     {
-        "name": "present",
+        "name": "purezento",
         "trans": [
             "② 名  礼物"
         ],
@@ -8029,14 +8029,14 @@
         "notation": "気候(きこう)"
     },
     {
-        "name": "soft",
+        "name": "sofuto",
         "trans": [
             "① 名·ナ形  计算机软件；柔软的"
         ],
         "notation": "ソフト"
     },
     {
-        "name": "America",
+        "name": "amerika",
         "trans": [
             "⓪ 名  美国"
         ],
@@ -8141,7 +8141,7 @@
         "notation": "続(つづ)ける"
     },
     {
-        "name": "center",
+        "name": "senta-",
         "trans": [
             "① 名  中心，中央"
         ],
@@ -8225,7 +8225,7 @@
         "notation": "ようやく"
     },
     {
-        "name": "fruit",
+        "name": "furu-tsu",
         "trans": [
             "② 名  水果"
         ],
@@ -8295,7 +8295,7 @@
         "notation": "爽(さわ)やか"
     },
     {
-        "name": "game",
+        "name": "ge-mu",
         "trans": [
             "① 名  游戏；竞技，比赛"
         ],
@@ -8337,7 +8337,7 @@
         "notation": "悩(なや)む"
     },
     {
-        "name": "suitcase",
+        "name": "su-tsuke-su",
         "trans": [
             "④ 名  行李箱"
         ],
@@ -8449,7 +8449,7 @@
         "notation": "入国(にゅうこく)"
     },
     {
-        "name": "mystery",
+        "name": "misuteri-",
         "trans": [
             "① 名  神秘；推理小说"
         ],
@@ -8519,7 +8519,7 @@
         "notation": "両方(りょうほう)"
     },
     {
-        "name": "manual",
+        "name": "manyuaru",
         "trans": [
             "⓪ 名  说明书，操作指南"
         ],
@@ -8610,7 +8610,7 @@
         "notation": "倍(ばい)"
     },
     {
-        "name": "relax",
+        "name": "rirakkusu",
         "trans": [
             "② 名·自动3  放松"
         ],
@@ -8673,7 +8673,7 @@
         "notation": "開(ひら)く"
     },
     {
-        "name": "leader",
+        "name": "ri-da-",
         "trans": [
             "① 名  领导，领袖"
         ],
@@ -8701,7 +8701,7 @@
         "notation": "傷(きず)"
     },
     {
-        "name": "lighter",
+        "name": "teita-",
         "trans": [
             "① 名  打火机"
         ],
@@ -8736,7 +8736,7 @@
         "notation": "女(おんな)の子(こ)"
     },
     {
-        "name": "jam",
+        "name": "jamu",
         "trans": [
             "① 名  果酱"
         ],
@@ -8806,7 +8806,7 @@
         "notation": "作品(さくひん)"
     },
     {
-        "name": "whiskey",
+        "name": "uisuki-",
         "trans": [
             "③ 名  威士忌"
         ],
@@ -8876,7 +8876,7 @@
         "notation": "字(じ)"
     },
     {
-        "name": "gum",
+        "name": "gamu",
         "trans": [
             "① 名  口香糖"
         ],
@@ -8911,7 +8911,7 @@
         "notation": "手軽(てがる)"
     },
     {
-        "name": "blouse",
+        "name": "burausu",
         "trans": [
             "② 名  女士衬衫"
         ],
@@ -8988,7 +8988,7 @@
         "notation": "電子辞書(でんしじしょ)"
     },
     {
-        "name": "sauce",
+        "name": "so-su",
         "trans": [
             "① 名  调味汁"
         ],
@@ -9233,7 +9233,7 @@
         "notation": "白菜(はくさい)"
     },
     {
-        "name": "milk",
+        "name": "miruku",
         "trans": [
             "① 名  牛奶"
         ],
@@ -9247,7 +9247,7 @@
         "notation": "広(ひろ)がる"
     },
     {
-        "name": "～senchi",
+        "name": "~senchi",
         "trans": [
             " 接尾  ……厘米"
         ],
@@ -9310,7 +9310,7 @@
         "notation": "生産(せいさん)"
     },
     {
-        "name": "brush",
+        "name": "burashi",
         "trans": [
             "① 名  刷子"
         ],
@@ -9338,7 +9338,7 @@
         "notation": "白(しろ)い"
     },
     {
-        "name": "bowling",
+        "name": "bo-ringu",
         "trans": [
             "⓪ 名  保龄球"
         ],
@@ -9457,7 +9457,7 @@
         "notation": "折(お)れる"
     },
     {
-        "name": "recycle",
+        "name": "risaikuru",
         "trans": [
             "② 名  再利用"
         ],
@@ -9499,7 +9499,7 @@
         "notation": "苦手(にがて)"
     },
     {
-        "name": "video camera",
+        "name": "bideokamera",
         "trans": [
             "④ 名  摄像机"
         ],
@@ -9555,7 +9555,7 @@
         "notation": "髭(ひげ)"
     },
     {
-        "name": "soup",
+        "name": "su-pu",
         "trans": [
             "① 名  （西餐）汤"
         ],
@@ -9583,7 +9583,7 @@
         "notation": "うっかり"
     },
     {
-        "name": "graph",
+        "name": "gurafu",
         "trans": [
             "① 名  图表"
         ],
@@ -9632,7 +9632,7 @@
         "notation": "事故(じこ)"
     },
     {
-        "name": "event",
+        "name": "ibento",
         "trans": [
             "⓪ 名  事件；集会，活动"
         ],
@@ -9758,7 +9758,7 @@
         "notation": "貿易(ぼうえき)"
     },
     {
-        "name": "Valentine’s Day",
+        "name": "barentainde-",
         "trans": [
             "⑤ 名  情人节"
         ],
@@ -9807,7 +9807,7 @@
         "notation": "西口(にしぐち)"
     },
     {
-        "name": "basketball",
+        "name": "basukettobo-ru",
         "trans": [
             "⑥ 名  篮球"
         ],
@@ -9828,7 +9828,7 @@
         "notation": "部長(ぶちょう)"
     },
     {
-        "name": "～rittoru",
+        "name": "~rittoru",
         "trans": [
             " 接尾  ……升"
         ],
@@ -9849,7 +9849,7 @@
         "notation": "製造(せいぞう)"
     },
     {
-        "name": "system",
+        "name": "shisutemu",
         "trans": [
             "① 名  系统"
         ],
@@ -9905,7 +9905,7 @@
         "notation": "外(そと)"
     },
     {
-        "name": "supermarket",
+        "name": "su-pa-ma-ketto",
         "trans": [
             "⑤ 名  超市"
         ],
@@ -9954,7 +9954,7 @@
         "notation": "待合室(まちあいしつ)"
     },
     {
-        "name": "～ken",
+        "name": "~noki",
         "trans": [
             " 接尾  （房屋）……栋"
         ],
@@ -9989,7 +9989,7 @@
         "notation": "一生懸命(いっしょうけんめい)"
     },
     {
-        "name": "screen",
+        "name": "sukuri-n",
         "trans": [
             "③ 名  屏幕"
         ],
@@ -10038,7 +10038,7 @@
         "notation": "雲(くも)"
     },
     {
-        "name": "orange",
+        "name": "orenji",
         "trans": [
             "② 名  橙子；橙色"
         ],
@@ -10101,7 +10101,7 @@
         "notation": "大根(だいこん)"
     },
     {
-        "name": "card",
+        "name": "ka-do",
         "trans": [
             "① 名  银行卡；卡片"
         ],
@@ -10171,7 +10171,7 @@
         "notation": "吐(は)く"
     },
     {
-        "name": "tennis court",
+        "name": "tenisuko-to",
         "trans": [
             "④ 名  网球场"
         ],
@@ -10185,7 +10185,7 @@
         "notation": "台詞(せりふ)"
     },
     {
-        "name": "escalator",
+        "name": "esukare-ta-",
         "trans": [
             "④ 名  自动扶梯"
         ],
@@ -10297,7 +10297,7 @@
         "notation": "弾(ひ)く"
     },
     {
-        "name": "～han",
+        "name": "~han",
         "trans": [
             " 接尾  （时间）……半"
         ],
@@ -10318,7 +10318,7 @@
         "notation": "もうすぐ"
     },
     {
-        "name": "television",
+        "name": "terebi",
         "trans": [
             "① 名  电视机"
         ],
@@ -10353,7 +10353,7 @@
         "notation": "道路(どうろ)"
     },
     {
-        "name": "后接否定",
+        "name": "taishite",
         "trans": [
             "① 副  （后接否定）并不太……"
         ],
@@ -10367,7 +10367,7 @@
         "notation": "敷金(しききん)"
     },
     {
-        "name": "人、动物",
+        "name": "iru",
         "trans": [
             "⓪ 自动2  （人、动物）有；存在"
         ],
@@ -10430,7 +10430,7 @@
         "notation": "以上(いじょう)"
     },
     {
-        "name": "stereo",
+        "name": "sutereo",
         "trans": [
             "⓪ 名  立体声，立体声设备"
         ],
@@ -10500,7 +10500,7 @@
         "notation": "老化(ろうか)"
     },
     {
-        "name": "picnic",
+        "name": "pikunikku",
         "trans": [
             "① 名·自动3  郊游"
         ],
@@ -10528,7 +10528,7 @@
         "notation": "残(のこ)り"
     },
     {
-        "name": "concert",
+        "name": "konsa-to",
         "trans": [
             "① 名  音乐会"
         ],
@@ -10563,7 +10563,7 @@
         "notation": "到着(とうちゃく)"
     },
     {
-        "name": "shin～",
+        "name": "shin~",
         "trans": [
             " 接头  新……"
         ],
@@ -10661,7 +10661,7 @@
         "notation": "日(ひ)"
     },
     {
-        "name": "dance",
+        "name": "dansu",
         "trans": [
             "① 名  跳舞，舞蹈"
         ],
@@ -10780,7 +10780,7 @@
         "notation": "きっと"
     },
     {
-        "name": "receipt",
+        "name": "reshi-to",
         "trans": [
             "② 名  收据，小票"
         ],
@@ -10829,7 +10829,7 @@
         "notation": "乗(の)り物(もの)"
     },
     {
-        "name": "volume",
+        "name": "boryu-mu",
         "trans": [
             "⓪ 名  体积，容量；音量"
         ],
@@ -10885,7 +10885,7 @@
         "notation": "主(おも)"
     },
     {
-        "name": "cheese",
+        "name": "chi-zu",
         "trans": [
             "① 名  芝士，奶酪"
         ],
@@ -10976,7 +10976,7 @@
         "notation": "中国(ちゅうごく)"
     },
     {
-        "name": "steak",
+        "name": "sute-ki",
         "trans": [
             "② 名  牛排"
         ],
@@ -11039,7 +11039,7 @@
         "notation": "すり"
     },
     {
-        "name": "cost",
+        "name": "kosuto",
         "trans": [
             "① 名  成本"
         ],
@@ -11081,14 +11081,14 @@
         "notation": "共同(きょうどう)"
     },
     {
-        "name": "momo",
+        "name": "mata",
         "trans": [
             "① 名  大腿"
         ],
         "notation": "股(また)"
     },
     {
-        "name": "欢欣雀跃",
+        "name": "wakuwaku",
         "trans": [
             "① 副·自动3  （欢欣雀跃）心扑通扑通地跳"
         ],
@@ -11102,7 +11102,7 @@
         "notation": "法律(ほうりつ)"
     },
     {
-        "name": "tree",
+        "name": "tsuri-",
         "trans": [
             "② 名  树"
         ],
@@ -11270,7 +11270,7 @@
         "notation": "小学生(しょうがくせい)"
     },
     {
-        "name": "～bansen",
+        "name": "~bansen",
         "trans": [
             " 接尾  ……号线"
         ],
@@ -11347,7 +11347,7 @@
         "notation": "踏(ふ)む"
     },
     {
-        "name": "muffler",
+        "name": "mufura-",
         "trans": [
             "① 名  围巾"
         ],
@@ -11368,7 +11368,7 @@
         "notation": "届(とど)ける"
     },
     {
-        "name": "career",
+        "name": "kyaria",
         "trans": [
             "① 名  履历；职业生涯"
         ],
@@ -11424,7 +11424,7 @@
         "notation": "健康(けんこう)"
     },
     {
-        "name": "Asia",
+        "name": "ajia",
         "trans": [
             "① 名  亚洲"
         ],
@@ -11438,7 +11438,7 @@
         "notation": "線(せん)"
     },
     {
-        "name": "melody",
+        "name": "merodeli-",
         "trans": [
             "① 名  旋律"
         ],
@@ -11459,7 +11459,7 @@
         "notation": "展覧会(てんらんかい)"
     },
     {
-        "name": "ski",
+        "name": "suki-",
         "trans": [
             "② 名·自动3  滑雪"
         ],
@@ -11599,7 +11599,7 @@
         "notation": "包(つつ)む"
     },
     {
-        "name": "mango",
+        "name": "mango-",
         "trans": [
             "① 名  芒果"
         ],
@@ -11697,7 +11697,7 @@
         "notation": "割合(わりあい)"
     },
     {
-        "name": "后接否定",
+        "name": "sorehodo",
         "trans": [
             "⓪ 副  那么，那样；（后接否定）没那么"
         ],
@@ -11725,7 +11725,7 @@
         "notation": "慣(な)れる"
     },
     {
-        "name": "byou",
+        "name": "~byou",
         "trans": [
             " 名  ……秒"
         ],
@@ -12040,7 +12040,7 @@
         "notation": "参加(さんか)"
     },
     {
-        "name": "Africa",
+        "name": "afurika",
         "trans": [
             "⓪ 名  非洲"
         ],
@@ -12068,7 +12068,7 @@
         "notation": "見(み)つかる"
     },
     {
-        "name": "service",
+        "name": "sa-bisu",
         "trans": [
             "① 名  服务；赠品"
         ],
@@ -12362,7 +12362,7 @@
         "notation": "各国(かっこく)"
     },
     {
-        "name": "locker",
+        "name": "rokka-",
         "trans": [
             "① 名  柜子"
         ],
@@ -12390,7 +12390,7 @@
         "notation": "広告(こうこく)"
     },
     {
-        "name": "lucky",
+        "name": "rakki-",
         "trans": [
             "① 名·ナ形  幸运"
         ],
@@ -12467,7 +12467,7 @@
         "notation": "喜(よろこ)ぶ"
     },
     {
-        "name": "lobby",
+        "name": "robi-",
         "trans": [
             "① 名  大厅，前厅"
         ],
@@ -12516,7 +12516,7 @@
         "notation": "失礼(しつれい)"
     },
     {
-        "name": "pineapple",
+        "name": "painappuru",
         "trans": [
             "③ 名  菠萝"
         ],
@@ -12586,7 +12586,7 @@
         "notation": "少子化(しょうしか)"
     },
     {
-        "name": "尊他语",
+        "name": "irassharu",
         "trans": [
             "④ 自动1  （尊他语）来；去；在"
         ],
@@ -12600,7 +12600,7 @@
         "notation": "再会(さいかい)"
     },
     {
-        "name": "belt",
+        "name": "beruto",
         "trans": [
             "⓪ 名  皮带，腰带"
         ],
@@ -12628,7 +12628,7 @@
         "notation": "採用(さいよう)"
     },
     {
-        "name": "power",
+        "name": "pawa-",
         "trans": [
             "① 名  力量，权力；动力"
         ],
@@ -12817,7 +12817,7 @@
         "notation": "助(たす)かる"
     },
     {
-        "name": "team",
+        "name": "chi-mu",
         "trans": [
             "① 名  队，组"
         ],
@@ -12838,7 +12838,7 @@
         "notation": "任(まか)せる"
     },
     {
-        "name": "ink",
+        "name": "inku",
         "trans": [
             "⓪ 名  墨水"
         ],
@@ -12929,7 +12929,7 @@
         "notation": "気分(きぶん)"
     },
     {
-        "name": "business",
+        "name": "bijinesu",
         "trans": [
             "① 名  商业；事务，工作"
         ],
@@ -12999,7 +12999,7 @@
         "notation": "乾杯(かんぱい)"
     },
     {
-        "name": "airport",
+        "name": "eapo-to",
         "trans": [
             "③ 名  机场"
         ],
@@ -13020,7 +13020,7 @@
         "notation": "履物(はきもの)"
     },
     {
-        "name": "sofa",
+        "name": "sofa-",
         "trans": [
             "① 名  沙发"
         ],
@@ -13034,7 +13034,7 @@
         "notation": "重(おも)たい"
     },
     {
-        "name": "ball pen",
+        "name": "bo-rupen",
         "trans": [
             "⓪ 名  圆珠笔"
         ],
@@ -13055,14 +13055,14 @@
         "notation": "経(た)つ"
     },
     {
-        "name": "glass",
+        "name": "gurasu",
         "trans": [
             "① 名  玻璃；玻璃杯"
         ],
         "notation": "グラス"
     },
     {
-        "name": "进展",
+        "name": "dondon",
         "trans": [
             "① 副  连续不断；（进展）顺利，（势头）旺盛"
         ],
@@ -13090,7 +13090,7 @@
         "notation": "紹介(しょうかい)"
     },
     {
-        "name": "后接否定",
+        "name": "nakanaka",
         "trans": [
             "⓪ 副  非常，相当；（后接否定）不容易……"
         ],
@@ -13104,7 +13104,7 @@
         "notation": "草(くさ)"
     },
     {
-        "name": "single room",
+        "name": "shingururu-mu",
         "trans": [
             "⑤ 名  单人间"
         ],
@@ -13125,7 +13125,7 @@
         "notation": "どこ"
     },
     {
-        "name": "Australia",
+        "name": "o-sutoraria",
         "trans": [
             "⑤ 名  澳大利亚"
         ],
@@ -13202,7 +13202,7 @@
         "notation": "昨日(きのう)"
     },
     {
-        "name": "check in",
+        "name": "chekkuin",
         "trans": [
             "③ 名·自动3  办理入住手续"
         ],
@@ -13251,7 +13251,7 @@
         "notation": "建設(けんせつ)"
     },
     {
-        "name": "lock",
+        "name": "rokku",
         "trans": [
             "① 名·他动3  锁；上锁"
         ],
@@ -13265,7 +13265,7 @@
         "notation": "着(き)せる"
     },
     {
-        "name": "type",
+        "name": "taipu",
         "trans": [
             "① 名  类型"
         ],
@@ -13370,7 +13370,7 @@
         "notation": "おおよそ"
     },
     {
-        "name": "basket",
+        "name": "basuketto",
         "trans": [
             "③ 名  篮，筐"
         ],
@@ -13454,14 +13454,14 @@
         "notation": "育(そだ)てる"
     },
     {
-        "name": "classmate",
+        "name": "kurasume-to",
         "trans": [
             "④ 名  同班同学"
         ],
         "notation": "クラスメート"
     },
     {
-        "name": "忐忑不安",
+        "name": "dokidoki",
         "trans": [
             "① 副·自动3  （忐忑不安）心扑通扑通地跳"
         ],
@@ -13475,7 +13475,7 @@
         "notation": "出張(しゅっちょう)"
     },
     {
-        "name": "cancel",
+        "name": "kyanseru",
         "trans": [
             "① 名·他动3  取消，作废"
         ],
@@ -13601,7 +13601,7 @@
         "notation": "氷(こおり)"
     },
     {
-        "name": "plastics",
+        "name": "purasuchikku",
         "trans": [
             "④ 名  塑料，塑胶"
         ],
@@ -13636,7 +13636,7 @@
         "notation": "自然(しぜん)に"
     },
     {
-        "name": "sign",
+        "name": "sain",
         "trans": [
             "① 名·自动3  信号，暗号；签名"
         ],
@@ -13790,7 +13790,7 @@
         "notation": "非常(ひじょう)に"
     },
     {
-        "name": "check",
+        "name": "chekku",
         "trans": [
             "① 名·他动3  检验，检查；支票；格子花纹"
         ],
@@ -13853,7 +13853,7 @@
         "notation": "そのほか"
     },
     {
-        "name": "percent",
+        "name": "pa-sento",
         "trans": [
             "③ 名  百分比，百分之……"
         ],
@@ -13902,14 +13902,14 @@
         "notation": "提案(ていあん)"
     },
     {
-        "name": "下雨或流水声",
+        "name": "zaazaa",
         "trans": [
             "① 副  （下雨或流水声）哗啦哗啦"
         ],
         "notation": "ざあざあ"
     },
     {
-        "name": "visa",
+        "name": "biza",
         "trans": [
             "① 名  签证"
         ],
@@ -13937,7 +13937,7 @@
         "notation": "接続(せつぞく)"
     },
     {
-        "name": "说外语",
+        "name": "perapera",
         "trans": [
             "① 副·ナ形  （说外语）流利；哗啦哗啦地（翻纸等）"
         ],
@@ -13958,7 +13958,7 @@
         "notation": "そのまま"
     },
     {
-        "name": "树叶、水滴等",
+        "name": "harahara",
         "trans": [
             "① 副·自动3  （树叶、水滴等）落下；担心，捏一把汗"
         ],
@@ -13986,7 +13986,7 @@
         "notation": "確(たし)か"
     },
     {
-        "name": "后接否定",
+        "name": "chittomo",
         "trans": [
             "③ 副  （后接否定）一点儿也不……"
         ],

--- a/public/dicts/Japanesebasicword.json
+++ b/public/dicts/Japanesebasicword.json
@@ -7,14 +7,14 @@
         "notation": "おはようございます"
     },
     {
-        "name": "konnichiwa",
+        "name": "konnichiha",
         "trans": [
             "Hello/ good afternoon"
         ],
         "notation": "こんにちは"
     },
     {
-        "name": "konbanwa",
+        "name": "konbanha",
         "trans": [
             "Good evening"
         ],


### PR DESCRIPTION
修复日语的所有词典，本人是日语的高分玩家，确定每一个词典都是敲过的并将我能力以内能改的词典进行了修复
<img width="854" alt="image" src="https://github.com/Kaiyiwing/qwerty-learner/assets/35193151/44657566-030b-45c7-b506-cffb638c7048">
<img width="1863" alt="image" src="https://github.com/Kaiyiwing/qwerty-learner/assets/35193151/eb0ffdb4-c226-43ad-ad1f-f56a2d9f84ec">
