### PR TITLE
添加译林版高中必修1所有单词

### DIFF
--- a/public/dicts/YiLin_1.json
+++ b/public/dicts/YiLin_1.json
@@ -1,0 +1,2167 @@
+[
+	{
+		"name": "potential",
+		"trans": [
+			"n. 潜力；可能性",
+			"adj. 潜在的，可能的"
+		],
+		"usphone": "pəˈtenʃl",
+		"ukphone": "pəˈtenʃl"
+	},
+	{
+		"name": "senior",
+		"trans": [
+			"adj. 中学的（招收 11 或13 岁以上学生）；级别高的；高级水平的；老年的",
+			"n. 级别（或地位）较高者；较...年长的人；高水平运动员"
+		],
+		"usphone": "ˈsiːniə",
+		"ukphone": "ˈsi:niə(r)"
+	},
+	{
+		"name": "path",
+		"trans": [
+			"n. 道路；小路；成功的途径"
+		],
+		"usphone": "pɑːθ",
+		"ukphone": "pɑːθ"
+	},
+	{
+		"name": "challenge",
+		"trans": [
+			"n. & vt. 挑战；质疑"
+		],
+		"usphone": "ˈtʃælɪndʒ",
+		"ukphone": "ˈtʃælɪndʒ"
+	},
+	{
+		"name": "thinking",
+		"trans": [
+			"n. 思维，思想；想法"
+		],
+		"usphone": "ˈθɪŋkɪŋ",
+		"ukphone": "ˈθɪŋkɪŋ"
+	},
+	{
+		"name": "positive",
+		"trans": [
+			"adj. 积极乐观的；良好的，正面的"
+		],
+		"usphone": "ˈpɒzətɪv",
+		"ukphone": "ˈpɒzətɪv"
+	},
+	{
+		"name": "opportunity",
+		"trans": [
+			"n. 机会，时机"
+		],
+		"usphone": "ˌɒpəˈtjuːnəti",
+		"ukphone": "ˌɒpəˈtjuːnəti"
+	},
+	{
+		"name": "lie in",
+		"trans": [
+			"存在于，在于"
+		]
+	},
+	{
+		"name": "rise to",
+		"trans": [
+			"能够处理"
+		]
+	},
+	{
+		"name": "acquire",
+		"trans": [
+			"vt. 获得，得到"
+		],
+		"usphone": "əˈkwaɪər",
+		"ukphone": "əˈkwaɪə(r)"
+	},
+	{
+		"name": "effort",
+		"trans": [
+			"n. 努力，费力的事；试图"
+		],
+		"usphone": "ˈefət",
+		"ukphone": "ˈefət(r)"
+	},
+	{
+		"name": "advance",
+		"trans": [
+			"n. 进步，进展；前进，行进",
+			"vt. & vi. 发展，进步"
+		],
+		"usphone": "ədˈvɑːns",
+		"ukphone": "ədˈvɑːns"
+	},
+	{
+		"name": "amazing",
+		"trans": [
+			"adj. 令人大为惊奇的，令人惊喜的"
+		],
+		"usphone": "əˈmeɪzɪŋ",
+		"ukphone": "əˈmeɪzɪŋ"
+	},
+	{
+		"name": "confidence",
+		"trans": [
+			"n. 信心，信任；把握"
+		],
+		"usphone": "ˈkɒnfɪdəns",
+		"ukphone": "ˈkɒnfɪdəns"
+	},
+	{
+		"name": "make a difference",
+		"trans": [
+			"起作用，有影响"
+		]
+	},
+	{
+		"name": "make the most of",
+		"trans": [
+			"充分利用，尽情享受"
+		]
+	},
+	{
+		"name": "resource",
+		"trans": [
+			"n. 资源；资料；谋略"
+		],
+		"usphone": "rɪˈsɔːs",
+		"ukphone": "rɪˈsɔːs"
+	},
+	{
+		"name": "take advantage of",
+		"trans": [
+			"利用"
+		]
+	},
+	{
+		"name": "facility",
+		"trans": [
+			"n. 设施，设备；场所"
+		],
+		"usphone": "fəˈsɪləti",
+		"ukphone": "fəˈsɪləti"
+	},
+	{
+		"name": "equal",
+		"trans": [
+			"adj. 相等的；平等的；相当的",
+			"n. 同等的人（物）",
+			"linking v. 与...相等",
+			"vt. 比得上"
+		],
+		"usphone": "ˈiːkwəl",
+		"ukphone": "ˈiːkwəl"
+	},
+	{
+		"name": "attitude",
+		"trans": [
+			"n. 态度，看法"
+		],
+		"usphone": "ˈætɪtjuːd",
+		"ukphone": "ˈætɪtjuːd"
+	},
+	{
+		"name": "goal",
+		"trans": [
+			"n. 目标；进球得分"
+		],
+		"usphone": "ɡəʊl",
+		"ukphone": "ɡəʊl"
+	},
+	{
+		"name": "balance",
+		"trans": [
+			"vt. 同等重视；（使）保持平衡；权衡重要性",
+			"n. 均衡，平衡；平衡能力"
+		],
+		"usphone": "ˈbæləns",
+		"ukphone": "ˈbæləns"
+	},
+	{
+		"name": "improve",
+		"trans": [
+			"vt. & vi. 改进，改善"
+		],
+		"usphone": "ɪmˈpruːv",
+		"ukphone": "ɪmˈpruːv"
+	},
+	{
+		"name": "last but not least",
+		"trans": [
+			"最后但同样重要的"
+		]
+	},
+	{
+		"name": "well-rounded",
+		"trans": [
+			"adj. 全面发展的；面面俱到的"
+		],
+		"usphone": "ˌwel ˈraʊndɪd",
+		"ukphone": "ˌwel ˈraʊndɪd"
+	},
+	{
+		"name": "individual",
+		"trans": [
+			"n. 个人",
+			"adj. 单独的，个别的"
+		],
+		"usphone": "ˌɪndɪˈvɪdʒuəl",
+		"ukphone": "ˌɪndɪˈvɪdʒuəl"
+	},
+	{
+		"name": "character",
+		"trans": [
+			"n. 品质，性格；特点；人物，角色；文字"
+		],
+		"usphone": "ˈkærəktər",
+		"ukphone": "ˈkærəktə(r)"
+	},
+	{
+		"name": "responsible",
+		"trans": [
+			"adj. 有责任，负责；可靠的"
+		],
+		"usphone": "rɪˈspɒnsəbl",
+		"ukphone": "rɪˈspɒnsəbl"
+	},
+	{
+		"name": "ahead",
+		"trans": [
+			"adv.（时间、空间）向前；提前"
+		],
+		"usphone": "əˈhed",
+		"ukphone": "əˈhed"
+	},
+	{
+		"name": "junior",
+		"trans": [
+			"adj.（学校）为 11 或 13岁以下儿童设立的；地位（或级别）低的；青少年的",
+			"n. 职位较低者；青少年运动员"
+		],
+		"usphone": "ˈdʒuːniər",
+		"ukphone": "ˈdʒuːniə(r)"
+	},
+	{
+		"name": "forward",
+		"trans": [
+			"adv. 向将来；向前；进展，前进"
+		],
+		"usphone": "ˈfɔːwəd",
+		"ukphone": "ˈfɔːwəd"
+	},
+	{
+		"name": "look forward to",
+		"trans": [
+			"盼望，期待"
+		]
+	},
+	{
+		"name": "independent",
+		"trans": [
+			"adj. 自主的，有主见的；自立的"
+		],
+		"usphone": "ˌɪndɪˈpendənt",
+		"ukphone": "ˌɪndɪˈpendənt"
+	},
+	{
+		"name": "focus",
+		"trans": [
+			"n. 焦点，重点",
+			"vt. & vi. 集中"
+		],
+		"usphone": "ˈfəʊkəs",
+		"ukphone": "ˈfəʊkəs"
+	},
+	{
+		"name": "detail",
+		"trans": [
+			"n. 细节；具体情况"
+		],
+		"usphone": "ˈdiːteɪl",
+		"ukphone": "ˈdiːteɪl"
+	},
+	{
+		"name": "as a result of",
+		"trans": [
+			"由于"
+		]
+	},
+	{
+		"name": "tip",
+		"trans": [
+			"n. 指点，实用的提示；尖端；小费"
+		],
+		"usphone": "tɪp",
+		"ukphone": "tɪp"
+	},
+	{
+		"name": "base",
+		"trans": [
+			"vt. 以...为基础（依据）",
+			"n. 根据；基础；基底；总部，大本营"
+		],
+		"usphone": "beɪs",
+		"ukphone": "beɪs"
+	},
+	{
+		"name": "remind",
+		"trans": [
+			"vt. 提醒，使想起"
+		],
+		"usphone": "rɪˈmaɪnd",
+		"ukphone": "rɪˈmaɪnd"
+	},
+	{
+		"name": "stick to",
+		"trans": [
+			"坚持；固守，维持"
+		]
+	},
+	{
+		"name": "proposal",
+		"trans": [
+			"n. 提议，建议，动议"
+		],
+		"usphone": "prəˈpəʊzl",
+		"ukphone": "prəˈpəʊzl"
+	},
+	{
+		"name": "aim",
+		"trans": [
+			"n. 目的，目标",
+			"vi. & vt. 力争做到；目的是；针对"
+		],
+		"usphone": "eɪm",
+		"ukphone": "eɪm"
+	},
+	{
+		"name": "style",
+		"trans": [
+			"n. 风格；方式；样式"
+		],
+		"usphone": "staɪl",
+		"ukphone": "staɪl"
+	},
+	{
+		"name": "technique",
+		"trans": [
+			"n. 技巧，技艺；技能"
+		],
+		"usphone": "tekˈniːk",
+		"ukphone": "tekˈniːk"
+	},
+	{
+		"name": "workshop",
+		"trans": [
+			"n. 研讨会，讲习班；车间，作坊"
+		],
+		"usphone": "ˈwɜːkʃɒp",
+		"ukphone": "ˈwɜːkʃɒp"
+	},
+	{
+		"name": "professional",
+		"trans": [
+			"adj. 职业的，专业的；有职业的；娴熟的，精通业务的",
+			"n. 专门人员，专业人士"
+		],
+		"usphone": "prəˈfeʃənl",
+		"ukphone": "prəˈfeʃənl"
+	},
+	{
+		"name": "material",
+		"trans": [
+			"n. 材料；素材",
+			"adj. 物质的，实际的；客观存在的"
+		],
+		"usphone": "məˈtɪəriəl",
+		"ukphone": "məˈtɪəriəl"
+	},
+	{
+		"name": "poster",
+		"trans": [
+			"n. 海报；（在网络留言板上）发布消息的人"
+		],
+		"usphone": "ˈpəʊstər",
+		"ukphone": "ˈpəʊstə(r)"
+	},
+	{
+		"name": "secondary",
+		"trans": [
+			"adj. 中学的；次要的"
+		],
+		"usphone": "ˈsekəndri",
+		"ukphone": "ˈsekəndri"
+	},
+	{
+		"name": "exchange",
+		"trans": [
+			"n. & vt. 交换；交流；兑换"
+		],
+		"usphone": "ɪksˈtʃeɪndʒ",
+		"ukphone": "ɪksˈtʃeɪndʒ"
+	},
+	{
+		"name": "host",
+		"trans": [
+			"n. 主人；东道主；主持人",
+			"vt. 主办；主持"
+		],
+		"usphone": "həʊst",
+		"ukphone": "həʊst"
+	},
+	{
+		"name": "a.m.",
+		"trans": [
+			"上午，午前"
+		],
+		"usphone": "ˌeɪ ˈem",
+		"ukphone": "ˌeɪ ˈem"
+	},
+	{
+		"name": "p.m.",
+		"trans": [
+			"下午，午后"
+		],
+		"usphone": "ˌpiː ˈem",
+		"ukphone": "ˌpiː ˈem"
+	},
+	{
+		"name": "biology",
+		"trans": [
+			"n. 生物学"
+		],
+		"usphone": "baɪˈɒlədʒi",
+		"ukphone": "baɪˈɒlədʒi"
+	},
+	{
+		"name": "tough",
+		"trans": [
+			"adj. 艰难的；严厉的；坚强的；坚固的"
+		],
+		"usphone": "tʌf",
+		"ukphone": "tʌf"
+	},
+	{
+		"name": "alarm",
+		"trans": [
+			"n. 闹钟；恐慌；警报；警报器",
+			"vt. 使惊恐，使害怕"
+		],
+		"usphone": "əˈlɑːm",
+		"ukphone": "əˈlɑːm"
+	},
+	{
+		"name": "contribution",
+		"trans": [
+			"n. 贡献；捐款；捐赠"
+		],
+		"usphone": "ˌkɒntrɪˈbjuːʃn",
+		"ukphone": "ˌkɒntrɪˈbjuːʃn"
+	},
+	{
+		"name": "fortunately",
+		"trans": [
+			"adv. 幸运地，幸亏"
+		],
+		"usphone": "ˈfɔːtʃənətli",
+		"ukphone": "ˈfɔːtʃənətli"
+	},
+	{
+		"name": "over time",
+		"trans": [
+			"随着时间流逝，久而久之"
+		]
+	},
+	{
+		"name": "option",
+		"trans": [
+			"n. 可选择的事物，选择；选修课"
+		],
+		"usphone": "ˈɒpʃn",
+		"ukphone": "ˈɒpʃn"
+	},
+	{
+		"name": "butter",
+		"trans": [
+			"n. 黄油"
+		],
+		"usphone": "ˈbʌtər",
+		"ukphone": "ˈbʌtə(r)"
+	},
+	{
+		"name": "pudding",
+		"trans": [
+			"n. 甜点；布丁"
+		],
+		"usphone": "ˈpʊdɪŋ",
+		"ukphone": "ˈpʊdɪŋ"
+	},
+	{
+		"name": "attract",
+		"trans": [
+			"vt. 吸引，使喜爱；招引；引起（反应）"
+		],
+		"usphone": "əˈtrækt",
+		"ukphone": "əˈtrækt"
+	},
+	{
+		"name": "rugby",
+		"trans": [
+			"n. 橄榄球运动"
+		],
+		"usphone": "ˈrʌɡbi",
+		"ukphone": "ˈrʌɡbi"
+	},
+	{
+		"name": "calligraphy",
+		"trans": [
+			"n. 书法，书法艺术"
+		],
+		"usphone": "kəˈlɪɡrəfi",
+		"ukphone": "kəˈlɪɡrəfi"
+	},
+	{
+		"name": "nest",
+		"trans": [
+			"n. 鸟窝；巢穴，窝"
+		],
+		"usphone": "nest",
+		"ukphone": "nest"
+	},
+	{
+		"name": "roof",
+		"trans": [
+			"n. 屋顶，顶部"
+		],
+		"usphone": "ruːf",
+		"ukphone": "ruːf"
+	},
+	{
+		"name": "battle",
+		"trans": [
+			"n. & vt. & vi. 争论；战斗，搏斗；斗争"
+		],
+		"usphone": "ˈbætl",
+		"ukphone": "ˈbætl"
+	},
+	{
+		"name": "see eye to eye with sb (on sth)",
+		"trans": [
+			"（在某事上）与某人看法一致"
+		]
+	},
+	{
+		"name": "argument",
+		"trans": [
+			"n. 争吵，争论；论点"
+		],
+		"usphone": "ˈɑːɡjumənt",
+		"ukphone": "ˈɑːɡjumənt"
+	},
+	{
+		"name": "teenager",
+		"trans": [
+			"n. 青少年"
+		],
+		"usphone": "ˈtiːneɪdʒər",
+		"ukphone": "ˈtiːneɪdʒə(r)"
+	},
+	{
+		"name": "tension",
+		"trans": [
+			"n. 紧张关系；紧张；拉伸"
+		],
+		"usphone": "ˈtenʃn",
+		"ukphone": "ˈtenʃn"
+	},
+	{
+		"name": "anxious",
+		"trans": [
+			"adj. 忧虑的，担心的；令人焦虑的；渴望的"
+		],
+		"usphone": "ˈæŋkʃəs",
+		"ukphone": "ˈæŋkʃəs"
+	},
+	{
+		"name": "rate",
+		"trans": [
+			"n. 速度；率",
+			"vi. & vt. 评价，评估"
+		],
+		"usphone": "reɪt",
+		"ukphone": "reɪt"
+	},
+	{
+		"name": "shoot",
+		"trans": [
+			"vi. & vt. (shot, shot)（使朝某方向）冲，奔；射击；射杀；摄影"
+		],
+		"usphone": "ʃuːt",
+		"ukphone": "ʃuːt"
+	},
+	{
+		"name": "shoot up",
+		"trans": [
+			"快速长高，蹿个儿"
+		]
+	},
+	{
+		"name": "spot",
+		"trans": [
+			"n. 粉刺；斑点；污渍；地点，场所"
+		],
+		"usphone": "spɒt",
+		"ukphone": "spɒt"
+	},
+	{
+		"name": "target",
+		"trans": [
+			"n.（攻击的）目标，对象；靶子",
+			"vt. 把...作为攻击目标；面向"
+		],
+		"usphone": "ˈtɑːɡɪt",
+		"ukphone": "ˈtɑːɡɪt"
+	},
+	{
+		"name": "anger",
+		"trans": [
+			"n. 怒气，怒火"
+		],
+		"usphone": "ˈæŋɡər",
+		"ukphone": "ˈæŋɡə(r)"
+	},
+	{
+		"name": "mental",
+		"trans": [
+			"adj. 思想的，精神的，智力的"
+		],
+		"usphone": "ˈmentl",
+		"ukphone": "ˈmentl"
+	},
+	{
+		"name": "adult",
+		"trans": [
+			"n. 成年人"
+		],
+		"usphone": "ˈædʌlt",
+		"ukphone": "ˈædʌlt"
+	},
+	{
+		"name": "desire",
+		"trans": [
+			"n. & vt. 渴望，希望"
+		],
+		"usphone": "dɪˈzaɪər",
+		"ukphone": "dɪˈzaɪə(r)"
+	},
+	{
+		"name": "struggle",
+		"trans": [
+			"vi. & n. 奋斗；斗争；搏斗"
+		],
+		"usphone": "ˈstrʌɡl",
+		"ukphone": "ˈstrʌɡl"
+	},
+	{
+		"name": "rough",
+		"trans": [
+			"adj. 艰难的；粗糙的；不确切的"
+		],
+		"usphone": "rʌf",
+		"ukphone": "rʌf"
+	},
+	{
+		"name": "breakdown",
+		"trans": [
+			"n.（关系）破裂；故障"
+		],
+		"usphone": "ˈbreɪkdaʊn",
+		"ukphone": "ˈbreɪkdaʊn"
+	},
+	{
+		"name": "regular",
+		"trans": [
+			"adj. 频繁的；有规律的"
+		],
+		"usphone": "ˈreɡjələr",
+		"ukphone": "ˈreɡjələ(r)"
+	},
+	{
+		"name": "calm",
+		"trans": [
+			"vt. 使平静，使镇静",
+			"adj. 镇静的，沉着的"
+		],
+		"usphone": "kɑːm",
+		"ukphone": "kɑːm"
+	},
+	{
+		"name": "calm down",
+		"trans": [
+			"平静，镇静，安静"
+		]
+	},
+	{
+		"name": "view",
+		"trans": [
+			"n. 看法；视线；景色",
+			"vt. 把...视为；观看"
+		],
+		"usphone": "vjuː",
+		"ukphone": "vjuː"
+	},
+	{
+		"name": "from one’s point of view",
+		"trans": [
+			"从某人的角度、观点出发"
+		]
+	},
+	{
+		"name": "think sth through",
+		"trans": [
+			"充分考虑，全盘考虑，想透"
+		]
+	},
+	{
+		"name": "concern",
+		"trans": [
+			"n. 担心，忧虑；关心",
+			"vt. 涉及；让（某人）担忧"
+		],
+		"usphone": "kənˈsɜːn",
+		"ukphone": "kənˈsɜːn"
+	},
+	{
+		"name": "back down",
+		"trans": [
+			"承认错误，认输"
+		]
+	},
+	{
+		"name": "normal",
+		"trans": [
+			"adj. 正常的，一般的",
+			"n. 常态，通常标准"
+		],
+		"usphone": "ˈnɔːml",
+		"ukphone": "ˈnɔːml"
+	},
+	{
+		"name": "stress",
+		"trans": [
+			"n. 精神压力，紧张；强调",
+			"vt. 强调，着重"
+		],
+		"usphone": "stres",
+		"ukphone": "stres"
+	},
+	{
+		"name": "editor",
+		"trans": [
+			"n. 主编，编辑；剪辑师"
+		],
+		"usphone": "ˈedɪtər",
+		"ukphone": "ˈedɪtə(r)"
+	},
+	{
+		"name": "argue",
+		"trans": [
+			"vi. 争吵，争辩，争论",
+			"vt. 说理，论证"
+		],
+		"usphone": "ˈɑːɡjuː",
+		"ukphone": "ˈɑːɡjuː"
+	},
+	{
+		"name": "skin",
+		"trans": [
+			"n. 皮肤；（兽）皮，毛皮"
+		],
+		"usphone": "skɪn",
+		"ukphone": "skɪn"
+	},
+	{
+		"name": "design",
+		"trans": [
+			"vt. 设计；制订",
+			"n. 设计；设计艺术"
+		],
+		"usphone": "dɪˈzaɪn",
+		"ukphone": "dɪˈzaɪn"
+	},
+	{
+		"name": "forum",
+		"trans": [
+			"n. 论坛，讨论会；公共集会场所"
+		],
+		"usphone": "ˈfɔːrəm",
+		"ukphone": "ˈfɔːrəm"
+	},
+	{
+		"name": "expert",
+		"trans": [
+			"n. 专家，行家",
+			"adj. 熟练的，内行的，专家的"
+		],
+		"usphone": "ˈekspɜːt",
+		"ukphone": "ˈekspɜːt"
+	},
+	{
+		"name": "likely",
+		"trans": [
+			"adj. 可能的，预料的，有希望的"
+		],
+		"usphone": "ˈlaɪkli",
+		"ukphone": "ˈlaɪkli"
+	},
+	{
+		"name": "unique",
+		"trans": [
+			"adj. 独一无二的；独特的；独具的，特有的"
+		],
+		"usphone": "juˈniːk",
+		"ukphone": "juˈniːk"
+	},
+	{
+		"name": "passive",
+		"trans": [
+			"adj. 消极的，被动的"
+		],
+		"usphone": "ˈpæsɪv",
+		"ukphone": "ˈpæsɪv"
+	},
+	{
+		"name": "performance",
+		"trans": [
+			"n. 表现；表演；执行，履行"
+		],
+		"usphone": "pəˈfɔːməns",
+		"ukphone": "pəˈfɔːməns"
+	},
+	{
+		"name": "cheer up",
+		"trans": [
+			"（使）变得高兴，振奋起来"
+		]
+	},
+	{
+		"name": "press",
+		"trans": [
+			"vt. & vi. 催促，逼迫；按，压；挤，推",
+			"n. 报章杂志，报刊；（the press）新闻工作者，新闻界"
+		],
+		"usphone": "pres",
+		"ukphone": "pres"
+	},
+	{
+		"name": "eager",
+		"trans": [
+			"adj. 热切的，渴望的，渴求的"
+		],
+		"usphone": "ˈiːɡər",
+		"ukphone": "ˈiːɡə(r)"
+	},
+	{
+		"name": "youth",
+		"trans": [
+			"n. 青年时期；青春；（the youth）年轻人"
+		],
+		"usphone": "juːθ",
+		"ukphone": "juːθ"
+	},
+	{
+		"name": "adventure",
+		"trans": [
+			"n. 冒险，冒险经历，奇遇"
+		],
+		"usphone": "ədˈventʃər",
+		"ukphone": "ədˈventʃə(r)"
+	},
+	{
+		"name": "adventure",
+		"trans": [
+			"n. 冒险，冒险经历，奇遇"
+		],
+		"usphone": "ədˈventʃər",
+		"ukphone": "ədˈventʃə(r)"
+	},
+	{
+		"name": "be on sb’s back about sth",
+		"trans": [
+			"缠磨，烦扰"
+		]
+	},
+	{
+		"name": "kangaroo",
+		"trans": [
+			"n. 袋鼠"
+		],
+		"usphone": "ˌkæŋɡəˈruː",
+		"ukphone": "ˌkæŋɡəˈruː"
+	},
+	{
+		"name": "flexible",
+		"trans": [
+			"adj. 灵活的，可变动的；柔韧的"
+		],
+		"usphone": "ˈfleksəbl",
+		"ukphone": "ˈfleksəbl"
+	},
+	{
+		"name": "account",
+		"trans": [
+			"n. 账户；描述；解释",
+			"vt. 认为是，视为"
+		],
+		"usphone": "əˈkaʊnt",
+		"ukphone": "əˈkaʊnt"
+	},
+	{
+		"name": "rent",
+		"trans": [
+			"n. 租金",
+			"vi. & vt. 租用；出租"
+		],
+		"usphone": "rent",
+		"ukphone": "rent"
+	},
+	{
+		"name": "grocery",
+		"trans": [
+			"n. 食品杂货；食品杂货店"
+		],
+		"usphone": "ˈɡrəʊsəri",
+		"ukphone": "ˈɡrəʊsəri"
+	},
+	{
+		"name": "secure",
+		"trans": [
+			"adj. 安心的；可靠的；牢固的"
+		],
+		"usphone": "sɪˈkjʊər",
+		"ukphone": "sɪˈkjʊə(r)"
+	},
+	{
+		"name": "graduate",
+		"trans": [
+			"vi. & vt. 毕业"
+		],
+		"usphone": "ˈɡrædʒueɪt",
+		"ukphone": "ˈɡrædʒueɪt"
+	},
+	{
+		"name": "graduate",
+		"trans": [
+			"n. 毕业生"
+		],
+		"usphone": "ˈɡrædʒuət",
+		"ukphone": "ˈɡrædʒuət"
+	},
+	{
+		"name": "gather",
+		"trans": [
+			"vi. 聚集，集合",
+			"vt. 收拢；搜集，收集；聚集"
+		],
+		"usphone": "ˈɡæðər",
+		"ukphone": "ˈɡæðə(r)"
+	},
+	{
+		"name": "emergency",
+		"trans": [
+			"n. 突发事件，紧急情况"
+		],
+		"usphone": "iˈmɜːdʒənsi",
+		"ukphone": "iˈmɜːdʒənsi"
+	},
+	{
+		"name": "volunteer",
+		"trans": [
+			"vt. & vi. 主动建议（或告诉）；自愿做，义务做",
+			"n. 志愿者"
+		],
+		"usphone": "ˌvɒlənˈtɪər",
+		"ukphone": "ˌvɒlənˈtɪə(r)"
+	},
+	{
+		"name": "pipe",
+		"trans": [
+			"n. 烟斗；管子；管乐器"
+		],
+		"usphone": "paɪp",
+		"ukphone": "paɪp"
+	},
+	{
+		"name": "figure",
+		"trans": [
+			"n. 数字；人物；体形，身材"
+		],
+		"usphone": "ˈfɪɡər",
+		"ukphone": "ˈfɪɡə(r)"
+	},
+	{
+		"name": "downtown",
+		"trans": [
+			"adv. 在市中心，往市中心"
+		],
+		"usphone": "ˌdaʊnˈtaʊn",
+		"ukphone": "ˌdaʊnˈtaʊn"
+	},
+	{
+		"name": "draw sth out of sth",
+		"trans": [
+			"提取，支取"
+		]
+	},
+	{
+		"name": "operation",
+		"trans": [
+			"n. 手术；运转，操作"
+		],
+		"usphone": "ˌɒpəˈreɪʃn",
+		"ukphone": "ˌɒpəˈreɪʃn"
+	},
+	{
+		"name": "lap",
+		"trans": [
+			"n. 大腿部"
+		],
+		"usphone": "læp",
+		"ukphone": "læp"
+	},
+	{
+		"name": "teller",
+		"trans": [
+			"n. 出纳员；叙述者"
+		],
+		"usphone": "ˈtelər",
+		"ukphone": "ˈtelə(r)"
+	},
+	{
+		"name": "scene",
+		"trans": [
+			"n.（戏剧等）场；场面，片段；地点，现场；景象，风光"
+		],
+		"usphone": "siːn",
+		"ukphone": "siːn"
+	},
+	{
+		"name": "scene",
+		"trans": [
+			"n. 公寓",
+			"adj. 平坦的；瘪了的"
+		],
+		"usphone": "flæt",
+		"ukphone": "flæt"
+	},
+	{
+		"name": "response",
+		"trans": [
+			"n. 回复；反应，响应"
+		],
+		"usphone": "rɪˈspɒns",
+		"ukphone": "rɪˈspɒns"
+	},
+	{
+		"name": "on the rocks",
+		"trans": [
+			"（关系）陷于困境，濒临崩溃"
+		]
+	},
+	{
+		"name": "awkward",
+		"trans": [
+			"adj. 局促不安的；令人尴尬的；难对付的；笨拙的"
+		],
+		"usphone": "ˈɔːkwəd",
+		"ukphone": "ˈɔːkwəd"
+	},
+	{
+		"name": "sight",
+		"trans": [
+			"n. 视野；视力；看见"
+		],
+		"usphone": "saɪt",
+		"ukphone": "saɪt"
+	},
+	{
+		"name": "out of one’s sight",
+		"trans": [
+			"脱离某人的视线"
+		]
+	},
+	{
+		"name": "original",
+		"trans": [
+			"adj. 起初的；独创的；原作的"
+		],
+		"usphone": "əˈrɪdʒənl",
+		"ukphone": "əˈrɪdʒənl"
+	},
+	{
+		"name": "medium",
+		"trans": [
+			"n. (pl. media) 传播信息的媒介，方法；手段，工具",
+			"adj. 中等的，中号的"
+		],
+		"usphone": "ˈmiːdiəm",
+		"ukphone": "ˈmiːdiəm"
+	},
+	{
+		"name": "social media",
+		"trans": [
+			"社交媒体"
+		]
+	},
+	{
+		"name": "make it",
+		"trans": [
+			"能够出席；准时到达；获得成功"
+		]
+	},
+	{
+		"name": "horrible",
+		"trans": [
+			"adj. 令人震惊的；可恶的，极坏的"
+		],
+		"usphone": "ˈhɒrəbl",
+		"ukphone": "ˈhɒrəbl"
+	},
+	{
+		"name": "chat",
+		"trans": [
+			"vi. & n. 聊天，闲聊"
+		],
+		"usphone": "tʃæt",
+		"ukphone": "tʃæt"
+	},
+	{
+		"name": "café",
+		"trans": [
+			"n. 咖啡馆，小餐馆"
+		],
+		"usphone": "ˈkæfeɪ",
+		"ukphone": "ˈkæfeɪ"
+	},
+	{
+		"name": "recover",
+		"trans": [
+			"vi. 恢复健康；恢复常态",
+			"vt. 全额收回；寻回；重新获得；恢复，重新控制"
+		],
+		"usphone": "rɪˈkʌvər",
+		"ukphone": "rɪˈkʌvə(r)"
+	},
+	{
+		"name": "respond",
+		"trans": [
+			"vi. & vt. 回答，回应；作出反应，响应"
+		],
+		"usphone": "rɪˈspɒnd",
+		"ukphone": "rɪˈspɒnd"
+	},
+	{
+		"name": "loss",
+		"trans": [
+			"n. 失去，丧失；亏损；去世；损失"
+		],
+		"usphone": "lɒs",
+		"ukphone": "lɒs"
+	},
+	{
+		"name": "at a loss",
+		"trans": [
+			"不知所措，困惑"
+		]
+	},
+	{
+		"name": "judge",
+		"trans": [
+			"vt. & vi. 评价，（尤指）批评；判断，认为",
+			"n. 法官；裁判员"
+		],
+		"usphone": "dʒʌdʒ",
+		"ukphone": "dʒʌdʒ"
+	},
+	{
+		"name": "in the wrong",
+		"trans": [
+			"有错，应承担责任"
+		]
+	},
+	{
+		"name": "apologize",
+		"trans": [
+			"vi. 道歉，谢罪"
+		],
+		"usphone": "əˈpɒlədʒaɪz",
+		"ukphone": "əˈpɒlədʒaɪz"
+	},
+	{
+		"name": "behaviour",
+		"trans": [
+			"n. 行为，举止，态度"
+		],
+		"usphone": "bɪˈheɪvjər",
+		"ukphone": "bɪˈheɪvjə(r)"
+	},
+	{
+		"name": "behavior",
+		"trans": [
+			"n. 行为，举止，态度"
+		],
+		"usphone": "bɪˈheɪvjər",
+		"ukphone": "bɪˈheɪvjə(r)"
+	},
+	{
+		"name": "case",
+		"trans": [
+			"n. 具体情况，事例；案件；容器"
+		],
+		"usphone": "keɪs",
+		"ukphone": "keɪs"
+	},
+	{
+		"name": "in any case",
+		"trans": [
+			"无论如何，不管怎样"
+		]
+	},
+	{
+		"name": "frank",
+		"trans": [
+			"adj. 坦率的，直率的"
+		],
+		"usphone": "fræŋk",
+		"ukphone": "fræŋk"
+	},
+	{
+		"name": "definitely",
+		"trans": [
+			"adv. 肯定，确实；确切地"
+		],
+		"usphone": "ˈdefɪnətli",
+		"ukphone": "ˈdefɪnətli"
+	},
+	{
+		"name": "trick",
+		"trans": [
+			"vt. 欺骗，欺诈",
+			"n. 诡计，花招；戏法"
+		],
+		"usphone": "trɪk",
+		"ukphone": "trɪk"
+	},
+	{
+		"name": "let go of",
+		"trans": [
+			"放弃，摒弃；松手，放开"
+		]
+	},
+	{
+		"name": "ignore",
+		"trans": [
+			"vt. 忽视，对...不予理会"
+		],
+		"usphone": "ɪɡˈnɔːr",
+		"ukphone": "ɪɡˈnɔː(r)"
+	},
+	{
+		"name": "suffer",
+		"trans": [
+			"vi. 受苦，受折磨；变差",
+			"vt. 遭受，蒙受"
+		],
+		"usphone": "ˈsʌfər",
+		"ukphone": "ˈsʌfə(r)"
+	},
+	{
+		"name": "misunderstand",
+		"trans": [
+			"vt. & vi. 误解，误会"
+		],
+		"usphone": "ˌmɪsʌndəˈstænd",
+		"ukphone": "ˌmɪsʌndəˈstænd"
+	},
+	{
+		"name": "contact",
+		"trans": [
+			"vt. & n. 联系，联络"
+		],
+		"usphone": "ˈkɒntækt",
+		"ukphone": "ˈkɒntækt"
+	},
+	{
+		"name": "explode",
+		"trans": [
+			"vi.（愤怒等感情）爆发，迸发；爆炸",
+			"vt. 使爆炸"
+		],
+		"usphone": "ɪkˈspləʊd",
+		"ukphone": "ɪkˈspləʊd"
+	},
+	{
+		"name": "generous",
+		"trans": [
+			"adj. 宽宏大量的，仁慈的；慷慨的"
+		],
+		"usphone": "ˈdʒenərəs",
+		"ukphone": "ˈdʒenərəs"
+	},
+	{
+		"name": "count on",
+		"trans": [
+			"依赖，依靠，指望"
+		]
+	},
+	{
+		"name": "eat away at",
+		"trans": [
+			"腐蚀，侵蚀，逐渐破坏"
+		]
+	},
+	{
+		"name": "shallow",
+		"trans": [
+			"adj. 肤浅的，浅薄的；浅的"
+		],
+		"usphone": "ˈʃæləʊ",
+		"ukphone": "ˈʃæləʊ"
+	},
+	{
+		"name": "blog",
+		"trans": [
+			"n. 博客，网志"
+		],
+		"usphone": "blɒɡ",
+		"ukphone": "blɒɡ"
+	},
+	{
+		"name": "come between ... and ...",
+		"trans": [
+			"损害...之间的关系，离间；妨碍"
+		]
+	},
+	{
+		"name": "in person",
+		"trans": [
+			"亲自，亲身"
+		]
+	},
+	{
+		"name": "theme",
+		"trans": [
+			"n. 主题；主旋律"
+		],
+		"usphone": "θiːm",
+		"ukphone": "θiːm"
+	},
+	{
+		"name": "slave",
+		"trans": [
+			"n. 奴隶"
+		],
+		"usphone": "sleɪv",
+		"ukphone": "sleɪv"
+	},
+	{
+		"name": "raft",
+		"trans": [
+			"n. 木排，筏"
+		],
+		"usphone": "rɑːft",
+		"ukphone": "rɑːft"
+	},
+	{
+		"name": "high point",
+		"trans": [
+			"最有意思（或最令人愉快、最好）的部分"
+		]
+	},
+	{
+		"name": "through thick and thin",
+		"trans": [
+			"不顾艰难险阻，同甘共苦"
+		]
+	},
+	{
+		"name": "opinion",
+		"trans": [
+			"n. 意见，看法；（群体的）观点，信仰"
+		],
+		"usphone": "əˈpɪnjən",
+		"ukphone": "əˈpɪnjən"
+	},
+	{
+		"name": "in one’s opinion",
+		"trans": [
+			"在某人看来"
+		]
+	},
+	{
+		"name": "quality",
+		"trans": [
+			"n. 品德，素质；质量；特征",
+			"adj. 优质的，高质量的"
+		],
+		"usphone": "ˈkwɒləti",
+		"ukphone": "ˈkwɒləti"
+	},
+	{
+		"name": "basis",
+		"trans": [
+			"n. (pl. bases) 基础；原因；基准"
+		],
+		"usphone": "ˈbeɪsɪs",
+		"ukphone": "ˈbeɪsɪs"
+	},
+	{
+		"name": "respect",
+		"trans": [
+			"vt. 尊重，尊敬",
+			"n. 尊敬，敬意；重视"
+		],
+		"usphone": "rɪˈspekt",
+		"ukphone": "rɪˈspekt"
+	},
+	{
+		"name": "get over",
+		"trans": [
+			"克服；恢复常态"
+		]
+	},
+	{
+		"name": "efficient",
+		"trans": [
+			"adj. 效率高的，有功效的"
+		],
+		"usphone": "ɪˈfɪʃnt",
+		"ukphone": "ɪˈfɪʃnt"
+	},
+	{
+		"name": "extra",
+		"trans": [
+			"adj. 额外的，分外的，附加的",
+			"adv. 额外，另外；特别，格外"
+		],
+		"usphone": "ˈekstrə",
+		"ukphone": "ˈekstrə"
+	},
+	{
+		"name": "bring out",
+		"trans": [
+			"使显现，使表现出"
+		]
+	},
+	{
+		"name": "measure",
+		"trans": [
+			"vt. 估量，判定；测量",
+			"n. 措施；衡量"
+		],
+		"usphone": "ˈmeʒər",
+		"ukphone": "ˈmeʒə(r)"
+	},
+	{
+		"name": "reflection",
+		"trans": [
+			"n. 沉思；反射；映像；反映"
+		],
+		"usphone": "rɪˈflekʃn",
+		"ukphone": "rɪˈflekʃn"
+	},
+	{
+		"name": "seek",
+		"trans": [
+			"vi. 试图；寻找；争取",
+			"vt. 寻求；寻找"
+		],
+		"usphone": "siːk",
+		"ukphone": "siːk"
+	},
+	{
+		"name": "escape",
+		"trans": [
+			"vi. & vt. 逃脱，躲避；逃跑；避开，避免；被遗忘",
+			"n. 逃离，逃脱"
+		],
+		"usphone": "ɪˈskeɪp",
+		"ukphone": "ɪˈskeɪp"
+	},
+	{
+		"name": "smooth out",
+		"trans": [
+			"消除（问题），克服（困难）"
+		]
+	},
+	{
+		"name": "be meant to do sth",
+		"trans": [
+			"注定要做某事，应做某事"
+		]
+	},
+	{
+		"name": "benefit",
+		"trans": [
+			"n. 优势，益处，成效",
+			"vt. 使受益",
+			"vi. 得益于"
+		],
+		"usphone": "ˈbenɪfɪt",
+		"ukphone": "ˈbenɪfɪt"
+	},
+	{
+		"name": "comfort",
+		"trans": [
+			"vt. 宽慰，抚慰",
+			"n. 舒服；安慰"
+		],
+		"usphone": "ˈkʌmfət",
+		"ukphone": "ˈkʌmfət"
+	},
+	{
+		"name": "joy",
+		"trans": [
+			"n. 高兴，愉快；令人高兴的人（或事），乐趣"
+		],
+		"usphone": "dʒɔɪ",
+		"ukphone": "dʒɔɪ"
+	},
+	{
+		"name": "failure",
+		"trans": [
+			"n. 失败；失败的人（或事）；未履行；故障"
+		],
+		"usphone": "ˈfeɪljər",
+		"ukphone": "ˈfeɪljə(r)"
+	},
+	{
+		"name": "take on",
+		"trans": [
+			"呈现，具有"
+		]
+	},
+	{
+		"name": "in full measure",
+		"trans": [
+			"最大程度地，最大限度地"
+		]
+	},
+	{
+		"name": "moment",
+		"trans": [
+			"n. 时光，时机；瞬间；某个时刻"
+		],
+		"usphone": "ˈməʊmənt",
+		"ukphone": "ˈməʊmənt"
+	},
+	{
+		"name": "indeed",
+		"trans": [
+			"adv. 其实，实际上；的确；真正地"
+		],
+		"usphone": "ɪnˈdiːd",
+		"ukphone": "ɪnˈdiːd"
+	},
+	{
+		"name": "well-meaning",
+		"trans": [
+			"adj. 出于好心的，善意的"
+		],
+		"usphone": "ˌwel ˈmiːnɪŋ",
+		"ukphone": "ˌwel ˈmiːnɪŋ"
+	},
+	{
+		"name": "recognize",
+		"trans": [
+			"vt. 承认，意识到；认出，辨别出"
+		],
+		"usphone": "ˈrekəɡnaɪz",
+		"ukphone": "ˈrekəɡnaɪz"
+	},
+	{
+		"name": "thorough",
+		"trans": [
+			"adj. 彻底的，全面的；仔细的"
+		],
+		"usphone": "ˈθʌrə",
+		"ukphone": "ˈθʌrə"
+	},
+	{
+		"name": "death",
+		"trans": [
+			"n. 死，死亡；死亡状态"
+		],
+		"usphone": "deθ",
+		"ukphone": "deθ"
+	},
+	{
+		"name": "company",
+		"trans": [
+			"n. 陪伴，作伴；公司"
+		],
+		"usphone": "ˈkʌmpəni",
+		"ukphone": "ˈkʌmpəni"
+	},
+	{
+		"name": "crowd",
+		"trans": [
+			"n. 一伙人，一帮人；人群",
+			"vt. 挤满，使拥挤",
+			"vi. 聚集；挤，涌"
+		],
+		"usphone": "kraʊd",
+		"ukphone": "kraʊd"
+	},
+	{
+		"name": "poet",
+		"trans": [
+			"n. 诗人"
+		],
+		"usphone": "ˈpəʊɪt",
+		"ukphone": "ˈpəʊɪt"
+	},
+	{
+		"name": "admire",
+		"trans": [
+			"vt. 钦佩；欣赏"
+		],
+		"usphone": "/ədˈmaɪər",
+		"ukphone": "/ədˈmaɪə(r)"
+	},
+	{
+		"name": "wine",
+		"trans": [
+			"n. 葡萄酒；果酒"
+		],
+		"usphone": "waɪn",
+		"ukphone": "waɪn"
+	},
+	{
+		"name": "skip",
+		"trans": [
+			"vt. 不做（应做的事情等）；跳过",
+			"vi. 蹦蹦跳跳地走；略过"
+		],
+		"usphone": "skɪp",
+		"ukphone": "skɪp"
+	},
+	{
+		"name": "yogurt",
+		"trans": [
+			"n. 酸奶"
+		],
+		"usphone": "ˈjɒɡət",
+		"ukphone": "ˈjɒɡət"
+	},
+	{
+		"name": "faint",
+		"trans": [
+			"vi. 昏厥",
+			"adj. 昏眩的；微弱的；可能性不大的"
+		],
+		"usphone": "feɪnt",
+		"ukphone": "feɪnt"
+	},
+	{
+		"name": "pass out",
+		"trans": [
+			"昏迷，失去知觉"
+		]
+	},
+	{
+		"name": "immediately",
+		"trans": [
+			"adv. 立即，马上",
+			"conj. 一...就"
+		],
+		"usphone": "ɪˈmiːdiətli",
+		"ukphone": "ɪˈmiːdiətli"
+	},
+	{
+		"name": "concentrate",
+		"trans": [
+			"vi. & vt. 集中（注意力、思想等）；全神贯注"
+		],
+		"usphone": "ˈkɒnsntreɪt",
+		"ukphone": "ˈkɒnsntreɪt"
+	},
+	{
+		"name": "sex",
+		"trans": [
+			"n. 性别"
+		],
+		"usphone": "seks",
+		"ukphone": "seks"
+	},
+	{
+		"name": "extreme",
+		"trans": [
+			"adj. 极端的；严重的",
+			"n. 极端不同的感情（或境况、行为方式等）"
+		],
+		"usphone": "ɪkˈstriːm",
+		"ukphone": "ɪkˈstriːm"
+	},
+	{
+		"name": "slim",
+		"trans": [
+			"vi. 变苗条，减肥",
+			"adj. 苗条的；微薄的，小的"
+		],
+		"usphone": "slɪm",
+		"ukphone": "slɪm"
+	},
+	{
+		"name": "slim down",
+		"trans": [
+			"变苗条，减肥"
+		]
+	},
+	{
+		"name": "per cent",
+		"trans": [
+			"n. 百分之..."
+		],
+		"usphone": "pə ˈsent",
+		"ukphone": "pə ˈsent"
+	},
+	{
+		"name": "concerned",
+		"trans": [
+			"adj. 担心的，忧虑的；关注的，关切的"
+		],
+		"usphone": "kənˈsɜːnd",
+		"ukphone": "kənˈsɜːnd"
+	},
+	{
+		"name": "effect",
+		"trans": [
+			"n. 效果，作用；影响"
+		],
+		"usphone": "ɪˈfekt",
+		"ukphone": "ɪˈfekt"
+	},
+	{
+		"name": "side effect",
+		"trans": [
+			"副作用"
+		]
+	},
+	{
+		"name": "prove",
+		"trans": [
+			"linking v. 后来被发现是",
+			"vt. 证明，证实"
+		],
+		"usphone": "pruːv",
+		"ukphone": "pruːv"
+	},
+	{
+		"name": "slightly",
+		"trans": [
+			"adv. 稍微，略微"
+		],
+		"usphone": "ˈslaɪtli",
+		"ukphone": "ˈslaɪtli"
+	},
+	{
+		"name": "diet",
+		"trans": [
+			"n. 日常饮食；节食",
+			"vi. 节食，进行规定饮食"
+		],
+		"usphone": "ˈdaɪət",
+		"ukphone": "ˈdaɪət"
+	},
+	{
+		"name": "nutrition",
+		"trans": [
+			"n. 营养"
+		],
+		"usphone": "njuˈtrɪʃn",
+		"ukphone": "njuˈtrɪʃn"
+	},
+	{
+		"name": "function",
+		"trans": [
+			"vi. 起作用，正常工作，运转",
+			"n. 作用，功能，职能"
+		],
+		"usphone": "ˈfʌŋkʃn",
+		"ukphone": "ˈfʌŋkʃn"
+	},
+	{
+		"name": "take in",
+		"trans": [
+			"摄入，吸收"
+		]
+	},
+	{
+		"name": "energetic",
+		"trans": [
+			"adj. 精力充沛的，充满活力的"
+		],
+		"usphone": "ˌenəˈdʒetɪk",
+		"ukphone": "ˌenəˈdʒetɪk"
+	},
+	{
+		"name": "effective",
+		"trans": [
+			"adj. 有效的；生效的"
+		],
+		"usphone": "ɪˈfektɪv",
+		"ukphone": "ɪˈfektɪv"
+	},
+	{
+		"name": "get into shape",
+		"trans": [
+			"强身健体"
+		]
+	},
+	{
+		"name": "frightened",
+		"trans": [
+			"adj. 害怕的，惊吓的，受惊的"
+		],
+		"usphone": "ˈfraɪtnd",
+		"ukphone": "ˈfraɪtnd"
+	},
+	{
+		"name": "within",
+		"trans": [
+			"prep. 在（某段时间）之内；在（某段距离、范围）之内；在...里"
+		],
+		"usphone": "wɪˈðɪn",
+		"ukphone": "wɪˈðɪn"
+	},
+	{
+		"name": "rather",
+		"trans": [
+			"adv. 相反，而是；相当；更准确地说"
+		],
+		"usphone": "ˈrɑːðər",
+		"ukphone": "ˈrɑːðə(r)"
+	},
+	{
+		"name": "aspect",
+		"trans": [
+			"n. 方面，层面"
+		],
+		"usphone": "ˈæspekt",
+		"ukphone": "ˈæspekt"
+	},
+	{
+		"name": "pressure",
+		"trans": [
+			"n. 心理压力，紧张；压力；要求，催促"
+		],
+		"usphone": "ˈpreʃər",
+		"ukphone": "ˈpreʃə(r)"
+	},
+	{
+		"name": "contribute",
+		"trans": [
+			"vi. & vt. 是...的原因之一；捐赠，捐献；增加，添加"
+		],
+		"usphone": "kənˈtrɪbjuːt",
+		"ukphone": "kənˈtrɪbjuːt"
+	},
+	{
+		"name": "contribute to",
+		"trans": [
+			"促成，造成"
+		]
+	},
+	{
+		"name": "in the short/long term",
+		"trans": [
+			"从短期 / 长期看"
+		]
+	},
+	{
+		"name": "memory",
+		"trans": [
+			"n. 记忆力，记性；记忆，回忆"
+		],
+		"usphone": "ˈmeməri",
+		"ukphone": "ˈmeməri"
+	},
+	{
+		"name": "attack",
+		"trans": [
+			"n. 发作；攻击；抨击",
+			"vt. & vi. 攻击；侵袭；抨击"
+		],
+		"usphone": "əˈtæk",
+		"ukphone": "əˈtæk"
+	},
+	{
+		"name": "amount",
+		"trans": [
+			"n. 数量"
+		],
+		"usphone": "əˈmaʊnt",
+		"ukphone": "əˈmaʊnt"
+	},
+	{
+		"name": "schedule",
+		"trans": [
+			"n. 日程安排，工作计划；时间表"
+		],
+		"usphone": "ˈʃedʒuːl; ˈskedʒuːl",
+		"ukphone": "ˈʃedʒuːl; ˈskedʒuːl"
+	},
+	{
+		"name": "negative",
+		"trans": [
+			"adj. 消极的，负面的；坏的，有害的；否定的"
+		],
+		"usphone": "ˈneɡətɪv",
+		"ukphone": "ˈneɡətɪv"
+	},
+	{
+		"name": "plastic",
+		"trans": [
+			"adj. 可塑的；塑料的",
+			"n. 塑料"
+		],
+		"usphone": "ˈplæstɪk",
+		"ukphone": "ˈplæstɪk"
+	},
+	{
+		"name": "surgery",
+		"trans": [
+			"n. 外科手术"
+		],
+		"usphone": "ˈsɜːdʒəri",
+		"ukphone": "ˈsɜːdʒəri"
+	},
+	{
+		"name": "plastic surgery",
+		"trans": [
+			"整形手术；整形外科"
+		]
+	},
+	{
+		"name": "campus",
+		"trans": [
+			"n.（大学、学院的）校园，校区"
+		],
+		"usphone": "ˈkæmpəs",
+		"ukphone": "ˈkæmpəs"
+	},
+	{
+		"name": "treatment",
+		"trans": [
+			"n. 治疗；对待，待遇；处理"
+		],
+		"usphone": "ˈtriːtmənt",
+		"ukphone": "ˈtriːtmənt"
+	},
+	{
+		"name": "guy",
+		"trans": [
+			"n. 小伙子，家伙"
+		],
+		"usphone": "ɡaɪ",
+		"ukphone": "ɡaɪ"
+	},
+	{
+		"name": "addition",
+		"trans": [
+			"n. 增加，添加；加法"
+		],
+		"usphone": "əˈdɪʃn",
+		"ukphone": "əˈdɪʃn"
+	},
+	{
+		"name": "in addition",
+		"trans": [
+			"此外"
+		]
+	},
+	{
+		"name": "saying",
+		"trans": [
+			"n. 格言，谚语，警句"
+		],
+		"usphone": "ˈseɪɪŋ",
+		"ukphone": "ˈseɪɪŋ"
+	},
+	{
+		"name": "hang over",
+		"trans": [
+			"使忧心忡忡，担心可能发生"
+		]
+	},
+	{
+		"name": "jeans",
+		"trans": [
+			"n. 牛仔裤"
+		],
+		"usphone": "dʒiːnz",
+		"ukphone": "dʒiːnz"
+	},
+	{
+		"name": "male",
+		"trans": [
+			"adj. 男性的；雄性的",
+			"n. 男性，雄性"
+		],
+		"usphone": "meɪl",
+		"ukphone": "meɪl"
+	},
+	{
+		"name": "female",
+		"trans": [
+			"adj. 女性的；雌性的",
+			"n. 女性，雌性"
+		],
+		"usphone": "ˈfiːmeɪl",
+		"ukphone": "ˈfiːmeɪl"
+	},
+	{
+		"name": "guard against",
+		"trans": [
+			"防范，防止，提防"
+		]
+	},
+	{
+		"name": "beauty",
+		"trans": [
+			"n. 美，美丽；美人，美好的东西"
+		],
+		"usphone": "ˈbjuːti",
+		"ukphone": "ˈbjuːti"
+	},
+	{
+		"name": "fight a losing battle",
+		"trans": [
+			"打一场无望取胜的仗"
+		]
+	},
+	{
+		"name": "live up to",
+		"trans": [
+			"达到，符合，不辜负"
+		]
+	},
+	{
+		"name": "end up",
+		"trans": [
+			"最终成为，最终处于"
+		]
+	},
+	{
+		"name": "fashion",
+		"trans": [
+			"n. 时尚，时兴；流行款式"
+		],
+		"usphone": "ˈfæʃn",
+		"ukphone": "ˈfæʃn"
+	},
+	{
+		"name": "shadow",
+		"trans": [
+			"n. 阴影，影子；昏暗处，阴暗处"
+		],
+		"usphone": "ˈʃædəʊ",
+		"ukphone": "ˈʃædəʊ"
+	},
+	{
+		"name": "digital",
+		"trans": [
+			"adj. 数码的，数字的"
+		],
+		"usphone": "ˈdɪdʒɪtl",
+		"ukphone": "ˈdɪdʒɪtl"
+	},
+	{
+		"name": "series",
+		"trans": [
+			"n. (pl. series) 一系列，连续"
+		],
+		"usphone": "ˈsɪəriːz",
+		"ukphone": "ˈsɪəriːz"
+	},
+	{
+		"name": "show off",
+		"trans": [
+			"显示，展示；炫耀，卖弄"
+		]
+	},
+	{
+		"name": "external",
+		"trans": [
+			"adj. 外来的，外在的；外面的，外部的"
+		],
+		"usphone": "ɪkˈstɜːnl",
+		"ukphone": "ɪkˈstɜːnl"
+	},
+	{
+		"name": "strength",
+		"trans": [
+			"n. 优势；力气，力量；实力"
+		],
+		"usphone": "streŋθ",
+		"ukphone": "streŋθ"
+	},
+	{
+		"name": "talent",
+		"trans": [
+			"n. 天资，天赋；人才，天才"
+		],
+		"usphone": "ˈtælənt",
+		"ukphone": "ˈtælənt"
+	},
+	{
+		"name": "piano",
+		"trans": [
+			"n. 钢琴"
+		],
+		"usphone": "piˈænəʊ",
+		"ukphone": "piˈænəʊ"
+	},
+	{
+		"name": "take pride in",
+		"trans": [
+			"为...自豪，为...骄傲"
+		]
+	},
+	{
+		"name": "content",
+		"trans": [
+			"n. 内容；目录"
+		],
+		"usphone": "ˈkɒntent",
+		"ukphone": "ˈkɒntent"
+	},
+	{
+		"name": "individuality",
+		"trans": [
+			"n. 个性，个人特征"
+		],
+		"usphone": "ˌɪndɪˌvɪdʒuˈæləti",
+		"ukphone": "ˌɪndɪˌvɪdʒuˈæləti"
+	},
+	{
+		"name": "achievement",
+		"trans": [
+			"n. 成就，成绩；达到，完成"
+		],
+		"usphone": "əˈtʃiːvmənt",
+		"ukphone": "əˈtʃiːvmənt"
+	},
+	{
+		"name": "app",
+		"trans": [
+			"n. 应用程序，应用软件（application 的缩写）"
+		],
+		"usphone": "æp",
+		"ukphone": "æp"
+	}
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -1179,6 +1179,17 @@ const childrenEnglish: DictionaryResource[] = [
     languageCategory: 'en',
   },
   {
+    id: 'Yilin1',
+    name: '高中必修1',
+    description: '译林版高中必修1',
+    category: '青少年英语',
+    tags: ['译林版'],
+    url: './dicts/YiLin_1.json',
+    length: 277,
+    language: 'en',
+    languageCategory: 'en',
+  },
+  {
     id: 'beishi1',
     name: '高中必修1',
     description: '北师大版高中必修1',


### PR DESCRIPTION
由于少了译林版教材，因此尝试补了一下，方便按照教学顺序来背单词。