### PR TITLE
fix: missing language tags

### DIFF
--- a/src/pages/Typing/components/WordPanel/components/Word/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Word/index.tsx
@@ -41,6 +41,7 @@ export default function WordComponent({ word, onFinish }: { word: Word; onFinish
   const pronunciationIsOpen = useAtomValue(pronunciationIsOpenAtom)
   const [isHoveringWord, setIsHoveringWord] = useState(false)
   const currentLanguage = useAtomValue(currentDictInfoAtom).language
+  const currentLanguageCategory = useAtomValue(currentDictInfoAtom).languageCategory
 
   useEffect(() => {
     // run only when word changes
@@ -223,7 +224,7 @@ export default function WordComponent({ word, onFinish }: { word: Word; onFinish
   return (
     <>
       <InputHandler updateInput={updateInput} />
-      <div className="flex flex-col justify-center pb-1 pt-4">
+      <div lang={currentLanguageCategory !== 'code' ? currentLanguageCategory : 'en'} className="flex flex-col justify-center pb-1 pt-4">
         {currentLanguage === 'romaji' && word.notation && <Notation notation={word.notation} />}
         <div className="relative">
           <div


### PR DESCRIPTION
为了使浏览器正确显示字体（尤其对于日文），所以我认为应该正确在显示文字的部分的标签上加上lang属性。
![YT`2C GE(MWKE%`9N{KDK{V](https://github.com/Kaiyiwing/qwerty-learner/assets/54099603/fea5cfdf-9755-4e82-8d4b-d6edab82b1f4)
![227UN(WRN1AKH}K9 ZU_OKE](https://github.com/Kaiyiwing/qwerty-learner/assets/54099603/73848bf0-2452-4405-847f-2decfb5bc050)
