### PR TITLE
添加windows下一键安装和运行脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ Gitee Pages: <https://kaiyiwing.gitee.io/qwerty-learner/>
 <br />
 <br />
 
+## 运行项目
+
+本项目是基于`React`开发的，需要node环境来运行。
+
+### 手动安装
+
+1. 安装NodeJS，参考[官方文档](https://nodejs.org/en/download)
+2. 打开命令行，在项目根目录下，运行`npm install`或`yarn install`来下载依赖。
+3. 执行`npm run start`来启动项目，项目默认地址为`http://localhost:5173/`
+4. 在浏览器中打开`http://localhost:5173/`来访问项目。
+
+### 脚本执行
+
+对于Windows用户，可以直接执行ps1脚本，来一键安装依赖并启动项目。
+
+1. 打开powershell，定位到项目根目录中的`scripts`目录
+2. 在命令行中，执行`.\install.ps1`
+3. 等待脚本完成。
+
+> 备注
+> 脚本依赖`winget`来安装node，仅在 Windows 10 1709（版本 16299）或更高版本上受支持！
+
 ## 如何贡献
 
 ### 贡献代码

--- a/README.md
+++ b/README.md
@@ -99,28 +99,6 @@ Gitee Pages: <https://kaiyiwing.gitee.io/qwerty-learner/>
 <br />
 <br />
 
-## 运行项目
-
-本项目是基于`React`开发的，需要node环境来运行。
-
-### 手动安装
-
-1. 安装NodeJS，参考[官方文档](https://nodejs.org/en/download)
-2. 打开命令行，在项目根目录下，运行`npm install`或`yarn install`来下载依赖。
-3. 执行`npm run start`来启动项目，项目默认地址为`http://localhost:5173/`
-4. 在浏览器中打开`http://localhost:5173/`来访问项目。
-
-### 脚本执行
-
-对于Windows用户，可以直接执行ps1脚本，来一键安装依赖并启动项目。
-
-1. 打开powershell，定位到项目根目录中的`scripts`目录
-2. 在命令行中，执行`.\install.ps1`
-3. 等待脚本完成。
-
-> 备注
-> 脚本依赖`winget`来安装node，仅在 Windows 10 1709（版本 16299）或更高版本上受支持！
-
 ## 如何贡献
 
 ### 贡献代码
@@ -131,6 +109,29 @@ Gitee Pages: <https://kaiyiwing.gitee.io/qwerty-learner/>
 ### 贡献词库
 
 [导入词典](./docs/toBuildDict.md)
+
+## 运行项目
+
+本项目是基于`React`开发的，需要 node 环境来运行。
+
+### 手动安装
+
+1. 安装 NodeJS，参考[官方文档](https://nodejs.org/en/download)
+2. 使用 `git clone` 下载项目到本地, 不使用 git 可能因为缺少依赖而无法运行
+3. 打开命令行，在项目根目录下，运行`yarn install`来下载依赖。
+4. 执行`yarn start`来启动项目，项目默认地址为`http://localhost:5173/`
+5. 在浏览器中打开`http://localhost:5173/`来访问项目。
+
+### 脚本执行
+
+对于 Windows 用户，可以直接执行 ps1 脚本，来一键安装依赖并启动项目。
+
+1. 打开 powershell，定位到项目根目录中的`scripts`目录
+2. 在命令行中，执行`.\install.ps1`
+3. 等待脚本完成。
+
+> 备注
+> 脚本依赖`winget`来安装 node，仅在 Windows 10 1709（版本 16299）或更高版本上受支持！
 
 ## 🏆 荣誉
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,5 @@
-function Test-CommandInstalled(     [string]$CommandName) {
+# 定义函数
+function Test-CommandInstalled([string]$CommandName) {
     $command = Get-Command $CommandName -ErrorAction SilentlyContinue
     if ($command) {
         return $true
@@ -9,26 +10,34 @@ function Test-CommandInstalled(     [string]$CommandName) {
 }
 
 $location = Get-Location
-if (!(Test-CommandInstalled node)) {
-    Write-Host "未检测到nodejs环境，尝试使用winget安装!"
 
+$hasWinget = false;
+
+# 检测Node命令是否存在
+if (!(Test-CommandInstalled node)) {
+    Write-Host "未检测到nodejs环境，尝试使用winget安装..."
+    # 检测winget是否存在
     if (!(Test-CommandInstalled winget)) {
         Write-Host "未检测到winget，无法完成安装，请检测系统版本，或尝试安装winget:https://www.microsoft.com/p/app-installer/9nblggh4nns1#activetab=pivot:overviewtab"
     }
     else {
+        $hasWinget = true;
         winget install OpenJS.Nodejs --slient
+        Write-Host "nodejs 安装完成"
     }
 }
-
-Set-Location ..
-Write-Host "开始安装依赖"
-yarn install --registry=https://registry.npm.taobao.org
-Write-Host "依赖安装完成，启动程序"
-
-Start-Job -ScriptBlock {
-    Start-Sleep 4
-    Start-Process http://localhost:5173/
-} | Out-Null
-
-npm run start
-Set-Location $location
+if ($hasWinget) {
+    Set-Location ..
+    Write-Host "开始安装依赖..."
+    yarn install --registry=https://registry.npm.taobao.org
+    Write-Host "依赖安装完成，启动程序..."
+    
+    Start-Job -ScriptBlock {
+        Start-Sleep 4
+        Start-Process http://localhost:5173/
+    } | Out-Null
+    
+    npm run start
+    Set-Location $location
+    
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,34 @@
+function Test-CommandInstalled(     [string]$CommandName) {
+    $command = Get-Command $CommandName -ErrorAction SilentlyContinue
+    if ($command) {
+        return $true
+    }
+    else {
+        return $false
+    }
+}
+
+$location = Get-Location
+if (!(Test-CommandInstalled node)) {
+    Write-Host "未检测到nodejs环境，尝试使用winget安装!"
+
+    if (!(Test-CommandInstalled winget)) {
+        Write-Host "未检测到winget，无法完成安装，请检测系统版本，或尝试安装winget:https://www.microsoft.com/p/app-installer/9nblggh4nns1#activetab=pivot:overviewtab"
+    }
+    else {
+        winget install OpenJS.Nodejs --slient
+    }
+}
+
+Set-Location ..
+Write-Host "开始安装依赖"
+yarn install --registry=https://registry.npm.taobao.org
+Write-Host "依赖安装完成，启动程序"
+
+Start-Job -ScriptBlock {
+    Start-Sleep 4
+    Start-Process http://localhost:5173/
+} | Out-Null
+
+npm run start
+Set-Location $location


### PR DESCRIPTION


添加了`install.ps1`脚本
Windows用户拉取代码后，可在powershell/pwsh/ 中执行该脚本。

脚本会检测是否安装了node，如果没有会使用winget安装。
安装完成后会自动还原依赖并运行程序，并自动打开浏览器。

实现一键安装、运行、打开程序。