### PR TITLE
fix: 解决镜像构建错误;优化镜像大小

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,17 @@
-# 运行下面的命令, 构建qwerty-learner镜像
-# docker build -t qwertylearner .
-# 下面的命令运行镜像, 访问localhost:8990访问应用, 8990可修改成你未占有的端口
-# docker run -d -p 8990:3000 --name qwertylearnerapp qwertylearner:latest
+FROM node:18 AS build
 
-FROM node:14
+# 设置工作目录
+WORKDIR /app
 
-LABEL maintainer="sevenyoungairye <lel.ng.top@gmail.com>"
+COPY package*.json ./
 
-WORKDIR /app/qwerty-learner
-
-COPY package*.json .
-
-COPY yarn.lock .
-
-RUN npm config set registry https://registry.npm.taobao.org
-
-RUN npm install yarn -g --force
-
-RUN yarn install
+RUN npm install
 
 COPY . .
 
-EXPOSE 5173
+RUN npm run build
 
-CMD yarn start --host=0.0.0.0
-
-
+# 将构建好的 React 应用复制到 Nginx 容器的默认站点目录
+FROM nginx:alpine
+COPY ./public/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/build /app

--- a/public/default.conf
+++ b/public/default.conf
@@ -1,0 +1,13 @@
+server {
+    listen       5173;
+    listen  [::]:5173;
+    server_name  localhost;
+    location / {
+        root   /app;
+        index  index.html index.htm;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /app;
+    }
+}


### PR DESCRIPTION
1. 解决 docker 构建镜像, node 版本过低的导致错误
  

```bash
 => ERROR [7/8] RUN yarn install                                                                                78.5s
------
 > [7/8] RUN yarn install:
0.478 yarn install v1.22.19
0.564 [1/4] Resolving packages...
0.945 [2/4] Fetching packages...
77.30 error daisyui@3.5.1: The engine "node" is incompatible with this module. Expected version ">=16.9.0". Got "14.21.3"
77.30 error Found incompatible module.
77.30 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
Dockerfile:20
--------------------
  18 |     RUN npm install yarn -g --force
  19 |     
  20 | >>> RUN yarn install
  21 |     
  22 |     COPY . .
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn install" did not complete successfully: exit code: 1
```

2. 缩小构建镜像体积
  

原构建脚本镜像体积过大 ( `2.78GB` )

```bash
REPOSITORY                    TAG          IMAGE ID       CREATED         SIZE
kevinyouu/qwertylearner       latest       9989cfa08d33   6 minutes ago   2.78GB
```

新的构建脚本镜像体积缩小至 `97.2MB`, 可直接从使用 `docker pull kevinyouu/qwertylearner` 拉取已构建好的镜像.容器端口与原脚本保持一致 (5173)

```bash
REPOSITORY                    TAG          IMAGE ID       CREATED              SIZE
kevinyouu/qwertylearner       latest       ebda44eaa212   About a minute ago   97.2MB
```