### PR TITLE
feat(Dicts): add a TOEFL dict

### DIFF
--- a/public/dicts/Categorized_TOEFL_Vocabulary_by_Zhanghongyan.json
+++ b/public/dicts/Categorized_TOEFL_Vocabulary_by_Zhanghongyan.json
@@ -1,0 +1,38301 @@
+[
+  {
+    "name": "parasite",
+    "trans": [
+      "1.1",
+      "n．寄生虫；寄生植物",
+      "【记】 para（旁边）+site（坐）→坐在旁边的→寄生虫"
+    ],
+    "ukphone": "ˋpærəsaIt",
+    "usphone": "ˋpærəsaIt"
+  },
+  {
+    "name": "parasitic",
+    "trans": [
+      "1.2",
+      "adj．寄生的"
+    ],
+    "ukphone": "ˌpærəˋsItIk",
+    "usphone": "ˌpærəˋsItIk"
+  },
+  {
+    "name": "mimicry",
+    "trans": [
+      "1.3",
+      "n．模仿；拟态（camouflage）",
+      "【记】 mimic（模枋）+ry"
+    ],
+    "ukphone": "ˋmImIkri",
+    "usphone": "ˋmImIkri"
+  },
+  {
+    "name": "symbiosis",
+    "trans": [
+      "1.4",
+      "n．共生（现象），合作（或互利、互依）关系"
+    ],
+    "ukphone": "ˌsImbaIˋoʊsIs",
+    "usphone": "ˌsImbaIˋoʊsIs"
+  },
+  {
+    "name": "symbiotic",
+    "trans": [
+      "1.5",
+      "adj．共生的"
+    ],
+    "ukphone": "ˌsImbaIˋα:tIk",
+    "usphone": "ˌsImbaIˋα:tIk"
+  },
+  {
+    "name": "creature",
+    "trans": [
+      "1.6",
+      "n．生物"
+    ],
+    "ukphone": "ˋkri:tʃər",
+    "usphone": "ˋkri:tʃər"
+  },
+  {
+    "name": "organism",
+    "trans": [
+      "1.7",
+      "n．生物，有机物",
+      "【记】 organ（器官）+ism"
+    ],
+    "ukphone": "ˋɔ:rgənIzəm",
+    "usphone": "ˋɔ:rgənIzəm"
+  },
+  {
+    "name": "strain",
+    "trans": [
+      "1.8",
+      "n.（动物、昆虫等的）种；血统"
+    ],
+    "ukphone": "streIn",
+    "usphone": "streIn"
+  },
+  {
+    "name": "species",
+    "trans": [
+      "1.9",
+      "n．物种"
+    ],
+    "ukphone": "ˋspi:ʃi:z",
+    "usphone": "ˋspi:ʃi:z"
+  },
+  {
+    "name": "vital",
+    "trans": [
+      "1.10",
+      "adj．活的，活体的"
+    ],
+    "ukphone": "ˋvaItl",
+    "usphone": "ˋvaItl"
+  },
+  {
+    "name": "ripe",
+    "trans": [
+      "1.11",
+      "adj．成熟的（mature, ready）"
+    ],
+    "ukphone": "raIp",
+    "usphone": "raIp"
+  },
+  {
+    "name": "evolve",
+    "trans": [
+      "1.12",
+      "v.（使）进化；（使）发展（develop, grow）"
+    ],
+    "ukphone": "iˋvα:lv",
+    "usphone": "iˋvα:lv"
+  },
+  {
+    "name": "evolutionary",
+    "trans": [
+      "1.13",
+      "adj．进化的"
+    ],
+    "ukphone": "ˌi:vəˋlu:ʃəneri",
+    "usphone": "ˌi:vəˋlu:ʃəneri"
+  },
+  {
+    "name": "Darwinism",
+    "trans": [
+      "1.14",
+      "n．达尔文学说，进化论"
+    ],
+    "ukphone": "ˋdα:rwInIzəm",
+    "usphone": "ˋdα:rwInIzəm"
+  },
+  {
+    "name": "extinct",
+    "trans": [
+      "1.15",
+      "adj．灭绝的",
+      "【记】 ex+tinct（促使）→促使出去→灭绝"
+    ],
+    "ukphone": "IkˋstIŋkt",
+    "usphone": "IkˋstIŋkt"
+  },
+  {
+    "name": "extinction",
+    "trans": [
+      "1.16",
+      "n．灭绝"
+    ],
+    "ukphone": "IkˋstIŋkʃn",
+    "usphone": "IkˋstIŋkʃn"
+  },
+  {
+    "name": "breed",
+    "trans": [
+      "1.17",
+      "vt．养育，繁殖（raise）n．品种（species, strain）"
+    ],
+    "ukphone": "bri:d",
+    "usphone": "bri:d"
+  },
+  {
+    "name": "reproduction",
+    "trans": [
+      "1.18",
+      "n．繁殖（multiplication）；复制品",
+      "【记】 re（重新）+production（生产）→复制"
+    ],
+    "ukphone": "ˌri:prəˋdʌkʃn",
+    "usphone": "ˌri:prəˋdʌkʃn"
+  },
+  {
+    "name": "proliferate",
+    "trans": [
+      "1.19",
+      "v．繁衍（multiply, increase）",
+      "【记】 pro（前）+lifer（后代）+ate→增殖，激增"
+    ],
+    "ukphone": "prəˋlIfəreIt",
+    "usphone": "prəˋlIfəreIt"
+  },
+  {
+    "name": "propagate",
+    "trans": [
+      "1.20",
+      "vt．繁殖（multiply, proliferate）；传播"
+    ],
+    "ukphone": "ˋprα:pəgeIt",
+    "usphone": "ˋprα:pəgeIt"
+  },
+  {
+    "name": "subsist",
+    "trans": [
+      "1.21",
+      "vi．生存（live, survive）"
+    ],
+    "ukphone": "səbˋsIst",
+    "usphone": "səbˋsIst"
+  },
+  {
+    "name": "exist",
+    "trans": [
+      "1.22",
+      "vi．生存（survive）"
+    ],
+    "ukphone": "IgˋzIst",
+    "usphone": "IgˋzIst"
+  },
+  {
+    "name": "posterity",
+    "trans": [
+      "1.23",
+      "n．后代（offspring, descendant）",
+      "【记】 post（后）+erity"
+    ],
+    "ukphone": "pα:ˋsterəti",
+    "usphone": "pα:ˋsterəti"
+  },
+  {
+    "name": "fermentation",
+    "trans": [
+      "1.24",
+      "n．发酵",
+      "【记】 ferm=ferv（热）+entation→热而发酵"
+    ],
+    "ukphone": "ˌfɜ:rmenˋteIʃn",
+    "usphone": "ˌfɜ:rmenˋteIʃn"
+  },
+  {
+    "name": "respiration",
+    "trans": [
+      "1.25",
+      "n．呼吸（breathing）",
+      "【记】 re（反复）+spir（呼吸）+ation"
+    ],
+    "ukphone": "ˌrespəˋreIʃn",
+    "usphone": "ˌrespəˋreIʃn"
+  },
+  {
+    "name": "stodgy",
+    "trans": [
+      "1.26",
+      "adj．难消化的"
+    ],
+    "ukphone": "ˋstα:dʒi",
+    "usphone": "ˋstα:dʒi"
+  },
+  {
+    "name": "secrete",
+    "trans": [
+      "1.27",
+      "vt．分泌（discharge, release）"
+    ],
+    "ukphone": "sIˋkri:t",
+    "usphone": "sIˋkri:t"
+  },
+  {
+    "name": "secretion",
+    "trans": [
+      "1.28",
+      "n．分泌（物）"
+    ],
+    "ukphone": "sIˋkri:ʃn",
+    "usphone": "sIˋkri:ʃn"
+  },
+  {
+    "name": "assimilate",
+    "trans": [
+      "1.29",
+      "vt．吸收（absorb, integrate, incorporate）",
+      "【记】 as+simil（相同）+ate→使相同→同化，吸收"
+    ],
+    "ukphone": "əˋsIməleIt",
+    "usphone": "əˋsIməleIt"
+  },
+  {
+    "name": "immune",
+    "trans": [
+      "1.30",
+      "adj．免除的；免疫的（unaffected, unsusceptible）",
+      "【记】 im（没有）+mune（责任）→没有责任→免除的"
+    ],
+    "ukphone": "Iˋmju:n",
+    "usphone": "Iˋmju:n"
+  },
+  {
+    "name": "immunity",
+    "trans": [
+      "1.31",
+      "n．免疫性"
+    ],
+    "ukphone": "Iˋmju:nəti",
+    "usphone": "Iˋmju:nəti"
+  },
+  {
+    "name": "metabolism",
+    "trans": [
+      "1.32",
+      "n．新陈代谢",
+      "【记】 meta（变化）+bolism→产生变化→新陈代谢"
+    ],
+    "ukphone": "məˋtæbəlIzəm",
+    "usphone": "məˋtæbəlIzəm"
+  },
+  {
+    "name": "morphology",
+    "trans": [
+      "1.33",
+      "n．形态学"
+    ],
+    "ukphone": "mɔ:rˋfα:lədʒi",
+    "usphone": "mɔ:rˋfα:lədʒi"
+  },
+  {
+    "name": "microscope",
+    "trans": [
+      "1.34",
+      "n．显微镜"
+    ],
+    "ukphone": "ˋmaIkrəskoʊp",
+    "usphone": "ˋmaIkrəskoʊp"
+  },
+  {
+    "name": "calorie",
+    "trans": [
+      "1.35",
+      "n．卡路里"
+    ],
+    "ukphone": "ˋkæləri",
+    "usphone": "ˋkæləri"
+  },
+  {
+    "name": "carbohydrate",
+    "trans": [
+      "1.36",
+      "n．碳水化合物，糖类"
+    ],
+    "ukphone": "ˌkα:rboʊˋhaIdreIt",
+    "usphone": "ˌkα:rboʊˋhaIdreIt"
+  },
+  {
+    "name": "glucose",
+    "trans": [
+      "1.37",
+      "n．葡萄糖"
+    ],
+    "ukphone": "ˋglu:koʊs",
+    "usphone": "ˋglu:koʊs"
+  },
+  {
+    "name": "protein",
+    "trans": [
+      "1.38",
+      "n．蛋白质 adj．蛋白质的"
+    ],
+    "ukphone": "ˋproʊti:n",
+    "usphone": "ˋproʊti:n"
+  },
+  {
+    "name": "organ",
+    "trans": [
+      "1.39",
+      "n．器官"
+    ],
+    "ukphone": "ˋɔ:rgən",
+    "usphone": "ˋɔ:rgən"
+  },
+  {
+    "name": "bacteria",
+    "trans": [
+      "1.40",
+      "n．［微］ 细菌"
+    ],
+    "ukphone": "bækˋtIriə",
+    "usphone": "bækˋtIriə"
+  },
+  {
+    "name": "vaccine",
+    "trans": [
+      "1.41",
+      "n．疫苗"
+    ],
+    "ukphone": "vækˋsi:n",
+    "usphone": "vækˋsi:n"
+  },
+  {
+    "name": "fungus",
+    "trans": [
+      "1.42",
+      "n．真菌，霉菌；菌类"
+    ],
+    "ukphone": "ˋfʌŋgəs",
+    "usphone": "ˋfʌŋgəs"
+  },
+  {
+    "name": "membrane",
+    "trans": [
+      "1.43",
+      "n．膜；薄膜；羊皮纸"
+    ],
+    "ukphone": "ˋmembreIn",
+    "usphone": "ˋmembreIn"
+  },
+  {
+    "name": "viability",
+    "trans": [
+      "1.44",
+      "n．生存能力，发育能力；可行性"
+    ],
+    "ukphone": "ˌvaIəˋbIləti",
+    "usphone": "ˌvaIəˋbIləti"
+  },
+  {
+    "name": "picturesque",
+    "trans": [
+      "2.1",
+      "adj．如画般的，生动的（vivid）",
+      "【记】 picture（图画）+sque"
+    ],
+    "ukphone": "ˌpIktʃəˋresk",
+    "usphone": "ˌpIktʃəˋresk"
+  },
+  {
+    "name": "vivid",
+    "trans": [
+      "2.2",
+      "adj．生动的（lively, active）"
+    ],
+    "ukphone": "ˋvIvId",
+    "usphone": "ˋvIvId"
+  },
+  {
+    "name": "sculpture",
+    "trans": [
+      "2.3",
+      "n．雕塑品（carving, engraving）"
+    ],
+    "ukphone": "ˋskʌlptʃər",
+    "usphone": "ˋskʌlptʃər"
+  },
+  {
+    "name": "statue",
+    "trans": [
+      "2.4",
+      "n．雕像"
+    ],
+    "ukphone": "ˋstætʃu:",
+    "usphone": "ˋstætʃu:"
+  },
+  {
+    "name": "draw",
+    "trans": [
+      "2.5",
+      "v．画"
+    ],
+    "ukphone": "drɔ:",
+    "usphone": "drɔ:"
+  },
+  {
+    "name": "gallery",
+    "trans": [
+      "2.6",
+      "n．画廊"
+    ],
+    "ukphone": "ˋgæləri",
+    "usphone": "ˋgæləri"
+  },
+  {
+    "name": "portrait",
+    "trans": [
+      "2.7",
+      "n．肖像，画像；描写"
+    ],
+    "ukphone": "ˋpɔ:rtrət",
+    "usphone": "ˋpɔ:rtrət"
+  },
+  {
+    "name": "impressionism",
+    "trans": [
+      "2.8",
+      "n．印象派"
+    ],
+    "ukphone": "ImˋpreʃənIzəm",
+    "usphone": "ImˋpreʃənIzəm"
+  },
+  {
+    "name": "portray",
+    "trans": [
+      "2.9",
+      "vt．绘制（delineate, depict）"
+    ],
+    "ukphone": "pɔ:rˋtreI",
+    "usphone": "pɔ:rˋtreI"
+  },
+  {
+    "name": "mold",
+    "trans": [
+      "2.10",
+      "vt．塑造（shape）"
+    ],
+    "ukphone": "moʊld",
+    "usphone": "moʊld"
+  },
+  {
+    "name": "embroider",
+    "trans": [
+      "2.11",
+      "vt．绣花",
+      "【记】 em+broider（刺绣）"
+    ],
+    "ukphone": "ImˋbrɔIdər",
+    "usphone": "ImˋbrɔIdər"
+  },
+  {
+    "name": "tragedy",
+    "trans": [
+      "2.12",
+      "n．悲剧"
+    ],
+    "ukphone": "ˋtrædʒədi",
+    "usphone": "ˋtrædʒədi"
+  },
+  {
+    "name": "opera",
+    "trans": [
+      "2.13",
+      "n．歌剧",
+      "【记】 通过创作（operate）而来"
+    ],
+    "ukphone": "ˋα:prə",
+    "usphone": "ˋα:prə"
+  },
+  {
+    "name": "enact",
+    "trans": [
+      "2.14",
+      "vt．扮演（impersonate）",
+      "【记】 en+act（扮演）"
+    ],
+    "ukphone": "Iˋnækt",
+    "usphone": "Iˋnækt"
+  },
+  {
+    "name": "pose",
+    "trans": [
+      "2.15",
+      "vt．构成；（使）摆好姿势（frame, constitute）"
+    ],
+    "ukphone": "poʊz",
+    "usphone": "poʊz"
+  },
+  {
+    "name": "rehearse",
+    "trans": [
+      "2.16",
+      "vt．预演，排练（prepare, try out）"
+    ],
+    "ukphone": "rIˋhɜ:rs",
+    "usphone": "rIˋhɜ:rs"
+  },
+  {
+    "name": "prelude",
+    "trans": [
+      "2.17",
+      "n．序幕（preface）",
+      "【记】 pre（先）+lude（玩，演奏）→先演奏→序曲"
+    ],
+    "ukphone": "ˋprelju:d",
+    "usphone": "ˋprelju:d"
+  },
+  {
+    "name": "character",
+    "trans": [
+      "2.18",
+      "n．角色"
+    ],
+    "ukphone": "ˋkærəktər",
+    "usphone": "ˋkærəktər"
+  },
+  {
+    "name": "role",
+    "trans": [
+      "2.19",
+      "n．角色（part）"
+    ],
+    "ukphone": "roʊl",
+    "usphone": "roʊl"
+  },
+  {
+    "name": "design",
+    "trans": [
+      "2.20",
+      "n．设计，图案 v．设计（pattern）",
+      "【记】 de+sign（标出）→设计"
+    ],
+    "ukphone": "dIˋzaIn",
+    "usphone": "dIˋzaIn"
+  },
+  {
+    "name": "profile",
+    "trans": [
+      "2.21",
+      "n．外形，轮廓（outline, contour, sketch）",
+      "【记】 pro（前）+file（线条）→前面的线条→轮廓"
+    ],
+    "ukphone": "ˋproʊfaIl",
+    "usphone": "ˋproʊfaIl"
+  },
+  {
+    "name": "renaissance",
+    "trans": [
+      "2.22",
+      "n．文艺复兴",
+      "【记】 re（重新）+naiss（出生）+ance→新生"
+    ],
+    "ukphone": "ˋrenəsα:ns",
+    "usphone": "ˋrenəsα:ns"
+  },
+  {
+    "name": "conjure",
+    "trans": [
+      "2.23",
+      "vt．用魔术做成（或变出）"
+    ],
+    "ukphone": "ˋkʌndʒər",
+    "usphone": "ˋkʌndʒər"
+  },
+  {
+    "name": "aesthetic",
+    "trans": [
+      "2.24",
+      "adj．审美的，美学的（artistic）",
+      "【记】 a+esthe（感觉）+tic→对美有感觉的→美学的"
+    ],
+    "ukphone": "esˋθetIk",
+    "usphone": "esˋθetIk"
+  },
+  {
+    "name": "romantic",
+    "trans": [
+      "2.25",
+      "adj．传奇式的，浪漫的"
+    ],
+    "ukphone": "roʊˋmæntIk",
+    "usphone": "roʊˋmæntIk"
+  },
+  {
+    "name": "mythology",
+    "trans": [
+      "2.26",
+      "n．神话；神话学；神话集"
+    ],
+    "ukphone": "mIˋθα:lədʒi",
+    "usphone": "mIˋθα:lədʒi"
+  },
+  {
+    "name": "arcade",
+    "trans": [
+      "2.27",
+      "n．拱廊"
+    ],
+    "ukphone": "α:rˋkeId",
+    "usphone": "α:rˋkeId"
+  },
+  {
+    "name": "pottery",
+    "trans": [
+      "2.28",
+      "n．陶器"
+    ],
+    "ukphone": "ˋpα:təri",
+    "usphone": "ˋpα:təri"
+  },
+  {
+    "name": "virtuoso",
+    "trans": [
+      "2.29",
+      "n．艺术品鉴赏家；古董收藏家；艺术大师"
+    ],
+    "ukphone": "ˌvɜ:rtʃuˋoʊsoʊ",
+    "usphone": "ˌvɜ:rtʃuˋoʊsoʊ"
+  },
+  {
+    "name": "fresco",
+    "trans": [
+      "2.30",
+      "n．壁画"
+    ],
+    "ukphone": "ˋfreskoʊ",
+    "usphone": "ˋfreskoʊ"
+  },
+  {
+    "name": "baroque",
+    "trans": [
+      "2.31",
+      "adj．巴洛克式的；结构复杂的，形式怪样的 n．巴洛克风格；巴洛克艺术"
+    ],
+    "ukphone": "bəˋroʊk",
+    "usphone": "bəˋroʊk"
+  },
+  {
+    "name": "Dadaism",
+    "trans": [
+      "2.32",
+      "n．达达派，达达主义（崇尚虚无的艺术派别）"
+    ],
+    "ukphone": "ˋdα:dα:Izəm",
+    "usphone": "ˋdα:dα:Izəm"
+  },
+  {
+    "name": "gregarious",
+    "trans": [
+      "3.1",
+      "adj．群居的",
+      "【记】 greg（群体）+arious→爱群体的"
+    ],
+    "ukphone": "grIˋgeriəs",
+    "usphone": "grIˋgeriəs"
+  },
+  {
+    "name": "swarm",
+    "trans": [
+      "3.2",
+      "n.（蜜蜂、蚂蚁等）群（throng, crowd, horde）"
+    ],
+    "ukphone": "swɔ:rm",
+    "usphone": "swɔ:rm"
+  },
+  {
+    "name": "flock",
+    "trans": [
+      "3.3",
+      "n．羊群，（禽、畜等的）群"
+    ],
+    "ukphone": "flα:k",
+    "usphone": "flα:k"
+  },
+  {
+    "name": "herd",
+    "trans": [
+      "3.4",
+      "n．兽群，牧群"
+    ],
+    "ukphone": "hɜ:rd",
+    "usphone": "hɜ:rd"
+  },
+  {
+    "name": "mammal",
+    "trans": [
+      "3.5",
+      "n．哺乳动物",
+      "【记】 mamma（乳）+l"
+    ],
+    "ukphone": "ˋmæml",
+    "usphone": "ˋmæml"
+  },
+  {
+    "name": "carnivore",
+    "trans": [
+      "3.6",
+      "n．食肉动物"
+    ],
+    "ukphone": "ˋkα:rnIvɔ:r",
+    "usphone": "ˋkα:rnIvɔ:r"
+  },
+  {
+    "name": "carnivorous",
+    "trans": [
+      "3.7",
+      "adj．食肉类的"
+    ],
+    "ukphone": "kα:rˋnIvərəs",
+    "usphone": "kα:rˋnIvərəs"
+  },
+  {
+    "name": "appetite",
+    "trans": [
+      "3.8",
+      "n．食欲"
+    ],
+    "ukphone": "ˋæpItaIt",
+    "usphone": "ˋæpItaIt"
+  },
+  {
+    "name": "herbivorous",
+    "trans": [
+      "3.9",
+      "adj．食草的"
+    ],
+    "ukphone": "hɜ:rˋbIvərəs",
+    "usphone": "hɜ:rˋbIvərəs"
+  },
+  {
+    "name": "omnivorous",
+    "trans": [
+      "3.10",
+      "adj．杂食的，什么都吃的"
+    ],
+    "ukphone": "α:mˋnIvərəs",
+    "usphone": "α:mˋnIvərəs"
+  },
+  {
+    "name": "predator",
+    "trans": [
+      "3.11",
+      "n．掠夺者，食肉动物"
+    ],
+    "ukphone": "ˋpredətər",
+    "usphone": "ˋpredətər"
+  },
+  {
+    "name": "predatory",
+    "trans": [
+      "3.12",
+      "adj．掠夺的，食肉的"
+    ],
+    "ukphone": "ˋpredətɔ:ri",
+    "usphone": "ˋpredətɔ:ri"
+  },
+  {
+    "name": "prey",
+    "trans": [
+      "3.13",
+      "n．被掠食者，牺牲者"
+    ],
+    "ukphone": "preI",
+    "usphone": "preI"
+  },
+  {
+    "name": "poikilotherm",
+    "trans": [
+      "3.14",
+      "n．变温动物，冷血动物"
+    ],
+    "ukphone": "pɔIˋkIləˌθɜ:rm",
+    "usphone": "pɔIˋkIləˌθɜ:rm"
+  },
+  {
+    "name": "rodent",
+    "trans": [
+      "3.15",
+      "n．啮齿动物"
+    ],
+    "ukphone": "ˋroʊdnt",
+    "usphone": "ˋroʊdnt"
+  },
+  {
+    "name": "scavenger",
+    "trans": [
+      "3.16",
+      "n．清道夫，食腐动物"
+    ],
+    "ukphone": "ˋskævIndʒər",
+    "usphone": "ˋskævIndʒər"
+  },
+  {
+    "name": "microbe",
+    "trans": [
+      "3.17",
+      "n．微生物，细菌"
+    ],
+    "ukphone": "ˋmaIkroʊb",
+    "usphone": "ˋmaIkroʊb"
+  },
+  {
+    "name": "reptile",
+    "trans": [
+      "3.18",
+      "n．爬行动物"
+    ],
+    "ukphone": "ˋreptaIl",
+    "usphone": "ˋreptaIl"
+  },
+  {
+    "name": "homotherm",
+    "trans": [
+      "3.19",
+      "n．恒温动物"
+    ],
+    "ukphone": "ˋhoʊməθɜ:rm",
+    "usphone": "ˋhoʊməθɜ:rm"
+  },
+  {
+    "name": "primate",
+    "trans": [
+      "3.20",
+      "n．灵长类的动物"
+    ],
+    "ukphone": "ˋpraImeIt",
+    "usphone": "ˋpraImeIt"
+  },
+  {
+    "name": "primates",
+    "trans": [
+      "3.21",
+      "n．灵长类"
+    ],
+    "ukphone": "ˋpraImeIts",
+    "usphone": "ˋpraImeIts"
+  },
+  {
+    "name": "mollusk",
+    "trans": [
+      "3.22",
+      "n．软体动物"
+    ],
+    "ukphone": "ˋmα:ləsk",
+    "usphone": "ˋmα:ləsk"
+  },
+  {
+    "name": "coelenterate",
+    "trans": [
+      "3.23",
+      "n．腔肠动物"
+    ],
+    "ukphone": "sIˋlentərət",
+    "usphone": "sIˋlentərət"
+  },
+  {
+    "name": "vertebrate",
+    "trans": [
+      "3.24",
+      "n．脊椎动物"
+    ],
+    "ukphone": "ˋvɜ:rtibrət",
+    "usphone": "ˋvɜ:rtibrət"
+  },
+  {
+    "name": "invertebrate",
+    "trans": [
+      "3.25",
+      "n．无脊椎动物"
+    ],
+    "ukphone": "Inˋvɜ:rtibrət",
+    "usphone": "Inˋvɜ:rtibrət"
+  },
+  {
+    "name": "finch",
+    "trans": [
+      "3.26",
+      "n．鸣禽",
+      "【记】 fin（尾翅）+ch"
+    ],
+    "ukphone": "fIntʃ",
+    "usphone": "fIntʃ"
+  },
+  {
+    "name": "fowl",
+    "trans": [
+      "3.27",
+      "n．鸡；家禽（chicken; poultry）"
+    ],
+    "ukphone": "faʊl",
+    "usphone": "faʊl"
+  },
+  {
+    "name": "monster",
+    "trans": [
+      "3.28",
+      "n．怪物，巨兽（demon）"
+    ],
+    "ukphone": "ˋmα:nstər",
+    "usphone": "ˋmα:nstər"
+  },
+  {
+    "name": "hordes",
+    "trans": [
+      "3.29",
+      "n．昆虫群"
+    ],
+    "ukphone": "hɔ:rdz",
+    "usphone": "hɔ:rdz"
+  },
+  {
+    "name": "insect",
+    "trans": [
+      "3.30",
+      "n．昆虫"
+    ],
+    "ukphone": "ˋInsekt",
+    "usphone": "ˋInsekt"
+  },
+  {
+    "name": "worm",
+    "trans": [
+      "3.31",
+      "n．虫，蠕虫"
+    ],
+    "ukphone": "wɜ:rm",
+    "usphone": "wɜ:rm"
+  },
+  {
+    "name": "beast",
+    "trans": [
+      "3.32",
+      "n．兽，畜牲"
+    ],
+    "ukphone": "bi:st",
+    "usphone": "bi:st"
+  },
+  {
+    "name": "aquatic",
+    "trans": [
+      "3.33",
+      "adj．水的，水上的，水生的，水栖的"
+    ],
+    "ukphone": "əˋkwætIk",
+    "usphone": "əˋkwætIk"
+  },
+  {
+    "name": "amphibian",
+    "trans": [
+      "3.34",
+      "adj．两栖类的；水陆两用的"
+    ],
+    "ukphone": "æmˋfIbiən",
+    "usphone": "æmˋfIbiən"
+  },
+  {
+    "name": "migrate",
+    "trans": [
+      "3.35",
+      "vi.（鸟类的）迁徙"
+    ],
+    "ukphone": "ˋmaIgreIt",
+    "usphone": "ˋmaIgreIt"
+  },
+  {
+    "name": "graze",
+    "trans": [
+      "3.36",
+      "v．放牧"
+    ],
+    "ukphone": "greIz",
+    "usphone": "greIz"
+  },
+  {
+    "name": "gasp",
+    "trans": [
+      "3.37",
+      "v．气喘，喘息（breathe, gulp）"
+    ],
+    "ukphone": "gæsp",
+    "usphone": "gæsp"
+  },
+  {
+    "name": "peck",
+    "trans": [
+      "3.38",
+      "v．啄，啄起（bite, nibble）"
+    ],
+    "ukphone": "pek",
+    "usphone": "pek"
+  },
+  {
+    "name": "trot",
+    "trans": [
+      "3.39",
+      "vi./n.（马）小跑，慢跑（jog）"
+    ],
+    "ukphone": "trα:t",
+    "usphone": "trα:t"
+  },
+  {
+    "name": "dormant",
+    "trans": [
+      "3.40",
+      "adj．休眠的（inactive）",
+      "【记】 dorm（睡眠）+ant"
+    ],
+    "ukphone": "ˋdɔ:rmənt",
+    "usphone": "ˋdɔ:rmənt"
+  },
+  {
+    "name": "offspring",
+    "trans": [
+      "3.41",
+      "n．子孙，后代（descendant）"
+    ],
+    "ukphone": "ˋɔ:fsprIŋ",
+    "usphone": "ˋɔ:fsprIŋ"
+  },
+  {
+    "name": "spawn",
+    "trans": [
+      "3.42",
+      "n./v．产卵（generate, produce）"
+    ],
+    "ukphone": "spɔ:n",
+    "usphone": "spɔ:n"
+  },
+  {
+    "name": "pregnant",
+    "trans": [
+      "3.43",
+      "adj．怀孕的，孕育的"
+    ],
+    "ukphone": "ˋpregnənt",
+    "usphone": "ˋpregnənt"
+  },
+  {
+    "name": "hatch",
+    "trans": [
+      "3.44",
+      "v．孵出，孵（卵）（incubate, breed, emerge from the egg）"
+    ],
+    "ukphone": "hætʃ",
+    "usphone": "hætʃ"
+  },
+  {
+    "name": "breed",
+    "trans": [
+      "3.45",
+      "v.（使）繁殖；教养，抚养"
+    ],
+    "ukphone": "bri:d",
+    "usphone": "bri:d"
+  },
+  {
+    "name": "domesticate",
+    "trans": [
+      "3.46",
+      "vt．驯养，教化（tame）"
+    ],
+    "ukphone": "dəˋmestIkeIt",
+    "usphone": "dəˋmestIkeIt"
+  },
+  {
+    "name": "fertilize",
+    "trans": [
+      "3.47",
+      "vt．使受精"
+    ],
+    "ukphone": "ˋfɜ:rtəlaIz",
+    "usphone": "ˋfɜ:rtəlaIz"
+  },
+  {
+    "name": "regeneration",
+    "trans": [
+      "3.48",
+      "n．再生，重建"
+    ],
+    "ukphone": "rIˌdʒenəˋreIʃn",
+    "usphone": "rIˌdʒenəˋreIʃn"
+  },
+  {
+    "name": "reproduce",
+    "trans": [
+      "3.49",
+      "v．繁殖，再生"
+    ],
+    "ukphone": "ˌri:prəˋdju:s",
+    "usphone": "ˌri:prəˋdju:s"
+  },
+  {
+    "name": "squeak",
+    "trans": [
+      "3.50",
+      "vi.（老鼠或物体）吱吱"
+    ],
+    "ukphone": "skwi:k",
+    "usphone": "skwi:k"
+  },
+  {
+    "name": "chirp",
+    "trans": [
+      "3.51",
+      "vi．喳喳（虫和鸟的叫声）"
+    ],
+    "ukphone": "tʃɜ:rp",
+    "usphone": "tʃɜ:rp"
+  },
+  {
+    "name": "hibernate",
+    "trans": [
+      "3.52",
+      "vi．冬眠"
+    ],
+    "ukphone": "ˋhaIbərneIt",
+    "usphone": "ˋhaIbərneIt"
+  },
+  {
+    "name": "camouflage",
+    "trans": [
+      "3.53",
+      "v./n．伪装"
+    ],
+    "ukphone": "ˋkæməflα:ʒ",
+    "usphone": "ˋkæməflα:ʒ"
+  },
+  {
+    "name": "extinction",
+    "trans": [
+      "3.54",
+      "n．灭绝"
+    ],
+    "ukphone": "IkˋstIŋkʃn",
+    "usphone": "IkˋstIŋkʃn"
+  },
+  {
+    "name": "monogamous",
+    "trans": [
+      "3.55",
+      "adj．单配的，一雌一雄的"
+    ],
+    "ukphone": "məˋnα:gəməs",
+    "usphone": "məˋnα:gəməs"
+  },
+  {
+    "name": "polyandrous",
+    "trans": [
+      "3.56",
+      "adj．一雌多雄（配合）的"
+    ],
+    "ukphone": "ˌpα:liˋændrəs",
+    "usphone": "ˌpα:liˋændrəs"
+  },
+  {
+    "name": "nest",
+    "trans": [
+      "3.57",
+      "n．巢，窝"
+    ],
+    "ukphone": "nest",
+    "usphone": "nest"
+  },
+  {
+    "name": "niche",
+    "trans": [
+      "3.58",
+      "n．小生态环境"
+    ],
+    "ukphone": "ni:ʃ",
+    "usphone": "ni:ʃ"
+  },
+  {
+    "name": "pest",
+    "trans": [
+      "3.59",
+      "n．有害物"
+    ],
+    "ukphone": "pest",
+    "usphone": "pest"
+  },
+  {
+    "name": "habitat",
+    "trans": [
+      "3.60",
+      "n.（动植物的）生活环境，产地，栖息地，居留地，自生地，聚集处"
+    ],
+    "ukphone": "ˋhæbItæt",
+    "usphone": "ˋhæbItæt"
+  },
+  {
+    "name": "rhinoceros",
+    "trans": [
+      "3.61",
+      "n．犀牛"
+    ],
+    "ukphone": "raIˋnα:sərəs",
+    "usphone": "raIˋnα:sərəs"
+  },
+  {
+    "name": "chimpanzee",
+    "trans": [
+      "3.62",
+      "n．非洲的小人猿，黑猩猩"
+    ],
+    "ukphone": "ˌtʃImpænˋzi:",
+    "usphone": "ˌtʃImpænˋzi:"
+  },
+  {
+    "name": "baboon",
+    "trans": [
+      "3.63",
+      "n．狒狒"
+    ],
+    "ukphone": "bæˋbu:n",
+    "usphone": "bæˋbu:n"
+  },
+  {
+    "name": "gorilla",
+    "trans": [
+      "3.64",
+      "n．大猩猩"
+    ],
+    "ukphone": "gəˋrIlə",
+    "usphone": "gəˋrIlə"
+  },
+  {
+    "name": "lizard",
+    "trans": [
+      "3.65",
+      "n．蜥蜴"
+    ],
+    "ukphone": "ˋlIzərd",
+    "usphone": "ˋlIzərd"
+  },
+  {
+    "name": "moth",
+    "trans": [
+      "3.66",
+      "n．蛾，蛀虫"
+    ],
+    "ukphone": "mɔ:θ",
+    "usphone": "mɔ:θ"
+  },
+  {
+    "name": "canary",
+    "trans": [
+      "3.67",
+      "n．金丝雀；淡黄色"
+    ],
+    "ukphone": "kəˋneri",
+    "usphone": "kəˋneri"
+  },
+  {
+    "name": "caterpillar",
+    "trans": [
+      "3.68",
+      "n．毛虫"
+    ],
+    "ukphone": "ˋkætərpIlər",
+    "usphone": "ˋkætərpIlər"
+  },
+  {
+    "name": "dinosaur",
+    "trans": [
+      "3.69",
+      "n．恐龙"
+    ],
+    "ukphone": "ˋdaInəsɔ:r",
+    "usphone": "ˋdaInəsɔ:r"
+  },
+  {
+    "name": "chameleon",
+    "trans": [
+      "3.70",
+      "n．变色龙"
+    ],
+    "ukphone": "kəˋmi:liən",
+    "usphone": "kəˋmi:liən"
+  },
+  {
+    "name": "larva",
+    "trans": [
+      "3.71",
+      "n．幼虫"
+    ],
+    "ukphone": "ˋlα:rvə",
+    "usphone": "ˋlα:rvə"
+  },
+  {
+    "name": "bat",
+    "trans": [
+      "3.72",
+      "n．蝙蝠；球棒"
+    ],
+    "ukphone": "bæt",
+    "usphone": "bæt"
+  },
+  {
+    "name": "family",
+    "trans": [
+      "3.73",
+      "n．科"
+    ],
+    "ukphone": "ˋfæməli",
+    "usphone": "ˋfæməli"
+  },
+  {
+    "name": "class",
+    "trans": [
+      "3.74",
+      "n．纲"
+    ],
+    "ukphone": "klæs",
+    "usphone": "klæs"
+  },
+  {
+    "name": "suborder",
+    "trans": [
+      "3.75",
+      "n．亚目"
+    ],
+    "ukphone": "sʌbˋɔ:rdər",
+    "usphone": "sʌbˋɔ:rdər"
+  },
+  {
+    "name": "order",
+    "trans": [
+      "3.76",
+      "n．目"
+    ],
+    "ukphone": "ˋɔ:rdər",
+    "usphone": "ˋɔ:rdər"
+  },
+  {
+    "name": "genus",
+    "trans": [
+      "3.77",
+      "n．种，类"
+    ],
+    "ukphone": "ˋdʒi:nəs",
+    "usphone": "ˋdʒi:nəs"
+  },
+  {
+    "name": "antenna",
+    "trans": [
+      "3.78",
+      "n．触须"
+    ],
+    "ukphone": "ænˋtenə",
+    "usphone": "ænˋtenə"
+  },
+  {
+    "name": "tentacle",
+    "trans": [
+      "3.79",
+      "n.（动物）触须、触角，（植物）腺毛"
+    ],
+    "ukphone": "ˋtentəkl",
+    "usphone": "ˋtentəkl"
+  },
+  {
+    "name": "spleen",
+    "trans": [
+      "3.80",
+      "n．脾脏"
+    ],
+    "ukphone": "spli:n",
+    "usphone": "spli:n"
+  },
+  {
+    "name": "hide",
+    "trans": [
+      "3.81",
+      "n．兽皮（skin）"
+    ],
+    "ukphone": "haId",
+    "usphone": "haId"
+  },
+  {
+    "name": "spine",
+    "trans": [
+      "3.82",
+      "n．脊骨（backbone）"
+    ],
+    "ukphone": "spaIn",
+    "usphone": "spaIn"
+  },
+  {
+    "name": "spineless",
+    "trans": [
+      "3.83",
+      "adj．无脊椎的"
+    ],
+    "ukphone": "ˋspaInləs",
+    "usphone": "ˋspaInləs"
+  },
+  {
+    "name": "toe",
+    "trans": [
+      "3.84",
+      "n．脚趾"
+    ],
+    "ukphone": "toʊ",
+    "usphone": "toʊ"
+  },
+  {
+    "name": "bill",
+    "trans": [
+      "3.85",
+      "n．鸟嘴"
+    ],
+    "ukphone": "bIl",
+    "usphone": "bIl"
+  },
+  {
+    "name": "beak",
+    "trans": [
+      "3.86",
+      "n．鸟嘴，喙"
+    ],
+    "ukphone": "bi:k",
+    "usphone": "bi:k"
+  },
+  {
+    "name": "fuzzy",
+    "trans": [
+      "3.87",
+      "adj．有绒毛的，绒毛状的（frizzy, downy）"
+    ],
+    "ukphone": "ˋfʌzi",
+    "usphone": "ˋfʌzi"
+  },
+  {
+    "name": "hump",
+    "trans": [
+      "3.88",
+      "n．驼峰"
+    ],
+    "ukphone": "hʌmp",
+    "usphone": "hʌmp"
+  },
+  {
+    "name": "scale",
+    "trans": [
+      "3.89",
+      "n．鳞片"
+    ],
+    "ukphone": "skeIl",
+    "usphone": "skeIl"
+  },
+  {
+    "name": "wing",
+    "trans": [
+      "3.90",
+      "n．翅，翅膀，翼"
+    ],
+    "ukphone": "wIŋ",
+    "usphone": "wIŋ"
+  },
+  {
+    "name": "fluffy",
+    "trans": [
+      "3.91",
+      "adj．绒毛的",
+      "【记】 fluff（绒毛）+y"
+    ],
+    "ukphone": "ˋflʌfi",
+    "usphone": "ˋflʌfi"
+  },
+  {
+    "name": "carnal",
+    "trans": [
+      "3.92",
+      "adj．肉体的（corporeal）",
+      "【记】 carn（肉）+al"
+    ],
+    "ukphone": "ˋkα:rnl",
+    "usphone": "ˋkα:rnl"
+  },
+  {
+    "name": "nervous",
+    "trans": [
+      "3.93",
+      "adj．神经的",
+      "【记】 nerv（神经）+ous"
+    ],
+    "ukphone": "ˋnɜ:rvəs",
+    "usphone": "ˋnɜ:rvəs"
+  },
+  {
+    "name": "fat",
+    "trans": [
+      "3.94",
+      "n．脂肪，肥肉"
+    ],
+    "ukphone": "fæt",
+    "usphone": "fæt"
+  },
+  {
+    "name": "grease",
+    "trans": [
+      "3.95",
+      "n．动物脂，脂肪"
+    ],
+    "ukphone": "gri:s",
+    "usphone": "gri:s"
+  },
+  {
+    "name": "greasy",
+    "trans": [
+      "3.96",
+      "adj．多脂的；油脂的（oily）"
+    ],
+    "ukphone": "ˋgri:si",
+    "usphone": "ˋgri:si"
+  },
+  {
+    "name": "turtle",
+    "trans": [
+      "3.97",
+      "n．海龟"
+    ],
+    "ukphone": "ˋtɜ:rtl",
+    "usphone": "ˋtɜ:rtl"
+  },
+  {
+    "name": "beaver",
+    "trans": [
+      "3.98",
+      "n．海狸（毛皮）"
+    ],
+    "ukphone": "ˋbi:vər",
+    "usphone": "ˋbi:vər"
+  },
+  {
+    "name": "jellyfish",
+    "trans": [
+      "3.99",
+      "n．水母",
+      "【记】 jelly（胶冻，果冻）+fish（鱼）"
+    ],
+    "ukphone": "ˋdʒelifIʃ",
+    "usphone": "ˋdʒelifIʃ"
+  },
+  {
+    "name": "starfish",
+    "trans": [
+      "3.100",
+      "n．海星"
+    ],
+    "ukphone": "ˋstα:rfIʃ",
+    "usphone": "ˋstα:rfIʃ"
+  },
+  {
+    "name": "whale",
+    "trans": [
+      "3.101",
+      "n．鲸"
+    ],
+    "ukphone": "weIl",
+    "usphone": "weIl"
+  },
+  {
+    "name": "porpoise",
+    "trans": [
+      "3.102",
+      "n．海豚，小鲸"
+    ],
+    "ukphone": "ˋpɔ:rpəs",
+    "usphone": "ˋpɔ:rpəs"
+  },
+  {
+    "name": "dolphin",
+    "trans": [
+      "3.103",
+      "n．海豚"
+    ],
+    "ukphone": "ˋdα:lfIn",
+    "usphone": "ˋdα:lfIn"
+  },
+  {
+    "name": "prawn",
+    "trans": [
+      "3.104",
+      "n．对虾，明虾，大虾"
+    ],
+    "ukphone": "prɔ:n",
+    "usphone": "prɔ:n"
+  },
+  {
+    "name": "shrimp",
+    "trans": [
+      "3.105",
+      "n．小虾"
+    ],
+    "ukphone": "ʃrImp",
+    "usphone": "ʃrImp"
+  },
+  {
+    "name": "lobster",
+    "trans": [
+      "3.106",
+      "n．龙虾"
+    ],
+    "ukphone": "ˋlα:bstər",
+    "usphone": "ˋlα:bstər"
+  },
+  {
+    "name": "sponge",
+    "trans": [
+      "3.107",
+      "n．海绵，海绵体，海绵状物"
+    ],
+    "ukphone": "spʌndʒ",
+    "usphone": "spʌndʒ"
+  },
+  {
+    "name": "plankton",
+    "trans": [
+      "3.108",
+      "n．浮游生物"
+    ],
+    "ukphone": "ˋplæŋktən",
+    "usphone": "ˋplæŋktən"
+  },
+  {
+    "name": "oyster",
+    "trans": [
+      "3.109",
+      "n．牡蛎，蚝"
+    ],
+    "ukphone": "ˋɔIstər",
+    "usphone": "ˋɔIstər"
+  },
+  {
+    "name": "clam",
+    "trans": [
+      "3.110",
+      "n．蛤"
+    ],
+    "ukphone": "klæm",
+    "usphone": "klæm"
+  },
+  {
+    "name": "coral",
+    "trans": [
+      "3.111",
+      "n．珊瑚，珊瑚虫"
+    ],
+    "ukphone": "ˋkɔ:rəl",
+    "usphone": "ˋkɔ:rəl"
+  },
+  {
+    "name": "crab",
+    "trans": [
+      "3.112",
+      "n．螃蟹，类似螃蟹的动物"
+    ],
+    "ukphone": "kræb",
+    "usphone": "kræb"
+  },
+  {
+    "name": "conch",
+    "trans": [
+      "3.113",
+      "n．贝壳；海螺壳"
+    ],
+    "ukphone": "kα:ntʃ",
+    "usphone": "kα:ntʃ"
+  },
+  {
+    "name": "squirrel",
+    "trans": [
+      "3.114",
+      "n．松鼠"
+    ],
+    "ukphone": "ˋskwɜ:rəl",
+    "usphone": "ˋskwɜ:rəl"
+  },
+  {
+    "name": "insular",
+    "trans": [
+      "4.1",
+      "adj．海岛的",
+      "【记】 insul（岛）+ar"
+    ],
+    "ukphone": "ˋInsələr",
+    "usphone": "ˋInsələr"
+  },
+  {
+    "name": "island",
+    "trans": [
+      "4.2",
+      "n．岛，岛屿，岛状物（孤立状态的物），安全岛"
+    ],
+    "ukphone": "ˋaIlənd",
+    "usphone": "ˋaIlənd"
+  },
+  {
+    "name": "peninsula",
+    "trans": [
+      "4.3",
+      "n．半岛",
+      "【记】 比较insular（海岛的）"
+    ],
+    "ukphone": "pəˋnInsələ",
+    "usphone": "pəˋnInsələ"
+  },
+  {
+    "name": "islet",
+    "trans": [
+      "4.4",
+      "n．小岛"
+    ],
+    "ukphone": "ˋaIlət",
+    "usphone": "ˋaIlət"
+  },
+  {
+    "name": "marine",
+    "trans": [
+      "4.5",
+      "adj．海的（marine, oceanic）；海上的；近海的",
+      "【记】 mari（海）+ine"
+    ],
+    "ukphone": "məˋri:n",
+    "usphone": "məˋri:n"
+  },
+  {
+    "name": "maritime",
+    "trans": [
+      "4.6",
+      "adj．海的（marine, oceanic）；海上的；近海的",
+      "【记】 mari（海）+time"
+    ],
+    "ukphone": "ˋmærItaIm",
+    "usphone": "ˋmærItaIm"
+  },
+  {
+    "name": "moist",
+    "trans": [
+      "4.7",
+      "adj．湿润的，多雨的（damp, humid）"
+    ],
+    "ukphone": "mɔIst",
+    "usphone": "mɔIst"
+  },
+  {
+    "name": "ledge",
+    "trans": [
+      "4.8",
+      "n．暗礁",
+      "【记】 联想“l”加edge（边）"
+    ],
+    "ukphone": "ledʒ",
+    "usphone": "ledʒ"
+  },
+  {
+    "name": "oasis",
+    "trans": [
+      "4.9",
+      "n.（沙漠中的）绿洲"
+    ],
+    "ukphone": "oʊˋeIsIs",
+    "usphone": "oʊˋeIsIs"
+  },
+  {
+    "name": "tide",
+    "trans": [
+      "4.10",
+      "n．潮汐"
+    ],
+    "ukphone": "taId",
+    "usphone": "taId"
+  },
+  {
+    "name": "ebb",
+    "trans": [
+      "4.11",
+      "vi．退潮"
+    ],
+    "ukphone": "eb",
+    "usphone": "eb"
+  },
+  {
+    "name": "continent",
+    "trans": [
+      "4.12",
+      "n．大陆"
+    ],
+    "ukphone": "ˋkα:ntInənt",
+    "usphone": "ˋkα:ntInənt"
+  },
+  {
+    "name": "terrestrial",
+    "trans": [
+      "4.13",
+      "adj．领土的"
+    ],
+    "ukphone": "təˋrestriəl",
+    "usphone": "təˋrestriəl"
+  },
+  {
+    "name": "outskirt",
+    "trans": [
+      "4.14",
+      "n．外边，郊区（surrounding）"
+    ],
+    "ukphone": "ˋaʊtskɜ:rt",
+    "usphone": "ˋaʊtskɜ:rt"
+  },
+  {
+    "name": "region",
+    "trans": [
+      "4.15",
+      "n．地区，领域（zone, area, field, domain）"
+    ],
+    "ukphone": "ˋri:dʒən",
+    "usphone": "ˋri:dʒən"
+  },
+  {
+    "name": "endemic",
+    "trans": [
+      "4.16",
+      "adj．地方的（native）"
+    ],
+    "ukphone": "enˋdemIk",
+    "usphone": "enˋdemIk"
+  },
+  {
+    "name": "cosmopolitan",
+    "trans": [
+      "4.17",
+      "adj．全世界的（global）",
+      "【记】 cosm（宇宙）+opolitan"
+    ],
+    "ukphone": "ˌkα:zməˋpα:lItən",
+    "usphone": "ˌkα:zməˋpα:lItən"
+  },
+  {
+    "name": "subterrane",
+    "trans": [
+      "4.18",
+      "n．地下（underground）"
+    ],
+    "ukphone": "ˌsʌbtəˋreIn",
+    "usphone": "ˌsʌbtəˋreIn"
+  },
+  {
+    "name": "subterranean",
+    "trans": [
+      "4.19",
+      "adj．地下的"
+    ],
+    "ukphone": "ˌsʌbtəˋreIniən",
+    "usphone": "ˌsʌbtəˋreIniən"
+  },
+  {
+    "name": "cavern",
+    "trans": [
+      "4.20",
+      "n．大山洞，大洞穴",
+      "【记】 比较cave（洞）"
+    ],
+    "ukphone": "ˋkævərn",
+    "usphone": "ˋkævərn"
+  },
+  {
+    "name": "flaw",
+    "trans": [
+      "4.21",
+      "n．裂隙；缺点，瑕疵"
+    ],
+    "ukphone": "flɔ:",
+    "usphone": "flɔ:"
+  },
+  {
+    "name": "cleft",
+    "trans": [
+      "4.22",
+      "n．裂缝（crevice）"
+    ],
+    "ukphone": "kleft",
+    "usphone": "kleft"
+  },
+  {
+    "name": "crevice",
+    "trans": [
+      "4.23",
+      "n．裂缝，破口（rift, slit）"
+    ],
+    "ukphone": "ˋkrevIs",
+    "usphone": "ˋkrevIs"
+  },
+  {
+    "name": "gap",
+    "trans": [
+      "4.24",
+      "n．裂口（opening）"
+    ],
+    "ukphone": "gæp",
+    "usphone": "gæp"
+  },
+  {
+    "name": "zone",
+    "trans": [
+      "4.25",
+      "n．带（region, area）"
+    ],
+    "ukphone": "zoʊn",
+    "usphone": "zoʊn"
+  },
+  {
+    "name": "equator",
+    "trans": [
+      "4.26",
+      "n．赤道"
+    ],
+    "ukphone": "IˋkweItər",
+    "usphone": "IˋkweItər"
+  },
+  {
+    "name": "longitude",
+    "trans": [
+      "4.27",
+      "n．经度",
+      "【记】 long（长）+itude→经度"
+    ],
+    "ukphone": "ˋlα:ndʒətju:d",
+    "usphone": "ˋlα:ndʒətju:d"
+  },
+  {
+    "name": "altitude",
+    "trans": [
+      "4.28",
+      "n.（尤指海拔）高度，高处（海拔甚高的地方）"
+    ],
+    "ukphone": "ˋæltItju:d",
+    "usphone": "ˋæltItju:d"
+  },
+  {
+    "name": "latitude",
+    "trans": [
+      "4.29",
+      "n．纬度",
+      "【记】 lati（阔）+tude→纬度"
+    ],
+    "ukphone": "ˋlætItju:d",
+    "usphone": "ˋlætItju:d"
+  },
+  {
+    "name": "meridian",
+    "trans": [
+      "4.30",
+      "n．子午线，正午"
+    ],
+    "ukphone": "məˋrIdiən",
+    "usphone": "məˋrIdiən"
+  },
+  {
+    "name": "subsidiary",
+    "trans": [
+      "4.31",
+      "n．支流（branch）",
+      "【记】 sub（下面）+sidi（坐）+ary→坐在下面辅助的"
+    ],
+    "ukphone": "səbˋsidiəri",
+    "usphone": "səbˋsidiəri"
+  },
+  {
+    "name": "Antarctic",
+    "trans": [
+      "4.32",
+      "adj．南极的，南极地带的"
+    ],
+    "ukphone": "ænˋtα:rktIk",
+    "usphone": "ænˋtα:rktIk"
+  },
+  {
+    "name": "Antarctica",
+    "trans": [
+      "4.33",
+      "n．南极洲"
+    ],
+    "ukphone": "ænˋtα:rktIkə",
+    "usphone": "ænˋtα:rktIkə"
+  },
+  {
+    "name": "Arctic",
+    "trans": [
+      "4.34",
+      "adj．北极的，北极区的 n．北极，北极圈"
+    ],
+    "ukphone": "ˋα:rktIk",
+    "usphone": "ˋα:rktIk"
+  },
+  {
+    "name": "coastland",
+    "trans": [
+      "4.35",
+      "n．沿海岸地区"
+    ],
+    "ukphone": "ˋkoʊstlænd",
+    "usphone": "ˋkoʊstlænd"
+  },
+  {
+    "name": "hemisphere",
+    "trans": [
+      "4.36",
+      "n．半球"
+    ],
+    "ukphone": "ˋhemIsfIr",
+    "usphone": "ˋhemIsfIr"
+  },
+  {
+    "name": "contour",
+    "trans": [
+      "4.37",
+      "n．轮廓；海岸线（outline, profile）",
+      "【记】 tour（旅行）"
+    ],
+    "ukphone": "ˋkα:ntʊr",
+    "usphone": "ˋkα:ntʊr"
+  },
+  {
+    "name": "geography",
+    "trans": [
+      "4.38",
+      "n．地理学，地理"
+    ],
+    "ukphone": "dʒiˋα:grəfi",
+    "usphone": "dʒiˋα:grəfi"
+  },
+  {
+    "name": "horizon",
+    "trans": [
+      "4.39",
+      "n．地平线"
+    ],
+    "ukphone": "həˋraIzn",
+    "usphone": "həˋraIzn"
+  },
+  {
+    "name": "lowland",
+    "trans": [
+      "4.40",
+      "n．低地，苏格兰低地 adj．低地的"
+    ],
+    "ukphone": "ˋloʊlənd",
+    "usphone": "ˋloʊlənd"
+  },
+  {
+    "name": "plain",
+    "trans": [
+      "4.41",
+      "n．平原，草原"
+    ],
+    "ukphone": "plein",
+    "usphone": "plein"
+  },
+  {
+    "name": "strait",
+    "trans": [
+      "4.42",
+      "n．地峡，海峡"
+    ],
+    "ukphone": "streIt",
+    "usphone": "streIt"
+  },
+  {
+    "name": "channel",
+    "trans": [
+      "4.43",
+      "n．海峡，水道，沟"
+    ],
+    "ukphone": "ˋtʃænl",
+    "usphone": "ˋtʃænl"
+  },
+  {
+    "name": "valley",
+    "trans": [
+      "4.44",
+      "n.（山）谷，流域"
+    ],
+    "ukphone": "ˋvæli",
+    "usphone": "ˋvæli"
+  },
+  {
+    "name": "volcano",
+    "trans": [
+      "4.45",
+      "n．火山"
+    ],
+    "ukphone": "vα:lˋkeInoʊ",
+    "usphone": "vα:lˋkeInoʊ"
+  },
+  {
+    "name": "plateau",
+    "trans": [
+      "4.46",
+      "n．高原",
+      "【记】 plat（平）+eau"
+    ],
+    "ukphone": "plæˋtoʊ",
+    "usphone": "plæˋtoʊ"
+  },
+  {
+    "name": "basin",
+    "trans": [
+      "4.47",
+      "n．盆地"
+    ],
+    "ukphone": "ˋbeIsn",
+    "usphone": "ˋbeIsn"
+  },
+  {
+    "name": "navigation",
+    "trans": [
+      "4.48",
+      "n．航海"
+    ],
+    "ukphone": "ˌnævIˋgeIʃn",
+    "usphone": "ˌnævIˋgeIʃn"
+  },
+  {
+    "name": "ranges",
+    "trans": [
+      "4.49",
+      "n．范围；山脉"
+    ],
+    "ukphone": "reIndʒIz",
+    "usphone": "reIndʒIz"
+  },
+  {
+    "name": "salinity",
+    "trans": [
+      "4.50",
+      "n．盐分，盐度"
+    ],
+    "ukphone": "səˋlInəti",
+    "usphone": "səˋlInəti"
+  },
+  {
+    "name": "sediment",
+    "trans": [
+      "4.51",
+      "n．沉淀物，沉积"
+    ],
+    "ukphone": "ˋsedImənt",
+    "usphone": "ˋsedImənt"
+  },
+  {
+    "name": "elevation",
+    "trans": [
+      "4.52",
+      "n．高地，正面图，海拔"
+    ],
+    "ukphone": "ˌelIˋveIʃn",
+    "usphone": "ˌelIˋveIʃn"
+  },
+  {
+    "name": "formation",
+    "trans": [
+      "4.53",
+      "n．形成，构成"
+    ],
+    "ukphone": "fɔ:rˋmeIʃn",
+    "usphone": "fɔ:rˋmeIʃn"
+  },
+  {
+    "name": "geothermy",
+    "trans": [
+      "4.54",
+      "n．地热"
+    ],
+    "ukphone": "ˌdʒi:oʊˋθɜ:rmI",
+    "usphone": "ˌdʒi:oʊˋθɜ:rmI"
+  },
+  {
+    "name": "terrain",
+    "trans": [
+      "4.55",
+      "n．地形"
+    ],
+    "ukphone": "təˋreIn",
+    "usphone": "təˋreIn"
+  },
+  {
+    "name": "topography",
+    "trans": [
+      "4.56",
+      "n．地形学"
+    ],
+    "ukphone": "təˋpα:grəfi",
+    "usphone": "təˋpα:grəfi"
+  },
+  {
+    "name": "tropical",
+    "trans": [
+      "4.57",
+      "adj．热带的"
+    ],
+    "ukphone": "ˋtrα:pIkl",
+    "usphone": "ˋtrα:pIkl"
+  },
+  {
+    "name": "tropics",
+    "trans": [
+      "4.58",
+      "n.（地球的）回归线，热带"
+    ],
+    "ukphone": "ˋtrα:pIks",
+    "usphone": "ˋtrα:pIks"
+  },
+  {
+    "name": "temperate",
+    "trans": [
+      "4.59",
+      "adj.（气候）温和的"
+    ],
+    "ukphone": "ˋtempərət",
+    "usphone": "ˋtempərət"
+  },
+  {
+    "name": "cistern",
+    "trans": [
+      "4.60",
+      "n．水箱；水池；贮水器"
+    ],
+    "ukphone": "ˋsIstərn",
+    "usphone": "ˋsIstərn"
+  },
+  {
+    "name": "lagoon",
+    "trans": [
+      "4.61",
+      "n．泻湖；环礁湖；咸水湖"
+    ],
+    "ukphone": "ləˋgu:n",
+    "usphone": "ləˋgu:n"
+  },
+  {
+    "name": "canal",
+    "trans": [
+      "4.62",
+      "n．运河；水道"
+    ],
+    "ukphone": "kəˋnæl",
+    "usphone": "kəˋnæl"
+  },
+  {
+    "name": "celestial",
+    "trans": [
+      "5.1",
+      "adj．天上的，天体的；神圣的（astronomical, heavenly）",
+      "【记】 celes（天）+tial"
+    ],
+    "ukphone": "səˋlestʃl",
+    "usphone": "səˋlestʃl"
+  },
+  {
+    "name": "universe",
+    "trans": [
+      "5.2",
+      "n．宇宙（cosmos）"
+    ],
+    "ukphone": "ˋju:nIvɜ:rs",
+    "usphone": "ˋju:nIvɜ:rs"
+  },
+  {
+    "name": "universal",
+    "trans": [
+      "5.3",
+      "adj．宇宙的；通用的，普遍的"
+    ],
+    "ukphone": "ˌju:nIˋvɜ:rsl",
+    "usphone": "ˌju:nIˋvɜ:rsl"
+  },
+  {
+    "name": "orbit",
+    "trans": [
+      "5.4",
+      "n．轨道（track, path）"
+    ],
+    "ukphone": "ˋɔ:rbIt",
+    "usphone": "ˋɔ:rbIt"
+  },
+  {
+    "name": "comet",
+    "trans": [
+      "5.5",
+      "n．彗星"
+    ],
+    "ukphone": "ˋkα:mət",
+    "usphone": "ˋkα:mət"
+  },
+  {
+    "name": "galaxy",
+    "trans": [
+      "5.6",
+      "n．星系；银河"
+    ],
+    "ukphone": "ˋgæləksi",
+    "usphone": "ˋgæləksi"
+  },
+  {
+    "name": "constellation",
+    "trans": [
+      "5.7",
+      "n．星座",
+      "【记】 con+stell（星星）+ation"
+    ],
+    "ukphone": "ˌkα:nstəˋleIʃn",
+    "usphone": "ˌkα:nstəˋleIʃn"
+  },
+  {
+    "name": "asteroid",
+    "trans": [
+      "5.8",
+      "n．小游星，小行星"
+    ],
+    "ukphone": "ˋæstərɔId",
+    "usphone": "ˋæstərɔId"
+  },
+  {
+    "name": "planet",
+    "trans": [
+      "5.9",
+      "n．行星"
+    ],
+    "ukphone": "ˋplænIt",
+    "usphone": "ˋplænIt"
+  },
+  {
+    "name": "chondrite",
+    "trans": [
+      "5.10",
+      "n．球粒状陨石"
+    ],
+    "ukphone": "ˋkα:ndraIt",
+    "usphone": "ˋkα:ndraIt"
+  },
+  {
+    "name": "cluster",
+    "trans": [
+      "5.11",
+      "n．星团"
+    ],
+    "ukphone": "ˋklʌstər",
+    "usphone": "ˋklʌstər"
+  },
+  {
+    "name": "meteor",
+    "trans": [
+      "5.12",
+      "n．流星；大气现象"
+    ],
+    "ukphone": "ˋmi:tiər",
+    "usphone": "ˋmi:tiər"
+  },
+  {
+    "name": "dwarf",
+    "trans": [
+      "5.13",
+      "n．白矮星"
+    ],
+    "ukphone": "dwɔ:rf",
+    "usphone": "dwɔ:rf"
+  },
+  {
+    "name": "star",
+    "trans": [
+      "5.14",
+      "n．星，恒星"
+    ],
+    "ukphone": "stα:r",
+    "usphone": "stα:r"
+  },
+  {
+    "name": "stellar",
+    "trans": [
+      "5.15",
+      "adj．恒星的"
+    ],
+    "ukphone": "ˋstelər",
+    "usphone": "ˋstelər"
+  },
+  {
+    "name": "cosmos",
+    "trans": [
+      "5.16",
+      "宇宙"
+    ],
+    "ukphone": "ˋkα:zmoʊs",
+    "usphone": "ˋkα:zmoʊs"
+  },
+  {
+    "name": "cosmic",
+    "trans": [
+      "5.17",
+      "adj．宇宙的"
+    ],
+    "ukphone": "ˋkα:zmIk",
+    "usphone": "ˋkα:zmIk"
+  },
+  {
+    "name": "cosmology",
+    "trans": [
+      "5.18",
+      "n．宇宙哲学，宇宙论"
+    ],
+    "ukphone": "kα:zˋmα:lədʒi",
+    "usphone": "kα:zˋmα:lədʒi"
+  },
+  {
+    "name": "nebula",
+    "trans": [
+      "5.19",
+      "n．星云，云翳"
+    ],
+    "ukphone": "ˋnebjələ",
+    "usphone": "ˋnebjələ"
+  },
+  {
+    "name": "quasar",
+    "trans": [
+      "5.20",
+      "n．恒星状球体，类星体"
+    ],
+    "ukphone": "ˋkweIzα:r",
+    "usphone": "ˋkweIzα:r"
+  },
+  {
+    "name": "space",
+    "trans": [
+      "5.21",
+      "n．空间"
+    ],
+    "ukphone": "speIs",
+    "usphone": "speIs"
+  },
+  {
+    "name": "planetoid",
+    "trans": [
+      "5.22",
+      "n．小行星"
+    ],
+    "ukphone": "ˋplænətɔId",
+    "usphone": "ˋplænətɔId"
+  },
+  {
+    "name": "intergalactic",
+    "trans": [
+      "5.23",
+      "adj．银河间的"
+    ],
+    "ukphone": "ˌIntərgəˋlæktIk",
+    "usphone": "ˌIntərgəˋlæktIk"
+  },
+  {
+    "name": "interplanetary",
+    "trans": [
+      "5.24",
+      "adj．行星间的，太阳系内的"
+    ],
+    "ukphone": "ˌIntərˋplænəteri",
+    "usphone": "ˌIntərˋplænəteri"
+  },
+  {
+    "name": "interstellar",
+    "trans": [
+      "5.25",
+      "adj．星际的"
+    ],
+    "ukphone": "ˌIntərˋstelər",
+    "usphone": "ˌIntərˋstelər"
+  },
+  {
+    "name": "corona",
+    "trans": [
+      "5.26",
+      "n．日冕"
+    ],
+    "ukphone": "kəˋroʊnə",
+    "usphone": "kəˋroʊnə"
+  },
+  {
+    "name": "chromosphere",
+    "trans": [
+      "5.27",
+      "n.（恒星尤指太阳的）色球（层）"
+    ],
+    "ukphone": "ˋkroʊməˌsfIr",
+    "usphone": "ˋkroʊməˌsfIr"
+  },
+  {
+    "name": "solar",
+    "trans": [
+      "5.28",
+      "adj．太阳的"
+    ],
+    "ukphone": "ˋsoʊlər",
+    "usphone": "ˋsoʊlər"
+  },
+  {
+    "name": "photosphere",
+    "trans": [
+      "5.29",
+      "n．光球（指用肉眼可看到的太阳强烈发光部分，是厚度为几百公里的一个壳层）"
+    ],
+    "ukphone": "ˋfoʊtoʊˌsfIr",
+    "usphone": "ˋfoʊtoʊˌsfIr"
+  },
+  {
+    "name": "pseudoscience",
+    "trans": [
+      "5.30",
+      "n．假科学，伪科学"
+    ],
+    "ukphone": "ˌsju:doʊˋsaIəns",
+    "usphone": "ˌsju:doʊˋsaIəns"
+  },
+  {
+    "name": "astronomy",
+    "trans": [
+      "5.31",
+      "n．天文学",
+      "【记】 astro（星星）+nomy（学科）→研究星星的学科"
+    ],
+    "ukphone": "əˋstrα:nəmi",
+    "usphone": "əˋstrα:nəmi"
+  },
+  {
+    "name": "astronomical",
+    "trans": [
+      "5.32",
+      "adj．天文学的；庞大到无法估计的"
+    ],
+    "ukphone": "ˌæstrəˋnα:mIkl",
+    "usphone": "ˌæstrəˋnα:mIkl"
+  },
+  {
+    "name": "astrology",
+    "trans": [
+      "5.33",
+      "n．占星术，占星学（以观测天象来预卜人间事务的一种方术）"
+    ],
+    "ukphone": "əˋstrα:lədʒi",
+    "usphone": "əˋstrα:lədʒi"
+  },
+  {
+    "name": "astrophysics",
+    "trans": [
+      "5.34",
+      "n．天体物理学"
+    ],
+    "ukphone": "ˌæstroʊˋfIzIks",
+    "usphone": "ˌæstroʊˋfIzIks"
+  },
+  {
+    "name": "Jupiter",
+    "trans": [
+      "5.35",
+      "n．木星"
+    ],
+    "ukphone": "ˋdʒu:pItər",
+    "usphone": "ˋdʒu:pItər"
+  },
+  {
+    "name": "lunar",
+    "trans": [
+      "5.36",
+      "adj．月的，月亮的"
+    ],
+    "ukphone": "ˋlu:nər",
+    "usphone": "ˋlu:nər"
+  },
+  {
+    "name": "Mars",
+    "trans": [
+      "5.37",
+      "n．火星；战神"
+    ],
+    "ukphone": "mα:rz",
+    "usphone": "mα:rz"
+  },
+  {
+    "name": "mercury",
+    "trans": [
+      "5.38",
+      "n．水银，汞；水星"
+    ],
+    "ukphone": "ˋmɜ:rkjəri",
+    "usphone": "ˋmɜ:rkjəri"
+  },
+  {
+    "name": "Earth",
+    "trans": [
+      "5.39",
+      "n．地球"
+    ],
+    "ukphone": "ɜ:rθ",
+    "usphone": "ɜ:rθ"
+  },
+  {
+    "name": "Uranus",
+    "trans": [
+      "5.40",
+      "n．天王星"
+    ],
+    "ukphone": "ˋjʊrənəs",
+    "usphone": "ˋjʊrənəs"
+  },
+  {
+    "name": "Venus",
+    "trans": [
+      "5.41",
+      "n．金星"
+    ],
+    "ukphone": "ˋvi:nəs",
+    "usphone": "ˋvi:nəs"
+  },
+  {
+    "name": "Pluto",
+    "trans": [
+      "5.42",
+      "n．冥王星；阴间之神"
+    ],
+    "ukphone": "ˋplu:toʊ",
+    "usphone": "ˋplu:toʊ"
+  },
+  {
+    "name": "Neptune",
+    "trans": [
+      "5.43",
+      "n．海王星"
+    ],
+    "ukphone": "ˋneptju:n",
+    "usphone": "ˋneptju:n"
+  },
+  {
+    "name": "Saturn",
+    "trans": [
+      "5.44",
+      "n．土星"
+    ],
+    "ukphone": "ˋsætɜ:rn",
+    "usphone": "ˋsætɜ:rn"
+  },
+  {
+    "name": "emission",
+    "trans": [
+      "5.45",
+      "n.（光、热等的）散发，发射，喷射"
+    ],
+    "ukphone": "iˋmIʃn",
+    "usphone": "iˋmIʃn"
+  },
+  {
+    "name": "infinite",
+    "trans": [
+      "5.46",
+      "adj．无穷的，无限的，无数的，极大的"
+    ],
+    "ukphone": "ˋInfInət",
+    "usphone": "ˋInfInət"
+  },
+  {
+    "name": "interferometer",
+    "trans": [
+      "5.47",
+      "n．干涉仪"
+    ],
+    "ukphone": "ˌInˋtɜ:rfIˋrα:mItər",
+    "usphone": "ˌInˋtɜ:rfIˋrα:mItər"
+  },
+  {
+    "name": "radiation",
+    "trans": [
+      "5.48",
+      "n．发散，辐射；放射物"
+    ],
+    "ukphone": "ˌreIdiˋeIʃn",
+    "usphone": "ˌreIdiˋeIʃn"
+  },
+  {
+    "name": "revolve",
+    "trans": [
+      "5.49",
+      "v.（使）旋转"
+    ],
+    "ukphone": "rIˋvα:lv",
+    "usphone": "rIˋvα:lv"
+  },
+  {
+    "name": "land",
+    "trans": [
+      "5.50",
+      "vt．着陆，降落"
+    ],
+    "ukphone": "lænd",
+    "usphone": "lænd"
+  },
+  {
+    "name": "spaceship",
+    "trans": [
+      "5.51",
+      "n．太空船（space shuttle）"
+    ],
+    "ukphone": "speIsʃIp",
+    "usphone": "speIsʃIp"
+  },
+  {
+    "name": "spacecraft",
+    "trans": [
+      "5.52",
+      "n．太空船"
+    ],
+    "ukphone": "ˋspeIskræft",
+    "usphone": "ˋspeIskræft"
+  },
+  {
+    "name": "telescope",
+    "trans": [
+      "5.53",
+      "n．望远镜"
+    ],
+    "ukphone": "ˋtelIskoʊp",
+    "usphone": "ˋtelIskoʊp"
+  },
+  {
+    "name": "holism",
+    "trans": [
+      "5.54",
+      "n．整体论"
+    ],
+    "ukphone": "ˋhoʊlIzəm",
+    "usphone": "ˋhoʊlIzəm"
+  },
+  {
+    "name": "supernova",
+    "trans": [
+      "5.55",
+      "n．超新星"
+    ],
+    "ukphone": "ˌsju:pərˋnoʊvə",
+    "usphone": "ˌsju:pərˋnoʊvə"
+  },
+  {
+    "name": "urban",
+    "trans": [
+      "6.1",
+      "adj．城市的（municipal, metropolitan）"
+    ],
+    "ukphone": "ˋɜ:rbən",
+    "usphone": "ˋɜ:rbən"
+  },
+  {
+    "name": "rustic",
+    "trans": [
+      "6.2",
+      "adj．乡村的（rural, unsophisticated）",
+      "【记】 rust（乡村）+ic"
+    ],
+    "ukphone": "ˋrʌstIk",
+    "usphone": "ˋrʌstIk"
+  },
+  {
+    "name": "community",
+    "trans": [
+      "6.3",
+      "n．社区；社会；公社",
+      "【记】 commune（公共的）+ity→公共状态→社会，社区"
+    ],
+    "ukphone": "kəˋmju:nəti",
+    "usphone": "kəˋmju:nəti"
+  },
+  {
+    "name": "metropolitan",
+    "trans": [
+      "6.4",
+      "adj．首都的，主要都市的，大城市的"
+    ],
+    "ukphone": "ˌmetrəˋpα:lItən",
+    "usphone": "ˌmetrəˋpα:lItən"
+  },
+  {
+    "name": "exotic",
+    "trans": [
+      "6.5",
+      "adj．外来的；有异国风情的（unusual, foreign）",
+      "【记】 exo（外面）+tic→外来的"
+    ],
+    "ukphone": "Igˋzα:tIk",
+    "usphone": "Igˋzα:tIk"
+  },
+  {
+    "name": "conventional",
+    "trans": [
+      "6.6",
+      "adj．传统的，习俗的（traditional, customary）"
+    ],
+    "ukphone": "kənˋvenʃənl",
+    "usphone": "kənˋvenʃənl"
+  },
+  {
+    "name": "convention",
+    "trans": [
+      "6.7",
+      "n．传统"
+    ],
+    "ukphone": "kənˋvenʃn",
+    "usphone": "kənˋvenʃn"
+  },
+  {
+    "name": "patriarchal",
+    "trans": [
+      "6.8",
+      "adj．家长的，族长的"
+    ],
+    "ukphone": "ˌpeItriˋα:rkl",
+    "usphone": "ˌpeItriˋα:rkl"
+  },
+  {
+    "name": "institutionalize",
+    "trans": [
+      "6.9",
+      "v．使制度化或习俗化"
+    ],
+    "ukphone": "ˌInstIˋtju:ʃənəlaIz",
+    "usphone": "ˌInstIˋtju:ʃənəlaIz"
+  },
+  {
+    "name": "clan",
+    "trans": [
+      "6.10",
+      "n．部落，氏族，宗族，党派"
+    ],
+    "ukphone": "klæn",
+    "usphone": "klæn"
+  },
+  {
+    "name": "status",
+    "trans": [
+      "6.11",
+      "n．地位（position, rank）"
+    ],
+    "ukphone": "ˋsteItəs",
+    "usphone": "ˋsteItəs"
+  },
+  {
+    "name": "taboo",
+    "trans": [
+      "6.12",
+      "n./vt．禁忌；禁止（ban, prohibition）"
+    ],
+    "ukphone": "təˋbu:",
+    "usphone": "təˋbu:"
+  },
+  {
+    "name": "ethics",
+    "trans": [
+      "6.13",
+      "n．伦理学",
+      "【记】 eth=ethn（种族）+ics→种族规范→伦理学"
+    ],
+    "ukphone": "ˋeθIks",
+    "usphone": "ˋeθIks"
+  },
+  {
+    "name": "genteel",
+    "trans": [
+      "6.14",
+      "adj．上流社会的（well-bred, courteous）",
+      "【记】 比较gentle（温柔）"
+    ],
+    "ukphone": "dʒenˋti:l",
+    "usphone": "dʒenˋti:l"
+  },
+  {
+    "name": "marital",
+    "trans": [
+      "6.15",
+      "adj．婚姻的（wedded, conjugal）",
+      "【记】 比较marriage（结婚）"
+    ],
+    "ukphone": "ˋmærItl",
+    "usphone": "ˋmærItl"
+  },
+  {
+    "name": "polygamous",
+    "trans": [
+      "6.16",
+      "adj．一夫多妻的，一妻多夫的"
+    ],
+    "ukphone": "pəˋlIgəməs",
+    "usphone": "pəˋlIgəməs"
+  },
+  {
+    "name": "household",
+    "trans": [
+      "6.17",
+      "n．一家人，家庭，家族"
+    ],
+    "ukphone": "ˋhaʊshoʊld",
+    "usphone": "ˋhaʊshoʊld"
+  },
+  {
+    "name": "archeology",
+    "trans": [
+      "7.1",
+      "n．考古学"
+    ],
+    "ukphone": "ˌα:rkiˋα:lədʒi",
+    "usphone": "ˌα:rkiˋα:lədʒi"
+  },
+  {
+    "name": "invaluable",
+    "trans": [
+      "7.2",
+      "adj．无价的（valuable, precious）",
+      "【记】 invaluable=valuable（有价值的）；比较valueless（无价值的）"
+    ],
+    "ukphone": "Inˋvæljuəbl",
+    "usphone": "Inˋvæljuəbl"
+  },
+  {
+    "name": "unearth",
+    "trans": [
+      "7.3",
+      "vt．发掘，发现（uncover, exhume）",
+      "【记】 un+earth（土地）→弄开土→挖掘"
+    ],
+    "ukphone": "ʌnˋɜ:rθ",
+    "usphone": "ʌnˋɜ:rθ"
+  },
+  {
+    "name": "scoop",
+    "trans": [
+      "7.4",
+      "vt．汲取；挖掘（dig, pick）"
+    ],
+    "ukphone": "sku:p",
+    "usphone": "sku:p"
+  },
+  {
+    "name": "exhume",
+    "trans": [
+      "7.5",
+      "vt．掘出（excavate, dig）",
+      "【记】 ex（出）+hume（土）→出土→掘出"
+    ],
+    "ukphone": "Igˋzju:m",
+    "usphone": "Igˋzju:m"
+  },
+  {
+    "name": "excavate",
+    "trans": [
+      "7.6",
+      "vt．挖掘（dig, delve）",
+      "【记】 ex+cav（洞）+ate→挖出洞→挖掘"
+    ],
+    "ukphone": "ˋekskəveIt",
+    "usphone": "ˋekskəveIt"
+  },
+  {
+    "name": "excavation",
+    "trans": [
+      "7.7",
+      "n．挖掘，发掘；挖掘成的洞；出土文物"
+    ],
+    "ukphone": "ˌekskəˋveIʃn",
+    "usphone": "ˌekskəˋveIʃn"
+  },
+  {
+    "name": "Neolithic",
+    "trans": [
+      "7.8",
+      "adj．新石器时代的"
+    ],
+    "ukphone": "ˌni:əˋlIθIk",
+    "usphone": "ˌni:əˋlIθIk"
+  },
+  {
+    "name": "Mesolithic",
+    "trans": [
+      "7.9",
+      "n．中石器时代（旧石器时代与新石器时代之间的时代）"
+    ],
+    "ukphone": "ˌmi:zəˋlIθIk",
+    "usphone": "ˌmi:zəˋlIθIk"
+  },
+  {
+    "name": "Paleolithic",
+    "trans": [
+      "7.10",
+      "adj．旧石器时代的"
+    ],
+    "ukphone": "ˌpælIəˋlIθIk",
+    "usphone": "ˌpælIəˋlIθIk"
+  },
+  {
+    "name": "origin",
+    "trans": [
+      "7.11",
+      "n．起源，由来"
+    ],
+    "ukphone": "ˋɔ:rIdʒIn",
+    "usphone": "ˋɔ:rIdʒIn"
+  },
+  {
+    "name": "chronological",
+    "trans": [
+      "7.12",
+      "adj．按年代顺序的"
+    ],
+    "ukphone": "ˌkrα:nəˋlα:dʒIkl",
+    "usphone": "ˌkrα:nəˋlα:dʒIkl"
+  },
+  {
+    "name": "archaic",
+    "trans": [
+      "7.13",
+      "adj．古的（old）",
+      "【记】 arch（古）+aic"
+    ],
+    "ukphone": "α:rˋkeIIk",
+    "usphone": "α:rˋkeIIk"
+  },
+  {
+    "name": "ascend",
+    "trans": [
+      "7.14",
+      "v．追溯"
+    ],
+    "ukphone": "əˋsend",
+    "usphone": "əˋsend"
+  },
+  {
+    "name": "originate",
+    "trans": [
+      "7.15",
+      "vi．发源于（initiate, start）"
+    ],
+    "ukphone": "əˋrIdʒIneIt",
+    "usphone": "əˋrIdʒIneIt"
+  },
+  {
+    "name": "primitive",
+    "trans": [
+      "7.16",
+      "adj．原始的，最初的（crude, original, primordial）"
+    ],
+    "ukphone": "ˋprImətIv",
+    "usphone": "ˋprImətIv"
+  },
+  {
+    "name": "remnant",
+    "trans": [
+      "7.17",
+      "n．残余；遗迹（remains, leftover, vestige）"
+    ],
+    "ukphone": "ˋremnənt",
+    "usphone": "ˋremnənt"
+  },
+  {
+    "name": "porcelain",
+    "trans": [
+      "7.18",
+      "n．瓷器（china）"
+    ],
+    "ukphone": "ˋpɔ:rsəlIn",
+    "usphone": "ˋpɔ:rsəlIn"
+  },
+  {
+    "name": "antique",
+    "trans": [
+      "7.19",
+      "n．古物，古董"
+    ],
+    "ukphone": "ænˋti:k",
+    "usphone": "ænˋti:k"
+  },
+  {
+    "name": "antiquity",
+    "trans": [
+      "7.20",
+      "n．古代，古老，古代的遗物"
+    ],
+    "ukphone": "ænˋtIkwəti",
+    "usphone": "ænˋtIkwəti"
+  },
+  {
+    "name": "skull",
+    "trans": [
+      "7.21",
+      "n．头脑；头骨"
+    ],
+    "ukphone": "skʌl",
+    "usphone": "skʌl"
+  },
+  {
+    "name": "artifact",
+    "trans": [
+      "7.22",
+      "n．人造物品"
+    ],
+    "ukphone": "ˋα:rtIfækt",
+    "usphone": "ˋα:rtIfækt"
+  },
+  {
+    "name": "pharaoh",
+    "trans": [
+      "7.23",
+      "n．法老；暴君"
+    ],
+    "ukphone": "ˋferoʊ",
+    "usphone": "ˋferoʊ"
+  },
+  {
+    "name": "tunnel",
+    "trans": [
+      "7.24",
+      "n．隧道；坑道；洞穴通道"
+    ],
+    "ukphone": "ˋtʌnl",
+    "usphone": "ˋtʌnl"
+  },
+  {
+    "name": "manuscript",
+    "trans": [
+      "7.25",
+      "n．手稿；原稿"
+    ],
+    "ukphone": "ˋmænjuskrIpt",
+    "usphone": "ˋmænjuskrIpt"
+  },
+  {
+    "name": "pit",
+    "trans": [
+      "8.1",
+      "n．坑，地坑（hole）；煤矿"
+    ],
+    "ukphone": "pIt",
+    "usphone": "pIt"
+  },
+  {
+    "name": "borehole",
+    "trans": [
+      "8.2",
+      "n．钻孔"
+    ],
+    "ukphone": "ˋbɔ:rhoʊl",
+    "usphone": "ˋbɔ:rhoʊl"
+  },
+  {
+    "name": "quartz",
+    "trans": [
+      "8.3",
+      "n．石英"
+    ],
+    "ukphone": "kwɔ:rts",
+    "usphone": "kwɔ:rts"
+  },
+  {
+    "name": "marble",
+    "trans": [
+      "8.4",
+      "n．大理石"
+    ],
+    "ukphone": "ˋmα:rbl",
+    "usphone": "ˋmα:rbl"
+  },
+  {
+    "name": "gem",
+    "trans": [
+      "8.5",
+      "n．宝石（jewel, precious stone）"
+    ],
+    "ukphone": "dʒem",
+    "usphone": "dʒem"
+  },
+  {
+    "name": "fieldstone",
+    "trans": [
+      "8.6",
+      "n.（建筑用的）散石，大卵石"
+    ],
+    "ukphone": "fi:ldstoʊn",
+    "usphone": "fi:ldstoʊn"
+  },
+  {
+    "name": "emerald",
+    "trans": [
+      "8.7",
+      "n．祖母绿，翡翠，绿宝石"
+    ],
+    "ukphone": "ˋemərəld",
+    "usphone": "ˋemərəld"
+  },
+  {
+    "name": "wiikite",
+    "trans": [
+      "8.8",
+      "杂铌矿"
+    ],
+    "ukphone": "ˋvi:kaIt",
+    "usphone": "ˋvi:kaIt"
+  },
+  {
+    "name": "granite",
+    "trans": [
+      "8.9",
+      "n．花岗岩"
+    ],
+    "ukphone": "ˋgrænIt",
+    "usphone": "ˋgrænIt"
+  },
+  {
+    "name": "lead",
+    "trans": [
+      "8.10",
+      "n．铅"
+    ],
+    "ukphone": "li:d",
+    "usphone": "li:d"
+  },
+  {
+    "name": "limestone",
+    "trans": [
+      "8.11",
+      "n．石灰石"
+    ],
+    "ukphone": "ˋlaImstoʊn",
+    "usphone": "ˋlaImstoʊn"
+  },
+  {
+    "name": "lava",
+    "trans": [
+      "8.12",
+      "n．熔岩，火山岩"
+    ],
+    "ukphone": "ˋlα:və",
+    "usphone": "ˋlα:və"
+  },
+  {
+    "name": "ruby",
+    "trans": [
+      "8.13",
+      "n．红宝石"
+    ],
+    "ukphone": "ˋru:bi",
+    "usphone": "ˋru:bi"
+  },
+  {
+    "name": "bonanza",
+    "trans": [
+      "8.14",
+      "n．富矿带；带来好运之事；幸运"
+    ],
+    "ukphone": "bəˋnænzə",
+    "usphone": "bəˋnænzə"
+  },
+  {
+    "name": "mineral",
+    "trans": [
+      "8.15",
+      "n．矿物，矿石"
+    ],
+    "ukphone": "ˋmInərəl",
+    "usphone": "ˋmInərəl"
+  },
+  {
+    "name": "ore",
+    "trans": [
+      "8.16",
+      "n．矿石"
+    ],
+    "ukphone": "ɔ:r",
+    "usphone": "ɔ:r"
+  },
+  {
+    "name": "vein",
+    "trans": [
+      "8.17",
+      "n．静脉，血管（blood vessel）；矿脉"
+    ],
+    "ukphone": "veIn",
+    "usphone": "veIn"
+  },
+  {
+    "name": "sediment",
+    "trans": [
+      "8.18",
+      "n．沉淀物",
+      "【记】 sedi=sit（坐）+ment→沉下去的东西→沉淀物"
+    ],
+    "ukphone": "ˋsedImənt",
+    "usphone": "ˋsedImənt"
+  },
+  {
+    "name": "fossil",
+    "trans": [
+      "8.19",
+      "n．化石"
+    ],
+    "ukphone": "ˋfα:sl",
+    "usphone": "ˋfα:sl"
+  },
+  {
+    "name": "petrify",
+    "trans": [
+      "8.20",
+      "vt．变为化石",
+      "【记】 petr（石头）+ify"
+    ],
+    "ukphone": "ˋpetrIfaI",
+    "usphone": "ˋpetrIfaI"
+  },
+  {
+    "name": "geology",
+    "trans": [
+      "8.21",
+      "n．地质学，地质概况"
+    ],
+    "ukphone": "dʒiˋα:lədʒi",
+    "usphone": "dʒiˋα:lədʒi"
+  },
+  {
+    "name": "aluminum",
+    "trans": [
+      "8.22",
+      "n．铝"
+    ],
+    "ukphone": "ˌæljəˋmIniəm］/［əˋlu:mInəm",
+    "usphone": "ˌæljəˋmIniəm］/［əˋlu:mInəm"
+  },
+  {
+    "name": "core",
+    "trans": [
+      "8.23",
+      "n．果核，中心，核心；地核"
+    ],
+    "ukphone": "kɔ:r",
+    "usphone": "kɔ:r"
+  },
+  {
+    "name": "crater",
+    "trans": [
+      "8.24",
+      "n．弹坑"
+    ],
+    "ukphone": "ˋkreItər",
+    "usphone": "ˋkreItər"
+  },
+  {
+    "name": "diamond",
+    "trans": [
+      "8.25",
+      "n．钻石，菱形"
+    ],
+    "ukphone": "ˋdaIəmənd",
+    "usphone": "ˋdaIəmənd"
+  },
+  {
+    "name": "glacial",
+    "trans": [
+      "8.26",
+      "adj．冰的，冰状的；冰河的，冰河时代的"
+    ],
+    "ukphone": "ˋgleIʃl",
+    "usphone": "ˋgleIʃl"
+  },
+  {
+    "name": "glacier",
+    "trans": [
+      "8.27",
+      "n．冰河，冰川"
+    ],
+    "ukphone": "ˋgleIʃər",
+    "usphone": "ˋgleIʃər"
+  },
+  {
+    "name": "iceberg",
+    "trans": [
+      "8.28",
+      "n．冰山",
+      "【记】 ice（冰）+berg（山）"
+    ],
+    "ukphone": "ˋaIsbɜ:rg",
+    "usphone": "ˋaIsbɜ:rg"
+  },
+  {
+    "name": "plate",
+    "trans": [
+      "8.29",
+      "n．板块；盘子；金属板"
+    ],
+    "ukphone": "pleIt",
+    "usphone": "pleIt"
+  },
+  {
+    "name": "tremor",
+    "trans": [
+      "8.30",
+      "n．震动，颤动"
+    ],
+    "ukphone": "ˋtremər",
+    "usphone": "ˋtremər"
+  },
+  {
+    "name": "earthquake",
+    "trans": [
+      "8.31",
+      "n．地震"
+    ],
+    "ukphone": "ˋɜ:rθkweIk",
+    "usphone": "ˋɜ:rθkweIk"
+  },
+  {
+    "name": "seism",
+    "trans": [
+      "8.32",
+      "n．地震"
+    ],
+    "ukphone": "ˋsaIzəm",
+    "usphone": "ˋsaIzəm"
+  },
+  {
+    "name": "seismic",
+    "trans": [
+      "8.33",
+      "adj．地震的"
+    ],
+    "ukphone": "ˋsaIzmIk",
+    "usphone": "ˋsaIzmIk"
+  },
+  {
+    "name": "seismology",
+    "trans": [
+      "8.34",
+      "n．地震学"
+    ],
+    "ukphone": "saIzˋmα:lədʒi",
+    "usphone": "saIzˋmα:lədʒi"
+  },
+  {
+    "name": "magnitude",
+    "trans": [
+      "8.35",
+      "n．震级"
+    ],
+    "ukphone": "ˋmægnItu:d",
+    "usphone": "ˋmægnItu:d"
+  },
+  {
+    "name": "cataclysm",
+    "trans": [
+      "8.36",
+      "n．地震，灾难，大洪水"
+    ],
+    "ukphone": "ˋkætəklIzəm",
+    "usphone": "ˋkætəklIzəm"
+  },
+  {
+    "name": "stratum",
+    "trans": [
+      "8.37",
+      "n．地层"
+    ],
+    "ukphone": "ˋstreItəm",
+    "usphone": "ˋstreItəm"
+  },
+  {
+    "name": "mantle",
+    "trans": [
+      "8.38",
+      "n．地幔"
+    ],
+    "ukphone": "ˋmæntl",
+    "usphone": "ˋmæntl"
+  },
+  {
+    "name": "lithogenous",
+    "trans": [
+      "8.39",
+      "a．岩成的"
+    ],
+    "ukphone": "lIˋθɔdʒInəs",
+    "usphone": "lIˋθɔdʒInəs"
+  },
+  {
+    "name": "lithosphere",
+    "trans": [
+      "8.40",
+      "n．岩石圈"
+    ],
+    "ukphone": "ˋlIθəsfIr",
+    "usphone": "ˋlIθəsfIr"
+  },
+  {
+    "name": "layer",
+    "trans": [
+      "8.41",
+      "n．层，阶层"
+    ],
+    "ukphone": "ˋler",
+    "usphone": "ˋler"
+  },
+  {
+    "name": "asthenosphere",
+    "trans": [
+      "8.42",
+      "n．软流圈"
+    ],
+    "ukphone": "æsˋθi:nəsfIr",
+    "usphone": "æsˋθi:nəsfIr"
+  },
+  {
+    "name": "crust",
+    "trans": [
+      "8.43",
+      "n．地壳；硬外皮（shell）"
+    ],
+    "ukphone": "krʌst",
+    "usphone": "krʌst"
+  },
+  {
+    "name": "fault",
+    "trans": [
+      "8.44",
+      "n．断层"
+    ],
+    "ukphone": "fɔ:lt",
+    "usphone": "fɔ:lt"
+  },
+  {
+    "name": "magma",
+    "trans": [
+      "8.45",
+      "n.（有机物或矿物的）稀糊，岩浆"
+    ],
+    "ukphone": "ˋmægmə",
+    "usphone": "ˋmægmə"
+  },
+  {
+    "name": "squirt",
+    "trans": [
+      "8.46",
+      "v．喷出（spurt）"
+    ],
+    "ukphone": "skwɜ:rt",
+    "usphone": "skwɜ:rt"
+  },
+  {
+    "name": "erupt",
+    "trans": [
+      "8.47",
+      "vi．爆发（explode, burst out）"
+    ],
+    "ukphone": "Iˋrʌpt",
+    "usphone": "Iˋrʌpt"
+  },
+  {
+    "name": "eruption",
+    "trans": [
+      "8.48",
+      "n．爆发；火山灰"
+    ],
+    "ukphone": "Iˋrʌpʃn",
+    "usphone": "Iˋrʌpʃn"
+  },
+  {
+    "name": "outburst",
+    "trans": [
+      "8.49",
+      "n.（火山，感情等）爆发，喷出（surge, explosion）"
+    ],
+    "ukphone": "ˋaʊtbɜ:rst",
+    "usphone": "ˋaʊtbɜ:rst"
+  },
+  {
+    "name": "volcanic",
+    "trans": [
+      "8.50",
+      "adj．火山的，像火山的"
+    ],
+    "ukphone": "vα:lˋkænIk",
+    "usphone": "vα:lˋkænIk"
+  },
+  {
+    "name": "thermal",
+    "trans": [
+      "8.51",
+      "adj．热的；热量的；保热的"
+    ],
+    "ukphone": "ˋθɜ:rml",
+    "usphone": "ˋθɜ:rml"
+  },
+  {
+    "name": "tundra",
+    "trans": [
+      "8.52",
+      "n．［生态］苔原；［地理］冻原；冻土地带"
+    ],
+    "ukphone": "ˋtʌndrə",
+    "usphone": "ˋtʌndrə"
+  },
+  {
+    "name": "advent",
+    "trans": [
+      "8.53",
+      "n．到来；出现"
+    ],
+    "ukphone": "ˋædvent",
+    "usphone": "ˋædvent"
+  },
+  {
+    "name": "toll",
+    "trans": [
+      "9.1",
+      "n．费（fee, charge）"
+    ],
+    "ukphone": "toʊl",
+    "usphone": "toʊl"
+  },
+  {
+    "name": "precious",
+    "trans": [
+      "9.2",
+      "adj．宝贵的，珍贵的（valuable）"
+    ],
+    "ukphone": "ˋpreʃəs",
+    "usphone": "ˋpreʃəs"
+  },
+  {
+    "name": "prosperous",
+    "trans": [
+      "9.3",
+      "adj．繁荣的（thriving, flourishing）"
+    ],
+    "ukphone": "ˋprα:spərəs",
+    "usphone": "ˋprα:spərəs"
+  },
+  {
+    "name": "prosperity",
+    "trans": [
+      "9.4",
+      "n．繁荣（well-being）"
+    ],
+    "ukphone": "prα:ˋsperəti",
+    "usphone": "prα:ˋsperəti"
+  },
+  {
+    "name": "rich",
+    "trans": [
+      "9.5",
+      "adj．肥沃的（fertile）"
+    ],
+    "ukphone": "rItʃ",
+    "usphone": "rItʃ"
+  },
+  {
+    "name": "rare",
+    "trans": [
+      "9.6",
+      "adj．稀罕的，珍贵的（scarce, uncommon）"
+    ],
+    "ukphone": "rer",
+    "usphone": "rer"
+  },
+  {
+    "name": "asset",
+    "trans": [
+      "9.7",
+      "n．财产，财富（possessions, property）"
+    ],
+    "ukphone": "ˋæset",
+    "usphone": "ˋæset"
+  },
+  {
+    "name": "fortune",
+    "trans": [
+      "9.8",
+      "n．财富（wealth）"
+    ],
+    "ukphone": "ˋfɔ:tʃu:n",
+    "usphone": "ˋfɔ:tʃu:n"
+  },
+  {
+    "name": "opulence",
+    "trans": [
+      "9.9",
+      "n．财富；富裕（wealth; affluence）",
+      "【记】 opul（财富）+ence"
+    ],
+    "ukphone": "ˋα:pjələns",
+    "usphone": "ˋα:pjələns"
+  },
+  {
+    "name": "finance",
+    "trans": [
+      "9.10",
+      "n．财政 vt．资助（sponsor, subsidize）",
+      "【记】 比较fiance（未婚夫）；fiancee（未婚妻）"
+    ],
+    "ukphone": "ˋfaInæns",
+    "usphone": "ˋfaInæns"
+  },
+  {
+    "name": "economic",
+    "trans": [
+      "9.11",
+      "adj．经济的"
+    ],
+    "ukphone": "ˌi:kəˋnα:mIk",
+    "usphone": "ˌi:kəˋnα:mIk"
+  },
+  {
+    "name": "indigent",
+    "trans": [
+      "9.12",
+      "adj．贫穷的（needy, poor）",
+      "【记】 indi（内部）+gent（缺乏）"
+    ],
+    "ukphone": "ˋIndIdʒənt",
+    "usphone": "ˋIndIdʒənt"
+  },
+  {
+    "name": "depression",
+    "trans": [
+      "9.13",
+      "n．萧条（recession）"
+    ],
+    "ukphone": "dIˋpreʃn",
+    "usphone": "dIˋpreʃn"
+  },
+  {
+    "name": "penury",
+    "trans": [
+      "9.14",
+      "n．贫穷（destitution）",
+      "【记】 penur（缺少）+y"
+    ],
+    "ukphone": "ˋpenjəri",
+    "usphone": "ˋpenjəri"
+  },
+  {
+    "name": "bidding",
+    "trans": [
+      "9.15",
+      "n．投标"
+    ],
+    "ukphone": "ˋbIdIŋ",
+    "usphone": "ˋbIdIŋ"
+  },
+  {
+    "name": "drawback",
+    "trans": [
+      "9.16",
+      "n．退款"
+    ],
+    "ukphone": "ˋdrɔ:bæk",
+    "usphone": "ˋdrɔ:bæk"
+  },
+  {
+    "name": "exponent",
+    "trans": [
+      "9.17",
+      "n．指数（index, indicator）",
+      "【记】 另一个意思是“支持者”，比较opponent（反对者）"
+    ],
+    "ukphone": "Ikˋspoʊnənt",
+    "usphone": "Ikˋspoʊnənt"
+  },
+  {
+    "name": "lease",
+    "trans": [
+      "9.18",
+      "n./v．出租（lend, loan）",
+      "【记】 联想“l”加ease（安心的）"
+    ],
+    "ukphone": "li:s",
+    "usphone": "li:s"
+  },
+  {
+    "name": "redress",
+    "trans": [
+      "9.19",
+      "n．补偿（remedy）"
+    ],
+    "ukphone": "rIˋdres",
+    "usphone": "rIˋdres"
+  },
+  {
+    "name": "compensation",
+    "trans": [
+      "9.20",
+      "n．补偿，赔偿"
+    ],
+    "ukphone": "ˌkα:mpenˋseIʃn",
+    "usphone": "ˌkα:mpenˋseIʃn"
+  },
+  {
+    "name": "deficit",
+    "trans": [
+      "9.21",
+      "n．赤字",
+      "【记】 de（坏）+fic（做）+it"
+    ],
+    "ukphone": "ˋdefIsIt",
+    "usphone": "ˋdefIsIt"
+  },
+  {
+    "name": "levy",
+    "trans": [
+      "9.22",
+      "n．课税 v．征收（collect, charge）"
+    ],
+    "ukphone": "ˋlevi",
+    "usphone": "ˋlevi"
+  },
+  {
+    "name": "ration",
+    "trans": [
+      "9.23",
+      "n．定量，配给量（share, allowance）v．配给，分发（allocate, share）"
+    ],
+    "ukphone": "ˋræʃn",
+    "usphone": "ˋræʃn"
+  },
+  {
+    "name": "rebate",
+    "trans": [
+      "9.24",
+      "n．返回款；折扣（refund, repayment）",
+      "【记】 比较debate（争论）"
+    ],
+    "ukphone": "ˋri:beIt",
+    "usphone": "ˋri:beIt"
+  },
+  {
+    "name": "merchandise",
+    "trans": [
+      "9.25",
+      "n．商品（commodities, goods）",
+      "【记】 比较merchant（商人）"
+    ],
+    "ukphone": "ˋmɜ:rtʃəndaIs",
+    "usphone": "ˋmɜ:rtʃəndaIs"
+  },
+  {
+    "name": "commerce",
+    "trans": [
+      "9.26",
+      "n．商业",
+      "【记】 注意和commence（开始）的区别"
+    ],
+    "ukphone": "ˋkα:mɜ:rs",
+    "usphone": "ˋkα:mɜ:rs"
+  },
+  {
+    "name": "enterprise",
+    "trans": [
+      "9.27",
+      "n．事业，企业"
+    ],
+    "ukphone": "ˋentərpraIz",
+    "usphone": "ˋentərpraIz"
+  },
+  {
+    "name": "currency",
+    "trans": [
+      "9.28",
+      "n．通货；通用；市价（money, exchange）"
+    ],
+    "ukphone": "ˋkɜ:rənsi",
+    "usphone": "ˋkɜ:rənsi"
+  },
+  {
+    "name": "inventory",
+    "trans": [
+      "9.29",
+      "n．物品清单；库存品"
+    ],
+    "ukphone": "ˋInvəntɔ:ri",
+    "usphone": "ˋInvəntɔ:ri"
+  },
+  {
+    "name": "quota",
+    "trans": [
+      "9.30",
+      "n．限额，定额（portion, share）"
+    ],
+    "ukphone": "ˋkwoʊtə",
+    "usphone": "ˋkwoʊtə"
+  },
+  {
+    "name": "tariff",
+    "trans": [
+      "9.31",
+      "n．关税，关税表"
+    ],
+    "ukphone": "ˋtærIf",
+    "usphone": "ˋtærIf"
+  },
+  {
+    "name": "inflation",
+    "trans": [
+      "9.32",
+      "n．通货膨胀"
+    ],
+    "ukphone": "InˋfleIʃn",
+    "usphone": "InˋfleIʃn"
+  },
+  {
+    "name": "deal",
+    "trans": [
+      "9.33",
+      "v．交易（handle）"
+    ],
+    "ukphone": "di:l",
+    "usphone": "di:l"
+  },
+  {
+    "name": "cause",
+    "trans": [
+      "9.34",
+      "n．事业（career）"
+    ],
+    "ukphone": "kɔ:z",
+    "usphone": "kɔ:z"
+  },
+  {
+    "name": "consume",
+    "trans": [
+      "9.35",
+      "vt．消费，消耗（spend）",
+      "【记】 con+sum（结束）+e→全部结束→用光"
+    ],
+    "ukphone": "kənˋsu:m",
+    "usphone": "kənˋsu:m"
+  },
+  {
+    "name": "disburse",
+    "trans": [
+      "9.36",
+      "vt．支付，支出；分配（distribute）",
+      "【记】 dis+burse（钱包）"
+    ],
+    "ukphone": "dIsˋbɜ:rs",
+    "usphone": "dIsˋbɜ:rs"
+  },
+  {
+    "name": "acting",
+    "trans": [
+      "9.37",
+      "adj．代理的（substitutive）",
+      "【记】 act（行动）+ing→代替执行的→代理的"
+    ],
+    "ukphone": "ˋæktIŋ",
+    "usphone": "ˋæktIŋ"
+  },
+  {
+    "name": "inertia",
+    "trans": [
+      "9.38",
+      "n．惯性，惯量"
+    ],
+    "ukphone": "Iˋnɜ:rʃə",
+    "usphone": "Iˋnɜ:rʃə"
+  },
+  {
+    "name": "discount",
+    "trans": [
+      "9.39",
+      "n./vt.（打）折扣（reduction）"
+    ],
+    "ukphone": "ˋdIskaʊnt",
+    "usphone": "ˋdIskaʊnt"
+  },
+  {
+    "name": "audit",
+    "trans": [
+      "9.40",
+      "n./vt．审查；查账（censor）"
+    ],
+    "ukphone": "ˋɔ:dIt",
+    "usphone": "ˋɔ:dIt"
+  },
+  {
+    "name": "shipment",
+    "trans": [
+      "9.41",
+      "n．装船，出货"
+    ],
+    "ukphone": "ˋʃIpmənt",
+    "usphone": "ˋʃIpmənt"
+  },
+  {
+    "name": "surplus",
+    "trans": [
+      "9.42",
+      "n．过剩，剩余（物资）adj．过剩的（extra, excess）",
+      "【记】 比较plus（加）"
+    ],
+    "ukphone": "ˋsɜ:rpləs",
+    "usphone": "ˋsɜ:rpləs"
+  },
+  {
+    "name": "residue",
+    "trans": [
+      "9.43",
+      "n．残余（remains, leftover, remnant）"
+    ],
+    "ukphone": "ˋrezIdu:",
+    "usphone": "ˋrezIdu:"
+  },
+  {
+    "name": "account",
+    "trans": [
+      "9.44",
+      "n．户头；账目"
+    ],
+    "ukphone": "əˋkaʊnt",
+    "usphone": "əˋkaʊnt"
+  },
+  {
+    "name": "bankruptcy",
+    "trans": [
+      "9.45",
+      "n．破产",
+      "【记】 bank（银行）+rupt（断）+cy"
+    ],
+    "ukphone": "ˋbæŋkrʌptsi",
+    "usphone": "ˋbæŋkrʌptsi"
+  },
+  {
+    "name": "savings",
+    "trans": [
+      "9.46",
+      "n．储蓄"
+    ],
+    "ukphone": "ˋseIvIŋz",
+    "usphone": "ˋseIvIŋz"
+  },
+  {
+    "name": "collateral",
+    "trans": [
+      "9.47",
+      "n．抵押品"
+    ],
+    "ukphone": "kəˋlætərəl",
+    "usphone": "kəˋlætərəl"
+  },
+  {
+    "name": "bill",
+    "trans": [
+      "9.48",
+      "n．钞票；账单"
+    ],
+    "ukphone": "bIl",
+    "usphone": "bIl"
+  },
+  {
+    "name": "check",
+    "trans": [
+      "9.49",
+      "n．支票"
+    ],
+    "ukphone": "tʃek",
+    "usphone": "tʃek"
+  },
+  {
+    "name": "coin",
+    "trans": [
+      "9.50",
+      "n．铸币"
+    ],
+    "ukphone": "kɔIn",
+    "usphone": "kɔIn"
+  },
+  {
+    "name": "depreciate",
+    "trans": [
+      "9.51",
+      "v．贬值",
+      "【记】 de（坏）+preci（价值）+ate"
+    ],
+    "ukphone": "dIˋpri:ʃieIt",
+    "usphone": "dIˋpri:ʃieIt"
+  },
+  {
+    "name": "merge",
+    "trans": [
+      "9.52",
+      "v．合并（combine, amalgamate）"
+    ],
+    "ukphone": "mɜ:rdʒ",
+    "usphone": "mɜ:rdʒ"
+  },
+  {
+    "name": "reimburse",
+    "trans": [
+      "9.53",
+      "vt．偿还（pay back, refund）",
+      "【记】 re（重新）+im=in（进入）+burse（钱包）→偿还"
+    ],
+    "ukphone": "ˌri:Imˋbɜ:rs",
+    "usphone": "ˌri:Imˋbɜ:rs"
+  },
+  {
+    "name": "garner",
+    "trans": [
+      "9.54",
+      "vt．储存（store）"
+    ],
+    "ukphone": "ˋgα:rnər",
+    "usphone": "ˋgα:rnər"
+  },
+  {
+    "name": "underestimate",
+    "trans": [
+      "9.55",
+      "vt．低估（undervalue）"
+    ],
+    "ukphone": "ˌʌndərˋestImeIt",
+    "usphone": "ˌʌndərˋestImeIt"
+  },
+  {
+    "name": "exchange",
+    "trans": [
+      "9.56",
+      "vt．兑换；交换（barter）"
+    ],
+    "ukphone": "IksˋtʃeIndʒ",
+    "usphone": "IksˋtʃeIndʒ"
+  },
+  {
+    "name": "assess",
+    "trans": [
+      "9.57",
+      "vt．估计（estimate, evaluate）"
+    ],
+    "ukphone": "əˋses",
+    "usphone": "əˋses"
+  },
+  {
+    "name": "consolidate",
+    "trans": [
+      "9.58",
+      "vt．合并（merge）",
+      "【记】 con+solid（固体的，结实的）+ate"
+    ],
+    "ukphone": "kənˋsα:lIdeIt",
+    "usphone": "kənˋsα:lIdeIt"
+  },
+  {
+    "name": "loan",
+    "trans": [
+      "9.59",
+      "n．贷款 vt．借（lend）"
+    ],
+    "ukphone": "loʊn",
+    "usphone": "loʊn"
+  },
+  {
+    "name": "refund",
+    "trans": [
+      "9.60",
+      "vt．退还，偿还（repay, pay back）",
+      "【记】 re（重新）+fund（钱）→重新还回钱→退还"
+    ],
+    "ukphone": "ˋri:fʌnd",
+    "usphone": "ˋri:fʌnd"
+  },
+  {
+    "name": "utility",
+    "trans": [
+      "9.61",
+      "n．效用（function, usefulness）"
+    ],
+    "ukphone": "ju:ˋtIləti",
+    "usphone": "ju:ˋtIləti"
+  },
+  {
+    "name": "selection",
+    "trans": [
+      "9.62",
+      "n．选择（choice）",
+      "【记】 select（选择）+ion"
+    ],
+    "ukphone": "sIˋlekʃn",
+    "usphone": "sIˋlekʃn"
+  },
+  {
+    "name": "option",
+    "trans": [
+      "9.63",
+      "n．选择，取舍（choice, alternative）"
+    ],
+    "ukphone": "ˋα:pʃn",
+    "usphone": "ˋα:pʃn"
+  },
+  {
+    "name": "economics",
+    "trans": [
+      "9.64",
+      "n．经济（学）"
+    ],
+    "ukphone": "ˌi:kəˋnα:mIks",
+    "usphone": "ˌi:kəˋnα:mIks"
+  },
+  {
+    "name": "output",
+    "trans": [
+      "9.65",
+      "n．产量，输出量（turnout, yield）",
+      "【记】 来自put out（生产）"
+    ],
+    "ukphone": "ˋaʊtpʊt",
+    "usphone": "ˋaʊtpʊt"
+  },
+  {
+    "name": "goods",
+    "trans": [
+      "9.66",
+      "n．货物（merchandise, commodity）"
+    ],
+    "ukphone": "gʊdz",
+    "usphone": "gʊdz"
+  },
+  {
+    "name": "opportunity",
+    "trans": [
+      "9.67",
+      "n．机会（chance）"
+    ],
+    "ukphone": "ˌα:pərˋtu:nəti",
+    "usphone": "ˌα:pərˋtu:nəti"
+  },
+  {
+    "name": "benefit",
+    "trans": [
+      "9.68",
+      "n．利益（profit, interest）"
+    ],
+    "ukphone": "ˋbenIfIt",
+    "usphone": "ˋbenIfIt"
+  },
+  {
+    "name": "contract",
+    "trans": [
+      "9.69",
+      "n．契约（agreement）"
+    ],
+    "ukphone": "ˋkα:ntrækt",
+    "usphone": "ˋkα:ntrækt"
+  },
+  {
+    "name": "lottery",
+    "trans": [
+      "9.70",
+      "n．奖券；抽奖"
+    ],
+    "ukphone": "ˋlα:təri",
+    "usphone": "ˋlα:təri"
+  },
+  {
+    "name": "transaction",
+    "trans": [
+      "9.71",
+      "n．交易（business, trade, deal）",
+      "【记】 trans（交换）+action（活动）→交易"
+    ],
+    "ukphone": "trænˋzækʃn",
+    "usphone": "trænˋzækʃn"
+  },
+  {
+    "name": "budget",
+    "trans": [
+      "9.72",
+      "n．预算 v．做预算"
+    ],
+    "ukphone": "ˋbʌdʒIt",
+    "usphone": "ˋbʌdʒIt"
+  },
+  {
+    "name": "patronage",
+    "trans": [
+      "9.73",
+      "n．赞助，资助",
+      "【记】 patron（赞助人）+age"
+    ],
+    "ukphone": "ˋpætrənIdʒ",
+    "usphone": "ˋpætrənIdʒ"
+  },
+  {
+    "name": "choose",
+    "trans": [
+      "9.74",
+      "vt．选择（select, pick）"
+    ],
+    "ukphone": "tʃu:z",
+    "usphone": "tʃu:z"
+  },
+  {
+    "name": "choice",
+    "trans": [
+      "9.75",
+      "n．选择（selection）"
+    ],
+    "ukphone": "tʃɔIs",
+    "usphone": "tʃɔIs"
+  },
+  {
+    "name": "barter",
+    "trans": [
+      "9.76",
+      "n./vt．易货（trade, exchange）"
+    ],
+    "ukphone": "ˋbα:rtər",
+    "usphone": "ˋbα:rtər"
+  },
+  {
+    "name": "purchase",
+    "trans": [
+      "9.77",
+      "n./vt．购买（buy）"
+    ],
+    "ukphone": "ˋpɜ:rtʃəs",
+    "usphone": "ˋpɜ:rtʃəs"
+  },
+  {
+    "name": "deposit",
+    "trans": [
+      "9.78",
+      "v．放置，存款（place, lay）n．押金",
+      "【记】 比较draw（取款）"
+    ],
+    "ukphone": "dIˋpα:zIt",
+    "usphone": "dIˋpα:zIt"
+  },
+  {
+    "name": "commission",
+    "trans": [
+      "9.79",
+      "n．佣金"
+    ],
+    "ukphone": "kəˋmIʃn",
+    "usphone": "kəˋmIʃn"
+  },
+  {
+    "name": "ransom",
+    "trans": [
+      "9.80",
+      "n．赔偿金（payment, redemption）"
+    ],
+    "ukphone": "ˋrænsəm",
+    "usphone": "ˋrænsəm"
+  },
+  {
+    "name": "toll",
+    "trans": [
+      "9.81",
+      "v．鸣（钟）（ring, strike）"
+    ],
+    "ukphone": "toʊl",
+    "usphone": "toʊl"
+  },
+  {
+    "name": "charge",
+    "trans": [
+      "9.82",
+      "n．费用 v．收费"
+    ],
+    "ukphone": "tʃα:rdʒ",
+    "usphone": "tʃα:rdʒ"
+  },
+  {
+    "name": "bond",
+    "trans": [
+      "9.83",
+      "n．公债"
+    ],
+    "ukphone": "bα:nd",
+    "usphone": "bα:nd"
+  },
+  {
+    "name": "custom",
+    "trans": [
+      "9.84",
+      "n．进口税"
+    ],
+    "ukphone": "ˋkʌstəm",
+    "usphone": "ˋkʌstəm"
+  },
+  {
+    "name": "bonus",
+    "trans": [
+      "9.85",
+      "n．红利；奖金（award, gift）"
+    ],
+    "ukphone": "ˋbəunəs",
+    "usphone": "ˋbəunəs"
+  },
+  {
+    "name": "interest",
+    "trans": [
+      "9.86",
+      "n．利息"
+    ],
+    "ukphone": "ˋIntrəst",
+    "usphone": "ˋIntrəst"
+  },
+  {
+    "name": "means",
+    "trans": [
+      "9.87",
+      "n．钱（money）"
+    ],
+    "ukphone": "mi:nz",
+    "usphone": "mi:nz"
+  },
+  {
+    "name": "debt",
+    "trans": [
+      "9.88",
+      "n．债务（liability）"
+    ],
+    "ukphone": "det",
+    "usphone": "det"
+  },
+  {
+    "name": "fund",
+    "trans": [
+      "9.89",
+      "n．资金，基金（money）vt．投资"
+    ],
+    "ukphone": "fʌnd",
+    "usphone": "fʌnd"
+  },
+  {
+    "name": "revenue",
+    "trans": [
+      "9.90",
+      "n．收入（income, returns, earnings）"
+    ],
+    "ukphone": "ˋrevənju:",
+    "usphone": "ˋrevənju:"
+  },
+  {
+    "name": "noxious",
+    "trans": [
+      "10.1",
+      "adj．有害的；有毒的（poisonous, toxic）",
+      "【记】 nox（毒）+ious"
+    ],
+    "ukphone": "ˋnα:kʃəs",
+    "usphone": "ˋnα:kʃəs"
+  },
+  {
+    "name": "pollute",
+    "trans": [
+      "10.2",
+      "vt．污染（contaminate, defile）"
+    ],
+    "ukphone": "pəˋlu:t",
+    "usphone": "pəˋlu:t"
+  },
+  {
+    "name": "pollutant",
+    "trans": [
+      "10.3",
+      "n．污染物质"
+    ],
+    "ukphone": "pəˋlu:tənt",
+    "usphone": "pəˋlu:tənt"
+  },
+  {
+    "name": "pollution",
+    "trans": [
+      "10.4",
+      "n．污染，玷污"
+    ],
+    "ukphone": "pəˋlu:ʃən",
+    "usphone": "pəˋlu:ʃən"
+  },
+  {
+    "name": "contaminate",
+    "trans": [
+      "10.5",
+      "vt．污染（defile, pollute）"
+    ],
+    "ukphone": "kənˋtæmIneIt",
+    "usphone": "kənˋtæmIneIt"
+  },
+  {
+    "name": "waste",
+    "trans": [
+      "10.6",
+      "n．废物"
+    ],
+    "ukphone": "weIst",
+    "usphone": "weIst"
+  },
+  {
+    "name": "sewage",
+    "trans": [
+      "10.7",
+      "n．下水道，污水"
+    ],
+    "ukphone": "ˋsju:Idʒ",
+    "usphone": "ˋsju:Idʒ"
+  },
+  {
+    "name": "fume",
+    "trans": [
+      "10.8",
+      "n.（浓烈或难闻的）烟，气体"
+    ],
+    "ukphone": "fju:m",
+    "usphone": "fju:m"
+  },
+  {
+    "name": "habitat",
+    "trans": [
+      "10.9",
+      "n.（动、植物的）生活环境，居留地（home, environment）"
+    ],
+    "ukphone": "ˋhæbItæt",
+    "usphone": "ˋhæbItæt"
+  },
+  {
+    "name": "balance",
+    "trans": [
+      "10.10",
+      "n./v．平衡（equilibrium）"
+    ],
+    "ukphone": "ˋbæləns",
+    "usphone": "ˋbæləns"
+  },
+  {
+    "name": "ecosystem",
+    "trans": [
+      "10.11",
+      "n．生态系统"
+    ],
+    "ukphone": "ˋi:koʊsIstəm",
+    "usphone": "ˋi:koʊsIstəm"
+  },
+  {
+    "name": "fauna",
+    "trans": [
+      "10.12",
+      "n．动物群，动物区系"
+    ],
+    "ukphone": "ˋfɔ:nə",
+    "usphone": "ˋfɔ:nə"
+  },
+  {
+    "name": "decibel",
+    "trans": [
+      "10.13",
+      "n．分贝"
+    ],
+    "ukphone": "ˋdesIbel",
+    "usphone": "ˋdesIbel"
+  },
+  {
+    "name": "ozonosphere",
+    "trans": [
+      "10.14",
+      "n．臭氧层"
+    ],
+    "ukphone": "oʊˋzoʊnəsfIr",
+    "usphone": "oʊˋzoʊnəsfIr"
+  },
+  {
+    "name": "surge",
+    "trans": [
+      "10.15",
+      "n．大浪，波涛；汹涌澎湃；激增"
+    ],
+    "ukphone": "sɜ:rdʒ",
+    "usphone": "sɜ:rdʒ"
+  },
+  {
+    "name": "hackneyed",
+    "trans": [
+      "11.1",
+      "adj．陈腐的（mouldy, stale）",
+      "【记】 参考hack（陈腐的）, Internet用语hacker（黑客）"
+    ],
+    "ukphone": "ˋhæknid",
+    "usphone": "ˋhæknid"
+  },
+  {
+    "name": "caustic",
+    "trans": [
+      "11.2",
+      "adj．腐蚀性的（abrasive, corrosive）"
+    ],
+    "ukphone": "ˋkɔ:stIk",
+    "usphone": "ˋkɔ:stIk"
+  },
+  {
+    "name": "erosion",
+    "trans": [
+      "11.3",
+      "n．腐蚀"
+    ],
+    "ukphone": "Iˋroʊʒn",
+    "usphone": "Iˋroʊʒn"
+  },
+  {
+    "name": "erode",
+    "trans": [
+      "11.4",
+      "vt．蚀，腐蚀（corrode, wear away）"
+    ],
+    "ukphone": "Iˋroʊd",
+    "usphone": "Iˋroʊd"
+  },
+  {
+    "name": "stale",
+    "trans": [
+      "11.5",
+      "adj．陈腐的（smelly, musty, flat）"
+    ],
+    "ukphone": "steIl",
+    "usphone": "steIl"
+  },
+  {
+    "name": "rot",
+    "trans": [
+      "11.6",
+      "v．腐烂（perish, decay）"
+    ],
+    "ukphone": "rα:t",
+    "usphone": "rα:t"
+  },
+  {
+    "name": "rotten",
+    "trans": [
+      "11.7",
+      "adj．腐烂的（decaying, decomposed）"
+    ],
+    "ukphone": "ˋrα:tn",
+    "usphone": "ˋrα:tn"
+  },
+  {
+    "name": "decay",
+    "trans": [
+      "11.8",
+      "v.（使）腐败（rot, decompose）"
+    ],
+    "ukphone": "dIˋkeI",
+    "usphone": "dIˋkeI"
+  },
+  {
+    "name": "corrode",
+    "trans": [
+      "11.9",
+      "v．腐蚀（erode, eat away）",
+      "【记】 比较erode（腐蚀）"
+    ],
+    "ukphone": "kəˋroʊd",
+    "usphone": "kəˋroʊd"
+  },
+  {
+    "name": "decomposition",
+    "trans": [
+      "11.10",
+      "n．分解，腐烂"
+    ],
+    "ukphone": "ˌdi:kα:mpəˋzIʃn",
+    "usphone": "ˌdi:kα:mpəˋzIʃn"
+  },
+  {
+    "name": "rust",
+    "trans": [
+      "11.11",
+      "v．生锈，氧化（oxidize）n．铁锈"
+    ],
+    "ukphone": "rʌst",
+    "usphone": "rʌst"
+  },
+  {
+    "name": "silica",
+    "trans": [
+      "11.12",
+      "n．硅土"
+    ],
+    "ukphone": "ˋsIlIkə",
+    "usphone": "ˋsIlIkə"
+  },
+  {
+    "name": "crystal",
+    "trans": [
+      "11.13",
+      "n．水晶，晶体"
+    ],
+    "ukphone": "ˋkrIstl",
+    "usphone": "ˋkrIstl"
+  },
+  {
+    "name": "gasoline",
+    "trans": [
+      "11.14",
+      "n．汽油"
+    ],
+    "ukphone": "ˋgæsəli:n",
+    "usphone": "ˋgæsəli:n"
+  },
+  {
+    "name": "methane",
+    "trans": [
+      "11.15",
+      "n．甲烷，沼气"
+    ],
+    "ukphone": "ˋmeθeIn",
+    "usphone": "ˋmeθeIn"
+  },
+  {
+    "name": "hydrocarbon",
+    "trans": [
+      "11.16",
+      "n．碳氢化合物"
+    ],
+    "ukphone": "ˌhaIdrəˋkα:rbən",
+    "usphone": "ˌhaIdrəˋkα:rbən"
+  },
+  {
+    "name": "petroleum",
+    "trans": [
+      "11.17",
+      "n．石油"
+    ],
+    "ukphone": "pəˋtroʊliəm",
+    "usphone": "pəˋtroʊliəm"
+  },
+  {
+    "name": "plastic",
+    "trans": [
+      "11.18",
+      "n．塑胶，可塑体，塑料制品"
+    ],
+    "ukphone": "ˋplæstIk",
+    "usphone": "ˋplæstIk"
+  },
+  {
+    "name": "intermediary",
+    "trans": [
+      "11.19",
+      "n．媒介物；居间者（mediator）",
+      "【记】 inter（中间）+medi（中间）+ary→媒介物"
+    ],
+    "ukphone": "ˌIntərˋmi:dieri",
+    "usphone": "ˌIntərˋmi:dieri"
+  },
+  {
+    "name": "catalysis",
+    "trans": [
+      "11.20",
+      "n．催化作用"
+    ],
+    "ukphone": "kəˋtæləsIs",
+    "usphone": "kəˋtæləsIs"
+  },
+  {
+    "name": "catalyst",
+    "trans": [
+      "11.21",
+      "n．催化剂"
+    ],
+    "ukphone": "ˋkætəlIst",
+    "usphone": "ˋkætəlIst"
+  },
+  {
+    "name": "adhesive",
+    "trans": [
+      "11.22",
+      "n．粘合剂 adj．胶粘；粘着性的"
+    ],
+    "ukphone": "ədˋhi:sIv",
+    "usphone": "ədˋhi:sIv"
+  },
+  {
+    "name": "scorch",
+    "trans": [
+      "11.23",
+      "vt．使褪色（discolor）"
+    ],
+    "ukphone": "skɔ:rtʃ",
+    "usphone": "skɔ:rtʃ"
+  },
+  {
+    "name": "bleach",
+    "trans": [
+      "11.24",
+      "vt．去色，漂白（blanch, whiten）n．漂白剂"
+    ],
+    "ukphone": "bli:tʃ",
+    "usphone": "bli:tʃ"
+  },
+  {
+    "name": "tint",
+    "trans": [
+      "11.25",
+      "vt．上色，染色 n．上色，色彩（tinge；hue）"
+    ],
+    "ukphone": "tInt",
+    "usphone": "tInt"
+  },
+  {
+    "name": "dye",
+    "trans": [
+      "11.26",
+      "n．颜料 v．染色（pigment）"
+    ],
+    "ukphone": "daI",
+    "usphone": "daI"
+  },
+  {
+    "name": "chemistry",
+    "trans": [
+      "11.27",
+      "n．化学"
+    ],
+    "ukphone": "ˋkemIstri",
+    "usphone": "ˋkemIstri"
+  },
+  {
+    "name": "biochemistry",
+    "trans": [
+      "11.28",
+      "n．生物化学",
+      "【记】 bio（生物）+chemistry（化学）"
+    ],
+    "ukphone": "ˌbaIoʊˋkemIstri",
+    "usphone": "ˌbaIoʊˋkemIstri"
+  },
+  {
+    "name": "hydronic",
+    "trans": [
+      "11.29",
+      "adj．液体循环加热（或冷却）的"
+    ],
+    "ukphone": "haIˋdrα:nIk",
+    "usphone": "haIˋdrα:nIk"
+  },
+  {
+    "name": "alchemy",
+    "trans": [
+      "11.30",
+      "n．炼金术，魔力"
+    ],
+    "ukphone": "ˋælkəmi",
+    "usphone": "ˋælkəmi"
+  },
+  {
+    "name": "artificial",
+    "trans": [
+      "11.31",
+      "adj．人造的，假的，非原产地的"
+    ],
+    "ukphone": "ˌα:rtIˋfIʃl",
+    "usphone": "ˌα:rtIˋfIʃl"
+  },
+  {
+    "name": "ion",
+    "trans": [
+      "11.32",
+      "n．离子"
+    ],
+    "ukphone": "ˋaIən",
+    "usphone": "ˋaIən"
+  },
+  {
+    "name": "molecule",
+    "trans": [
+      "11.33",
+      "n．分子；些微"
+    ],
+    "ukphone": "ˋmα:lIkju:l",
+    "usphone": "ˋmα:lIkju:l"
+  },
+  {
+    "name": "solubility",
+    "trans": [
+      "11.34",
+      "n．溶度，溶性，溶解性；可解决性，可解释性"
+    ],
+    "ukphone": "ˌsα:ljuˋbIləti",
+    "usphone": "ˌsα:ljuˋbIləti"
+  },
+  {
+    "name": "solution",
+    "trans": [
+      "11.35",
+      "n．解答，解决办法，溶解，溶液"
+    ],
+    "ukphone": "səˋlu:ʃn",
+    "usphone": "səˋlu:ʃn"
+  },
+  {
+    "name": "solvent",
+    "trans": [
+      "11.36",
+      "adj．溶解的，有溶解力的；有偿付能力的 n．溶媒，溶剂"
+    ],
+    "ukphone": "ˋsα:lvənt",
+    "usphone": "ˋsα:lvənt"
+  },
+  {
+    "name": "dissolve",
+    "trans": [
+      "11.37",
+      "v．溶解；解散"
+    ],
+    "ukphone": "dIˋzα:lv",
+    "usphone": "dIˋzα:lv"
+  },
+  {
+    "name": "element",
+    "trans": [
+      "11.38",
+      "n．元素"
+    ],
+    "ukphone": "ˋelImənt",
+    "usphone": "ˋelImənt"
+  },
+  {
+    "name": "impurity",
+    "trans": [
+      "11.39",
+      "n．杂质"
+    ],
+    "ukphone": "Imˋpjʊrəti",
+    "usphone": "Imˋpjʊrəti"
+  },
+  {
+    "name": "blend",
+    "trans": [
+      "11.40",
+      "v./n．混合（combine, mix）"
+    ],
+    "ukphone": "blend",
+    "usphone": "blend"
+  },
+  {
+    "name": "compound",
+    "trans": [
+      "11.41",
+      "n．混合物，化合物"
+    ],
+    "ukphone": "ˋkα:mpaʊnd",
+    "usphone": "ˋkα:mpaʊnd"
+  },
+  {
+    "name": "substance",
+    "trans": [
+      "11.42",
+      "n．物质；实质"
+    ],
+    "ukphone": "ˋsʌbstəns",
+    "usphone": "ˋsʌbstəns"
+  },
+  {
+    "name": "particle",
+    "trans": [
+      "11.43",
+      "n．颗粒，微粒",
+      "【记】 比较article（文章）"
+    ],
+    "ukphone": "ˋpα:rtIkl",
+    "usphone": "ˋpα:rtIkl"
+  },
+  {
+    "name": "explosive",
+    "trans": [
+      "11.44",
+      "adj．爆炸的 n．炸药"
+    ],
+    "ukphone": "IkˋsploʊsIv",
+    "usphone": "IkˋsploʊsIv"
+  },
+  {
+    "name": "blast",
+    "trans": [
+      "11.45",
+      "n．爆破"
+    ],
+    "ukphone": "blæst",
+    "usphone": "blæst"
+  },
+  {
+    "name": "explode",
+    "trans": [
+      "11.46",
+      "v.（使）爆炸（blast）"
+    ],
+    "ukphone": "Ikˋsploʊd",
+    "usphone": "Ikˋsploʊd"
+  },
+  {
+    "name": "burning",
+    "trans": [
+      "11.47",
+      "adj．燃烧的"
+    ],
+    "ukphone": "ˋbɜ:rnIŋ",
+    "usphone": "ˋbɜ:rnIŋ"
+  },
+  {
+    "name": "kindle",
+    "trans": [
+      "11.48",
+      "vt．燃起（ignite, inflame）",
+      "【记】 比较candle（蜡烛）"
+    ],
+    "ukphone": "ˋkIndl",
+    "usphone": "ˋkIndl"
+  },
+  {
+    "name": "sear",
+    "trans": [
+      "11.49",
+      "vt．烧灼"
+    ],
+    "ukphone": "sIr",
+    "usphone": "sIr"
+  },
+  {
+    "name": "ignite",
+    "trans": [
+      "11.50",
+      "vt．使燃烧（inflame, kindle）"
+    ],
+    "ukphone": "IgˋnaIt",
+    "usphone": "IgˋnaIt"
+  },
+  {
+    "name": "action",
+    "trans": [
+      "11.51",
+      "n．作用"
+    ],
+    "ukphone": "ˋækʃn",
+    "usphone": "ˋækʃn"
+  },
+  {
+    "name": "combination",
+    "trans": [
+      "11.52",
+      "n．化合；组合"
+    ],
+    "ukphone": "ˌkα:mbIˋneIʃn",
+    "usphone": "ˌkα:mbIˋneIʃn"
+  },
+  {
+    "name": "neutralize",
+    "trans": [
+      "11.53",
+      "v．中和（counteract）"
+    ],
+    "ukphone": "ˋnju:trəlaIz",
+    "usphone": "ˋnju:trəlaIz"
+  },
+  {
+    "name": "polymerization",
+    "trans": [
+      "11.54",
+      "n．聚合"
+    ],
+    "ukphone": "ˌpα:limərəˋzeIʃn",
+    "usphone": "ˌpα:limərəˋzeIʃn"
+  },
+  {
+    "name": "functional",
+    "trans": [
+      "11.55",
+      "adj．起作用的（useful）"
+    ],
+    "ukphone": "ˋfʌŋkʃənl",
+    "usphone": "ˋfʌŋkʃənl"
+  },
+  {
+    "name": "synthetic",
+    "trans": [
+      "11.56",
+      "adj．综合的；合成的（artificial, man-made）"
+    ],
+    "ukphone": "sInˋθetIk",
+    "usphone": "sInˋθetIk"
+  },
+  {
+    "name": "carbon",
+    "trans": [
+      "11.57",
+      "n．碳"
+    ],
+    "ukphone": "ˋkα:rbən",
+    "usphone": "ˋkα:rbən"
+  },
+  {
+    "name": "copper",
+    "trans": [
+      "11.58",
+      "n．铜"
+    ],
+    "ukphone": "ˋkα:pər",
+    "usphone": "ˋkα:pər"
+  },
+  {
+    "name": "lead",
+    "trans": [
+      "11.59",
+      "n．铅"
+    ],
+    "ukphone": "li:d",
+    "usphone": "li:d"
+  },
+  {
+    "name": "Mercury",
+    "trans": [
+      "11.60",
+      "n．水星；［罗马神话］ 墨丘利神（众神的信使）"
+    ],
+    "ukphone": "ˋmɜ:rkjəri",
+    "usphone": "ˋmɜ:rkjəri"
+  },
+  {
+    "name": "nickel",
+    "trans": [
+      "11.61",
+      "n．镍，镍币"
+    ],
+    "ukphone": "ˋnIkl",
+    "usphone": "ˋnIkl"
+  },
+  {
+    "name": "platinum",
+    "trans": [
+      "11.62",
+      "n．白金，铂"
+    ],
+    "ukphone": "ˋplætInəm",
+    "usphone": "ˋplætInəm"
+  },
+  {
+    "name": "silver",
+    "trans": [
+      "11.63",
+      "n．银，银子"
+    ],
+    "ukphone": "ˋsIlvər",
+    "usphone": "ˋsIlvər"
+  },
+  {
+    "name": "sodium",
+    "trans": [
+      "11.64",
+      "n．钠"
+    ],
+    "ukphone": "ˋsoʊdiəm",
+    "usphone": "ˋsoʊdiəm"
+  },
+  {
+    "name": "tin",
+    "trans": [
+      "11.65",
+      "n．锡，马口铁"
+    ],
+    "ukphone": "tIn",
+    "usphone": "tIn"
+  },
+  {
+    "name": "zinc",
+    "trans": [
+      "11.66",
+      "n．锌"
+    ],
+    "ukphone": "zIŋk",
+    "usphone": "zIŋk"
+  },
+  {
+    "name": "calcium",
+    "trans": [
+      "11.67",
+      "n．钙（元素符号Ca）"
+    ],
+    "ukphone": "ˋkælsiəm",
+    "usphone": "ˋkælsiəm"
+  },
+  {
+    "name": "helium",
+    "trans": [
+      "11.68",
+      "n．氦（化学元素，符号为He）"
+    ],
+    "ukphone": "ˋhi:liəm",
+    "usphone": "ˋhi:liəm"
+  },
+  {
+    "name": "silicon",
+    "trans": [
+      "11.69",
+      "n．硅，硅元素"
+    ],
+    "ukphone": "ˋsIlIkən",
+    "usphone": "ˋsIlIkən"
+  },
+  {
+    "name": "ammonia",
+    "trans": [
+      "11.70",
+      "n．氨，氨水"
+    ],
+    "ukphone": "əˋmoʊniə",
+    "usphone": "əˋmoʊniə"
+  },
+  {
+    "name": "sulfur",
+    "trans": [
+      "11.71",
+      "n．硫磺，硫黄"
+    ],
+    "ukphone": "ˋsʌlfər",
+    "usphone": "ˋsʌlfər"
+  },
+  {
+    "name": "iodine",
+    "trans": [
+      "11.72",
+      "n．碘，碘酒"
+    ],
+    "ukphone": "ˋaIədaIn",
+    "usphone": "ˋaIədaIn"
+  },
+  {
+    "name": "oxygen",
+    "trans": [
+      "11.73",
+      "n．氧气",
+      "【记】 oxy（氧）+gen; 如 oxyacid（含氧酸），oxyhydrogen（氧氢混合气）"
+    ],
+    "ukphone": "ˋα:ksIdʒən",
+    "usphone": "ˋα:ksIdʒən"
+  },
+  {
+    "name": "pigment",
+    "trans": [
+      "11.74",
+      "n．［物］［生化］色素；颜料"
+    ],
+    "ukphone": "ˋpIgmənt",
+    "usphone": "ˋpIgmənt"
+  },
+  {
+    "name": "nitrogen",
+    "trans": [
+      "11.75",
+      "n．［化学］ 氮"
+    ],
+    "ukphone": "ˋnaItrədʒən",
+    "usphone": "ˋnaItrədʒən"
+  },
+  {
+    "name": "shrub",
+    "trans": [
+      "12.1",
+      "n．灌木丛（bush）"
+    ],
+    "ukphone": "ʃrʌb",
+    "usphone": "ʃrʌb"
+  },
+  {
+    "name": "laurel",
+    "trans": [
+      "12.2",
+      "n．月桂树；桂冠，殊荣"
+    ],
+    "ukphone": "ˋlɔ:rəl",
+    "usphone": "ˋlɔ:rəl"
+  },
+  {
+    "name": "prairie",
+    "trans": [
+      "12.3",
+      "n．大草原，牧场，<美方>林间小空地"
+    ],
+    "ukphone": "ˋpreri",
+    "usphone": "ˋpreri"
+  },
+  {
+    "name": "sequoia",
+    "trans": [
+      "12.4",
+      "n．美洲杉"
+    ],
+    "ukphone": "sIˋkwɔIə",
+    "usphone": "sIˋkwɔIə"
+  },
+  {
+    "name": "herb",
+    "trans": [
+      "12.5",
+      "n．药草，香草"
+    ],
+    "ukphone": "ɜ:rb",
+    "usphone": "ɜ:rb"
+  },
+  {
+    "name": "plant",
+    "trans": [
+      "12.6",
+      "n．植物，庄稼"
+    ],
+    "ukphone": "plænt",
+    "usphone": "plænt"
+  },
+  {
+    "name": "fern",
+    "trans": [
+      "12.7",
+      "n．蕨类植物"
+    ],
+    "ukphone": "fɜ:rn",
+    "usphone": "fɜ:rn"
+  },
+  {
+    "name": "orchid",
+    "trans": [
+      "12.8",
+      "n．兰，兰花；淡紫色"
+    ],
+    "ukphone": "ˋɔ:rkId",
+    "usphone": "ˋɔ:rkId"
+  },
+  {
+    "name": "rosette",
+    "trans": [
+      "12.9",
+      "n．玫瑰形饰物，圆花饰"
+    ],
+    "ukphone": "roʊˋzet",
+    "usphone": "roʊˋzet"
+  },
+  {
+    "name": "germinate",
+    "trans": [
+      "12.10",
+      "v．发芽（sprout）",
+      "【记】 germ（幼芽）+inate→发芽"
+    ],
+    "ukphone": "ˋdʒɜ:rmIneIt",
+    "usphone": "ˋdʒɜ:rmIneIt"
+  },
+  {
+    "name": "sprout",
+    "trans": [
+      "12.11",
+      "v．萌芽，长出（bud, burgeon, germinate）"
+    ],
+    "ukphone": "spraʊt",
+    "usphone": "spraʊt"
+  },
+  {
+    "name": "timber",
+    "trans": [
+      "12.12",
+      "n．木材，木料（lumber, wood）",
+      "【记】 比较timbre（音色）"
+    ],
+    "ukphone": "ˋtImbər",
+    "usphone": "ˋtImbər"
+  },
+  {
+    "name": "cluster",
+    "trans": [
+      "12.13",
+      "n．丛，束（bunch）v．丛生；聚集（concentrate）"
+    ],
+    "ukphone": "ˋklʌstər",
+    "usphone": "ˋklʌstər"
+  },
+  {
+    "name": "bunch",
+    "trans": [
+      "12.14",
+      "n．串，束"
+    ],
+    "ukphone": "bʌntʃ",
+    "usphone": "bʌntʃ"
+  },
+  {
+    "name": "bark",
+    "trans": [
+      "12.15",
+      "n．树皮"
+    ],
+    "ukphone": "bα:rk",
+    "usphone": "bα:rk"
+  },
+  {
+    "name": "twig",
+    "trans": [
+      "12.16",
+      "n．小树枝（small branch）",
+      "【记】 比较wig（假发）"
+    ],
+    "ukphone": "twIg",
+    "usphone": "twIg"
+  },
+  {
+    "name": "bough",
+    "trans": [
+      "12.17",
+      "n．大树枝，主枝"
+    ],
+    "ukphone": "baʊ",
+    "usphone": "baʊ"
+  },
+  {
+    "name": "branch",
+    "trans": [
+      "12.18",
+      "n．枝，分枝"
+    ],
+    "ukphone": "bræntʃ",
+    "usphone": "bræntʃ"
+  },
+  {
+    "name": "stem",
+    "trans": [
+      "12.19",
+      "n．茎，干；词干"
+    ],
+    "ukphone": "stem",
+    "usphone": "stem"
+  },
+  {
+    "name": "stalk",
+    "trans": [
+      "12.20",
+      "n．茎，柄，梗，秆"
+    ],
+    "ukphone": "stɔ:k",
+    "usphone": "stɔ:k"
+  },
+  {
+    "name": "trunk",
+    "trans": [
+      "12.21",
+      "n．干线；树干"
+    ],
+    "ukphone": "trʌŋk",
+    "usphone": "trʌŋk"
+  },
+  {
+    "name": "leafstalk",
+    "trans": [
+      "12.22",
+      "n．叶柄"
+    ],
+    "ukphone": "ˋli:fstɔ:k",
+    "usphone": "ˋli:fstɔ:k"
+  },
+  {
+    "name": "leaflet",
+    "trans": [
+      "12.23",
+      "n．小叶；传单"
+    ],
+    "ukphone": "ˋli:flət",
+    "usphone": "ˋli:flət"
+  },
+  {
+    "name": "bud",
+    "trans": [
+      "12.24",
+      "n．芽 v．发芽"
+    ],
+    "ukphone": "bʌd",
+    "usphone": "bʌd"
+  },
+  {
+    "name": "flower",
+    "trans": [
+      "12.25",
+      "n．花，开花的植物"
+    ],
+    "ukphone": "ˋflaʊər",
+    "usphone": "ˋflaʊər"
+  },
+  {
+    "name": "foliage",
+    "trans": [
+      "12.26",
+      "n．树叶；植物"
+    ],
+    "ukphone": "ˋfoʊliIdʒ",
+    "usphone": "ˋfoʊliIdʒ"
+  },
+  {
+    "name": "petal",
+    "trans": [
+      "12.27",
+      "n．花瓣"
+    ],
+    "ukphone": "ˋpetl",
+    "usphone": "ˋpetl"
+  },
+  {
+    "name": "cell",
+    "trans": [
+      "12.28",
+      "n．单元；细胞"
+    ],
+    "ukphone": "sel",
+    "usphone": "sel"
+  },
+  {
+    "name": "tissue",
+    "trans": [
+      "12.29",
+      "n．组织"
+    ],
+    "ukphone": "ˋtIʃu:",
+    "usphone": "ˋtIʃu:"
+  },
+  {
+    "name": "husk",
+    "trans": [
+      "12.30",
+      "n.（果类或谷物的）外壳［常用pl.］，皮"
+    ],
+    "ukphone": "hʌsk",
+    "usphone": "hʌsk"
+  },
+  {
+    "name": "pollen",
+    "trans": [
+      "12.31",
+      "n．花粉 vt．传授花粉给…"
+    ],
+    "ukphone": "ˋpα:lən",
+    "usphone": "ˋpα:lən"
+  },
+  {
+    "name": "root",
+    "trans": [
+      "12.32",
+      "n．根，根部"
+    ],
+    "ukphone": "ru:t",
+    "usphone": "ru:t"
+  },
+  {
+    "name": "log",
+    "trans": [
+      "12.33",
+      "n．圆木（wood, timber）"
+    ],
+    "ukphone": "lα:g",
+    "usphone": "lα:g"
+  },
+  {
+    "name": "flora",
+    "trans": [
+      "12.34",
+      "n．植物界",
+      "【记】 flor（花草）+a→植物界"
+    ],
+    "ukphone": "ˋflɔ:rə",
+    "usphone": "ˋflɔ:rə"
+  },
+  {
+    "name": "botany",
+    "trans": [
+      "12.35",
+      "n．植物学",
+      "【记】 botan（草）+y→植物学"
+    ],
+    "ukphone": "ˋbα:təni",
+    "usphone": "ˋbα:təni"
+  },
+  {
+    "name": "botanical",
+    "trans": [
+      "12.36",
+      "adj．植物学的 n．植物性药材"
+    ],
+    "ukphone": "bəˋtænIkl",
+    "usphone": "bəˋtænIkl"
+  },
+  {
+    "name": "crossbreed",
+    "trans": [
+      "12.37",
+      "n．杂种 v．异种交配，培育杂种，（使）杂交"
+    ],
+    "ukphone": "ˋkrɔ:sˌbri:d",
+    "usphone": "ˋkrɔ:sˌbri:d"
+  },
+  {
+    "name": "necrosis",
+    "trans": [
+      "12.38",
+      "n．坏疽，骨疽"
+    ],
+    "ukphone": "neˋkroʊsIs",
+    "usphone": "neˋkroʊsIs"
+  },
+  {
+    "name": "peel",
+    "trans": [
+      "12.39",
+      "v．剥，削，剥落"
+    ],
+    "ukphone": "pi:l",
+    "usphone": "pi:l"
+  },
+  {
+    "name": "photosynthesis",
+    "trans": [
+      "12.40",
+      "n．光合作用"
+    ],
+    "ukphone": "ˌfoʊtoʊˋsInθəsIs",
+    "usphone": "ˌfoʊtoʊˋsInθəsIs"
+  },
+  {
+    "name": "pollinate",
+    "trans": [
+      "12.41",
+      "vt．对…授粉"
+    ],
+    "ukphone": "ˋpα:ləneIt",
+    "usphone": "ˋpα:ləneIt"
+  },
+  {
+    "name": "pollination",
+    "trans": [
+      "12.42",
+      "n．授粉"
+    ],
+    "ukphone": "ˌpα:ləˋneIʃn",
+    "usphone": "ˌpα:ləˋneIʃn"
+  },
+  {
+    "name": "seeds",
+    "trans": [
+      "12.43",
+      "n．雏形；种子形"
+    ],
+    "ukphone": "si:dz",
+    "usphone": "si:dz"
+  },
+  {
+    "name": "shell",
+    "trans": [
+      "12.44",
+      "vt．去壳；脱落"
+    ],
+    "ukphone": "ʃel",
+    "usphone": "ʃel"
+  },
+  {
+    "name": "shoot",
+    "trans": [
+      "12.45",
+      "vi．发出，发芽"
+    ],
+    "ukphone": "ʃu:t",
+    "usphone": "ʃu:t"
+  },
+  {
+    "name": "starch",
+    "trans": [
+      "12.46",
+      "n．淀粉"
+    ],
+    "ukphone": "stα:rtʃ",
+    "usphone": "stα:rtʃ"
+  },
+  {
+    "name": "vitamin",
+    "trans": [
+      "12.47",
+      "n．维他命，维生素"
+    ],
+    "ukphone": "ˋvaItəmIn",
+    "usphone": "ˋvaItəmIn"
+  },
+  {
+    "name": "luxuriant",
+    "trans": [
+      "12.48",
+      "adj．多产的，繁茂的",
+      "【记】 luxur（丰富）+iant→多产的"
+    ],
+    "ukphone": "lʌgˋʒʊriənt",
+    "usphone": "lʌgˋʒʊriənt"
+  },
+  {
+    "name": "spore",
+    "trans": [
+      "12.49",
+      "n．孢子"
+    ],
+    "ukphone": "spɔ:r",
+    "usphone": "spɔ:r"
+  },
+  {
+    "name": "juvenile",
+    "trans": [
+      "13.1",
+      "adj．青少年的（adolescent, young）",
+      "【记】 juven（年青）+ile"
+    ],
+    "ukphone": "ˋdʒu:vənaIl",
+    "usphone": "ˋdʒu:vənaIl"
+  },
+  {
+    "name": "adult",
+    "trans": [
+      "13.2",
+      "n．成人 adj．成人的，成熟的（mature）"
+    ],
+    "ukphone": "ˋædʌlt",
+    "usphone": "ˋædʌlt"
+  },
+  {
+    "name": "human",
+    "trans": [
+      "13.3",
+      "adj．人类的，人性的"
+    ],
+    "ukphone": "ˋhju:mən",
+    "usphone": "ˋhju:mən"
+  },
+  {
+    "name": "anthropology",
+    "trans": [
+      "13.4",
+      "n．人类学"
+    ],
+    "ukphone": "ˌænθrəˋpα:lədʒi",
+    "usphone": "ˌænθrəˋpα:lədʒi"
+  },
+  {
+    "name": "tribe",
+    "trans": [
+      "13.5",
+      "n．部落，部族"
+    ],
+    "ukphone": "traIb",
+    "usphone": "traIb"
+  },
+  {
+    "name": "ethnic",
+    "trans": [
+      "13.6",
+      "adj．种族的（racial, national）",
+      "【记】 ethn（种族）+ic"
+    ],
+    "ukphone": "ˋeθnIk",
+    "usphone": "ˋeθnIk"
+  },
+  {
+    "name": "ethnology",
+    "trans": [
+      "13.7",
+      "n．人种学，人类文化学"
+    ],
+    "ukphone": "eθˋnα:lədʒi",
+    "usphone": "eθˋnα:lədʒi"
+  },
+  {
+    "name": "minority",
+    "trans": [
+      "13.8",
+      "n．少数；少数民族",
+      "【记】 minor（小，少）+ity→少的状态→少数"
+    ],
+    "ukphone": "maIˋnɔ:rəti",
+    "usphone": "maIˋnɔ:rəti"
+  },
+  {
+    "name": "descent",
+    "trans": [
+      "13.9",
+      "n．血统（ancestry）"
+    ],
+    "ukphone": "dIˋsent",
+    "usphone": "dIˋsent"
+  },
+  {
+    "name": "hybrid",
+    "trans": [
+      "13.10",
+      "n．杂种；混血儿"
+    ],
+    "ukphone": "ˋhaIbrId",
+    "usphone": "ˋhaIbrId"
+  },
+  {
+    "name": "intelligence",
+    "trans": [
+      "13.11",
+      "n．智力",
+      "【记】 intel（中间）+lig（选择）+ence→从中选出好的智力"
+    ],
+    "ukphone": "InˋtelIdʒəns",
+    "usphone": "InˋtelIdʒəns"
+  },
+  {
+    "name": "intellectual",
+    "trans": [
+      "13.12",
+      "adj．智力的",
+      "【记】 intellect（智力）+ual"
+    ],
+    "ukphone": "ˌIntəˋlektʃuəl",
+    "usphone": "ˌIntəˋlektʃuəl"
+  },
+  {
+    "name": "aboriginal",
+    "trans": [
+      "13.13",
+      "n．土著 adj．土著的，原来的（native）",
+      "【记】 ab+original（原版的，原来的）"
+    ],
+    "ukphone": "ˌæbəˋrIdʒənl",
+    "usphone": "ˌæbəˋrIdʒənl"
+  },
+  {
+    "name": "ancestor",
+    "trans": [
+      "13.14",
+      "n．祖先，祖宗"
+    ],
+    "ukphone": "ˋænsestər",
+    "usphone": "ˋænsestər"
+  },
+  {
+    "name": "forerunner",
+    "trans": [
+      "13.15",
+      "n．先驱，祖先（ancestor, predecessor）",
+      "【记】 fore（前）+runner（奔跑者）→先驱"
+    ],
+    "ukphone": "ˋfɔ:rʌnər",
+    "usphone": "ˋfɔ:rʌnər"
+  },
+  {
+    "name": "hominid",
+    "trans": [
+      "13.16",
+      "n．原始人类"
+    ],
+    "ukphone": "ˋhα:mInId",
+    "usphone": "ˋhα:mInId"
+  },
+  {
+    "name": "cranial",
+    "trans": [
+      "13.17",
+      "adj．头盖的，头盖形的"
+    ],
+    "ukphone": "ˋkreIniəl",
+    "usphone": "ˋkreIniəl"
+  },
+  {
+    "name": "nomadic",
+    "trans": [
+      "13.18",
+      "adj．游牧的；流浪的；游动的"
+    ],
+    "ukphone": "noʊˋmædIk",
+    "usphone": "noʊˋmædIk"
+  },
+  {
+    "name": "catalog",
+    "trans": [
+      "13.19",
+      "n．［图情］［计］目录；登记"
+    ],
+    "ukphone": "ˋkætəlɔ:g",
+    "usphone": "ˋkætəlɔ:g"
+  },
+  {
+    "name": "natural",
+    "trans": [
+      "14.1",
+      "adj．自然的"
+    ],
+    "ukphone": "ˋnætʃrəl",
+    "usphone": "ˋnætʃrəl"
+  },
+  {
+    "name": "scenic",
+    "trans": [
+      "14.2",
+      "adj．风景优美的（picturesque）"
+    ],
+    "ukphone": "ˋsi:nIk",
+    "usphone": "ˋsi:nIk"
+  },
+  {
+    "name": "scenery",
+    "trans": [
+      "14.3",
+      "n．景色"
+    ],
+    "ukphone": "ˋsi:nəri",
+    "usphone": "ˋsi:nəri"
+  },
+  {
+    "name": "spectacle",
+    "trans": [
+      "14.4",
+      "n．奇观，景象（sight, scene）"
+    ],
+    "ukphone": "ˋspektəkl",
+    "usphone": "ˋspektəkl"
+  },
+  {
+    "name": "shade",
+    "trans": [
+      "14.5",
+      "n．荫"
+    ],
+    "ukphone": "ʃeId",
+    "usphone": "ʃeId"
+  },
+  {
+    "name": "jungle",
+    "trans": [
+      "14.6",
+      "n．丛林"
+    ],
+    "ukphone": "ˋdʒʌŋgl",
+    "usphone": "ˋdʒʌŋgl"
+  },
+  {
+    "name": "meadow",
+    "trans": [
+      "14.7",
+      "n．草地，牧场"
+    ],
+    "ukphone": "ˋmedoʊ",
+    "usphone": "ˋmedoʊ"
+  },
+  {
+    "name": "lawn",
+    "trans": [
+      "14.8",
+      "n．草地，草坪，草场"
+    ],
+    "ukphone": "lɔ:n",
+    "usphone": "lɔ:n"
+  },
+  {
+    "name": "summit",
+    "trans": [
+      "14.9",
+      "n．山顶（peak, top, apex）"
+    ],
+    "ukphone": "ˋsʌmIt",
+    "usphone": "ˋsʌmIt"
+  },
+  {
+    "name": "gorge",
+    "trans": [
+      "14.10",
+      "n．峡谷（ravine, canyon）"
+    ],
+    "ukphone": "gɔ:rdʒ",
+    "usphone": "gɔ:rdʒ"
+  },
+  {
+    "name": "puddle",
+    "trans": [
+      "14.11",
+      "n．小水洼"
+    ],
+    "ukphone": "ˋpʌdl",
+    "usphone": "ˋpʌdl"
+  },
+  {
+    "name": "creek",
+    "trans": [
+      "14.12",
+      "n．小湾；小溪（brook）"
+    ],
+    "ukphone": "kri:k",
+    "usphone": "kri:k"
+  },
+  {
+    "name": "canyon",
+    "trans": [
+      "14.13",
+      "n．<美>峡谷，溪谷"
+    ],
+    "ukphone": "ˋkænjən",
+    "usphone": "ˋkænjən"
+  },
+  {
+    "name": "spring",
+    "trans": [
+      "14.14",
+      "n．泉水"
+    ],
+    "ukphone": "sprIŋ",
+    "usphone": "sprIŋ"
+  },
+  {
+    "name": "trickle",
+    "trans": [
+      "14.15",
+      "vi．滴，淌 n．滴；细流（dribble, drip）"
+    ],
+    "ukphone": "ˋtrIkl",
+    "usphone": "ˋtrIkl"
+  },
+  {
+    "name": "crystal",
+    "trans": [
+      "14.16",
+      "adj．清澈的 n．水晶；结晶"
+    ],
+    "ukphone": "ˋkrIstl",
+    "usphone": "ˋkrIstl"
+  },
+  {
+    "name": "limpid",
+    "trans": [
+      "14.17",
+      "adj．清澈的（transparent, clear）"
+    ],
+    "ukphone": "ˋlImpId",
+    "usphone": "ˋlImpId"
+  },
+  {
+    "name": "prolific",
+    "trans": [
+      "15.1",
+      "adj．多产的（productive）"
+    ],
+    "ukphone": "prəˋlIfIk",
+    "usphone": "prəˋlIfIk"
+  },
+  {
+    "name": "rich",
+    "trans": [
+      "15.2",
+      "adj．富有的（wealthy）"
+    ],
+    "ukphone": "rItʃ",
+    "usphone": "rItʃ"
+  },
+  {
+    "name": "fertile",
+    "trans": [
+      "15.3",
+      "adj．肥沃的；多产的（fruitful; rich）",
+      "【记】 fert=fer（带来）+ile→能带来粮食→肥沃的"
+    ],
+    "ukphone": "ˋfɜ:rtl",
+    "usphone": "ˋfɜ:rtl"
+  },
+  {
+    "name": "harvest",
+    "trans": [
+      "15.4",
+      "n./v．收获（glean, gather）"
+    ],
+    "ukphone": "ˋhα:rvIst",
+    "usphone": "ˋhα:rvIst"
+  },
+  {
+    "name": "agriculture",
+    "trans": [
+      "15.5",
+      "n．农业，农艺，农学"
+    ],
+    "ukphone": "ˋægrIkʌltʃər",
+    "usphone": "ˋægrIkʌltʃər"
+  },
+  {
+    "name": "agricultural",
+    "trans": [
+      "15.6",
+      "adj．农业的，农艺的"
+    ],
+    "ukphone": "ˌægrIˋkʌltʃərəl",
+    "usphone": "ˌægrIˋkʌltʃərəl"
+  },
+  {
+    "name": "aquaculture",
+    "trans": [
+      "15.7",
+      "n．水产业"
+    ],
+    "ukphone": "ˋækwəkʌltʃər",
+    "usphone": "ˋækwəkʌltʃər"
+  },
+  {
+    "name": "arable",
+    "trans": [
+      "15.8",
+      "adj．适于耕种的（farmable, fruitful）",
+      "【记】 ara（耕种）+ble"
+    ],
+    "ukphone": "ˋærəbl",
+    "usphone": "ˋærəbl"
+  },
+  {
+    "name": "indigenous",
+    "trans": [
+      "15.9",
+      "adj．土产的，当地的",
+      "【记】 indi（内部）+gen（产生）+ous→内部产生→土产的"
+    ],
+    "ukphone": "InˋdIdʒənəs",
+    "usphone": "InˋdIdʒənəs"
+  },
+  {
+    "name": "fertilizer",
+    "trans": [
+      "15.10",
+      "n．肥料",
+      "【记】 来自fertilize（施肥）"
+    ],
+    "ukphone": "ˋfɜ:rtəlaIzər",
+    "usphone": "ˋfɜ:rtəlaIzər"
+  },
+  {
+    "name": "husbandry",
+    "trans": [
+      "15.11",
+      "n．耕种；管理（farming management）",
+      "【记】 husband（丈夫）+ry→丈夫负责→耕种"
+    ],
+    "ukphone": "ˋhʌzbəndri",
+    "usphone": "ˋhʌzbəndri"
+  },
+  {
+    "name": "graze",
+    "trans": [
+      "15.12",
+      "v．吃草（feed）"
+    ],
+    "ukphone": "greIz",
+    "usphone": "greIz"
+  },
+  {
+    "name": "cultivate",
+    "trans": [
+      "15.13",
+      "vt．耕种；培养（till; foster, train）",
+      "【记】 cult（培养）+ivate"
+    ],
+    "ukphone": "ˋkʌltIveIt",
+    "usphone": "ˋkʌltIveIt"
+  },
+  {
+    "name": "cultivation",
+    "trans": [
+      "15.14",
+      "n．耕种；培养"
+    ],
+    "ukphone": "ˌkʌltIˋveIʃn",
+    "usphone": "ˌkʌltIˋveIʃn"
+  },
+  {
+    "name": "manure",
+    "trans": [
+      "15.15",
+      "vt．施肥（fertilizer, dung）"
+    ],
+    "ukphone": "məˋnʊr",
+    "usphone": "məˋnʊr"
+  },
+  {
+    "name": "horticulture",
+    "trans": [
+      "15.16",
+      "n．园艺"
+    ],
+    "ukphone": "ˋhɔ:rtIkʌltʃər",
+    "usphone": "ˋhɔ:rtIkʌltʃər"
+  },
+  {
+    "name": "hydroponics",
+    "trans": [
+      "15.17",
+      "n．水耕法，水栽培"
+    ],
+    "ukphone": "ˌhaIdrəˋpα:nIks",
+    "usphone": "ˌhaIdrəˋpα:nIks"
+  },
+  {
+    "name": "insecticide",
+    "trans": [
+      "15.18",
+      "n．杀虫剂"
+    ],
+    "ukphone": "InˋsektIsaId",
+    "usphone": "InˋsektIsaId"
+  },
+  {
+    "name": "irrigate",
+    "trans": [
+      "15.19",
+      "vt．灌溉，修水利"
+    ],
+    "ukphone": "ˋIrIgeIt",
+    "usphone": "ˋIrIgeIt"
+  },
+  {
+    "name": "pesticide",
+    "trans": [
+      "15.20",
+      "n．杀虫剂"
+    ],
+    "ukphone": "ˋpestIsaId",
+    "usphone": "ˋpestIsaId"
+  },
+  {
+    "name": "ridge",
+    "trans": [
+      "15.21",
+      "v．起皱，成脊状延伸，翻土作垄"
+    ],
+    "ukphone": "rIdʒ",
+    "usphone": "rIdʒ"
+  },
+  {
+    "name": "silt",
+    "trans": [
+      "15.22",
+      "n．淤泥，残渣，煤粉，泥沙"
+    ],
+    "ukphone": "sIlt",
+    "usphone": "sIlt"
+  },
+  {
+    "name": "tractor",
+    "trans": [
+      "15.23",
+      "n．拖拉机"
+    ],
+    "ukphone": "ˋtræktər",
+    "usphone": "ˋtræktər"
+  },
+  {
+    "name": "squash",
+    "trans": [
+      "15.24",
+      "n．南瓜"
+    ],
+    "ukphone": "skwα:ʃ",
+    "usphone": "skwα:ʃ"
+  },
+  {
+    "name": "cotton",
+    "trans": [
+      "15.25",
+      "n．棉花，棉线"
+    ],
+    "ukphone": "ˋkα:tn",
+    "usphone": "ˋkα:tn"
+  },
+  {
+    "name": "garlic",
+    "trans": [
+      "15.26",
+      "n．大蒜，蒜头"
+    ],
+    "ukphone": "ˋgα:rlIk",
+    "usphone": "ˋgα:rlIk"
+  },
+  {
+    "name": "eggplant",
+    "trans": [
+      "15.27",
+      "n．茄子"
+    ],
+    "ukphone": "ˋegplænt",
+    "usphone": "ˋegplænt"
+  },
+  {
+    "name": "fodder",
+    "trans": [
+      "15.28",
+      "n．饲料，草料"
+    ],
+    "ukphone": "ˋfα:dər",
+    "usphone": "ˋfα:dər"
+  },
+  {
+    "name": "hay",
+    "trans": [
+      "15.29",
+      "n．干草"
+    ],
+    "ukphone": "heI",
+    "usphone": "heI"
+  },
+  {
+    "name": "haystack",
+    "trans": [
+      "15.30",
+      "n．干草堆"
+    ],
+    "ukphone": "ˋheIstæk",
+    "usphone": "ˋheIstæk"
+  },
+  {
+    "name": "vegetable",
+    "trans": [
+      "15.31",
+      "n．蔬菜，植物 adj．蔬菜的，植物的"
+    ],
+    "ukphone": "ˋvedʒtəbl",
+    "usphone": "ˋvedʒtəbl"
+  },
+  {
+    "name": "weed",
+    "trans": [
+      "15.32",
+      "n．野草，杂草 v．除草，铲除"
+    ],
+    "ukphone": "wi:d",
+    "usphone": "wi:d"
+  },
+  {
+    "name": "sorghum",
+    "trans": [
+      "15.33",
+      "n．高粱属的植物"
+    ],
+    "ukphone": "ˋsɔ:rgəm",
+    "usphone": "ˋsɔ:rgəm"
+  },
+  {
+    "name": "livestock",
+    "trans": [
+      "15.34",
+      "n．家畜，牲畜"
+    ],
+    "ukphone": "ˋlaIvstα:k",
+    "usphone": "ˋlaIvstα:k"
+  },
+  {
+    "name": "poultry",
+    "trans": [
+      "15.35",
+      "n．家禽"
+    ],
+    "ukphone": "ˋpoʊltri",
+    "usphone": "ˋpoʊltri"
+  },
+  {
+    "name": "buffalo",
+    "trans": [
+      "15.36",
+      "n.（印度、非洲等的）水牛"
+    ],
+    "ukphone": "ˋbʌfəloʊ",
+    "usphone": "ˋbʌfəloʊ"
+  },
+  {
+    "name": "cattle",
+    "trans": [
+      "15.37",
+      "n．牛，家养牲畜"
+    ],
+    "ukphone": "ˋkætl",
+    "usphone": "ˋkætl"
+  },
+  {
+    "name": "fowl",
+    "trans": [
+      "15.38",
+      "n．家禽，禽，禽肉"
+    ],
+    "ukphone": "faʊl",
+    "usphone": "faʊl"
+  },
+  {
+    "name": "sow",
+    "trans": [
+      "15.39",
+      "v．播种，散布，使密布"
+    ],
+    "ukphone": "soʊ］/［saʊ",
+    "usphone": "soʊ］/［saʊ"
+  },
+  {
+    "name": "conservatory",
+    "trans": [
+      "15.40",
+      "n．温室（greenhouse）"
+    ],
+    "ukphone": "kənˋsɜ:rvətɔ:ri",
+    "usphone": "kənˋsɜ:rvətɔ:ri"
+  },
+  {
+    "name": "barn",
+    "trans": [
+      "15.41",
+      "n．谷仓；畜棚，畜舍"
+    ],
+    "ukphone": "bα:rn",
+    "usphone": "bα:rn"
+  },
+  {
+    "name": "cowshed",
+    "trans": [
+      "15.42",
+      "n．牛棚，牛舍"
+    ],
+    "ukphone": "ˋkaʊʃed",
+    "usphone": "ˋkaʊʃed"
+  },
+  {
+    "name": "granary",
+    "trans": [
+      "15.43",
+      "n．谷仓"
+    ],
+    "ukphone": "ˋgrænəri",
+    "usphone": "ˋgrænəri"
+  },
+  {
+    "name": "greenhouse",
+    "trans": [
+      "15.44",
+      "n．温室，花房"
+    ],
+    "ukphone": "ˋgri:nhaʊs",
+    "usphone": "ˋgri:nhaʊs"
+  },
+  {
+    "name": "seedbed",
+    "trans": [
+      "15.45",
+      "n．苗床"
+    ],
+    "ukphone": "ˋsi:dbed",
+    "usphone": "ˋsi:dbed"
+  },
+  {
+    "name": "sheepfold",
+    "trans": [
+      "15.46",
+      "n．羊圈"
+    ],
+    "ukphone": "ˋʃi:pfoʊld",
+    "usphone": "ˋʃi:pfoʊld"
+  },
+  {
+    "name": "orchard",
+    "trans": [
+      "15.47",
+      "n．果园，果园里的全部果树"
+    ],
+    "ukphone": "ˋɔ:rtʃərd",
+    "usphone": "ˋɔ:rtʃərd"
+  },
+  {
+    "name": "pasture",
+    "trans": [
+      "15.48",
+      "n．牧地，草原，牧场"
+    ],
+    "ukphone": "ˋpæstʃər",
+    "usphone": "ˋpæstʃər"
+  },
+  {
+    "name": "pigpen",
+    "trans": [
+      "15.49",
+      "n．猪舍，猪舍似的地方"
+    ],
+    "ukphone": "ˋpIgpen",
+    "usphone": "ˋpIgpen"
+  },
+  {
+    "name": "pigsty",
+    "trans": [
+      "15.50",
+      "n．猪舍，脏房子"
+    ],
+    "ukphone": "ˋpIgstaI",
+    "usphone": "ˋpIgstaI"
+  },
+  {
+    "name": "plantation",
+    "trans": [
+      "15.51",
+      "n．耕地，种植园，大农场；森林，人造林"
+    ],
+    "ukphone": "plænˋteIʃn",
+    "usphone": "plænˋteIʃn"
+  },
+  {
+    "name": "ranch",
+    "trans": [
+      "15.52",
+      "n．大农场 v．经营牧场"
+    ],
+    "ukphone": "ræntʃ",
+    "usphone": "ræntʃ"
+  },
+  {
+    "name": "trough",
+    "trans": [
+      "15.53",
+      "n．槽，水槽，饲料槽；木钵"
+    ],
+    "ukphone": "ˋtrɔ:f",
+    "usphone": "ˋtrɔ:f"
+  },
+  {
+    "name": "plow",
+    "trans": [
+      "15.54",
+      "v．［农机］ 犁；耕地；破浪前进；开路"
+    ],
+    "ukphone": "plaʊ",
+    "usphone": "plaʊ"
+  },
+  {
+    "name": "implicit",
+    "trans": [
+      "16.1",
+      "adj．含蓄的",
+      "【记】 im（进入）+plic（重叠）+it→重叠状态→含蓄的"
+    ],
+    "ukphone": "ImˋplIsIt",
+    "usphone": "ImˋplIsIt"
+  },
+  {
+    "name": "concise",
+    "trans": [
+      "16.2",
+      "adj．简明的（succinct, terse）",
+      "【记】 con+cise（切）→切掉多余的→简明的"
+    ],
+    "ukphone": "kənˋsaIs",
+    "usphone": "kənˋsaIs"
+  },
+  {
+    "name": "succinct",
+    "trans": [
+      "16.3",
+      "adj．简明的，简洁的（terse, concise）"
+    ],
+    "ukphone": "səkˋsIŋkt",
+    "usphone": "səkˋsIŋkt"
+  },
+  {
+    "name": "fluent",
+    "trans": [
+      "16.4",
+      "adj．流利的，流畅的（fluid, smooth）",
+      "【记】 flu（流动）+ent→流利的"
+    ],
+    "ukphone": "ˋflu:ənt",
+    "usphone": "ˋflu:ənt"
+  },
+  {
+    "name": "cogent",
+    "trans": [
+      "16.5",
+      "adj．强有力的；有说服力的（convincing; compelling）"
+    ],
+    "ukphone": "ˋkoʊdʒənt",
+    "usphone": "ˋkoʊdʒənt"
+  },
+  {
+    "name": "persuasive",
+    "trans": [
+      "16.6",
+      "adj．有说服力的",
+      "【记】 动词persuade（说服）"
+    ],
+    "ukphone": "pərˋsweIsIv",
+    "usphone": "pərˋsweIsIv"
+  },
+  {
+    "name": "character",
+    "trans": [
+      "16.7",
+      "n．文字"
+    ],
+    "ukphone": "ˋkærəktər",
+    "usphone": "ˋkærəktər"
+  },
+  {
+    "name": "glossary",
+    "trans": [
+      "16.8",
+      "n．词汇表",
+      "【记】 gloss（舌头，语言）+ary→词汇表"
+    ],
+    "ukphone": "ˋglα:səri",
+    "usphone": "ˋglα:səri"
+  },
+  {
+    "name": "dialect",
+    "trans": [
+      "16.9",
+      "n．方言，土语（vernacular, jargon）",
+      "【记】 dia+lect（说）→方言"
+    ],
+    "ukphone": "ˋdaIəlekt",
+    "usphone": "ˋdaIəlekt"
+  },
+  {
+    "name": "clause",
+    "trans": [
+      "16.10",
+      "n．分句"
+    ],
+    "ukphone": "klɔ:z",
+    "usphone": "klɔ:z"
+  },
+  {
+    "name": "linguistics",
+    "trans": [
+      "16.11",
+      "n．语言学",
+      "【记】 lingu（语言）+istics（学科后缀）→语言学"
+    ],
+    "ukphone": "lIŋˋgwIstIks",
+    "usphone": "lIŋˋgwIstIks"
+  },
+  {
+    "name": "phonetics",
+    "trans": [
+      "16.12",
+      "n．语音学",
+      "【记】 phone（声音）+tics→语音学"
+    ],
+    "ukphone": "fəˋnetIks",
+    "usphone": "fəˋnetIks"
+  },
+  {
+    "name": "tense",
+    "trans": [
+      "16.13",
+      "n．时态"
+    ],
+    "ukphone": "tens",
+    "usphone": "tens"
+  },
+  {
+    "name": "version",
+    "trans": [
+      "16.14",
+      "n．说法；版本（description, account）"
+    ],
+    "ukphone": "ˋvɜ:rʒn",
+    "usphone": "ˋvɜ:rʒn"
+  },
+  {
+    "name": "genre",
+    "trans": [
+      "16.15",
+      "n．体裁；风格（style; manner）",
+      "【记】 通常指文学等类型"
+    ],
+    "ukphone": "ˋʒα:nrə",
+    "usphone": "ˋʒα:nrə"
+  },
+  {
+    "name": "tag",
+    "trans": [
+      "16.16",
+      "n．附加语；标签（label, tab）"
+    ],
+    "ukphone": "tæg",
+    "usphone": "tæg"
+  },
+  {
+    "name": "slogan",
+    "trans": [
+      "16.17",
+      "n．口号；标语（motto）"
+    ],
+    "ukphone": "ˋsloʊgən",
+    "usphone": "ˋsloʊgən"
+  },
+  {
+    "name": "lyric",
+    "trans": [
+      "16.18",
+      "n．歌词"
+    ],
+    "ukphone": "ˋlIrIk",
+    "usphone": "ˋlIrIk"
+  },
+  {
+    "name": "verse",
+    "trans": [
+      "16.19",
+      "n．诗，韵文"
+    ],
+    "ukphone": "vɜ:rs",
+    "usphone": "vɜ:rs"
+  },
+  {
+    "name": "fiction",
+    "trans": [
+      "16.20",
+      "n．小说",
+      "【记】 fict（做）+ion→做出的故事→小说"
+    ],
+    "ukphone": "ˋfIkʃn",
+    "usphone": "ˋfIkʃn"
+  },
+  {
+    "name": "byword",
+    "trans": [
+      "16.21",
+      "n．谚语（adage）"
+    ],
+    "ukphone": "ˋbaIwɜ:rd",
+    "usphone": "ˋbaIwɜ:rd"
+  },
+  {
+    "name": "fable",
+    "trans": [
+      "16.22",
+      "n．寓言，传说（allegory）"
+    ],
+    "ukphone": "ˋfeIbl",
+    "usphone": "ˋfeIbl"
+  },
+  {
+    "name": "term",
+    "trans": [
+      "16.23",
+      "n．术语（expression）"
+    ],
+    "ukphone": "tɜ:rm",
+    "usphone": "tɜ:rm"
+  },
+  {
+    "name": "maxim",
+    "trans": [
+      "16.24",
+      "n．格言，箴言（proverb, motto）",
+      "【记】 比较maximum（最大值）；minimum（最小值）"
+    ],
+    "ukphone": "ˋmæksIm",
+    "usphone": "ˋmæksIm"
+  },
+  {
+    "name": "satire",
+    "trans": [
+      "16.25",
+      "n．讽刺文学"
+    ],
+    "ukphone": "ˋsætaIər",
+    "usphone": "ˋsætaIər"
+  },
+  {
+    "name": "farce",
+    "trans": [
+      "16.26",
+      "n．闹剧"
+    ],
+    "ukphone": "fα:rs",
+    "usphone": "fα:rs"
+  },
+  {
+    "name": "adage",
+    "trans": [
+      "16.27",
+      "n．格言，谚语（proverb）"
+    ],
+    "ukphone": "ˋædIdʒ",
+    "usphone": "ˋædIdʒ"
+  },
+  {
+    "name": "synopsis",
+    "trans": [
+      "16.28",
+      "n．大纲，梗概（outline, summary）"
+    ],
+    "ukphone": "sIˋnα:psIs",
+    "usphone": "sIˋnα:psIs"
+  },
+  {
+    "name": "compile",
+    "trans": [
+      "16.29",
+      "vt．收集；编纂（collect, put together）",
+      "【记】 com+pile（堆）→有序地堆→编"
+    ],
+    "ukphone": "kəmˋpaIl",
+    "usphone": "kəmˋpaIl"
+  },
+  {
+    "name": "entitle",
+    "trans": [
+      "16.30",
+      "vt．题目为，取名为"
+    ],
+    "ukphone": "InˋtaItl",
+    "usphone": "InˋtaItl"
+  },
+  {
+    "name": "emend",
+    "trans": [
+      "16.31",
+      "vt．修订（amend, improve）",
+      "【记】 e+mend（修补）→修订"
+    ],
+    "ukphone": "iˋmend",
+    "usphone": "iˋmend"
+  },
+  {
+    "name": "paraphrase",
+    "trans": [
+      "16.32",
+      "vt．意译；改写（rewrite）",
+      "【记】 para（旁边）+phrase（词句）→在旁边用不同的词写→改写"
+    ],
+    "ukphone": "ˋpærəfreIz",
+    "usphone": "ˋpærəfreIz"
+  },
+  {
+    "name": "adapt",
+    "trans": [
+      "16.33",
+      "v．改编（revise, amend）"
+    ],
+    "ukphone": "əˋdæpt",
+    "usphone": "əˋdæpt"
+  },
+  {
+    "name": "adaptable",
+    "trans": [
+      "16.34",
+      "adj．可修改的（flexible, pliant）"
+    ],
+    "ukphone": "əˋdæptəbl",
+    "usphone": "əˋdæptəbl"
+  },
+  {
+    "name": "adaptation",
+    "trans": [
+      "16.35",
+      "n．改写；修改"
+    ],
+    "ukphone": "ˌædæpˋteIʃn",
+    "usphone": "ˌædæpˋteIʃn"
+  },
+  {
+    "name": "excerpt",
+    "trans": [
+      "16.36",
+      "n．摘录（selection, extract）"
+    ],
+    "ukphone": "ˋeksɜ:rpt",
+    "usphone": "ˋeksɜ:rpt"
+  },
+  {
+    "name": "abstract",
+    "trans": [
+      "16.37",
+      "vt．摘要，提炼",
+      "【记】 abs+tract（拉）→从原文中拉出来→摘要"
+    ],
+    "ukphone": "æbˋstrækt",
+    "usphone": "æbˋstrækt"
+  },
+  {
+    "name": "abstraction",
+    "trans": [
+      "16.38",
+      "n．摘要"
+    ],
+    "ukphone": "æbˋstrækʃn",
+    "usphone": "æbˋstrækʃn"
+  },
+  {
+    "name": "abridge",
+    "trans": [
+      "16.39",
+      "vt．缩短，删节（shorten, condense, abbreviate）",
+      "【记】 a+bridge→桥使路程变短→弄短→删节"
+    ],
+    "ukphone": "əˋbrIdʒ",
+    "usphone": "əˋbrIdʒ"
+  },
+  {
+    "name": "coin",
+    "trans": [
+      "16.40",
+      "vt．创造（create, fashion, invent）"
+    ],
+    "ukphone": "kɔIn",
+    "usphone": "kɔIn"
+  },
+  {
+    "name": "didactic",
+    "trans": [
+      "17.1",
+      "adj．教诲的，说教的（instructive）"
+    ],
+    "ukphone": "daIˋdæktIk",
+    "usphone": "daIˋdæktIk"
+  },
+  {
+    "name": "sermon",
+    "trans": [
+      "17.2",
+      "n．说教（speech）"
+    ],
+    "ukphone": "ˋsɜ:rmən",
+    "usphone": "ˋsɜ:rmən"
+  },
+  {
+    "name": "initiate",
+    "trans": [
+      "17.3",
+      "vt．启蒙，使初步了解；传授"
+    ],
+    "ukphone": "IˋnIʃieIt",
+    "usphone": "IˋnIʃieIt"
+  },
+  {
+    "name": "instill",
+    "trans": [
+      "17.4",
+      "vt．灌输（infuse, impart）",
+      "【记】 in（进入）+still（滴）→灌输"
+    ],
+    "ukphone": "InˋstIl",
+    "usphone": "InˋstIl"
+  },
+  {
+    "name": "instruct",
+    "trans": [
+      "17.5",
+      "vt．教"
+    ],
+    "ukphone": "Inˋstrʌkt",
+    "usphone": "Inˋstrʌkt"
+  },
+  {
+    "name": "enlighten",
+    "trans": [
+      "17.6",
+      "vt．启发，开导；启蒙（edify, illuminate）",
+      "【记】 en+light（光）+en"
+    ],
+    "ukphone": "InˋlaItn",
+    "usphone": "InˋlaItn"
+  },
+  {
+    "name": "edify",
+    "trans": [
+      "17.7",
+      "vt．陶冶，教化（enlighten, teach）"
+    ],
+    "ukphone": "ˋedIfaI",
+    "usphone": "ˋedIfaI"
+  },
+  {
+    "name": "lead",
+    "trans": [
+      "17.8",
+      "vt．引导"
+    ],
+    "ukphone": "li:d",
+    "usphone": "li:d"
+  },
+  {
+    "name": "direct",
+    "trans": [
+      "17.9",
+      "vt．引导（instruct）"
+    ],
+    "ukphone": "dəˋrekt",
+    "usphone": "dəˋrekt"
+  },
+  {
+    "name": "conduct",
+    "trans": [
+      "17.10",
+      "vt．引导（lead）"
+    ],
+    "ukphone": "kənˋdʌkt",
+    "usphone": "kənˋdʌkt"
+  },
+  {
+    "name": "curriculum",
+    "trans": [
+      "17.11",
+      "n．课程"
+    ],
+    "ukphone": "kəˋrIkjələm",
+    "usphone": "kəˋrIkjələm"
+  },
+  {
+    "name": "discipline",
+    "trans": [
+      "17.12",
+      "n．学科"
+    ],
+    "ukphone": "ˋdIsəplIn",
+    "usphone": "ˋdIsəplIn"
+  },
+  {
+    "name": "compatible",
+    "trans": [
+      "18.1",
+      "adj．兼容的（harmonious, congruous）"
+    ],
+    "ukphone": "kəmˋpætəbl",
+    "usphone": "kəmˋpætəbl"
+  },
+  {
+    "name": "boundary",
+    "trans": [
+      "18.2",
+      "n．边界（border, limit）"
+    ],
+    "ukphone": "ˋbaʊndri",
+    "usphone": "ˋbaʊndri"
+  },
+  {
+    "name": "boundless",
+    "trans": [
+      "18.3",
+      "adj．无限的（vast, limitless）"
+    ],
+    "ukphone": "ˋbaʊndləs",
+    "usphone": "ˋbaʊndləs"
+  },
+  {
+    "name": "endless",
+    "trans": [
+      "18.4",
+      "adj．无止境的（everlasting）"
+    ],
+    "ukphone": "ˋendləs",
+    "usphone": "ˋendləs"
+  },
+  {
+    "name": "cohesive",
+    "trans": [
+      "18.5",
+      "adj．有凝聚力的"
+    ],
+    "ukphone": "koʊˋhi:sIv",
+    "usphone": "koʊˋhi:sIv"
+  },
+  {
+    "name": "horizontal",
+    "trans": [
+      "18.6",
+      "adj．水平的"
+    ],
+    "ukphone": "ˌhɔ:rəˋzα:ntl",
+    "usphone": "ˌhɔ:rəˋzα:ntl"
+  },
+  {
+    "name": "bulk",
+    "trans": [
+      "18.7",
+      "n．容积"
+    ],
+    "ukphone": "bʌlk",
+    "usphone": "bʌlk"
+  },
+  {
+    "name": "brim",
+    "trans": [
+      "18.8",
+      "n.（杯、碗的）边（margin, edge, rim）"
+    ],
+    "ukphone": "brIm",
+    "usphone": "brIm"
+  },
+  {
+    "name": "edge",
+    "trans": [
+      "18.9",
+      "n．边（rim, margin）"
+    ],
+    "ukphone": "edʒ",
+    "usphone": "edʒ"
+  },
+  {
+    "name": "rim",
+    "trans": [
+      "18.10",
+      "n．边缘（edge, border）"
+    ],
+    "ukphone": "rIm",
+    "usphone": "rIm"
+  },
+  {
+    "name": "brink",
+    "trans": [
+      "18.11",
+      "n．边缘（margin, edge, rim）"
+    ],
+    "ukphone": "brIŋk",
+    "usphone": "brIŋk"
+  },
+  {
+    "name": "constituent",
+    "trans": [
+      "18.12",
+      "n．成分（component）"
+    ],
+    "ukphone": "kənˋstItʃuənt",
+    "usphone": "kənˋstItʃuənt"
+  },
+  {
+    "name": "dimension",
+    "trans": [
+      "18.13",
+      "n．尺度；（数）维（size, proportion）"
+    ],
+    "ukphone": "daIˋmenʃn",
+    "usphone": "daIˋmenʃn"
+  },
+  {
+    "name": "elasticity",
+    "trans": [
+      "18.14",
+      "n．弹性"
+    ],
+    "ukphone": "ˌi:læˋstIsəti",
+    "usphone": "ˌi:læˋstIsəti"
+  },
+  {
+    "name": "cohesion",
+    "trans": [
+      "18.15",
+      "n．附着（力），结合，凝聚力"
+    ],
+    "ukphone": "koʊˋhi:ʒn",
+    "usphone": "koʊˋhi:ʒn"
+  },
+  {
+    "name": "pressure",
+    "trans": [
+      "18.16",
+      "n．压力",
+      "【记】 press（压）+ure"
+    ],
+    "ukphone": "ˋpreʃər",
+    "usphone": "ˋpreʃər"
+  },
+  {
+    "name": "gravity",
+    "trans": [
+      "18.17",
+      "n．引力",
+      "【记】 grav（重）+ity"
+    ],
+    "ukphone": "ˋgrævəti",
+    "usphone": "ˋgrævəti"
+  },
+  {
+    "name": "impetus",
+    "trans": [
+      "18.18",
+      "n．推动力（urge, momentum）",
+      "【记】 im（进入）+pet（追求）+us→追求力→推动力"
+    ],
+    "ukphone": "ˋImpItəs",
+    "usphone": "ˋImpItəs"
+  },
+  {
+    "name": "release",
+    "trans": [
+      "18.19",
+      "n./vt．释放（give off, discharge, dismiss, emit）"
+    ],
+    "ukphone": "rIˋli:s",
+    "usphone": "rIˋli:s"
+  },
+  {
+    "name": "decelerate",
+    "trans": [
+      "18.20",
+      "v.（使）减速（decrease the speed of）",
+      "【记】 反义词 accelerate（加速）"
+    ],
+    "ukphone": "ˌdi:ˋseləreIt",
+    "usphone": "ˌdi:ˋseləreIt"
+  },
+  {
+    "name": "precipitate",
+    "trans": [
+      "18.21",
+      "v．向下投掷",
+      "【记】 pre（提前）+cipit（落下）+ate→降下"
+    ],
+    "ukphone": "prIˋsIpIteIt",
+    "usphone": "prIˋsIpIteIt"
+  },
+  {
+    "name": "expedite",
+    "trans": [
+      "18.22",
+      "vt．加速（speed up, hasten）",
+      "【记】 ex+ped（脚）+ite→脚跨出去→加速"
+    ],
+    "ukphone": "ˋekspədaIt",
+    "usphone": "ˋekspədaIt"
+  },
+  {
+    "name": "quiver",
+    "trans": [
+      "18.23",
+      "vt．振动，颤抖（shiver, tremble）"
+    ],
+    "ukphone": "ˋkwIvər",
+    "usphone": "ˋkwIvər"
+  },
+  {
+    "name": "jar",
+    "trans": [
+      "18.24",
+      "vt．震动"
+    ],
+    "ukphone": "dʒα:r",
+    "usphone": "dʒα:r"
+  },
+  {
+    "name": "vibration",
+    "trans": [
+      "18.25",
+      "n．震动"
+    ],
+    "ukphone": "vaIˋbreIʃn",
+    "usphone": "vaIˋbreIʃn"
+  },
+  {
+    "name": "discharge",
+    "trans": [
+      "18.26",
+      "v．释放（let out, release, liberate）"
+    ],
+    "ukphone": "dIsˋtʃα:rdʒ",
+    "usphone": "dIsˋtʃα:rdʒ"
+  },
+  {
+    "name": "shrink",
+    "trans": [
+      "18.27",
+      "vi．收缩（contract, compress, dwindle）"
+    ],
+    "ukphone": "ʃrIŋk",
+    "usphone": "ʃrIŋk"
+  },
+  {
+    "name": "diffuse",
+    "trans": [
+      "18.28",
+      "vt．传播，扩散（scatter, spread）",
+      "【记】 di（分开）+fuse（流）→分流→散播"
+    ],
+    "ukphone": "dIˋfju:s",
+    "usphone": "dIˋfju:s"
+  },
+  {
+    "name": "emit",
+    "trans": [
+      "18.29",
+      "vt．发出，放射（discharge, give off）"
+    ],
+    "ukphone": "iˋmIt",
+    "usphone": "iˋmIt"
+  },
+  {
+    "name": "transpire",
+    "trans": [
+      "18.30",
+      "vt．发散；排出（exhale, send out）"
+    ],
+    "ukphone": "trænˋspaIər",
+    "usphone": "trænˋspaIər"
+  },
+  {
+    "name": "constitute",
+    "trans": [
+      "18.31",
+      "vt．构成，组成（form, compose, make up）"
+    ],
+    "ukphone": "ˋkα:nstətju:t",
+    "usphone": "ˋkα:nstətju:t"
+  },
+  {
+    "name": "eject",
+    "trans": [
+      "18.32",
+      "vt．喷出；逐出（emit; ejaculate）",
+      "【记】 e（出）+ject（扔）→扔出→喷出"
+    ],
+    "ukphone": "iˋdʒekt",
+    "usphone": "iˋdʒekt"
+  },
+  {
+    "name": "radiate",
+    "trans": [
+      "18.33",
+      "vt．射出（emit, give off）"
+    ],
+    "ukphone": "ˋreIdieIt",
+    "usphone": "ˋreIdieIt"
+  },
+  {
+    "name": "molecule",
+    "trans": [
+      "18.34",
+      "n．分子",
+      "【记】 mole（“摩尔”）+cule（“小”的后缀）"
+    ],
+    "ukphone": "ˋmα:lIkju:l",
+    "usphone": "ˋmα:lIkju:l"
+  },
+  {
+    "name": "ion",
+    "trans": [
+      "18.35",
+      "n．离子"
+    ],
+    "ukphone": "ˋaIən",
+    "usphone": "ˋaIən"
+  },
+  {
+    "name": "electron",
+    "trans": [
+      "18.36",
+      "n．电子"
+    ],
+    "ukphone": "Iˋlektrα:n",
+    "usphone": "Iˋlektrα:n"
+  },
+  {
+    "name": "neutron",
+    "trans": [
+      "18.37",
+      "n．中子"
+    ],
+    "ukphone": "ˋnju:trα:n",
+    "usphone": "ˋnju:trα:n"
+  },
+  {
+    "name": "nucleus",
+    "trans": [
+      "18.38",
+      "n．核子"
+    ],
+    "ukphone": "ˋnju:kliəs",
+    "usphone": "ˋnju:kliəs"
+  },
+  {
+    "name": "proton",
+    "trans": [
+      "18.39",
+      "n．质子"
+    ],
+    "ukphone": "ˋproʊtα:n",
+    "usphone": "ˋproʊtα:n"
+  },
+  {
+    "name": "atom",
+    "trans": [
+      "18.40",
+      "n．原子"
+    ],
+    "ukphone": "ˋætəm",
+    "usphone": "ˋætəm"
+  },
+  {
+    "name": "nuclear",
+    "trans": [
+      "18.41",
+      "adj．原子的"
+    ],
+    "ukphone": "ˋnju:kliər",
+    "usphone": "ˋnju:kliər"
+  },
+  {
+    "name": "physics",
+    "trans": [
+      "18.42",
+      "n．物理学"
+    ],
+    "ukphone": "ˋfIzIks",
+    "usphone": "ˋfIzIks"
+  },
+  {
+    "name": "fusion",
+    "trans": [
+      "18.43",
+      "n．熔合"
+    ],
+    "ukphone": "ˋfju:ʒn",
+    "usphone": "ˋfju:ʒn"
+  },
+  {
+    "name": "thermometer",
+    "trans": [
+      "18.44",
+      "n．温度计",
+      "【记】 thermo (热) +meter"
+    ],
+    "ukphone": "θərˋmα:mItər",
+    "usphone": "θərˋmα:mItər"
+  },
+  {
+    "name": "temperature",
+    "trans": [
+      "18.45",
+      "n．温度"
+    ],
+    "ukphone": "ˋtemprətʃər",
+    "usphone": "ˋtemprətʃər"
+  },
+  {
+    "name": "thaw",
+    "trans": [
+      "18.46",
+      "v.（使）溶化，（使）融解（melt, defrost）"
+    ],
+    "ukphone": "θɔ:",
+    "usphone": "θɔ:"
+  },
+  {
+    "name": "centigrade",
+    "trans": [
+      "18.47",
+      "adj．摄氏的",
+      "【记】 centi（百）+grade（级，度）"
+    ],
+    "ukphone": "ˋsentIgreId",
+    "usphone": "ˋsentIgreId"
+  },
+  {
+    "name": "clot",
+    "trans": [
+      "18.48",
+      "n./v.（使）凝块（gelatinize, congeal）"
+    ],
+    "ukphone": "klα:t",
+    "usphone": "klα:t"
+  },
+  {
+    "name": "sublimate",
+    "trans": [
+      "18.49",
+      "vt．使升华（elevate, refine）",
+      "【记】 sublime（崇高的）+ate"
+    ],
+    "ukphone": "ˋsʌblImeIt",
+    "usphone": "ˋsʌblImeIt"
+  },
+  {
+    "name": "distillation",
+    "trans": [
+      "18.50",
+      "n．蒸馏",
+      "【记】 de+still（水滴）+ation"
+    ],
+    "ukphone": "ˌdIstIˋleIʃn",
+    "usphone": "ˌdIstIˋleIʃn"
+  },
+  {
+    "name": "chaos",
+    "trans": [
+      "18.51",
+      "n．混乱（disorder）"
+    ],
+    "ukphone": "ˋkeIα:s",
+    "usphone": "ˋkeIα:s"
+  },
+  {
+    "name": "clutter",
+    "trans": [
+      "18.52",
+      "n．混乱 vt．使混乱（litter, disarray）"
+    ],
+    "ukphone": "ˋklʌtər",
+    "usphone": "ˋklʌtər"
+  },
+  {
+    "name": "equilibrium",
+    "trans": [
+      "18.53",
+      "n．平衡状态（balance）"
+    ],
+    "ukphone": "ˌi:kwIˋlIbriəm",
+    "usphone": "ˌi:kwIˋlIbriəm"
+  },
+  {
+    "name": "density",
+    "trans": [
+      "18.54",
+      "n．密度"
+    ],
+    "ukphone": "ˋdensəti",
+    "usphone": "ˋdensəti"
+  },
+  {
+    "name": "liquid",
+    "trans": [
+      "18.55",
+      "n．液体"
+    ],
+    "ukphone": "ˋlIkwId",
+    "usphone": "ˋlIkwId"
+  },
+  {
+    "name": "dilute",
+    "trans": [
+      "18.56",
+      "vt．稀释；冲淡（thin, weaken）",
+      "【记】 di（分开）+lute（冲）→冲开→冲淡"
+    ],
+    "ukphone": "daIˋlu:t",
+    "usphone": "daIˋlu:t"
+  },
+  {
+    "name": "dehydrate",
+    "trans": [
+      "18.57",
+      "vt.（使）脱水（dry）",
+      "【记】 de（去除）+ hydrate（水合物）"
+    ],
+    "ukphone": "di:ˋhaIdreIt",
+    "usphone": "di:ˋhaIdreIt"
+  },
+  {
+    "name": "declivity",
+    "trans": [
+      "18.58",
+      "n．下倾的斜面",
+      "【记】 de+cliv（倾斜）+ity"
+    ],
+    "ukphone": "dIˋklIvəti",
+    "usphone": "dIˋklIvəti"
+  },
+  {
+    "name": "foam",
+    "trans": [
+      "18.59",
+      "n．泡沫（bubble, froth）"
+    ],
+    "ukphone": "foʊm",
+    "usphone": "foʊm"
+  },
+  {
+    "name": "ventilation",
+    "trans": [
+      "18.60",
+      "n．通风（airing, air circulation）"
+    ],
+    "ukphone": "ˌventIˋleIʃn",
+    "usphone": "ˌventIˋleIʃn"
+  },
+  {
+    "name": "evaporate",
+    "trans": [
+      "18.61",
+      "v．蒸发（vaporize）",
+      "【记】 e+vapor（蒸汽）+ate"
+    ],
+    "ukphone": "IˋvæpəreIt",
+    "usphone": "IˋvæpəreIt"
+  },
+  {
+    "name": "evaporation",
+    "trans": [
+      "18.62",
+      "n．蒸发（作用）"
+    ],
+    "ukphone": "IˌvæpəˋreIʃn",
+    "usphone": "IˌvæpəˋreIʃn"
+  },
+  {
+    "name": "thermodynamics",
+    "trans": [
+      "18.63",
+      "n．热力学"
+    ],
+    "ukphone": "ˌθɜ:rmoʊdaIˋnæmIks",
+    "usphone": "ˌθɜ:rmoʊdaIˋnæmIks"
+  },
+  {
+    "name": "friction",
+    "trans": [
+      "18.64",
+      "n．摩擦"
+    ],
+    "ukphone": "ˋfrIkʃn",
+    "usphone": "ˋfrIkʃn"
+  },
+  {
+    "name": "attrition",
+    "trans": [
+      "18.65",
+      "n．磨损（wear and tear）"
+    ],
+    "ukphone": "əˋtrIʃn",
+    "usphone": "əˋtrIʃn"
+  },
+  {
+    "name": "chafe",
+    "trans": [
+      "18.66",
+      "vt．擦热（rub, scrape）"
+    ],
+    "ukphone": "tʃeIf",
+    "usphone": "tʃeIf"
+  },
+  {
+    "name": "resonance",
+    "trans": [
+      "18.67",
+      "n．回声，反响",
+      "【记】 re（反复）+son（声音）+ance→回声"
+    ],
+    "ukphone": "ˋrezənəns",
+    "usphone": "ˋrezənəns"
+  },
+  {
+    "name": "echo",
+    "trans": [
+      "18.68",
+      "n．回声，回音，回波"
+    ],
+    "ukphone": "ˋekoʊ",
+    "usphone": "ˋekoʊ"
+  },
+  {
+    "name": "ultrasonics",
+    "trans": [
+      "18.69",
+      "n．超音波学"
+    ],
+    "ukphone": "ˌʌltrəˋsα:nIks",
+    "usphone": "ˌʌltrəˋsα:nIks"
+  },
+  {
+    "name": "sonar",
+    "trans": [
+      "18.70",
+      "n．声呐，声波定位仪"
+    ],
+    "ukphone": "ˋsoʊnα:r",
+    "usphone": "ˋsoʊnα:r"
+  },
+  {
+    "name": "acoustic",
+    "trans": [
+      "18.71",
+      "adj．音响的"
+    ],
+    "ukphone": "əˋku:stIk",
+    "usphone": "əˋku:stIk"
+  },
+  {
+    "name": "band",
+    "trans": [
+      "18.72",
+      "n．波段（stripe）"
+    ],
+    "ukphone": "bænd",
+    "usphone": "bænd"
+  },
+  {
+    "name": "charge",
+    "trans": [
+      "18.73",
+      "n．电荷 v．充电（fill, replenish）"
+    ],
+    "ukphone": "tʃα:rdʒ",
+    "usphone": "tʃα:rdʒ"
+  },
+  {
+    "name": "electricity",
+    "trans": [
+      "18.74",
+      "n．电流，电，电学"
+    ],
+    "ukphone": "IˌlekˋtrIsəti",
+    "usphone": "IˌlekˋtrIsəti"
+  },
+  {
+    "name": "electromagnet",
+    "trans": [
+      "18.75",
+      "n．电磁石"
+    ],
+    "ukphone": "IˌlektroʊˋmægnIt",
+    "usphone": "IˌlektroʊˋmægnIt"
+  },
+  {
+    "name": "electromagnetism",
+    "trans": [
+      "18.76",
+      "n．电磁，电磁学"
+    ],
+    "ukphone": "IˌlektroʊˋmægnItIzəm",
+    "usphone": "IˌlektroʊˋmægnItIzəm"
+  },
+  {
+    "name": "electronic",
+    "trans": [
+      "18.77",
+      "adj．电子的"
+    ],
+    "ukphone": "Iˌlekˋtrα:nIk",
+    "usphone": "Iˌlekˋtrα:nIk"
+  },
+  {
+    "name": "electronics",
+    "trans": [
+      "18.78",
+      "n．电子学"
+    ],
+    "ukphone": "Iˌlekˋtrα:nIks",
+    "usphone": "Iˌlekˋtrα:nIks"
+  },
+  {
+    "name": "amplifier",
+    "trans": [
+      "18.79",
+      "n．［电工］ 扩音器，放大器"
+    ],
+    "ukphone": "ˋæmplIfaIər",
+    "usphone": "ˋæmplIfaIər"
+  },
+  {
+    "name": "battery",
+    "trans": [
+      "18.80",
+      "n．电池"
+    ],
+    "ukphone": "ˋbætri",
+    "usphone": "ˋbætri"
+  },
+  {
+    "name": "chip",
+    "trans": [
+      "18.81",
+      "n．芯片"
+    ],
+    "ukphone": "tʃIp",
+    "usphone": "tʃIp"
+  },
+  {
+    "name": "conductor",
+    "trans": [
+      "18.82",
+      "n．导体"
+    ],
+    "ukphone": "kənˋdʌktər",
+    "usphone": "kənˋdʌktər"
+  },
+  {
+    "name": "insulator",
+    "trans": [
+      "18.83",
+      "n．绝缘体，绝热器"
+    ],
+    "ukphone": "ˋInsəleItər",
+    "usphone": "ˋInsəleItər"
+  },
+  {
+    "name": "magnet",
+    "trans": [
+      "18.84",
+      "n．磁体，磁铁"
+    ],
+    "ukphone": "ˋmægnət",
+    "usphone": "ˋmægnət"
+  },
+  {
+    "name": "magnetism",
+    "trans": [
+      "18.85",
+      "n．磁，磁力；吸引力；磁学"
+    ],
+    "ukphone": "ˋmægnətIzəm",
+    "usphone": "ˋmægnətIzəm"
+  },
+  {
+    "name": "semiconductor",
+    "trans": [
+      "18.86",
+      "n．半导体"
+    ],
+    "ukphone": "ˌsemikənˋdʌktər",
+    "usphone": "ˌsemikənˋdʌktər"
+  },
+  {
+    "name": "transistor",
+    "trans": [
+      "18.87",
+      "n．晶体管"
+    ],
+    "ukphone": "trænˋzIstər",
+    "usphone": "trænˋzIstər"
+  },
+  {
+    "name": "ultraviolet",
+    "trans": [
+      "18.88",
+      "adj．紫外线的，紫外的 n．紫外线辐射"
+    ],
+    "ukphone": "ˌʌltrəˋvaIələt",
+    "usphone": "ˌʌltrəˋvaIələt"
+  },
+  {
+    "name": "microwave",
+    "trans": [
+      "18.89",
+      "n．微波（波长为1毫米至30厘米的高频电磁波）"
+    ],
+    "ukphone": "ˋmaIkrəweIv",
+    "usphone": "ˋmaIkrəweIv"
+  },
+  {
+    "name": "mechanics",
+    "trans": [
+      "18.90",
+      "n．〈用作单数〉机械学、力学；〈用作复数〉技巧，结构"
+    ],
+    "ukphone": "məˋkænIks",
+    "usphone": "məˋkænIks"
+  },
+  {
+    "name": "gravitation",
+    "trans": [
+      "18.91",
+      "n．地心吸力，引力作用"
+    ],
+    "ukphone": "ˌgrævIˋteIʃn",
+    "usphone": "ˌgrævIˋteIʃn"
+  },
+  {
+    "name": "oscillation",
+    "trans": [
+      "18.92",
+      "n．摆动，振动"
+    ],
+    "ukphone": "ˌα:sIˋleIʃn",
+    "usphone": "ˌα:sIˋleIʃn"
+  },
+  {
+    "name": "statics",
+    "trans": [
+      "18.93",
+      "n．静力学"
+    ],
+    "ukphone": "ˋstætIks",
+    "usphone": "ˋstætIks"
+  },
+  {
+    "name": "relativity",
+    "trans": [
+      "18.94",
+      "n．相对性，相关性，相对论"
+    ],
+    "ukphone": "ˌreləˋtIvəti",
+    "usphone": "ˌreləˋtIvəti"
+  },
+  {
+    "name": "velocity",
+    "trans": [
+      "18.95",
+      "n．速度，速率"
+    ],
+    "ukphone": "vəˋlα:səti",
+    "usphone": "vəˋlα:səti"
+  },
+  {
+    "name": "dynamics",
+    "trans": [
+      "18.96",
+      "n．动力学"
+    ],
+    "ukphone": "daIˋnæmIks",
+    "usphone": "daIˋnæmIks"
+  },
+  {
+    "name": "force",
+    "trans": [
+      "18.97",
+      "n．力"
+    ],
+    "ukphone": "fɔ:rs",
+    "usphone": "fɔ:rs"
+  },
+  {
+    "name": "current",
+    "trans": [
+      "18.98",
+      "n.（液体、气体的）流"
+    ],
+    "ukphone": "ˋkɜ:rənt",
+    "usphone": "ˋkɜ:rənt"
+  },
+  {
+    "name": "accelerate",
+    "trans": [
+      "18.99",
+      "vt．加速 vi．增速，进行（expedite, speed）",
+      "【记】 ac+celer（速度）+ate→加速"
+    ],
+    "ukphone": "əkˋseləreIt",
+    "usphone": "əkˋseləreIt"
+  },
+  {
+    "name": "acceleration",
+    "trans": [
+      "18.100",
+      "n．加速度"
+    ],
+    "ukphone": "əkˌseləˋreIʃn",
+    "usphone": "əkˌseləˋreIʃn"
+  },
+  {
+    "name": "transparent",
+    "trans": [
+      "18.101",
+      "物 理"
+    ],
+    "ukphone": "trænsˋpærənt",
+    "usphone": "trænsˋpærənt"
+  },
+  {
+    "name": "opaque",
+    "trans": [
+      "18.102",
+      "n．不透明物 adj．不透明的，不传热的"
+    ],
+    "ukphone": "oʊˋpeIk",
+    "usphone": "oʊˋpeIk"
+  },
+  {
+    "name": "translucent",
+    "trans": [
+      "18.103",
+      "adj．半透明的，透明的"
+    ],
+    "ukphone": "trænsˋlu:snt",
+    "usphone": "trænsˋlu:snt"
+  },
+  {
+    "name": "optical",
+    "trans": [
+      "18.104",
+      "adj．眼的，视力的，光学的"
+    ],
+    "ukphone": "ˋα:ptIkl",
+    "usphone": "ˋα:ptIkl"
+  },
+  {
+    "name": "optics",
+    "trans": [
+      "18.105",
+      "n．光学"
+    ],
+    "ukphone": "ˋα:ptIks",
+    "usphone": "ˋα:ptIks"
+  },
+  {
+    "name": "ray",
+    "trans": [
+      "18.106",
+      "n．光线"
+    ],
+    "ukphone": "reI",
+    "usphone": "reI"
+  },
+  {
+    "name": "spectrum",
+    "trans": [
+      "18.107",
+      "n．光，光谱，型谱，频谱"
+    ],
+    "ukphone": "ˋspektrəm",
+    "usphone": "ˋspektrəm"
+  },
+  {
+    "name": "wavelength",
+    "trans": [
+      "18.108",
+      "n．波长"
+    ],
+    "ukphone": "ˋweIvleŋθ",
+    "usphone": "ˋweIvleŋθ"
+  },
+  {
+    "name": "magnifier",
+    "trans": [
+      "18.109",
+      "n．放大镜，放大器"
+    ],
+    "ukphone": "ˋmægnIfaIər",
+    "usphone": "ˋmægnIfaIər"
+  },
+  {
+    "name": "lens",
+    "trans": [
+      "18.110",
+      "n．透镜，镜头"
+    ],
+    "ukphone": "lenz",
+    "usphone": "lenz"
+  },
+  {
+    "name": "vortex",
+    "trans": [
+      "18.111",
+      "n．［航］ ［流］ 涡流；漩涡；（动乱、争论等的）中心；旋风"
+    ],
+    "ukphone": "ˋvɔ:rteks",
+    "usphone": "ˋvɔ:rteks"
+  },
+  {
+    "name": "buffer",
+    "trans": [
+      "18.112",
+      "n．［计］ 缓冲区；缓冲器"
+    ],
+    "ukphone": "ˋbʌfər",
+    "usphone": "ˋbʌfər"
+  },
+  {
+    "name": "fission",
+    "trans": [
+      "18.113",
+      "n．裂变；分裂"
+    ],
+    "ukphone": "ˋfIʃn",
+    "usphone": "ˋfIʃn"
+  },
+  {
+    "name": "factious",
+    "trans": [
+      "19.1",
+      "adj．党派的（tribal）",
+      "【记】 faction（党派）的形容词"
+    ],
+    "ukphone": "ˋfækʃəs",
+    "usphone": "ˋfækʃəs"
+  },
+  {
+    "name": "partisan",
+    "trans": [
+      "19.2",
+      "adj．党派的，派系感强的"
+    ],
+    "ukphone": "ˋpα:rtəzn",
+    "usphone": "ˋpα:rtəzn"
+  },
+  {
+    "name": "board",
+    "trans": [
+      "19.3",
+      "n．委员会"
+    ],
+    "ukphone": "bɔ:rd",
+    "usphone": "bɔ:rd"
+  },
+  {
+    "name": "Senate",
+    "trans": [
+      "19.4",
+      "n．参议院，上院"
+    ],
+    "ukphone": "ˋsenət",
+    "usphone": "ˋsenət"
+  },
+  {
+    "name": "Congress",
+    "trans": [
+      "19.5",
+      "n.（代表）大会；（美国等国的）国会，议会"
+    ],
+    "ukphone": "ˋkα:ŋgrəs",
+    "usphone": "ˋkα:ŋgrəs"
+  },
+  {
+    "name": "diplomatic",
+    "trans": [
+      "19.6",
+      "adj．外交的；有策略的（tactful）"
+    ],
+    "ukphone": "ˌdIpləˋmætIk",
+    "usphone": "ˌdIpləˋmætIk"
+  },
+  {
+    "name": "diplomacy",
+    "trans": [
+      "19.7",
+      "n．外交；策略（tact）"
+    ],
+    "ukphone": "dIˋploʊməsi",
+    "usphone": "dIˋploʊməsi"
+  },
+  {
+    "name": "confederate",
+    "trans": [
+      "19.8",
+      "n．同盟（partner, company）"
+    ],
+    "ukphone": "kənˋfedərət",
+    "usphone": "kənˋfedərət"
+  },
+  {
+    "name": "league",
+    "trans": [
+      "19.9",
+      "n．同盟，联盟；联合会"
+    ],
+    "ukphone": "li:g",
+    "usphone": "li:g"
+  },
+  {
+    "name": "affiliate",
+    "trans": [
+      "19.10",
+      "v．加盟，入会（associate, ally）"
+    ],
+    "ukphone": "əˋfIlieIt",
+    "usphone": "əˋfIlieIt"
+  },
+  {
+    "name": "unconventional",
+    "trans": [
+      "19.11",
+      "adj．自由的，非常规的，非传统的"
+    ],
+    "ukphone": "ˌʌnkənˋvenʃənl",
+    "usphone": "ˌʌnkənˋvenʃənl"
+  },
+  {
+    "name": "dictatorial",
+    "trans": [
+      "19.12",
+      "adj．独裁的，专断的（tyrannical）",
+      "【记】 dictat（说，命令）+orial→独裁的"
+    ],
+    "ukphone": "ˌdIktəˋtɔ:riəl",
+    "usphone": "ˌdIktəˋtɔ:riəl"
+  },
+  {
+    "name": "domestic",
+    "trans": [
+      "19.13",
+      "adj．国内的；家庭的"
+    ],
+    "ukphone": "dəˋmestIk",
+    "usphone": "dəˋmestIk"
+  },
+  {
+    "name": "potent",
+    "trans": [
+      "19.14",
+      "adj．强有力的；有全权的（cogent, powerful）",
+      "【记】 poten（力量）+t→强有力的"
+    ],
+    "ukphone": "ˋpoʊtnt",
+    "usphone": "ˋpoʊtnt"
+  },
+  {
+    "name": "authoritative",
+    "trans": [
+      "19.15",
+      "adj．权威性的，官方的"
+    ],
+    "ukphone": "əˋθɔ:rəteItIv",
+    "usphone": "əˋθɔ:rəteItIv"
+  },
+  {
+    "name": "influential",
+    "trans": [
+      "19.16",
+      "adj．有影响的；有权势的（powerful）"
+    ],
+    "ukphone": "ˌInfluˋenʃl",
+    "usphone": "ˌInfluˋenʃl"
+  },
+  {
+    "name": "centralized",
+    "trans": [
+      "19.17",
+      "adj．集中的，中央集权的"
+    ],
+    "ukphone": "ˋsentrəlaIzd",
+    "usphone": "ˋsentrəlaIzd"
+  },
+  {
+    "name": "authority",
+    "trans": [
+      "19.18",
+      "n．权威"
+    ],
+    "ukphone": "əˋθɔ:rəti",
+    "usphone": "əˋθɔ:rəti"
+  },
+  {
+    "name": "privilege",
+    "trans": [
+      "19.19",
+      "n．特权（prerogative）",
+      "【记】 privi（个人）+lege（法律）→个人的法律→特权"
+    ],
+    "ukphone": "ˋprIvəlIdʒ",
+    "usphone": "ˋprIvəlIdʒ"
+  },
+  {
+    "name": "democracy",
+    "trans": [
+      "19.20",
+      "n．民主",
+      "【记】 demo（人民）+cracy（统治）→人民统治的→民主"
+    ],
+    "ukphone": "dIˋmα:krəsi",
+    "usphone": "dIˋmα:krəsi"
+  },
+  {
+    "name": "petition",
+    "trans": [
+      "19.21",
+      "n．请愿 vt．向…请愿",
+      "【记】 pet（寻求）+ition→请愿"
+    ],
+    "ukphone": "pəˋtIʃn",
+    "usphone": "pəˋtIʃn"
+  },
+  {
+    "name": "domain",
+    "trans": [
+      "19.22",
+      "n．领土，领域（field, region）"
+    ],
+    "ukphone": "doʊˋmeIn",
+    "usphone": "doʊˋmeIn"
+  },
+  {
+    "name": "territory",
+    "trans": [
+      "19.23",
+      "n．领土；版图；地域"
+    ],
+    "ukphone": "ˋterətɔ:ri",
+    "usphone": "ˋterətɔ:ri"
+  },
+  {
+    "name": "nationality",
+    "trans": [
+      "19.24",
+      "n．国籍",
+      "【记】 nation（国家）+ality→国籍"
+    ],
+    "ukphone": "ˌnæʃəˋnæləti",
+    "usphone": "ˌnæʃəˋnæləti"
+  },
+  {
+    "name": "kingdom",
+    "trans": [
+      "19.25",
+      "n．王国（realm）",
+      "【记】 king（国王）+dom（地域）→国王统治的地域→王国"
+    ],
+    "ukphone": "ˋkIŋdəm",
+    "usphone": "ˋkIŋdəm"
+  },
+  {
+    "name": "realm",
+    "trans": [
+      "19.26",
+      "n．王国；领域（field, domain）"
+    ],
+    "ukphone": "relm",
+    "usphone": "relm"
+  },
+  {
+    "name": "regimen",
+    "trans": [
+      "19.27",
+      "n．政权",
+      "【记】 regi（统治）+men（人）→政权"
+    ],
+    "ukphone": "ˋredʒImən",
+    "usphone": "ˋredʒImən"
+  },
+  {
+    "name": "sovereignty",
+    "trans": [
+      "19.28",
+      "n．主权"
+    ],
+    "ukphone": "ˋsα:vrənti",
+    "usphone": "ˋsα:vrənti"
+  },
+  {
+    "name": "autonomy",
+    "trans": [
+      "19.29",
+      "n．自治权（independence）",
+      "【记】 auto（自己）+nomy（统治）→自己统治→自治权"
+    ],
+    "ukphone": "ɔ:ˋtα:nəmi",
+    "usphone": "ɔ:ˋtα:nəmi"
+  },
+  {
+    "name": "commission",
+    "trans": [
+      "19.30",
+      "n．委员会"
+    ],
+    "ukphone": "kəˋmIʃn",
+    "usphone": "kəˋmIʃn"
+  },
+  {
+    "name": "committee",
+    "trans": [
+      "19.31",
+      "n．委员会，委员"
+    ],
+    "ukphone": "kəˋmIti",
+    "usphone": "kəˋmIti"
+  },
+  {
+    "name": "election",
+    "trans": [
+      "19.32",
+      "n．选举",
+      "【记】 elect（选择）+ion→选举"
+    ],
+    "ukphone": "Iˋlekʃn",
+    "usphone": "Iˋlekʃn"
+  },
+  {
+    "name": "ballot",
+    "trans": [
+      "19.33",
+      "n．选票（vote, poll）"
+    ],
+    "ukphone": "ˋbælət",
+    "usphone": "ˋbælət"
+  },
+  {
+    "name": "ideology",
+    "trans": [
+      "19.34",
+      "n．意识形态",
+      "【记】 ideo（意识）+ology（学科）→意识形态"
+    ],
+    "ukphone": "ˌaIdiˋα:lədʒi",
+    "usphone": "ˌaIdiˋα:lədʒi"
+  },
+  {
+    "name": "parade",
+    "trans": [
+      "19.35",
+      "n．游行（procession, march）"
+    ],
+    "ukphone": "pəˋreId",
+    "usphone": "pəˋreId"
+  },
+  {
+    "name": "govern",
+    "trans": [
+      "19.36",
+      "v．决定；支配；控制（determine; control）"
+    ],
+    "ukphone": "ˋgʌvərn",
+    "usphone": "ˋgʌvərn"
+  },
+  {
+    "name": "confer",
+    "trans": [
+      "19.37",
+      "v．协商",
+      "【记】 con（共同）+fer→共同带来观点→协商"
+    ],
+    "ukphone": "kənˋfɜ:r",
+    "usphone": "kənˋfɜ:r"
+  },
+  {
+    "name": "entitle",
+    "trans": [
+      "19.38",
+      "vt．给…权利"
+    ],
+    "ukphone": "InˋtaItl",
+    "usphone": "InˋtaItl"
+  },
+  {
+    "name": "exploit",
+    "trans": [
+      "19.39",
+      "vt．剥削；开发（explore）",
+      "【记】 ex+ploit（重叠）→从重叠中拿出→开发"
+    ],
+    "ukphone": "IkˋsplɔIt",
+    "usphone": "IkˋsplɔIt"
+  },
+  {
+    "name": "maneuver",
+    "trans": [
+      "19.40",
+      "vt．调遣 n．策略（move, step, tactic）",
+      "【记】 man（手）+euver（劳动）→用手劳动→操纵"
+    ],
+    "ukphone": "məˋnu:vər",
+    "usphone": "məˋnu:vər"
+  },
+  {
+    "name": "reform",
+    "trans": [
+      "19.41",
+      "vt./n．改革，革新（regenerate）",
+      "【记】 re（再次）+form（形状）→再改形→改革"
+    ],
+    "ukphone": "rIˋfɔ:rm",
+    "usphone": "rIˋfɔ:rm"
+  },
+  {
+    "name": "inspect",
+    "trans": [
+      "19.42",
+      "vt．检查（examine, survey）；视察",
+      "【记】 in（内）+spect（看）→看里面→检查"
+    ],
+    "ukphone": "Inˋspekt",
+    "usphone": "Inˋspekt"
+  },
+  {
+    "name": "emigrate",
+    "trans": [
+      "19.43",
+      "v．移民",
+      "【记】 e（出）+migr（移）+ate→移出→移民"
+    ],
+    "ukphone": "ˋemIgreIt",
+    "usphone": "ˋemIgreIt"
+  },
+  {
+    "name": "immigrate",
+    "trans": [
+      "19.44",
+      "vt．移居入境",
+      "【记】 im（进）+migr（移）+ate→移进"
+    ],
+    "ukphone": "ˋImIgreIt",
+    "usphone": "ˋImIgreIt"
+  },
+  {
+    "name": "exile",
+    "trans": [
+      "19.45",
+      "vt．流放（banish, deport）n．放逐"
+    ],
+    "ukphone": "ˋeksaIl",
+    "usphone": "ˋeksaIl"
+  },
+  {
+    "name": "enslave",
+    "trans": [
+      "19.46",
+      "vt．奴役",
+      "【记】 en+slave（奴隶）→奴役"
+    ],
+    "ukphone": "InˋsleIv",
+    "usphone": "InˋsleIv"
+  },
+  {
+    "name": "hustle",
+    "trans": [
+      "19.47",
+      "vt．驱赶（hurry, hasten）"
+    ],
+    "ukphone": "ˋhʌsl",
+    "usphone": "ˋhʌsl"
+  },
+  {
+    "name": "impel",
+    "trans": [
+      "19.48",
+      "vt．驱使（compel, urge）",
+      "【记】 im（进入）+pel（推动）→驱使"
+    ],
+    "ukphone": "Imˋpel",
+    "usphone": "Imˋpel"
+  },
+  {
+    "name": "oust",
+    "trans": [
+      "19.49",
+      "vt．驱逐（dismiss, throw out）"
+    ],
+    "ukphone": "aʊst",
+    "usphone": "aʊst"
+  },
+  {
+    "name": "banish",
+    "trans": [
+      "19.50",
+      "vt．驱逐出境（exile, expel）"
+    ],
+    "ukphone": "ˋbænIʃ",
+    "usphone": "ˋbænIʃ"
+  },
+  {
+    "name": "deport",
+    "trans": [
+      "19.51",
+      "vt．驱逐出境，放逐"
+    ],
+    "ukphone": "dIˋpɔ:rt",
+    "usphone": "dIˋpɔ:rt"
+  },
+  {
+    "name": "enable",
+    "trans": [
+      "19.52",
+      "vt．使能够（make possible, allow, help）"
+    ],
+    "ukphone": "IˋneIbl",
+    "usphone": "IˋneIbl"
+  },
+  {
+    "name": "reign",
+    "trans": [
+      "19.53",
+      "vt．统治（govern, rule）"
+    ],
+    "ukphone": "reIn",
+    "usphone": "reIn"
+  },
+  {
+    "name": "dominate",
+    "trans": [
+      "19.54",
+      "vt．统治，支配，控制（control）",
+      "【记】 domin（统治）+ate→统治"
+    ],
+    "ukphone": "ˋdα:mIneIt",
+    "usphone": "ˋdα:mIneIt"
+  },
+  {
+    "name": "abdicate",
+    "trans": [
+      "19.55",
+      "vt．放弃权力（abandon）",
+      "【记】 ab+dic（说话，命令）+ate→不再命令→放弃权力"
+    ],
+    "ukphone": "ˋæbdIkeIt",
+    "usphone": "ˋæbdIkeIt"
+  },
+  {
+    "name": "administer",
+    "trans": [
+      "19.56",
+      "vt．管理（govern, supervise）",
+      "【记】 ad+minister（部长）→做部长→管理"
+    ],
+    "ukphone": "ədˋmInIstər",
+    "usphone": "ədˋmInIstər"
+  },
+  {
+    "name": "administration",
+    "trans": [
+      "19.57",
+      "n．行政（management）",
+      "【记】 administer(执行)+ation"
+    ],
+    "ukphone": "ədˌmInIˋstreIʃn",
+    "usphone": "ədˌmInIˋstreIʃn"
+  },
+  {
+    "name": "institute",
+    "trans": [
+      "19.58",
+      "vt．建立（establish, set up, start）"
+    ],
+    "ukphone": "ˋInstItju:t",
+    "usphone": "ˋInstItju:t"
+  },
+  {
+    "name": "amendment",
+    "trans": [
+      "19.59",
+      "n．改善，改正"
+    ],
+    "ukphone": "əˋmendmənt",
+    "usphone": "əˋmendmənt"
+  },
+  {
+    "name": "colonize",
+    "trans": [
+      "19.60",
+      "vt．拓殖，殖民"
+    ],
+    "ukphone": "ˋkα:lənaIz",
+    "usphone": "ˋkα:lənaIz"
+  },
+  {
+    "name": "check",
+    "trans": [
+      "19.61",
+      "n./v．检查（examine；inspect）"
+    ],
+    "ukphone": "tʃek",
+    "usphone": "tʃek"
+  },
+  {
+    "name": "monarchy",
+    "trans": [
+      "19.62",
+      "n．君主政体，君主政治，君主国"
+    ],
+    "ukphone": "ˋmα:nərki",
+    "usphone": "ˋmα:nərki"
+  },
+  {
+    "name": "republican",
+    "trans": [
+      "19.63",
+      "adj．共和国的，共和政体的，共和主义的，有关共和的"
+    ],
+    "ukphone": "rIˋpʌblIkən",
+    "usphone": "rIˋpʌblIkən"
+  },
+  {
+    "name": "anarchism",
+    "trans": [
+      "19.64",
+      "n．无政府主义"
+    ],
+    "ukphone": "ˋænərkIzəm",
+    "usphone": "ˋænərkIzəm"
+  },
+  {
+    "name": "doctrine",
+    "trans": [
+      "19.65",
+      "n．主义（principle）"
+    ],
+    "ukphone": "ˋdα:ktrIn",
+    "usphone": "ˋdα:ktrIn"
+  },
+  {
+    "name": "immigrant",
+    "trans": [
+      "19.66",
+      "adj.（从外国）移来的，移民的，移居的"
+    ],
+    "ukphone": "ˋImIgrənt",
+    "usphone": "ˋImIgrənt"
+  },
+  {
+    "name": "municipal",
+    "trans": [
+      "19.67",
+      "adj．市政的，市立的；地方性的，地方自治的"
+    ],
+    "ukphone": "mju:ˋnIsIpl",
+    "usphone": "mju:ˋnIsIpl"
+  },
+  {
+    "name": "strike",
+    "trans": [
+      "19.68",
+      "n．罢工（work stoppage）"
+    ],
+    "ukphone": "straIk",
+    "usphone": "straIk"
+  },
+  {
+    "name": "scandal",
+    "trans": [
+      "19.69",
+      "n．丑闻（disgrace, defamation）"
+    ],
+    "ukphone": "ˋskændl",
+    "usphone": "ˋskændl"
+  },
+  {
+    "name": "vote",
+    "trans": [
+      "19.70",
+      "n．投票，选票"
+    ],
+    "ukphone": "voʊt",
+    "usphone": "voʊt"
+  },
+  {
+    "name": "welfare",
+    "trans": [
+      "19.71",
+      "n．福利；安宁，幸福"
+    ],
+    "ukphone": "ˋwelfer",
+    "usphone": "ˋwelfer"
+  },
+  {
+    "name": "bureaucracy",
+    "trans": [
+      "19.72",
+      "n．官僚主义；官僚机构；官僚政治"
+    ],
+    "ukphone": "bjʊˋrα:krəsi",
+    "usphone": "bjʊˋrα:krəsi"
+  },
+  {
+    "name": "parliament",
+    "trans": [
+      "19.73",
+      "n．议会，国会"
+    ],
+    "ukphone": "ˋpα:rləmənt",
+    "usphone": "ˋpα:rləmənt"
+  },
+  {
+    "name": "designation",
+    "trans": [
+      "19.74",
+      "n．指定；名称；指示；选派"
+    ],
+    "ukphone": "ˌdezIgˋneIʃn",
+    "usphone": "ˌdezIgˋneIʃn"
+  },
+  {
+    "name": "euphonious",
+    "trans": [
+      "20.1",
+      "adj．悦耳的（sweet）",
+      "【记】 eu（好）+phon（声音）+ious→悦耳的"
+    ],
+    "ukphone": "ju:ˋfoʊniəs",
+    "usphone": "ju:ˋfoʊniəs"
+  },
+  {
+    "name": "harsh",
+    "trans": [
+      "20.2",
+      "adj．刺耳的（hoarse, unpleasant）"
+    ],
+    "ukphone": "hα:rʃ",
+    "usphone": "hα:rʃ"
+  },
+  {
+    "name": "jazz",
+    "trans": [
+      "20.3",
+      "n．爵士乐"
+    ],
+    "ukphone": "dʒæz",
+    "usphone": "dʒæz"
+  },
+  {
+    "name": "movement",
+    "trans": [
+      "20.4",
+      "n．乐章"
+    ],
+    "ukphone": "ˋmu:vmənt",
+    "usphone": "ˋmu:vmənt"
+  },
+  {
+    "name": "note",
+    "trans": [
+      "20.5",
+      "n．音符"
+    ],
+    "ukphone": "noʊt",
+    "usphone": "noʊt"
+  },
+  {
+    "name": "score",
+    "trans": [
+      "20.6",
+      "n．乐谱"
+    ],
+    "ukphone": "skɔ:r",
+    "usphone": "skɔ:r"
+  },
+  {
+    "name": "instrument",
+    "trans": [
+      "20.7",
+      "n．乐器"
+    ],
+    "ukphone": "ˋInstrəmənt",
+    "usphone": "ˋInstrəmənt"
+  },
+  {
+    "name": "lyric",
+    "trans": [
+      "20.8",
+      "n．抒情诗"
+    ],
+    "ukphone": "ˋlIrIk",
+    "usphone": "ˋlIrIk"
+  },
+  {
+    "name": "conservatory",
+    "trans": [
+      "20.9",
+      "n．音乐学校"
+    ],
+    "ukphone": "kənˋsɜ:rvətɔ:ri",
+    "usphone": "kənˋsɜ:rvətɔ:ri"
+  },
+  {
+    "name": "episode",
+    "trans": [
+      "20.10",
+      "n．插曲（interlude）；一段情节"
+    ],
+    "ukphone": "ˋepIsoʊd",
+    "usphone": "ˋepIsoʊd"
+  },
+  {
+    "name": "orchestra",
+    "trans": [
+      "20.11",
+      "n．管弦乐队（band, ensemble）"
+    ],
+    "ukphone": "ˋɔ:rkIstrə",
+    "usphone": "ˋɔ:rkIstrə"
+  },
+  {
+    "name": "chorus",
+    "trans": [
+      "20.12",
+      "n．合唱团（choir, ensemble）"
+    ],
+    "ukphone": "ˋkɔ:rəs",
+    "usphone": "ˋkɔ:rəs"
+  },
+  {
+    "name": "concert",
+    "trans": [
+      "20.13",
+      "n．音乐会"
+    ],
+    "ukphone": "ˋkα:nsərt",
+    "usphone": "ˋkα:nsərt"
+  },
+  {
+    "name": "band",
+    "trans": [
+      "20.14",
+      "n．乐队"
+    ],
+    "ukphone": "bænd",
+    "usphone": "bænd"
+  },
+  {
+    "name": "record",
+    "trans": [
+      "20.15",
+      "v．记录，录音（register）"
+    ],
+    "ukphone": "ˋrekərd］/［rIˋkɔ:rd",
+    "usphone": "ˋrekərd］/［rIˋkɔ:rd"
+  },
+  {
+    "name": "percussion",
+    "trans": [
+      "20.16",
+      "n．打击乐器；震荡",
+      "【记】 per（全部）+cuss（震动）+ion→震荡"
+    ],
+    "ukphone": "pərˋkʌʃn",
+    "usphone": "pərˋkʌʃn"
+  },
+  {
+    "name": "string",
+    "trans": [
+      "20.17",
+      "n．弦乐"
+    ],
+    "ukphone": "strIŋ",
+    "usphone": "strIŋ"
+  },
+  {
+    "name": "wind",
+    "trans": [
+      "20.18",
+      "n．管乐"
+    ],
+    "ukphone": "wInd",
+    "usphone": "wInd"
+  },
+  {
+    "name": "counsel",
+    "trans": [
+      "21.1",
+      "n．律师"
+    ],
+    "ukphone": "ˋkaʊnsl",
+    "usphone": "ˋkaʊnsl"
+  },
+  {
+    "name": "crew",
+    "trans": [
+      "21.2",
+      "n．船员"
+    ],
+    "ukphone": "kru:",
+    "usphone": "kru:"
+  },
+  {
+    "name": "aviator",
+    "trans": [
+      "21.3",
+      "n．飞行家（pilot）"
+    ],
+    "ukphone": "ˋeIvieItər",
+    "usphone": "ˋeIvieItər"
+  },
+  {
+    "name": "playwright",
+    "trans": [
+      "21.4",
+      "n．剧作家",
+      "【记】 play（戏剧）+wright（作家）"
+    ],
+    "ukphone": "ˋpleIraIt",
+    "usphone": "ˋpleIraIt"
+  },
+  {
+    "name": "operator",
+    "trans": [
+      "21.5",
+      "n．接线员"
+    ],
+    "ukphone": "ˋα:pəreItər",
+    "usphone": "ˋα:pəreItər"
+  },
+  {
+    "name": "clergy",
+    "trans": [
+      "21.6",
+      "n．神职人员"
+    ],
+    "ukphone": "ˋklɜ:rdʒi",
+    "usphone": "ˋklɜ:rdʒi"
+  },
+  {
+    "name": "auditor",
+    "trans": [
+      "21.7",
+      "n．审计员；旁听者",
+      "【记】 audi（听）+or"
+    ],
+    "ukphone": "ˋɔ:dItər",
+    "usphone": "ˋɔ:dItər"
+  },
+  {
+    "name": "athlete",
+    "trans": [
+      "21.8",
+      "n．运动员"
+    ],
+    "ukphone": "ˋæθli:t",
+    "usphone": "ˋæθli:t"
+  },
+  {
+    "name": "satirist",
+    "trans": [
+      "21.9",
+      "n．讽刺作家"
+    ],
+    "ukphone": "ˋsætərIst",
+    "usphone": "ˋsætərIst"
+  },
+  {
+    "name": "sculptor",
+    "trans": [
+      "21.10",
+      "n．雕刻家"
+    ],
+    "ukphone": "ˋskʌlptər",
+    "usphone": "ˋskʌlptər"
+  },
+  {
+    "name": "mathematician",
+    "trans": [
+      "21.11",
+      "n．数学家"
+    ],
+    "ukphone": "ˌmæθəməˋtIʃn",
+    "usphone": "ˌmæθəməˋtIʃn"
+  },
+  {
+    "name": "astronaut",
+    "trans": [
+      "21.12",
+      "n．太空人，宇航员"
+    ],
+    "ukphone": "ˋæstrənɔ:t",
+    "usphone": "ˋæstrənɔ:t"
+  },
+  {
+    "name": "astronomer",
+    "trans": [
+      "21.13",
+      "n．天文学家"
+    ],
+    "ukphone": "əˋstrα:nəmər",
+    "usphone": "əˋstrα:nəmər"
+  },
+  {
+    "name": "spaceman",
+    "trans": [
+      "21.14",
+      "n．太空船上的飞行员，宇宙人"
+    ],
+    "ukphone": "ˋspeIsmæn",
+    "usphone": "ˋspeIsmæn"
+  },
+  {
+    "name": "botanist",
+    "trans": [
+      "21.15",
+      "n．植物学家"
+    ],
+    "ukphone": "ˋbα:tənIst",
+    "usphone": "ˋbα:tənIst"
+  },
+  {
+    "name": "choreographer",
+    "trans": [
+      "21.16",
+      "n．舞蹈设计师"
+    ],
+    "ukphone": "ˌkɔ:riˋα:grəfər",
+    "usphone": "ˌkɔ:riˋα:grəfər"
+  },
+  {
+    "name": "scout",
+    "trans": [
+      "21.17",
+      "n．侦察员；童子军"
+    ],
+    "ukphone": "skaut",
+    "usphone": "skaut"
+  },
+  {
+    "name": "geographer",
+    "trans": [
+      "21.18",
+      "n．地理学者"
+    ],
+    "ukphone": "dʒiˋα:grəfər",
+    "usphone": "dʒiˋα:grəfər"
+  },
+  {
+    "name": "geologist",
+    "trans": [
+      "21.19",
+      "n．地质学者"
+    ],
+    "ukphone": "dʒiˋα:lədʒIst",
+    "usphone": "dʒiˋα:lədʒIst"
+  },
+  {
+    "name": "educator",
+    "trans": [
+      "21.20",
+      "n．教育家"
+    ],
+    "ukphone": "ˋedʒukeItər",
+    "usphone": "ˋedʒukeItər"
+  },
+  {
+    "name": "faculty",
+    "trans": [
+      "21.21",
+      "n．全体教员"
+    ],
+    "ukphone": "ˋfæklti",
+    "usphone": "ˋfæklti"
+  },
+  {
+    "name": "treasurer",
+    "trans": [
+      "21.22",
+      "n．司库，财务员，出纳员"
+    ],
+    "ukphone": "ˋtreʒərər",
+    "usphone": "ˋtreʒərər"
+  },
+  {
+    "name": "archeologist",
+    "trans": [
+      "21.23",
+      "n．考古学家"
+    ],
+    "ukphone": "ˌα:rkiˋα:lədʒIst",
+    "usphone": "ˌα:rkiˋα:lədʒIst"
+  },
+  {
+    "name": "paleoanthropologist",
+    "trans": [
+      "21.24",
+      "n．古人类学家"
+    ],
+    "ukphone": "ˌpeIlioʊˌænθrəˋpα:lədʒIst",
+    "usphone": "ˌpeIlioʊˌænθrəˋpα:lədʒIst"
+  },
+  {
+    "name": "pilot",
+    "trans": [
+      "21.25",
+      "n．飞行员，领航员，引水员"
+    ],
+    "ukphone": "ˋpaIlət",
+    "usphone": "ˋpaIlət"
+  },
+  {
+    "name": "meteorologist",
+    "trans": [
+      "21.26",
+      "n．气象学者"
+    ],
+    "ukphone": "ˌmi:tiəˋrα:lədʒIst",
+    "usphone": "ˌmi:tiəˋrα:lədʒIst"
+  },
+  {
+    "name": "anthropologist",
+    "trans": [
+      "21.27",
+      "n．人类学者，人类学家"
+    ],
+    "ukphone": "ˌænθrəˋpα:lədʒIst",
+    "usphone": "ˌænθrəˋpα:lədʒIst"
+  },
+  {
+    "name": "artist",
+    "trans": [
+      "21.28",
+      "n．艺术家，画家"
+    ],
+    "ukphone": "ˋα:rtIst",
+    "usphone": "ˋα:rtIst"
+  },
+  {
+    "name": "imagist",
+    "trans": [
+      "21.29",
+      "n．意象派诗人"
+    ],
+    "ukphone": "ˋImidʒIst",
+    "usphone": "ˋImidʒIst"
+  },
+  {
+    "name": "inventor",
+    "trans": [
+      "21.30",
+      "n．发明家"
+    ],
+    "ukphone": "Inˋventər",
+    "usphone": "Inˋventər"
+  },
+  {
+    "name": "mechanic",
+    "trans": [
+      "21.31",
+      "n．技工，机修工，机械师"
+    ],
+    "ukphone": "məˋkænIk",
+    "usphone": "məˋkænIk"
+  },
+  {
+    "name": "biographer",
+    "trans": [
+      "21.32",
+      "n．传记作者"
+    ],
+    "ukphone": "baIˋα:grəfər",
+    "usphone": "baIˋα:grəfər"
+  },
+  {
+    "name": "censor",
+    "trans": [
+      "21.33",
+      "n．检查员 vt．检查"
+    ],
+    "ukphone": "ˋsensər",
+    "usphone": "ˋsensər"
+  },
+  {
+    "name": "physician",
+    "trans": [
+      "21.34",
+      "n．医师（doctor）"
+    ],
+    "ukphone": "fIˋzIʃn",
+    "usphone": "fIˋzIʃn"
+  },
+  {
+    "name": "hermit",
+    "trans": [
+      "21.35",
+      "n．隐居者"
+    ],
+    "ukphone": "ˋhɜ:rmIt",
+    "usphone": "ˋhɜ:rmIt"
+  },
+  {
+    "name": "recluse",
+    "trans": [
+      "21.36",
+      "n．隐士（hermit）",
+      "【记】 re（重新）+cluse（close关闭）→隐居"
+    ],
+    "ukphone": "ˋreklu:s",
+    "usphone": "ˋreklu:s"
+  },
+  {
+    "name": "ecologist",
+    "trans": [
+      "21.37",
+      "n．生态学者"
+    ],
+    "ukphone": "iˋkα:lədʒIst",
+    "usphone": "iˋkα:lədʒIst"
+  },
+  {
+    "name": "critic",
+    "trans": [
+      "21.38",
+      "n．批评家，评论家；吹毛求疵者"
+    ],
+    "ukphone": "ˋkrItIk",
+    "usphone": "ˋkrItIk"
+  },
+  {
+    "name": "philanthropist",
+    "trans": [
+      "21.39",
+      "n．慈善家"
+    ],
+    "ukphone": "fIˋlænθrəpIst",
+    "usphone": "fIˋlænθrəpIst"
+  },
+  {
+    "name": "attorney",
+    "trans": [
+      "21.40",
+      "n．代理人，辩护律师（lawyer）"
+    ],
+    "ukphone": "əˋtɜ:rni",
+    "usphone": "əˋtɜ:rni"
+  },
+  {
+    "name": "congressman",
+    "trans": [
+      "21.41",
+      "n．国会议员"
+    ],
+    "ukphone": "ˋkα:ŋgrəsmən",
+    "usphone": "ˋkα:ŋgrəsmən"
+  },
+  {
+    "name": "connoisseur",
+    "trans": [
+      "21.42",
+      "n．鉴赏家，行家",
+      "【记】 con+nois（知道）+seur→懂行的人"
+    ],
+    "ukphone": "ˌkα:nəˋsɜ:r",
+    "usphone": "ˌkα:nəˋsɜ:r"
+  },
+  {
+    "name": "entrepreneur",
+    "trans": [
+      "21.43",
+      "n．企业家；主办人"
+    ],
+    "ukphone": "ˌα:ntrəprəˋnɜ:r",
+    "usphone": "ˌα:ntrəprəˋnɜ:r"
+  },
+  {
+    "name": "principal",
+    "trans": [
+      "21.44",
+      "n．校长（head, headmaster）"
+    ],
+    "ukphone": "ˋprInsəpl",
+    "usphone": "ˋprInsəpl"
+  },
+  {
+    "name": "staff",
+    "trans": [
+      "21.45",
+      "n．全体人员或职员"
+    ],
+    "ukphone": "stæf",
+    "usphone": "stæf"
+  },
+  {
+    "name": "commander",
+    "trans": [
+      "21.46",
+      "n．司令官，指挥员"
+    ],
+    "ukphone": "kəˋmændər",
+    "usphone": "kəˋmændər"
+  },
+  {
+    "name": "commentator",
+    "trans": [
+      "21.47",
+      "n．注释者，评论家"
+    ],
+    "ukphone": "ˋkα:mənteItər",
+    "usphone": "ˋkα:mənteItər"
+  },
+  {
+    "name": "attendant",
+    "trans": [
+      "21.48",
+      "n．侍者，护理人员（waiter）"
+    ],
+    "ukphone": "əˋtendənt",
+    "usphone": "əˋtendənt"
+  },
+  {
+    "name": "trapper",
+    "trans": [
+      "21.49",
+      "n．设陷阱捕兽者"
+    ],
+    "ukphone": "ˋtræpər",
+    "usphone": "ˋtræpər"
+  },
+  {
+    "name": "orator",
+    "trans": [
+      "21.50",
+      "n．演讲者（speaker）"
+    ],
+    "ukphone": "ˋɔ:rətər",
+    "usphone": "ˋɔ:rətər"
+  },
+  {
+    "name": "idiot",
+    "trans": [
+      "21.51",
+      "n．白痴，傻子",
+      "【记】 idio（个人）+t→特殊的个人→白痴"
+    ],
+    "ukphone": "ˋIdiət",
+    "usphone": "ˋIdiət"
+  },
+  {
+    "name": "idiocy",
+    "trans": [
+      "21.52",
+      "n．白痴",
+      "【记】 来自idiot"
+    ],
+    "ukphone": "ˋIdiəsi",
+    "usphone": "ˋIdiəsi"
+  },
+  {
+    "name": "moron",
+    "trans": [
+      "21.53",
+      "n．低能儿，白痴（idiot）",
+      "【记】 moro（笨）+n"
+    ],
+    "ukphone": "ˋmɔ:rα:n",
+    "usphone": "ˋmɔ:rα:n"
+  },
+  {
+    "name": "illiterate",
+    "trans": [
+      "21.54",
+      "n．文盲（uneducated）",
+      "【记】 il（不）+literate（识字的）"
+    ],
+    "ukphone": "IˋlItərət",
+    "usphone": "IˋlItərət"
+  },
+  {
+    "name": "proxy",
+    "trans": [
+      "21.55",
+      "n．代理人（deputy）"
+    ],
+    "ukphone": "ˋprα:ksi",
+    "usphone": "ˋprα:ksi"
+  },
+  {
+    "name": "deputy",
+    "trans": [
+      "21.56",
+      "n．代理人（representative）"
+    ],
+    "ukphone": "ˋdepjuti",
+    "usphone": "ˋdepjuti"
+  },
+  {
+    "name": "proprietor",
+    "trans": [
+      "21.57",
+      "n．所有者，经营者"
+    ],
+    "ukphone": "prəˋpraIətər",
+    "usphone": "prəˋpraIətər"
+  },
+  {
+    "name": "consumer",
+    "trans": [
+      "21.58",
+      "n．顾客，消费者（customer）"
+    ],
+    "ukphone": "kənˋsju:mər",
+    "usphone": "kənˋsju:mər"
+  },
+  {
+    "name": "employer",
+    "trans": [
+      "21.59",
+      "n．雇用者，雇主"
+    ],
+    "ukphone": "ImˋplɔIər",
+    "usphone": "ImˋplɔIər"
+  },
+  {
+    "name": "employee",
+    "trans": [
+      "21.60",
+      "n．雇员"
+    ],
+    "ukphone": "ImˋplɔIi:",
+    "usphone": "ImˋplɔIi:"
+  },
+  {
+    "name": "debtor",
+    "trans": [
+      "21.61",
+      "n．债务人"
+    ],
+    "ukphone": "ˋdetər",
+    "usphone": "ˋdetər"
+  },
+  {
+    "name": "arbitrator",
+    "trans": [
+      "21.62",
+      "n．仲裁者（mediator, arbiter）"
+    ],
+    "ukphone": "ˋα:rbItreItər",
+    "usphone": "ˋα:rbItreItər"
+  },
+  {
+    "name": "superintendent",
+    "trans": [
+      "21.63",
+      "n．主管，负责人，指挥者（supervisor, manager）",
+      "【记】 super（上面）+intendent（监督）"
+    ],
+    "ukphone": "ˌsju:pərInˋtendənt",
+    "usphone": "ˌsju:pərInˋtendənt"
+  },
+  {
+    "name": "apprentice",
+    "trans": [
+      "21.64",
+      "n．学徒（disciple）"
+    ],
+    "ukphone": "əˋprentIs",
+    "usphone": "əˋprentIs"
+  },
+  {
+    "name": "tenant",
+    "trans": [
+      "21.65",
+      "n．租户，房客（occupant, inhabitant）"
+    ],
+    "ukphone": "ˋtenənt",
+    "usphone": "ˋtenənt"
+  },
+  {
+    "name": "miser",
+    "trans": [
+      "21.66",
+      "n．守财奴，吝啬鬼"
+    ],
+    "ukphone": "ˋmaIzər",
+    "usphone": "ˋmaIzər"
+  },
+  {
+    "name": "donor",
+    "trans": [
+      "21.67",
+      "n．捐助者（contributor）"
+    ],
+    "ukphone": "ˋdoʊnər",
+    "usphone": "ˋdoʊnər"
+  },
+  {
+    "name": "personnel",
+    "trans": [
+      "21.68",
+      "n．人员，职员",
+      "【记】 person（人）+nel"
+    ],
+    "ukphone": "ˌpɜ:rsəˋnel",
+    "usphone": "ˌpɜ:rsəˋnel"
+  },
+  {
+    "name": "benefactor",
+    "trans": [
+      "21.69",
+      "n．恩人，捐助人",
+      "【记】 bene（好）+fact（做）+or→做好事的人"
+    ],
+    "ukphone": "ˋbenIfæktər",
+    "usphone": "ˋbenIfæktər"
+  },
+  {
+    "name": "mortal",
+    "trans": [
+      "21.70",
+      "n．凡人（human）",
+      "【记】 mort（死）+al"
+    ],
+    "ukphone": "ˋmɔ:rtl",
+    "usphone": "ˋmɔ:rtl"
+  },
+  {
+    "name": "company",
+    "trans": [
+      "21.71",
+      "n．伙伴"
+    ],
+    "ukphone": "ˋkʌmpəni",
+    "usphone": "ˋkʌmpəni"
+  },
+  {
+    "name": "audience",
+    "trans": [
+      "21.72",
+      "n．观众（spectator）"
+    ],
+    "ukphone": "ˋɔ:diəns",
+    "usphone": "ˋɔ:diəns"
+  },
+  {
+    "name": "recipient",
+    "trans": [
+      "21.73",
+      "n．接受者（receiver, payee）"
+    ],
+    "ukphone": "rIˋsIpiənt",
+    "usphone": "rIˋsIpiənt"
+  },
+  {
+    "name": "resident",
+    "trans": [
+      "21.74",
+      "n．居民（inhabitant, occupant）"
+    ],
+    "ukphone": "ˋrezIdənt",
+    "usphone": "ˋrezIdənt"
+  },
+  {
+    "name": "inhabitant",
+    "trans": [
+      "21.75",
+      "n．居民，住户（resident, occupant）",
+      "【记】 inhabit+ant"
+    ],
+    "ukphone": "InˋhæbItənt",
+    "usphone": "InˋhæbItənt"
+  },
+  {
+    "name": "bachelor",
+    "trans": [
+      "21.76",
+      "n．单身汉（unmarried man）；学士"
+    ],
+    "ukphone": "ˋbætʃələr",
+    "usphone": "ˋbætʃələr"
+  },
+  {
+    "name": "idol",
+    "trans": [
+      "21.77",
+      "n．偶像"
+    ],
+    "ukphone": "ˋaIdl",
+    "usphone": "ˋaIdl"
+  },
+  {
+    "name": "novice",
+    "trans": [
+      "21.78",
+      "n．新信徒；生手（beginner, tyro, layman）",
+      "【记】 nov（新）+ice（表示人）"
+    ],
+    "ukphone": "ˋnα:vIs",
+    "usphone": "ˋnα:vIs"
+  },
+  {
+    "name": "believer",
+    "trans": [
+      "21.79",
+      "n．信徒（faithful）",
+      "【记】 来自believe（相信）"
+    ],
+    "ukphone": "bIˋli:vər",
+    "usphone": "bIˋli:vər"
+  },
+  {
+    "name": "cult",
+    "trans": [
+      "21.80",
+      "n．崇拜者"
+    ],
+    "ukphone": "kʌlt",
+    "usphone": "kʌlt"
+  },
+  {
+    "name": "fanatic",
+    "trans": [
+      "21.81",
+      "n．盲信者；狂热分子",
+      "【记】 fan（迷）+atic→着迷的人→盲信者"
+    ],
+    "ukphone": "fəˋnætIk",
+    "usphone": "fəˋnætIk"
+  },
+  {
+    "name": "adherent",
+    "trans": [
+      "21.82",
+      "n．信奉者（supporter）",
+      "【记】 adhere（粘着）+ent→坚持的人"
+    ],
+    "ukphone": "ədˋhIrənt",
+    "usphone": "ədˋhIrənt"
+  },
+  {
+    "name": "faithful",
+    "trans": [
+      "21.83",
+      "n．信徒",
+      "【记】 faith（忠诚）+ful"
+    ],
+    "ukphone": "ˋfeIθfl",
+    "usphone": "ˋfeIθfl"
+  },
+  {
+    "name": "disciple",
+    "trans": [
+      "21.84",
+      "n．门徒（apprentice）"
+    ],
+    "ukphone": "dIˋsaIpl",
+    "usphone": "dIˋsaIpl"
+  },
+  {
+    "name": "champion",
+    "trans": [
+      "21.85",
+      "n．冠军"
+    ],
+    "ukphone": "ˋtʃæmpiən",
+    "usphone": "ˋtʃæmpiən"
+  },
+  {
+    "name": "assassin",
+    "trans": [
+      "21.86",
+      "n．刺客"
+    ],
+    "ukphone": "əˋsæsn",
+    "usphone": "əˋsæsn"
+  },
+  {
+    "name": "bandit",
+    "trans": [
+      "21.87",
+      "n．强盗（robber, pirate）"
+    ],
+    "ukphone": "ˋbændIt",
+    "usphone": "ˋbændIt"
+  },
+  {
+    "name": "burglar",
+    "trans": [
+      "21.88",
+      "n．夜盗，窃贼"
+    ],
+    "ukphone": "ˋbɜ:rglər",
+    "usphone": "ˋbɜ:rglər"
+  },
+  {
+    "name": "barbarian",
+    "trans": [
+      "21.89",
+      "n．野蛮人",
+      "【记】 barbar（愚昧）+ian（人）"
+    ],
+    "ukphone": "bα:rˋberiən",
+    "usphone": "bα:rˋberiən"
+  },
+  {
+    "name": "exile",
+    "trans": [
+      "21.90",
+      "n．被流放者"
+    ],
+    "ukphone": "ˋeksaIl",
+    "usphone": "ˋeksaIl"
+  },
+  {
+    "name": "rebel",
+    "trans": [
+      "21.91",
+      "n．背叛者（traitor）"
+    ],
+    "ukphone": "ˋrebl",
+    "usphone": "ˋrebl"
+  },
+  {
+    "name": "addict",
+    "trans": [
+      "21.92",
+      "n．沉溺于…者（indulger, surrender）"
+    ],
+    "ukphone": "ˋædIkt",
+    "usphone": "ˋædIkt"
+  },
+  {
+    "name": "egoist",
+    "trans": [
+      "21.93",
+      "n．自我主义者",
+      "【记】 ego（我）+ist"
+    ],
+    "ukphone": "ˋi:goʊIst",
+    "usphone": "ˋi:goʊIst"
+  },
+  {
+    "name": "eyewitness",
+    "trans": [
+      "21.94",
+      "n．目击者（spectator）",
+      "【记】 eye（眼睛）+witness（证人）"
+    ],
+    "ukphone": "ˋaIwItnəs",
+    "usphone": "ˋaIwItnəs"
+  },
+  {
+    "name": "spectator",
+    "trans": [
+      "21.95",
+      "n．旁观者；观众（viewer, audience）",
+      "【记】 sepct（看）+ator（人）"
+    ],
+    "ukphone": "ˋspekteItər",
+    "usphone": "ˋspekteItər"
+  },
+  {
+    "name": "spouse",
+    "trans": [
+      "21.96",
+      "n．配偶（partner, mate）"
+    ],
+    "ukphone": "spaʊs",
+    "usphone": "spaʊs"
+  },
+  {
+    "name": "couple",
+    "trans": [
+      "21.97",
+      "n．一对（夫妇）（pair）"
+    ],
+    "ukphone": "ˋkʌpl",
+    "usphone": "ˋkʌpl"
+  },
+  {
+    "name": "beneficiary",
+    "trans": [
+      "21.98",
+      "n．受益者"
+    ],
+    "ukphone": "ˌbenIˋfIʃieri",
+    "usphone": "ˌbenIˋfIʃieri"
+  },
+  {
+    "name": "inferior",
+    "trans": [
+      "21.99",
+      "n．下级，晚辈",
+      "【记】 infer（低）+ior；比较superior（上级）"
+    ],
+    "ukphone": "InˋfIriər",
+    "usphone": "InˋfIriər"
+  },
+  {
+    "name": "zealot",
+    "trans": [
+      "21.100",
+      "n．热心者（fanatic, bigot）"
+    ],
+    "ukphone": "ˋzelət",
+    "usphone": "ˋzelət"
+  },
+  {
+    "name": "precursor",
+    "trans": [
+      "21.101",
+      "n．先驱",
+      "n．先锋派，前卫"
+    ],
+    "ukphone": "ˋævα:ˋgα:rd",
+    "usphone": "ˋævα:ˋgα:rd"
+  },
+  {
+    "name": "alumni",
+    "trans": [
+      "21.103",
+      "n．男毕业生，男校友"
+    ],
+    "ukphone": "əˋlʌmnaI",
+    "usphone": "əˋlʌmnaI"
+  },
+  {
+    "name": "skeptic",
+    "trans": [
+      "21.104",
+      "n．怀疑者"
+    ],
+    "ukphone": "ˋskeptIk",
+    "usphone": "ˋskeptIk"
+  },
+  {
+    "name": "malcontent",
+    "trans": [
+      "21.105",
+      "n．不平者，不满者",
+      "【记】 mal（坏）+content（满意的）"
+    ],
+    "ukphone": "ˌmælkənˋtent",
+    "usphone": "ˌmælkənˋtent"
+  },
+  {
+    "name": "foe",
+    "trans": [
+      "21.106",
+      "n．敌人（enemy, adversary）"
+    ],
+    "ukphone": "foʊ",
+    "usphone": "foʊ"
+  },
+  {
+    "name": "opponent",
+    "trans": [
+      "21.107",
+      "n．敌人；对手（enemy; rival）"
+    ],
+    "ukphone": "əˋpoʊnənt",
+    "usphone": "əˋpoʊnənt"
+  },
+  {
+    "name": "rival",
+    "trans": [
+      "21.108",
+      "n．对手 v．竞争"
+    ],
+    "ukphone": "ˋraIvl",
+    "usphone": "ˋraIvl"
+  },
+  {
+    "name": "celebrity",
+    "trans": [
+      "21.109",
+      "n．名人（person of note）"
+    ],
+    "ukphone": "səˋlebrəti",
+    "usphone": "səˋlebrəti"
+  },
+  {
+    "name": "figurehead",
+    "trans": [
+      "21.110",
+      "n．名义领袖",
+      "【记】 figuar（形象）+head（头，首领）"
+    ],
+    "ukphone": "ˋfIgjərhed",
+    "usphone": "ˋfIgjərhed"
+  },
+  {
+    "name": "veteran",
+    "trans": [
+      "21.111",
+      "n．老兵，老手（ex-serviceman, old soldier）"
+    ],
+    "ukphone": "ˋvetərən",
+    "usphone": "ˋvetərən"
+  },
+  {
+    "name": "traitor",
+    "trans": [
+      "21.112",
+      "n．叛徒，卖国贼（betrayer）"
+    ],
+    "ukphone": "ˋtreItər",
+    "usphone": "ˋtreItər"
+  },
+  {
+    "name": "advocate",
+    "trans": [
+      "21.113",
+      "n．辩护者；拥护者",
+      "【记】 ad+voc（说）+ate"
+    ],
+    "ukphone": "ˋædvəkeIt",
+    "usphone": "ˋædvəkeIt"
+  },
+  {
+    "name": "feminist",
+    "trans": [
+      "21.114",
+      "n．男女平等主义者，女权扩张论者"
+    ],
+    "ukphone": "ˋfemənIst",
+    "usphone": "ˋfemənIst"
+  },
+  {
+    "name": "humanitarian",
+    "trans": [
+      "21.115",
+      "n．人道主义者"
+    ],
+    "ukphone": "hju:ˌmænIˋteriən",
+    "usphone": "hju:ˌmænIˋteriən"
+  },
+  {
+    "name": "throng",
+    "trans": [
+      "21.116",
+      "n．群众（crowd, swarm）"
+    ],
+    "ukphone": "θrɔ:ŋ",
+    "usphone": "θrɔ:ŋ"
+  },
+  {
+    "name": "civilian",
+    "trans": [
+      "21.117",
+      "n．平民 adj．平民的"
+    ],
+    "ukphone": "səˋvIliən",
+    "usphone": "səˋvIliən"
+  },
+  {
+    "name": "monarch",
+    "trans": [
+      "21.118",
+      "n．君主，最高统治者",
+      "【记】 mon（单个）+arch（统治者）→君主"
+    ],
+    "ukphone": "ˋmα:nərk",
+    "usphone": "ˋmα:nərk"
+  },
+  {
+    "name": "conservative",
+    "trans": [
+      "21.119",
+      "n．保守的人 adj．保守的"
+    ],
+    "ukphone": "kənˋsɜ:rvətIv",
+    "usphone": "kənˋsɜ:rvətIv"
+  },
+  {
+    "name": "envoy",
+    "trans": [
+      "21.120",
+      "n．使者，公使"
+    ],
+    "ukphone": "ˋenvɔI",
+    "usphone": "ˋenvɔI"
+  },
+  {
+    "name": "aristocrat",
+    "trans": [
+      "21.121",
+      "n．贵族（blue blood）",
+      "【记】 aristo（最好）+crat（统治者）"
+    ],
+    "ukphone": "əˋrIstəkræt",
+    "usphone": "əˋrIstəkræt"
+  },
+  {
+    "name": "gentry",
+    "trans": [
+      "21.122",
+      "n．贵族"
+    ],
+    "ukphone": "ˋdʒentri",
+    "usphone": "ˋdʒentri"
+  },
+  {
+    "name": "autocrat",
+    "trans": [
+      "21.123",
+      "n．独裁者（dictator）",
+      "【记】 auto（自己）+crat（统治者）→独裁者"
+    ],
+    "ukphone": "ˋɔ:təkræt",
+    "usphone": "ˋɔ:təkræt"
+  },
+  {
+    "name": "delegate",
+    "trans": [
+      "21.124",
+      "n．代表（deputy, representative）",
+      "【记】 de（加强）+leg（法律）+ate→加强法律之人→代表"
+    ],
+    "ukphone": "ˋdelIgət",
+    "usphone": "ˋdelIgət"
+  },
+  {
+    "name": "democrat",
+    "trans": [
+      "21.125",
+      "n．民主党人"
+    ],
+    "ukphone": "ˋdeməkræt",
+    "usphone": "ˋdeməkræt"
+  },
+  {
+    "name": "independent",
+    "trans": [
+      "21.126",
+      "n．中立派，无党派者"
+    ],
+    "ukphone": "ˌIndIˋpendənt",
+    "usphone": "ˌIndIˋpendənt"
+  },
+  {
+    "name": "candidate",
+    "trans": [
+      "21.127",
+      "n．候选人"
+    ],
+    "ukphone": "ˋkændIdət",
+    "usphone": "ˋkændIdət"
+  },
+  {
+    "name": "priest",
+    "trans": [
+      "21.128",
+      "n．牧师；神父；教士"
+    ],
+    "ukphone": "pri:st",
+    "usphone": "pri:st"
+  },
+  {
+    "name": "inhabitant",
+    "trans": [
+      "21.129",
+      "n．居民；居住者"
+    ],
+    "ukphone": "InˋhæbItənt",
+    "usphone": "InˋhæbItənt"
+  },
+  {
+    "name": "occupation",
+    "trans": [
+      "21.130",
+      "n．职业；占有（期）；消遣"
+    ],
+    "ukphone": "ˌα:kjuˋpeIʃn",
+    "usphone": "ˌα:kjuˋpeIʃn"
+  },
+  {
+    "name": "balmy",
+    "trans": [
+      "22.1",
+      "adj．温和的（refreshing, mild, temperate, moderate）",
+      "【记】 balm（香气）+y"
+    ],
+    "ukphone": "ˋbα:mi",
+    "usphone": "ˋbα:mi"
+  },
+  {
+    "name": "humid",
+    "trans": [
+      "22.2",
+      "adj．潮湿的（damp, moist）"
+    ],
+    "ukphone": "ˋhju:mId",
+    "usphone": "ˋhju:mId"
+  },
+  {
+    "name": "humidity",
+    "trans": [
+      "22.3",
+      "n．潮湿（moisture）",
+      "【记】 humid（湿）+ity→潮湿"
+    ],
+    "ukphone": "hju:ˋmIdəti",
+    "usphone": "hju:ˋmIdəti"
+  },
+  {
+    "name": "damp",
+    "trans": [
+      "22.4",
+      "adj．潮湿的，有湿气的（wet, moist）"
+    ],
+    "ukphone": "dæmp",
+    "usphone": "dæmp"
+  },
+  {
+    "name": "dank",
+    "trans": [
+      "22.5",
+      "adj．阴湿的（damp, clammy）"
+    ],
+    "ukphone": "dæŋk",
+    "usphone": "dæŋk"
+  },
+  {
+    "name": "moisture",
+    "trans": [
+      "22.6",
+      "n．潮湿，湿气"
+    ],
+    "ukphone": "ˋmɔIstʃər",
+    "usphone": "ˋmɔIstʃər"
+  },
+  {
+    "name": "saturate",
+    "trans": [
+      "22.7",
+      "v．使饱和，浸透，使充满"
+    ],
+    "ukphone": "ˋsætʃəreIt",
+    "usphone": "ˋsætʃəreIt"
+  },
+  {
+    "name": "drought",
+    "trans": [
+      "22.8",
+      "n．干旱（aridity, dry period, prolonged lack of rain）"
+    ],
+    "ukphone": "draʊt",
+    "usphone": "draʊt"
+  },
+  {
+    "name": "arid",
+    "trans": [
+      "22.9",
+      "adj．干旱的（barren, infertile, dry）"
+    ],
+    "ukphone": "ˋærId",
+    "usphone": "ˋærId"
+  },
+  {
+    "name": "chilly",
+    "trans": [
+      "22.10",
+      "adj．寒冷的"
+    ],
+    "ukphone": "ˋtʃIli",
+    "usphone": "ˋtʃIli"
+  },
+  {
+    "name": "chill",
+    "trans": [
+      "22.11",
+      "n．寒冷 vt．使变冷"
+    ],
+    "ukphone": "tʃIl",
+    "usphone": "tʃIl"
+  },
+  {
+    "name": "frigid",
+    "trans": [
+      "22.12",
+      "adj．严寒的（icy, freezing）；冷淡的",
+      "【记】 frig（寒冷）+id"
+    ],
+    "ukphone": "ˋfrIdʒId",
+    "usphone": "ˋfrIdʒId"
+  },
+  {
+    "name": "serene",
+    "trans": [
+      "22.13",
+      "adj．晴朗的"
+    ],
+    "ukphone": "səˋri:n",
+    "usphone": "səˋri:n"
+  },
+  {
+    "name": "tepid",
+    "trans": [
+      "22.14",
+      "adj．微温的（lukewarm, warm）"
+    ],
+    "ukphone": "ˋtepId",
+    "usphone": "ˋtepId"
+  },
+  {
+    "name": "gale",
+    "trans": [
+      "22.15",
+      "n．大风（storm, tempest）"
+    ],
+    "ukphone": "geIl",
+    "usphone": "geIl"
+  },
+  {
+    "name": "hurricane",
+    "trans": [
+      "22.16",
+      "n．飓风",
+      "【记】 twister 龙卷风，tornado 龙卷风"
+    ],
+    "ukphone": "ˋhɜ:rəkən",
+    "usphone": "ˋhɜ:rəkən"
+  },
+  {
+    "name": "atmosphere",
+    "trans": [
+      "22.17",
+      "n．气氛；大气层"
+    ],
+    "ukphone": "ˋætməsfIr",
+    "usphone": "ˋætməsfIr"
+  },
+  {
+    "name": "climate",
+    "trans": [
+      "22.18",
+      "n．气候，气氛（weather, atmosphere）"
+    ],
+    "ukphone": "ˋklaImət",
+    "usphone": "ˋklaImət"
+  },
+  {
+    "name": "barometer",
+    "trans": [
+      "22.19",
+      "n．气压计（indicator）",
+      "【记】 baro（压力）+meter"
+    ],
+    "ukphone": "bəˋrα:mItər",
+    "usphone": "bəˋrα:mItər"
+  },
+  {
+    "name": "breeze",
+    "trans": [
+      "22.20",
+      "n．微风"
+    ],
+    "ukphone": "bri:z",
+    "usphone": "bri:z"
+  },
+  {
+    "name": "blast",
+    "trans": [
+      "22.21",
+      "n．一阵（风）（gust, blow）"
+    ],
+    "ukphone": "blæst",
+    "usphone": "blæst"
+  },
+  {
+    "name": "whirlwind",
+    "trans": [
+      "22.22",
+      "n．旋风"
+    ],
+    "ukphone": "ˋwɜ:rlwInd",
+    "usphone": "ˋwɜ:rlwInd"
+  },
+  {
+    "name": "typhoon",
+    "trans": [
+      "22.23",
+      "n．台风"
+    ],
+    "ukphone": "taIˋfu:n",
+    "usphone": "taIˋfu:n"
+  },
+  {
+    "name": "tornado",
+    "trans": [
+      "22.24",
+      "n．旋风，龙卷风，大雷雨"
+    ],
+    "ukphone": "tɔ:rˋneIdoʊ",
+    "usphone": "tɔ:rˋneIdoʊ"
+  },
+  {
+    "name": "meteorology",
+    "trans": [
+      "22.25",
+      "n．气象学，气象状态"
+    ],
+    "ukphone": "ˌmi:tiəˋrα:lədʒi",
+    "usphone": "ˌmi:tiəˋrα:lədʒi"
+  },
+  {
+    "name": "troposphere",
+    "trans": [
+      "22.26",
+      "n．对流层"
+    ],
+    "ukphone": "ˋtroʊpəsfIr",
+    "usphone": "ˋtroʊpəsfIr"
+  },
+  {
+    "name": "funnel",
+    "trans": [
+      "22.27",
+      "n．漏斗云"
+    ],
+    "ukphone": "ˋfʌnl",
+    "usphone": "ˋfʌnl"
+  },
+  {
+    "name": "smog",
+    "trans": [
+      "22.28",
+      "n．烟雾"
+    ],
+    "ukphone": "smα:g",
+    "usphone": "smα:g"
+  },
+  {
+    "name": "fog",
+    "trans": [
+      "22.29",
+      "n．雾，烟雾，尘雾",
+      "【记】 比较frog（青蛙）"
+    ],
+    "ukphone": "fɔ:g",
+    "usphone": "fɔ:g"
+  },
+  {
+    "name": "precipitate",
+    "trans": [
+      "22.30",
+      "v．凝结（形成雨、雪）",
+      "【记】 pre（提前）+cipit（落下）+ate→降下"
+    ],
+    "ukphone": "prIˋsIpIteIt",
+    "usphone": "prIˋsIpIteIt"
+  },
+  {
+    "name": "precipitation",
+    "trans": [
+      "22.31",
+      "n．降水"
+    ],
+    "ukphone": "prIˌsIpIˋteIʃn",
+    "usphone": "prIˌsIpIˋteIʃn"
+  },
+  {
+    "name": "drizzle",
+    "trans": [
+      "22.32",
+      "v．下细雨（rain, sprinkle）"
+    ],
+    "ukphone": "ˋdrIzl",
+    "usphone": "ˋdrIzl"
+  },
+  {
+    "name": "blizzard",
+    "trans": [
+      "22.33",
+      "n．大风雪"
+    ],
+    "ukphone": "ˋblIzərd",
+    "usphone": "ˋblIzərd"
+  },
+  {
+    "name": "dew",
+    "trans": [
+      "22.34",
+      "n．露，露水般的东西"
+    ],
+    "ukphone": "dju:",
+    "usphone": "dju:"
+  },
+  {
+    "name": "downpour",
+    "trans": [
+      "22.35",
+      "n．倾盆大雨"
+    ],
+    "ukphone": "ˋdaʊnpɔ:r",
+    "usphone": "ˋdaʊnpɔ:r"
+  },
+  {
+    "name": "droplet",
+    "trans": [
+      "22.36",
+      "n．小滴"
+    ],
+    "ukphone": "ˋdrα:plət",
+    "usphone": "ˋdrα:plət"
+  },
+  {
+    "name": "frost",
+    "trans": [
+      "22.37",
+      "n．霜，霜冻，严寒 v．结霜"
+    ],
+    "ukphone": "frɔ:st",
+    "usphone": "frɔ:st"
+  },
+  {
+    "name": "vapor",
+    "trans": [
+      "22.38",
+      "n．水汽，水蒸气"
+    ],
+    "ukphone": "ˋveIpər",
+    "usphone": "ˋveIpər"
+  },
+  {
+    "name": "tempest",
+    "trans": [
+      "22.39",
+      "n．暴风雨"
+    ],
+    "ukphone": "ˋtempIst",
+    "usphone": "ˋtempIst"
+  },
+  {
+    "name": "shower",
+    "trans": [
+      "22.40",
+      "n．阵雨；淋浴"
+    ],
+    "ukphone": "ˋʃaʊər",
+    "usphone": "ˋʃaʊər"
+  },
+  {
+    "name": "hail",
+    "trans": [
+      "22.41",
+      "n．冰雹"
+    ],
+    "ukphone": "heIl",
+    "usphone": "heIl"
+  },
+  {
+    "name": "condense",
+    "trans": [
+      "22.42",
+      "v.（使）浓缩，精简"
+    ],
+    "ukphone": "kənˋdens",
+    "usphone": "kənˋdens"
+  },
+  {
+    "name": "crystal",
+    "trans": [
+      "22.43",
+      "adj．结晶状的"
+    ],
+    "ukphone": "ˋkrIstl",
+    "usphone": "ˋkrIstl"
+  },
+  {
+    "name": "penal",
+    "trans": [
+      "23.1",
+      "adj．受刑罚的，刑事的",
+      "【记】 pen（惩罚）+al"
+    ],
+    "ukphone": "ˋpi:nl",
+    "usphone": "ˋpi:nl"
+  },
+  {
+    "name": "illicit",
+    "trans": [
+      "23.2",
+      "adj．违法的（unlawful, illegal）"
+    ],
+    "ukphone": "IˋlIsIt",
+    "usphone": "IˋlIsIt"
+  },
+  {
+    "name": "unruly",
+    "trans": [
+      "23.3",
+      "adj．不守法的（disorderly）",
+      "【记】 un（不）+rul（e）（法）+y"
+    ],
+    "ukphone": "ʌnˋru:li",
+    "usphone": "ʌnˋru:li"
+  },
+  {
+    "name": "illegitimate",
+    "trans": [
+      "23.4",
+      "adj．非法的；私生的（illegal）",
+      "【记】 il（不）+legitim（合法）+ate→不合法的"
+    ],
+    "ukphone": "ˌIləˋdʒItəmət",
+    "usphone": "ˌIləˋdʒItəmət"
+  },
+  {
+    "name": "default",
+    "trans": [
+      "23.5",
+      "n．不履行责任（nonfulfilment），缺乏 v．不履行；拖欠",
+      "【记】 de（犯）+fault（错误）→拖（债）"
+    ],
+    "ukphone": "dIˋfɔ:lt",
+    "usphone": "dIˋfɔ:lt"
+  },
+  {
+    "name": "violate",
+    "trans": [
+      "23.6",
+      "v．违犯，违背，侵犯（break, offend）"
+    ],
+    "ukphone": "ˋvaIəleIt",
+    "usphone": "ˋvaIəleIt"
+  },
+  {
+    "name": "violation",
+    "trans": [
+      "23.7",
+      "n．违犯"
+    ],
+    "ukphone": "ˌvaIəˋleIʃn",
+    "usphone": "ˌvaIəˋleIʃn"
+  },
+  {
+    "name": "infringe",
+    "trans": [
+      "23.8",
+      "v．侵犯（encroach, intrude）；违反"
+    ],
+    "ukphone": "InˋfrIndʒ",
+    "usphone": "InˋfrIndʒ"
+  },
+  {
+    "name": "bound",
+    "trans": [
+      "23.9",
+      "adj．负有义务的"
+    ],
+    "ukphone": "baʊnd",
+    "usphone": "baʊnd"
+  },
+  {
+    "name": "compulsory",
+    "trans": [
+      "23.10",
+      "adj．义务的；必修的（obligatory, mandatory, required）",
+      "【记】 com+puls（推，冲）+ory"
+    ],
+    "ukphone": "kəmˋpʌlsəri",
+    "usphone": "kəmˋpʌlsəri"
+  },
+  {
+    "name": "oblige",
+    "trans": [
+      "23.11",
+      "vt．强迫（force）"
+    ],
+    "ukphone": "əˋblaIdʒ",
+    "usphone": "əˋblaIdʒ"
+  },
+  {
+    "name": "obligatory",
+    "trans": [
+      "23.12",
+      "adj．义务的；必须的（compulsory, necessary）",
+      "【记】 oblig（强迫）+atory→必须的"
+    ],
+    "ukphone": "əˋblIgətɔ:ri",
+    "usphone": "əˋblIgətɔ:ri"
+  },
+  {
+    "name": "responsible",
+    "trans": [
+      "23.13",
+      "adj．有责任的"
+    ],
+    "ukphone": "rIˋspα:nsəbl",
+    "usphone": "rIˋspα:nsəbl"
+  },
+  {
+    "name": "domineering",
+    "trans": [
+      "23.14",
+      "adj．专权的（tyrannical, dictatorial）",
+      "【记】 domin（统治）+eering→统治者的→盛气凌人的"
+    ],
+    "ukphone": "ˌdα:məˋnIrIŋ",
+    "usphone": "ˌdα:məˋnIrIŋ"
+  },
+  {
+    "name": "mandatory",
+    "trans": [
+      "23.15",
+      "adj．命令的；强制的（obligatory, compulsory）"
+    ],
+    "ukphone": "ˋmændətɔ:ri",
+    "usphone": "ˋmændətɔ:ri"
+  },
+  {
+    "name": "licensed",
+    "trans": [
+      "23.16",
+      "adj．被许可的（permissive）",
+      "【记】 licen（允许）+sed"
+    ],
+    "ukphone": "ˋlaIsnst",
+    "usphone": "ˋlaIsnst"
+  },
+  {
+    "name": "heirship",
+    "trans": [
+      "23.17",
+      "n．继承权"
+    ],
+    "ukphone": "ˋerʃIp",
+    "usphone": "ˋerʃIp"
+  },
+  {
+    "name": "jurisdiction",
+    "trans": [
+      "23.18",
+      "n．司法权",
+      "【记】 juris（法律）+dict（说，命令）+ion→法律上命令→司法权"
+    ],
+    "ukphone": "ˌdʒʊrIsˋdIkʃn",
+    "usphone": "ˌdʒʊrIsˋdIkʃn"
+  },
+  {
+    "name": "arbitration",
+    "trans": [
+      "23.19",
+      "n．调停，仲裁",
+      "【记】 arbi（判断，裁决）+tration→进行裁决"
+    ],
+    "ukphone": "ˌα:rbIˋtreIʃn",
+    "usphone": "ˌα:rbIˋtreIʃn"
+  },
+  {
+    "name": "fine",
+    "trans": [
+      "23.20",
+      "n．罚金"
+    ],
+    "ukphone": "faIn",
+    "usphone": "faIn"
+  },
+  {
+    "name": "confiscate",
+    "trans": [
+      "23.21",
+      "vt．没收，充公（seize）",
+      "【记】 con+fisc（钱，财）+ate"
+    ],
+    "ukphone": "ˋkα:nfIskeIt",
+    "usphone": "ˋkα:nfIskeIt"
+  },
+  {
+    "name": "convict",
+    "trans": [
+      "23.22",
+      "vt．判罪；证明（penalize; prove）",
+      "【记】 con+vict（征服）→（征服）罪犯→判罪"
+    ],
+    "ukphone": "kənˋvIkt",
+    "usphone": "kənˋvIkt"
+  },
+  {
+    "name": "verdict",
+    "trans": [
+      "23.23",
+      "n．判决（decision, judgment）"
+    ],
+    "ukphone": "ˋvɜ:rdIkt",
+    "usphone": "ˋvɜ:rdIkt"
+  },
+  {
+    "name": "judgment",
+    "trans": [
+      "23.24",
+      "n．判决",
+      "【记】 judg（判断）+ment"
+    ],
+    "ukphone": "ˋdʒʌdʒmənt",
+    "usphone": "ˋdʒʌdʒmənt"
+  },
+  {
+    "name": "indemnity",
+    "trans": [
+      "23.25",
+      "n．赔偿",
+      "【记】 in（不）+demn（损坏）+ity→使不再坏→赔偿"
+    ],
+    "ukphone": "Inˋdemnəti",
+    "usphone": "Inˋdemnəti"
+  },
+  {
+    "name": "imprisonment",
+    "trans": [
+      "23.26",
+      "n．监禁"
+    ],
+    "ukphone": "ImˋprIznmənt",
+    "usphone": "ImˋprIznmənt"
+  },
+  {
+    "name": "invalidate",
+    "trans": [
+      "23.27",
+      "vt．使作废（nullify）"
+    ],
+    "ukphone": "InˋvælIdeIt",
+    "usphone": "InˋvælIdeIt"
+  },
+  {
+    "name": "captivity",
+    "trans": [
+      "23.28",
+      "n．囚禁，拘留"
+    ],
+    "ukphone": "kæpˋtIvəti",
+    "usphone": "kæpˋtIvəti"
+  },
+  {
+    "name": "trial",
+    "trans": [
+      "23.29",
+      "n．审判（hearing, inquisition）"
+    ],
+    "ukphone": "ˋtraIəl",
+    "usphone": "ˋtraIəl"
+  },
+  {
+    "name": "detain",
+    "trans": [
+      "23.30",
+      "vt．拘留；阻止",
+      "【记】 de+tain（拿，抓）→拘留"
+    ],
+    "ukphone": "dIˋteIn",
+    "usphone": "dIˋteIn"
+  },
+  {
+    "name": "extenuate",
+    "trans": [
+      "23.31",
+      "vt．使（罪过等）显得轻微（diminish, lessen）",
+      "【记】 ex+tenu（细薄）+ate→使轻微"
+    ],
+    "ukphone": "IkˋstenjueIt",
+    "usphone": "IkˋstenjueIt"
+  },
+  {
+    "name": "saddle",
+    "trans": [
+      "23.32",
+      "vt．使负担（burden, load）"
+    ],
+    "ukphone": "ˋsædl",
+    "usphone": "ˋsædl"
+  },
+  {
+    "name": "court",
+    "trans": [
+      "23.33",
+      "n．法庭（bar）"
+    ],
+    "ukphone": "kɔ:rt",
+    "usphone": "kɔ:rt"
+  },
+  {
+    "name": "bar",
+    "trans": [
+      "23.34",
+      "n．法院（court）"
+    ],
+    "ukphone": "bα:r",
+    "usphone": "bα:r"
+  },
+  {
+    "name": "authorize",
+    "trans": [
+      "23.35",
+      "vt．授权（empower, permit）"
+    ],
+    "ukphone": "ˋɔ:θəraIz",
+    "usphone": "ˋɔ:θəraIz"
+  },
+  {
+    "name": "empower",
+    "trans": [
+      "23.36",
+      "vt．授权；使能够",
+      "【记】 em+power（权力）→获得权力"
+    ],
+    "ukphone": "Imˋpaʊər",
+    "usphone": "Imˋpaʊər"
+  },
+  {
+    "name": "plea",
+    "trans": [
+      "23.37",
+      "n．恳求（appeal）"
+    ],
+    "ukphone": "pli:",
+    "usphone": "pli:"
+  },
+  {
+    "name": "oath",
+    "trans": [
+      "23.38",
+      "n．誓言；誓约；宣誓（oath, pledge, promise）"
+    ],
+    "ukphone": "oʊθ",
+    "usphone": "oʊθ"
+  },
+  {
+    "name": "pledge",
+    "trans": [
+      "23.39",
+      "n．誓言 vt．使发誓（promise, vow）"
+    ],
+    "ukphone": "pledʒ",
+    "usphone": "pledʒ"
+  },
+  {
+    "name": "plaintiff",
+    "trans": [
+      "23.40",
+      "n．原告",
+      "【记】 plain（哀诉）+tiff"
+    ],
+    "ukphone": "ˋpleIntIf",
+    "usphone": "ˋpleIntIf"
+  },
+  {
+    "name": "plead",
+    "trans": [
+      "23.41",
+      "v．抗辩；恳求（argue, protest; beg）"
+    ],
+    "ukphone": "pli:d",
+    "usphone": "pli:d"
+  },
+  {
+    "name": "flee",
+    "trans": [
+      "23.42",
+      "v．逃跑，逃离（escape）"
+    ],
+    "ukphone": "fli:",
+    "usphone": "fli:"
+  },
+  {
+    "name": "defend",
+    "trans": [
+      "23.43",
+      "vt．辩护"
+    ],
+    "ukphone": "dIˋfend",
+    "usphone": "dIˋfend"
+  },
+  {
+    "name": "proscribe",
+    "trans": [
+      "23.44",
+      "vt．禁止（ban, forbid, forestall）",
+      "【记】 pro（前）+scribe（写）→写在前面→禁止"
+    ],
+    "ukphone": "proʊˋskraIb",
+    "usphone": "proʊˋskraIb"
+  },
+  {
+    "name": "forbid",
+    "trans": [
+      "23.45",
+      "vt．禁止（prohibit, prevent）",
+      "【记】 for（前）+bid（出价）→预先出价→阻止（别人）"
+    ],
+    "ukphone": "fərˋbId",
+    "usphone": "fərˋbId"
+  },
+  {
+    "name": "abstinence",
+    "trans": [
+      "23.46",
+      "n．禁戒；节制"
+    ],
+    "ukphone": "ˋæbstInəns",
+    "usphone": "ˋæbstInəns"
+  },
+  {
+    "name": "abstain",
+    "trans": [
+      "23.47",
+      "vi．戒绝",
+      "【记】 abs（不）+tain（拿住）→不拿住→放弃"
+    ],
+    "ukphone": "əbˋsteIn",
+    "usphone": "əbˋsteIn"
+  },
+  {
+    "name": "ban",
+    "trans": [
+      "23.48",
+      "n．禁令 vt．禁止（prohibit, forbid）"
+    ],
+    "ukphone": "bæn",
+    "usphone": "bæn"
+  },
+  {
+    "name": "veto",
+    "trans": [
+      "23.49",
+      "n．否决，否决权（rejection）vt．否决，禁止（negate）",
+      "【记】 比较vote（投票）"
+    ],
+    "ukphone": "ˋvi:toʊ",
+    "usphone": "ˋvi:toʊ"
+  },
+  {
+    "name": "revise",
+    "trans": [
+      "23.50",
+      "vt．修订（amend, emend, edit）",
+      "【记】 re（再）+vise（看）→重新审查"
+    ],
+    "ukphone": "rIˋvaIz",
+    "usphone": "rIˋvaIz"
+  },
+  {
+    "name": "verify",
+    "trans": [
+      "23.51",
+      "vt．验证（confirm, substantiate）"
+    ],
+    "ukphone": "ˋverIfaI",
+    "usphone": "ˋverIfaI"
+  },
+  {
+    "name": "deserve",
+    "trans": [
+      "23.52",
+      "vt．应得"
+    ],
+    "ukphone": "dIˋzɜ:rv",
+    "usphone": "dIˋzɜ:rv"
+  },
+  {
+    "name": "stipulate",
+    "trans": [
+      "23.53",
+      "vt．约定，规定（set, specify）"
+    ],
+    "ukphone": "ˋstIpjuleIt",
+    "usphone": "ˋstIpjuleIt"
+  },
+  {
+    "name": "testify",
+    "trans": [
+      "23.54",
+      "vt．证明，证实；作证（give evidence, verify）"
+    ],
+    "ukphone": "ˋtestIfaI",
+    "usphone": "ˋtestIfaI"
+  },
+  {
+    "name": "testimony",
+    "trans": [
+      "23.55",
+      "n．证言（evidence, affirmation）"
+    ],
+    "ukphone": "ˋtestImoʊni",
+    "usphone": "ˋtestImoʊni"
+  },
+  {
+    "name": "justify",
+    "trans": [
+      "23.56",
+      "vt．证明…是正当的（defend, vindicate）",
+      "【记】 just（公正的）+ify"
+    ],
+    "ukphone": "ˋdʒʌstIfaI",
+    "usphone": "ˋdʒʌstIfaI"
+  },
+  {
+    "name": "substantiate",
+    "trans": [
+      "23.57",
+      "vt．证实（corroborate, verify）"
+    ],
+    "ukphone": "səbˋstænʃieIt",
+    "usphone": "səbˋstænʃieIt"
+  },
+  {
+    "name": "confirm",
+    "trans": [
+      "23.58",
+      "vt．证实，确认（substantiate, verify）",
+      "【记】 con+firm（坚实的）"
+    ],
+    "ukphone": "kənˋfɜ:rm",
+    "usphone": "kənˋfɜ:rm"
+  },
+  {
+    "name": "affirm",
+    "trans": [
+      "23.59",
+      "vt．证实（assert）",
+      "【记】 af（一再）+firm（肯定）→断言"
+    ],
+    "ukphone": "əˋfɜ:rm",
+    "usphone": "əˋfɜ:rm"
+  },
+  {
+    "name": "assure",
+    "trans": [
+      "23.60",
+      "vt．使确信，向…保证（guarantee, pledge）",
+      "【记】 as+sure（确信）"
+    ],
+    "ukphone": "əˋʃʊr",
+    "usphone": "əˋʃʊr"
+  },
+  {
+    "name": "evidence",
+    "trans": [
+      "23.61",
+      "n．证据；证人"
+    ],
+    "ukphone": "ˋevIdəns",
+    "usphone": "ˋevIdəns"
+  },
+  {
+    "name": "follow",
+    "trans": [
+      "23.62",
+      "v．跟随，遵循（abide by, obey）"
+    ],
+    "ukphone": "ˋfα:loʊ",
+    "usphone": "ˋfα:loʊ"
+  },
+  {
+    "name": "observe",
+    "trans": [
+      "23.63",
+      "vt．遵守（follow）",
+      "【记】 TOEFL常考词义为“遵守”"
+    ],
+    "ukphone": "əbˋzɜ:rv",
+    "usphone": "əbˋzɜ:rv"
+  },
+  {
+    "name": "observance",
+    "trans": [
+      "23.64",
+      "n．遵守"
+    ],
+    "ukphone": "əbˋzɜ:rvəns",
+    "usphone": "əbˋzɜ:rvəns"
+  },
+  {
+    "name": "abide",
+    "trans": [
+      "23.65",
+      "vi．遵守（adhere, observe）",
+      "【记】 abide by（遵守）"
+    ],
+    "ukphone": "əˋbaId",
+    "usphone": "əˋbaId"
+  },
+  {
+    "name": "accuse",
+    "trans": [
+      "23.66",
+      "vt．控告；归咎（charge）"
+    ],
+    "ukphone": "əˋkju:z",
+    "usphone": "əˋkju:z"
+  },
+  {
+    "name": "accusation",
+    "trans": [
+      "23.67",
+      "n．控告"
+    ],
+    "ukphone": "ˌækjuˋzeIʃn",
+    "usphone": "ˌækjuˋzeIʃn"
+  },
+  {
+    "name": "complaint",
+    "trans": [
+      "23.68",
+      "n．控告；诉苦，抱怨"
+    ],
+    "ukphone": "kəmˋpleInt",
+    "usphone": "kəmˋpleInt"
+  },
+  {
+    "name": "impeach",
+    "trans": [
+      "23.69",
+      "vt．弹劾；控告（accuse）",
+      "【记】 im（进入）+peach（告发）"
+    ],
+    "ukphone": "Imˋpi:tʃ",
+    "usphone": "Imˋpi:tʃ"
+  },
+  {
+    "name": "indictment",
+    "trans": [
+      "23.70",
+      "n．起诉（charge, accusation）",
+      "【记】 in+dict（言，说）+ment→说出缘由→起诉"
+    ],
+    "ukphone": "InˋdaItmənt",
+    "usphone": "InˋdaItmənt"
+  },
+  {
+    "name": "incriminate",
+    "trans": [
+      "23.71",
+      "vt．控告（accuse）；使负罪",
+      "【记】 in（进入）+crimin（罪行）+ate→使负罪"
+    ],
+    "ukphone": "InˋkrImIneIt",
+    "usphone": "InˋkrImIneIt"
+  },
+  {
+    "name": "prosecute",
+    "trans": [
+      "23.72",
+      "v．起诉；检举（accuse, charge）"
+    ],
+    "ukphone": "ˋprα:sIkju:t",
+    "usphone": "ˋprα:sIkju:t"
+  },
+  {
+    "name": "denounce",
+    "trans": [
+      "23.73",
+      "vt．告发",
+      "【记】 de（坏）+nounce（讲话）→讲坏话→告发"
+    ],
+    "ukphone": "dIˋnaʊns",
+    "usphone": "dIˋnaʊns"
+  },
+  {
+    "name": "lawsuit",
+    "trans": [
+      "23.74",
+      "n．诉讼",
+      "【记】 law（法律）+suit（诉讼）"
+    ],
+    "ukphone": "ˋlɔ:sju:t",
+    "usphone": "ˋlɔ:sju:t"
+  },
+  {
+    "name": "query",
+    "trans": [
+      "23.75",
+      "n．质问，问题 v．询问（inquiry）"
+    ],
+    "ukphone": "ˋkwIri",
+    "usphone": "ˋkwIri"
+  },
+  {
+    "name": "interrogate",
+    "trans": [
+      "23.76",
+      "vt．审问；询问",
+      "【记】 inter（中间）+rog（问）+ate→审问"
+    ],
+    "ukphone": "InˋterəgeIt",
+    "usphone": "InˋterəgeIt"
+  },
+  {
+    "name": "impunity",
+    "trans": [
+      "23.77",
+      "n．免罚（let-off）",
+      "【记】 im（不）+pun（罚）+ity"
+    ],
+    "ukphone": "Imˋpju:nəti",
+    "usphone": "Imˋpju:nəti"
+  },
+  {
+    "name": "exempt",
+    "trans": [
+      "23.78",
+      "vt．免除（prevent, immune）adj．被免除的（excused）"
+    ],
+    "ukphone": "Igˋzempt",
+    "usphone": "Igˋzempt"
+  },
+  {
+    "name": "condone",
+    "trans": [
+      "23.79",
+      "vt．宽恕，赦免（forgive, pardon）"
+    ],
+    "ukphone": "kənˋdoʊn",
+    "usphone": "kənˋdoʊn"
+  },
+  {
+    "name": "liberate",
+    "trans": [
+      "23.80",
+      "vt．释放（discharge, release）",
+      "【记】 liber（自由）+ate→使…自由，解放"
+    ],
+    "ukphone": "ˋlIbəreIt",
+    "usphone": "ˋlIbəreIt"
+  },
+  {
+    "name": "remit",
+    "trans": [
+      "23.81",
+      "vt．赦免",
+      "【记】 re（再）+mit（送）→再送出去→汇款"
+    ],
+    "ukphone": "ˋri:mIt",
+    "usphone": "ˋri:mIt"
+  },
+  {
+    "name": "release",
+    "trans": [
+      "23.82",
+      "n．释放，让渡，豁免"
+    ],
+    "ukphone": "rIˋli:s",
+    "usphone": "rIˋli:s"
+  },
+  {
+    "name": "absolve",
+    "trans": [
+      "23.83",
+      "vt．赦免；解除（责任等）（free, emancipate）",
+      "【记】 ab+solve（解决）→解除责任→赦免"
+    ],
+    "ukphone": "əbˋzα:lv",
+    "usphone": "əbˋzα:lv"
+  },
+  {
+    "name": "acquit",
+    "trans": [
+      "23.84",
+      "vt．宣告无罪（exonerate, vindicate）",
+      "【记】 ac+quit（免除）→开释"
+    ],
+    "ukphone": "əˋkwIt",
+    "usphone": "əˋkwIt"
+  },
+  {
+    "name": "abolish",
+    "trans": [
+      "23.85",
+      "vt．废除，取消（abandon, annul, terminate）",
+      "【记】 abolis（消失）+h→废除"
+    ],
+    "ukphone": "əˋbα:lIʃ",
+    "usphone": "əˋbα:lIʃ"
+  },
+  {
+    "name": "term",
+    "trans": [
+      "23.86",
+      "n．条款"
+    ],
+    "ukphone": "tɜ:rm",
+    "usphone": "tɜ:rm"
+  },
+  {
+    "name": "clause",
+    "trans": [
+      "23.87",
+      "n．条款"
+    ],
+    "ukphone": "klɔ:z",
+    "usphone": "klɔ:z"
+  },
+  {
+    "name": "bill",
+    "trans": [
+      "23.88",
+      "n．法案"
+    ],
+    "ukphone": "bIl",
+    "usphone": "bIl"
+  },
+  {
+    "name": "constitution",
+    "trans": [
+      "23.89",
+      "n．宪法"
+    ],
+    "ukphone": "ˌkα:nstəˋtju:ʃn",
+    "usphone": "ˌkα:nstəˋtju:ʃn"
+  },
+  {
+    "name": "decree",
+    "trans": [
+      "23.90",
+      "n．法令，规定（regulation, order）v．颁布"
+    ],
+    "ukphone": "dIˋkri:",
+    "usphone": "dIˋkri:"
+  },
+  {
+    "name": "legislate",
+    "trans": [
+      "23.91",
+      "vi．立法（make law）",
+      "【记】 legis（法律）+late(放)→放出法律→立法"
+    ],
+    "ukphone": "ˋledʒIsleIt",
+    "usphone": "ˋledʒIsleIt"
+  },
+  {
+    "name": "legislation",
+    "trans": [
+      "23.92",
+      "n．立法，法律的制定（或通过）"
+    ],
+    "ukphone": "ˌledʒIsˋleIʃn",
+    "usphone": "ˌledʒIsˋleIʃn"
+  },
+  {
+    "name": "legalize",
+    "trans": [
+      "23.93",
+      "vt．合法化，法律认可（authorize, legitimate）"
+    ],
+    "ukphone": "ˋli:gəlaIz",
+    "usphone": "ˋli:gəlaIz"
+  },
+  {
+    "name": "prescribe",
+    "trans": [
+      "23.94",
+      "v．指示，规定（dictate）"
+    ],
+    "ukphone": "prIˋskraIb",
+    "usphone": "prIˋskraIb"
+  },
+  {
+    "name": "set",
+    "trans": [
+      "23.95",
+      "vt．规定"
+    ],
+    "ukphone": "set",
+    "usphone": "set"
+  },
+  {
+    "name": "credential",
+    "trans": [
+      "23.96",
+      "n．凭证（reference, certificate）",
+      "【记】 cred（相信）+ential"
+    ],
+    "ukphone": "krəˋdenʃl",
+    "usphone": "krəˋdenʃl"
+  },
+  {
+    "name": "standard",
+    "trans": [
+      "23.97",
+      "n．标准，规格（criteria）adj．标准的（regular）"
+    ],
+    "ukphone": "ˋstændərd",
+    "usphone": "ˋstændərd"
+  },
+  {
+    "name": "enact",
+    "trans": [
+      "23.98",
+      "vt．制定（法律）（impersonate）",
+      "【记】 en+act（扮演）"
+    ],
+    "ukphone": "Iˋnækt",
+    "usphone": "Iˋnækt"
+  },
+  {
+    "name": "confidential",
+    "trans": [
+      "24.1",
+      "adj．机密的",
+      "【记】 confident+ial→相信的人才知道→机密的"
+    ],
+    "ukphone": "ˌkα:nfIˋdenʃl",
+    "usphone": "ˌkα:nfIˋdenʃl"
+  },
+  {
+    "name": "clandestine",
+    "trans": [
+      "24.2",
+      "adj．秘密的（secret, covert）",
+      "【记】 分割记忆clan（宗派）+destine（注定）"
+    ],
+    "ukphone": "klænˋdestIn",
+    "usphone": "klænˋdestIn"
+  },
+  {
+    "name": "cipher",
+    "trans": [
+      "24.3",
+      "n．暗号；密码（code）",
+      "【记】 比较记忆decipher（解码）"
+    ],
+    "ukphone": "ˋsaIfər",
+    "usphone": "ˋsaIfər"
+  },
+  {
+    "name": "dissimulate",
+    "trans": [
+      "24.4",
+      "vt．假装，掩饰（disguise, dissemble）",
+      "【记】 比较simulate（模仿）"
+    ],
+    "ukphone": "dIˋsImjuleIt",
+    "usphone": "dIˋsImjuleIt"
+  },
+  {
+    "name": "disarm",
+    "trans": [
+      "24.5",
+      "vt．缴械；消除（敌意）",
+      "【记】 dis（不再）+arm=army（军队）"
+    ],
+    "ukphone": "dIsˋα:rm",
+    "usphone": "dIsˋα:rm"
+  },
+  {
+    "name": "disarming",
+    "trans": [
+      "24.6",
+      "adj．消除敌意的（relieving, soothing）"
+    ],
+    "ukphone": "dIsˋα:rmIŋ",
+    "usphone": "dIsˋα:rmIŋ"
+  },
+  {
+    "name": "scout",
+    "trans": [
+      "24.7",
+      "v．侦察"
+    ],
+    "ukphone": "skaʊt",
+    "usphone": "skaʊt"
+  },
+  {
+    "name": "fort",
+    "trans": [
+      "24.8",
+      "n．要塞，堡垒"
+    ],
+    "ukphone": "fɔ:rt",
+    "usphone": "fɔ:rt"
+  },
+  {
+    "name": "fortress",
+    "trans": [
+      "24.9",
+      "n．堡垒，要塞"
+    ],
+    "ukphone": "ˋfɔ:rtrəs",
+    "usphone": "ˋfɔ:rtrəs"
+  },
+  {
+    "name": "hatchet",
+    "trans": [
+      "24.10",
+      "n．短柄斧"
+    ],
+    "ukphone": "ˋhætʃIt",
+    "usphone": "ˋhætʃIt"
+  },
+  {
+    "name": "dagger",
+    "trans": [
+      "24.11",
+      "n．短剑"
+    ],
+    "ukphone": "ˋdægər",
+    "usphone": "ˋdægər"
+  },
+  {
+    "name": "armor",
+    "trans": [
+      "24.12",
+      "n．装甲，武器"
+    ],
+    "ukphone": "ˋα:rmər",
+    "usphone": "ˋα:rmər"
+  },
+  {
+    "name": "corps",
+    "trans": [
+      "24.13",
+      "n．军团，兵团"
+    ],
+    "ukphone": "kɔ:rz",
+    "usphone": "kɔ:rz"
+  },
+  {
+    "name": "armament",
+    "trans": [
+      "24.14",
+      "n．兵力，军力（arms, munitions）",
+      "【记】 arma（军队）+ment"
+    ],
+    "ukphone": "ˋα:rməmənt",
+    "usphone": "ˋα:rməmənt"
+  },
+  {
+    "name": "enlist",
+    "trans": [
+      "24.15",
+      "vt．征召，招募（enroll）",
+      "【记】 en+list（列入名单）"
+    ],
+    "ukphone": "InˋlIst",
+    "usphone": "InˋlIst"
+  },
+  {
+    "name": "recruit",
+    "trans": [
+      "24.16",
+      "vt．征兵，征募（enlist, enroll）"
+    ],
+    "ukphone": "rIˋkru:t",
+    "usphone": "rIˋkru:t"
+  },
+  {
+    "name": "array",
+    "trans": [
+      "24.17",
+      "n．队列，排列（order, display）"
+    ],
+    "ukphone": "əˋreI",
+    "usphone": "əˋreI"
+  },
+  {
+    "name": "squad",
+    "trans": [
+      "24.18",
+      "n．小队；班"
+    ],
+    "ukphone": "skwα:d",
+    "usphone": "skwα:d"
+  },
+  {
+    "name": "raid",
+    "trans": [
+      "24.19",
+      "n./v．袭击（attack, foray）"
+    ],
+    "ukphone": "reId",
+    "usphone": "reId"
+  },
+  {
+    "name": "charge",
+    "trans": [
+      "24.20",
+      "v．猛攻（attack）"
+    ],
+    "ukphone": "tʃα:rdʒ",
+    "usphone": "tʃα:rdʒ"
+  },
+  {
+    "name": "encroach",
+    "trans": [
+      "24.21",
+      "vi．蚕食，侵占（intrude, trespass）",
+      "【记】 比较crochet（钩）"
+    ],
+    "ukphone": "Inˋkroʊtʃ",
+    "usphone": "Inˋkroʊtʃ"
+  },
+  {
+    "name": "despoil",
+    "trans": [
+      "24.22",
+      "vt．夺取"
+    ],
+    "ukphone": "dIˋspɔIl",
+    "usphone": "dIˋspɔIl"
+  },
+  {
+    "name": "invade",
+    "trans": [
+      "24.23",
+      "vt．侵入，侵略，侵犯（intrude, agress）"
+    ],
+    "ukphone": "InˋveId",
+    "usphone": "InˋveId"
+  },
+  {
+    "name": "assault",
+    "trans": [
+      "24.24",
+      "vt．袭击 n．攻击（attack, assail）"
+    ],
+    "ukphone": "əˋsɔ:lt",
+    "usphone": "əˋsɔ:lt"
+  },
+  {
+    "name": "exterminate",
+    "trans": [
+      "24.25",
+      "vt．消灭（eradicate, eliminate）",
+      "【记】 ex+termin（范围）+ate→清除出范围→消灭"
+    ],
+    "ukphone": "Ikˋstɜ:rmIneIt",
+    "usphone": "Ikˋstɜ:rmIneIt"
+  },
+  {
+    "name": "extinguish",
+    "trans": [
+      "24.26",
+      "vt．消灭（exterminate）"
+    ],
+    "ukphone": "IkˋstIŋgwIʃ",
+    "usphone": "IkˋstIŋgwIʃ"
+  },
+  {
+    "name": "absorb",
+    "trans": [
+      "24.27",
+      "vt．并吞",
+      "【记】 ab+sorb（吸）"
+    ],
+    "ukphone": "əbˋzɔ:rb",
+    "usphone": "əbˋzɔ:rb"
+  },
+  {
+    "name": "onset",
+    "trans": [
+      "24.28",
+      "n．攻击（attack）",
+      "【记】 来自set on（攻击）"
+    ],
+    "ukphone": "ˋα:nset",
+    "usphone": "ˋα:nset"
+  },
+  {
+    "name": "repulse",
+    "trans": [
+      "24.29",
+      "vt．击退（repel）",
+      "【记】 re（反）+pulse（推）→排斥"
+    ],
+    "ukphone": "rIˋpʌls",
+    "usphone": "rIˋpʌls"
+  },
+  {
+    "name": "expedition",
+    "trans": [
+      "24.30",
+      "n．远征（exploration）",
+      "【记】 ex+ped（脚）+ition→脚出动→远征"
+    ],
+    "ukphone": "ˌekspəˋdIʃn",
+    "usphone": "ˌekspəˋdIʃn"
+  },
+  {
+    "name": "siege",
+    "trans": [
+      "24.31",
+      "n./vt．围困，围攻（besiege, encircle）"
+    ],
+    "ukphone": "si:dʒ",
+    "usphone": "si:dʒ"
+  },
+  {
+    "name": "envelop",
+    "trans": [
+      "24.32",
+      "vt．包围（besiege, enclose）"
+    ],
+    "ukphone": "Inˋveləp",
+    "usphone": "Inˋveləp"
+  },
+  {
+    "name": "beset",
+    "trans": [
+      "24.33",
+      "vt．包围（besiege, surround）"
+    ],
+    "ukphone": "bIˋset",
+    "usphone": "bIˋset"
+  },
+  {
+    "name": "besiege",
+    "trans": [
+      "24.34",
+      "vt．围（enclose）",
+      "【记】 be+siege（围攻）"
+    ],
+    "ukphone": "bIˋsi:dʒ",
+    "usphone": "bIˋsi:dʒ"
+  },
+  {
+    "name": "morale",
+    "trans": [
+      "24.35",
+      "n．民心；士气",
+      "【记】 比较moral（道德）"
+    ],
+    "ukphone": "məˋræl",
+    "usphone": "məˋræl"
+  },
+  {
+    "name": "mandate",
+    "trans": [
+      "24.36",
+      "n．命令；要求（command）",
+      "【记】 mand（命令）+ate"
+    ],
+    "ukphone": "ˋmændeIt",
+    "usphone": "ˋmændeIt"
+  },
+  {
+    "name": "tactics",
+    "trans": [
+      "24.37",
+      "n．战术",
+      "【记】 tact（机智）+ics"
+    ],
+    "ukphone": "ˋtæktIks",
+    "usphone": "ˋtæktIks"
+  },
+  {
+    "name": "naval",
+    "trans": [
+      "24.38",
+      "adj．海军的",
+      "【记】 比较navy（海军）"
+    ],
+    "ukphone": "ˋneIvl",
+    "usphone": "ˋneIvl"
+  },
+  {
+    "name": "military",
+    "trans": [
+      "24.39",
+      "adj．军事的，军用的"
+    ],
+    "ukphone": "ˋmIləteri",
+    "usphone": "ˋmIləteri"
+  },
+  {
+    "name": "contagious",
+    "trans": [
+      "25.1",
+      "adj．传染的（catching, infectious）",
+      "【记】 con+tag（接触）+ious"
+    ],
+    "ukphone": "kənˋteIdʒəs",
+    "usphone": "kənˋteIdʒəs"
+  },
+  {
+    "name": "catching",
+    "trans": [
+      "25.2",
+      "adj．传染的（contagious, infectious）；迷人的",
+      "【记】 catch（抓）+ing→心被抓住→迷人的"
+    ],
+    "ukphone": "ˋkætʃIŋ",
+    "usphone": "ˋkætʃIŋ"
+  },
+  {
+    "name": "infect",
+    "trans": [
+      "25.3",
+      "vt．传染，感染（spread, affect）",
+      "【记】 in（进入）+fect（做）→做进去→传染进去"
+    ],
+    "ukphone": "Inˋfekt",
+    "usphone": "Inˋfekt"
+  },
+  {
+    "name": "infectious",
+    "trans": [
+      "25.4",
+      "adj．传染的，感染性的（contagious）",
+      "【记】 infect（传染）+ious"
+    ],
+    "ukphone": "Inˋfekʃəs",
+    "usphone": "Inˋfekʃəs"
+  },
+  {
+    "name": "contract",
+    "trans": [
+      "25.5",
+      "vt．感染（infect）"
+    ],
+    "ukphone": "ˋkα:ntrækt",
+    "usphone": "ˋkα:ntrækt"
+  },
+  {
+    "name": "acute",
+    "trans": [
+      "25.6",
+      "adj．急性的"
+    ],
+    "ukphone": "əˋkju:t",
+    "usphone": "əˋkju:t"
+  },
+  {
+    "name": "feverish",
+    "trans": [
+      "25.7",
+      "adj．发烧的",
+      "【记】 fever（发烧）+ish"
+    ],
+    "ukphone": "ˋfi:vərIʃ",
+    "usphone": "ˋfi:vərIʃ"
+  },
+  {
+    "name": "invalid",
+    "trans": [
+      "25.8",
+      "adj．有病的"
+    ],
+    "ukphone": "InˋvælId",
+    "usphone": "InˋvælId"
+  },
+  {
+    "name": "morbid",
+    "trans": [
+      "25.9",
+      "adj．病态的，不健康的（sick, diseased）",
+      "【记】 morb（病）+id→疾病的"
+    ],
+    "ukphone": "ˋmɔ:rbId",
+    "usphone": "ˋmɔ:rbId"
+  },
+  {
+    "name": "numb",
+    "trans": [
+      "25.10",
+      "adj．麻木的（senseless, dead）"
+    ],
+    "ukphone": "nʌm",
+    "usphone": "nʌm"
+  },
+  {
+    "name": "unconscious",
+    "trans": [
+      "25.11",
+      "adj．失去知觉的；不察觉的"
+    ],
+    "ukphone": "ʌnˋkα:nʃəs",
+    "usphone": "ʌnˋkα:nʃəs"
+  },
+  {
+    "name": "fragile",
+    "trans": [
+      "25.12",
+      "adj．体质弱的",
+      "【记】 frag（碎）+ile→易碎的"
+    ],
+    "ukphone": "ˋfrædʒl",
+    "usphone": "ˋfrædʒl"
+  },
+  {
+    "name": "susceptible",
+    "trans": [
+      "25.13",
+      "adj．易受感染的（vulnerable, exposed）",
+      "【记】 sus（下面）+cept（接受）+ible→接受的→受感染的"
+    ],
+    "ukphone": "səˋseptəbl",
+    "usphone": "səˋseptəbl"
+  },
+  {
+    "name": "malady",
+    "trans": [
+      "25.14",
+      "n．疾病",
+      "【记】 mal（坏）+ady→坏的东西→疾病"
+    ],
+    "ukphone": "ˋmælədi",
+    "usphone": "ˋmælədi"
+  },
+  {
+    "name": "corpse",
+    "trans": [
+      "25.15",
+      "n．尸体"
+    ],
+    "ukphone": "kɔ:rps",
+    "usphone": "kɔ:rps"
+  },
+  {
+    "name": "gash",
+    "trans": [
+      "25.16",
+      "n．深的切口",
+      "【记】 比较gush（喷涌而出）"
+    ],
+    "ukphone": "gæʃ",
+    "usphone": "gæʃ"
+  },
+  {
+    "name": "symptom",
+    "trans": [
+      "25.17",
+      "n．症状，征候，征兆（sign, indication）"
+    ],
+    "ukphone": "ˋsImptəm",
+    "usphone": "ˋsImptəm"
+  },
+  {
+    "name": "fracture",
+    "trans": [
+      "25.18",
+      "n./v．骨折（crack）",
+      "【记】 fract（碎裂）+ure→断的状态→骨折"
+    ],
+    "ukphone": "ˋfræktʃər",
+    "usphone": "ˋfræktʃər"
+  },
+  {
+    "name": "bleed",
+    "trans": [
+      "25.19",
+      "v．流血"
+    ],
+    "ukphone": "bli:d",
+    "usphone": "bli:d"
+  },
+  {
+    "name": "tingle",
+    "trans": [
+      "25.20",
+      "vi．刺痛"
+    ],
+    "ukphone": "ˋtIŋgl",
+    "usphone": "ˋtIŋgl"
+  },
+  {
+    "name": "recur",
+    "trans": [
+      "25.21",
+      "vi．复发，重来（repeat, return）"
+    ],
+    "ukphone": "rIˋkɜ:r",
+    "usphone": "rIˋkɜ:r"
+  },
+  {
+    "name": "relapse",
+    "trans": [
+      "25.22",
+      "vi．复发；回复（recur）",
+      "【记】 re（重新）+lapse（错误）→再犯错误→复发"
+    ],
+    "ukphone": "rIˋlæps",
+    "usphone": "rIˋlæps"
+  },
+  {
+    "name": "bruise",
+    "trans": [
+      "25.23",
+      "vt．打伤 n．瘀伤"
+    ],
+    "ukphone": "bru:z",
+    "usphone": "bru:z"
+  },
+  {
+    "name": "fester",
+    "trans": [
+      "25.24",
+      "vt．使化脓（decay）"
+    ],
+    "ukphone": "ˋfestər",
+    "usphone": "ˋfestər"
+  },
+  {
+    "name": "intoxicate",
+    "trans": [
+      "25.25",
+      "vt．使中毒",
+      "【记】 in（进入）+toxic（毒）+ate→进入毒→使中毒"
+    ],
+    "ukphone": "Inˋtα:ksIkeIt",
+    "usphone": "Inˋtα:ksIkeIt"
+  },
+  {
+    "name": "survive",
+    "trans": [
+      "25.26",
+      "vt．幸免于… vi．活下来（outlive, remain）"
+    ],
+    "ukphone": "sərˋvaIv",
+    "usphone": "sərˋvaIv"
+  },
+  {
+    "name": "diagnose",
+    "trans": [
+      "25.27",
+      "vt．诊断，分析（analyze）"
+    ],
+    "ukphone": "ˌdaIəgˋnoʊs",
+    "usphone": "ˌdaIəgˋnoʊs"
+  },
+  {
+    "name": "diagnosis",
+    "trans": [
+      "25.28",
+      "n．诊断",
+      "【记】 dia（穿过）+gnos（知道）+is→穿过（身体）知道→诊断"
+    ],
+    "ukphone": "ˌdaIəgˋnoʊsIs",
+    "usphone": "ˌdaIəgˋnoʊsIs"
+  },
+  {
+    "name": "inject",
+    "trans": [
+      "25.29",
+      "vt．注射；注入（infuse）",
+      "【记】 in（进）+ject（扔）→扔进去→注射"
+    ],
+    "ukphone": "Inˋdʒekt",
+    "usphone": "Inˋdʒekt"
+  },
+  {
+    "name": "heal",
+    "trans": [
+      "25.30",
+      "v．治愈，（使）和解 n．痊愈（cure, recover）"
+    ],
+    "ukphone": "hi:l",
+    "usphone": "hi:l"
+  },
+  {
+    "name": "remedy",
+    "trans": [
+      "25.31",
+      "n．治疗法，药物 vt．治疗（cure, rectify）"
+    ],
+    "ukphone": "ˋremədi",
+    "usphone": "ˋremədi"
+  },
+  {
+    "name": "treatment",
+    "trans": [
+      "25.32",
+      "n．治疗"
+    ],
+    "ukphone": "ˋtri:tmənt",
+    "usphone": "ˋtri:tmənt"
+  },
+  {
+    "name": "prescription",
+    "trans": [
+      "25.33",
+      "n．药方"
+    ],
+    "ukphone": "prIˋskrIpʃn",
+    "usphone": "prIˋskrIpʃn"
+  },
+  {
+    "name": "dissect",
+    "trans": [
+      "25.34",
+      "vt．解剖",
+      "【记】 dis+sect（部分）→去除部分→解剖"
+    ],
+    "ukphone": "dIˋsekt",
+    "usphone": "dIˋsekt"
+  },
+  {
+    "name": "sterile",
+    "trans": [
+      "25.35",
+      "adj．消过毒的（sanitary）"
+    ],
+    "ukphone": "ˋsterəl",
+    "usphone": "ˋsterəl"
+  },
+  {
+    "name": "clinic",
+    "trans": [
+      "25.36",
+      "n．门诊所"
+    ],
+    "ukphone": "ˋklInIk",
+    "usphone": "ˋklInIk"
+  },
+  {
+    "name": "anatomy",
+    "trans": [
+      "25.37",
+      "n．剖析；解剖学"
+    ],
+    "ukphone": "əˋnætəmi",
+    "usphone": "əˋnætəmi"
+  },
+  {
+    "name": "healthful",
+    "trans": [
+      "25.38",
+      "adj．有益健康的（wholesome）"
+    ],
+    "ukphone": "ˋhelθfl",
+    "usphone": "ˋhelθfl"
+  },
+  {
+    "name": "condition",
+    "trans": [
+      "25.39",
+      "n．健康情形（circumstance）"
+    ],
+    "ukphone": "kənˋdIʃn",
+    "usphone": "kənˋdIʃn"
+  },
+  {
+    "name": "hygiene",
+    "trans": [
+      "25.40",
+      "n．卫生（sanitation）"
+    ],
+    "ukphone": "ˋhaIdʒi:n",
+    "usphone": "ˋhaIdʒi:n"
+  },
+  {
+    "name": "sanitation",
+    "trans": [
+      "25.41",
+      "n．卫生；卫生设施"
+    ],
+    "ukphone": "ˌsænIˋteIʃn",
+    "usphone": "ˌsænIˋteIʃn"
+  },
+  {
+    "name": "physical",
+    "trans": [
+      "25.42",
+      "adj．身体的；物质的"
+    ],
+    "ukphone": "ˋfIzIkl",
+    "usphone": "ˋfIzIkl"
+  },
+  {
+    "name": "sustenance",
+    "trans": [
+      "25.43",
+      "n．营养物"
+    ],
+    "ukphone": "ˋsʌstənəns",
+    "usphone": "ˋsʌstənəns"
+  },
+  {
+    "name": "malnourished",
+    "trans": [
+      "25.44",
+      "adj．营养失调的，营养不良的"
+    ],
+    "ukphone": "ˌmælˋnɜ:rIʃt",
+    "usphone": "ˌmælˋnɜ:rIʃt"
+  },
+  {
+    "name": "nutrition",
+    "trans": [
+      "25.45",
+      "n．营养；营养学"
+    ],
+    "ukphone": "njuˋtrIʃn",
+    "usphone": "njuˋtrIʃn"
+  },
+  {
+    "name": "mental",
+    "trans": [
+      "25.46",
+      "adj．精神的，智力的"
+    ],
+    "ukphone": "ˋmentl",
+    "usphone": "ˋmentl"
+  },
+  {
+    "name": "spiritual",
+    "trans": [
+      "25.47",
+      "adj．心灵的"
+    ],
+    "ukphone": "ˋspIrItʃuəl",
+    "usphone": "ˋspIrItʃuəl"
+  },
+  {
+    "name": "subject",
+    "trans": [
+      "25.48",
+      "n．试验对象"
+    ],
+    "ukphone": "ˋsʌbdʒIkt",
+    "usphone": "ˋsʌbdʒIkt"
+  },
+  {
+    "name": "aerobic",
+    "trans": [
+      "25.49",
+      "adj．需氧的；有氧健身法的"
+    ],
+    "ukphone": "eˋroʊbIk",
+    "usphone": "eˋroʊbIk"
+  },
+  {
+    "name": "inoculation",
+    "trans": [
+      "25.50",
+      "n．接种；接木"
+    ],
+    "ukphone": "Iˌnα:kjuˋleIʃn",
+    "usphone": "Iˌnα:kjuˋleIʃn"
+  },
+  {
+    "name": "blessed",
+    "trans": [
+      "26.1",
+      "adj．受祝福的"
+    ],
+    "ukphone": "ˋblesId",
+    "usphone": "ˋblesId"
+  },
+  {
+    "name": "invocation",
+    "trans": [
+      "26.2",
+      "n．祈祷（plea, prayer）"
+    ],
+    "ukphone": "ˌInvəˋkeIʃn",
+    "usphone": "ˌInvəˋkeIʃn"
+  },
+  {
+    "name": "pious",
+    "trans": [
+      "26.3",
+      "adj．虔诚的（loyal, faithful）"
+    ],
+    "ukphone": "ˋpaIəs",
+    "usphone": "ˋpaIəs"
+  },
+  {
+    "name": "devout",
+    "trans": [
+      "26.4",
+      "adj．虔诚的（pious, religious）"
+    ],
+    "ukphone": "dIˋvaʊt",
+    "usphone": "dIˋvaʊt"
+  },
+  {
+    "name": "cult",
+    "trans": [
+      "26.5",
+      "n．崇拜(常用于修饰另一个名词)；宗教教派"
+    ],
+    "ukphone": "kʌlt",
+    "usphone": "kʌlt"
+  },
+  {
+    "name": "consecrate",
+    "trans": [
+      "26.6",
+      "vt．奉为神圣；奉献（dedicate, devote）",
+      "【记】 比较sacred（神圣的）"
+    ],
+    "ukphone": "ˋkα:nsIkreIt",
+    "usphone": "ˋkα:nsIkreIt"
+  },
+  {
+    "name": "creed",
+    "trans": [
+      "26.7",
+      "n．信仰，信条（belief, faith）"
+    ],
+    "ukphone": "kri:d",
+    "usphone": "kri:d"
+  },
+  {
+    "name": "doomed",
+    "trans": [
+      "26.8",
+      "adj．命定的，注定失败的"
+    ],
+    "ukphone": "du:md",
+    "usphone": "du:md"
+  },
+  {
+    "name": "destine",
+    "trans": [
+      "26.9",
+      "vt．命运注定"
+    ],
+    "ukphone": "ˋdestIn",
+    "usphone": "ˋdestIn"
+  },
+  {
+    "name": "destiny",
+    "trans": [
+      "26.10",
+      "n．命运（fate）"
+    ],
+    "ukphone": "ˋdestəni",
+    "usphone": "ˋdestəni"
+  },
+  {
+    "name": "fatalism",
+    "trans": [
+      "26.11",
+      "n．宿命论",
+      "【记】 fat=fate（命运）+alism→宿命论"
+    ],
+    "ukphone": "ˋfeItəlIzəm",
+    "usphone": "ˋfeItəlIzəm"
+  },
+  {
+    "name": "sacred",
+    "trans": [
+      "26.12",
+      "adj．上帝的；神圣的（holy, heavenly）"
+    ],
+    "ukphone": "ˋseIkrId",
+    "usphone": "ˋseIkrId"
+  },
+  {
+    "name": "Christian",
+    "trans": [
+      "26.13",
+      "n．基督教徒 adj．基督教的"
+    ],
+    "ukphone": "ˋkrIstʃən",
+    "usphone": "ˋkrIstʃən"
+  },
+  {
+    "name": "doctrine",
+    "trans": [
+      "26.14",
+      "n．教义（dogma）"
+    ],
+    "ukphone": "ˋdα:ktrIn",
+    "usphone": "ˋdα:ktrIn"
+  },
+  {
+    "name": "dogma",
+    "trans": [
+      "26.15",
+      "n．教义，教条（belief, view）"
+    ],
+    "ukphone": "ˋdɔ:gmə",
+    "usphone": "ˋdɔ:gmə"
+  },
+  {
+    "name": "rite",
+    "trans": [
+      "26.16",
+      "n．宗教仪式（ritual, procedure, ceremony）"
+    ],
+    "ukphone": "raIt",
+    "usphone": "raIt"
+  },
+  {
+    "name": "religion",
+    "trans": [
+      "26.17",
+      "n．宗教"
+    ],
+    "ukphone": "rIˋlIdʒən",
+    "usphone": "rIˋlIdʒən"
+  },
+  {
+    "name": "deity",
+    "trans": [
+      "26.18",
+      "宗 教"
+    ],
+    "ukphone": "ˋdeIəti",
+    "usphone": "ˋdeIəti"
+  },
+  {
+    "name": "oracle",
+    "trans": [
+      "26.19",
+      "n．神谕",
+      "【记】 ora（嘴）+cle→神的嘴巴"
+    ],
+    "ukphone": "ˋɔ:rəkl",
+    "usphone": "ˋɔ:rəkl"
+  },
+  {
+    "name": "atheism",
+    "trans": [
+      "26.20",
+      "n．无神论",
+      "【记】 a（无）+the（神）+ism→无神论"
+    ],
+    "ukphone": "ˋeIθiIzəm",
+    "usphone": "ˋeIθiIzəm"
+  },
+  {
+    "name": "heresy",
+    "trans": [
+      "26.21",
+      "n．异端；邪说",
+      "【记】 here（异）+sy→异端"
+    ],
+    "ukphone": "ˋherəsi",
+    "usphone": "ˋherəsi"
+  },
+  {
+    "name": "immerse",
+    "trans": [
+      "26.22",
+      "vt．给…施洗礼（indulge）",
+      "【记】 im（进）+merse（沉）→沉进去→沉浸→给…施洗礼"
+    ],
+    "ukphone": "Iˋmɜ:rs",
+    "usphone": "Iˋmɜ:rs"
+  },
+  {
+    "name": "invoke",
+    "trans": [
+      "26.23",
+      "vt．恳求，祈求（beg, pray）",
+      "【记】 in+voke（喊）→恳求"
+    ],
+    "ukphone": "Inˋvoʊk",
+    "usphone": "Inˋvoʊk"
+  },
+  {
+    "name": "enchant",
+    "trans": [
+      "26.24",
+      "vt．施魔法于（enthrall, fascinate）",
+      "【记】 en+chant（歌曲）→施魔曲→施魔法于"
+    ],
+    "ukphone": "Inˋtʃænt",
+    "usphone": "Inˋtʃænt"
+  },
+  {
+    "name": "preach",
+    "trans": [
+      "26.25",
+      "vt．说教，布道；鼓吹（advocate, advise）",
+      "【记】 联想reach（到达）"
+    ],
+    "ukphone": "pri:tʃ",
+    "usphone": "pri:tʃ"
+  },
+  {
+    "name": "exodus",
+    "trans": [
+      "26.26",
+      "n．大批离去"
+    ],
+    "ukphone": "ˋeksədəs",
+    "usphone": "ˋeksədəs"
+  },
+  {
+    "name": "rank",
+    "trans": [
+      "27.1",
+      "v．排序，排行 n．等级"
+    ],
+    "ukphone": "ræŋk",
+    "usphone": "ræŋk"
+  },
+  {
+    "name": "discrete",
+    "trans": [
+      "27.2",
+      "adj．不连续的；离散的（separate）"
+    ],
+    "ukphone": "dIˋskri:t",
+    "usphone": "dIˋskri:t"
+  },
+  {
+    "name": "symmetry",
+    "trans": [
+      "27.3",
+      "n．对称（性），匀称（balance, harmony）",
+      "【记】 sym（共同）+metry（测量）→两边测量一样→对称"
+    ],
+    "ukphone": "ˋsImətri",
+    "usphone": "ˋsImətri"
+  },
+  {
+    "name": "sequence",
+    "trans": [
+      "27.4",
+      "n．序列（procession, progression）",
+      "【记】 sequ（跟随）+ence→跟随着→序列"
+    ],
+    "ukphone": "ˋsi:kwəns",
+    "usphone": "ˋsi:kwəns"
+  },
+  {
+    "name": "dual",
+    "trans": [
+      "27.5",
+      "adj．二重的；两层的（double; twofold）"
+    ],
+    "ukphone": "ˋdju:əl",
+    "usphone": "ˋdju:əl"
+  },
+  {
+    "name": "induction",
+    "trans": [
+      "27.6",
+      "n．感应，感应现象；归纳"
+    ],
+    "ukphone": "Inˋdʌkʃn",
+    "usphone": "Inˋdʌkʃn"
+  },
+  {
+    "name": "inference",
+    "trans": [
+      "27.7",
+      "n．推论"
+    ],
+    "ukphone": "ˋInfərəns",
+    "usphone": "ˋInfərəns"
+  },
+  {
+    "name": "circular",
+    "trans": [
+      "27.8",
+      "adj．循环的，圆的（circuitous, roundabout）",
+      "【记】 circul（绕圈）+ar"
+    ],
+    "ukphone": "ˋsɜ:rkjələr",
+    "usphone": "ˋsɜ:rkjələr"
+  },
+  {
+    "name": "circulate",
+    "trans": [
+      "27.9",
+      "v.（使）循环"
+    ],
+    "ukphone": "ˋsɜ:rkjəleIt",
+    "usphone": "ˋsɜ:rkjəleIt"
+  },
+  {
+    "name": "circulation",
+    "trans": [
+      "27.10",
+      "n．循环"
+    ],
+    "ukphone": "ˌsɜ:rkjəˋleIʃn",
+    "usphone": "ˌsɜ:rkjəˋleIʃn"
+  },
+  {
+    "name": "probability",
+    "trans": [
+      "27.11",
+      "n．可能性，或然性，概率"
+    ],
+    "ukphone": "ˌprα:bəˋbIləti",
+    "usphone": "ˌprα:bəˋbIləti"
+  },
+  {
+    "name": "qualitative",
+    "trans": [
+      "27.12",
+      "adj．性质上的，定性的"
+    ],
+    "ukphone": "ˋkwα:ləteItIv",
+    "usphone": "ˋkwα:ləteItIv"
+  },
+  {
+    "name": "dispersion",
+    "trans": [
+      "27.13",
+      "n．离差，差量"
+    ],
+    "ukphone": "dIˋspɜ:rʃn",
+    "usphone": "dIˋspɜ:rʃn"
+  },
+  {
+    "name": "vertical",
+    "trans": [
+      "27.14",
+      "adj．垂直的（perpendicular, upright）"
+    ],
+    "ukphone": "ˋvɜ:rtIkl",
+    "usphone": "ˋvɜ:rtIkl"
+  },
+  {
+    "name": "plumb",
+    "trans": [
+      "27.15",
+      "adj．垂直的（straight, vertical）"
+    ],
+    "ukphone": "plʌm",
+    "usphone": "plʌm"
+  },
+  {
+    "name": "upright",
+    "trans": [
+      "27.16",
+      "adj./adv．垂直的(地)，笔直的（地）（vertical, upstanding）",
+      "【记】 up（上）+right（正的）"
+    ],
+    "ukphone": "ˋʌpraIt",
+    "usphone": "ˋʌpraIt"
+  },
+  {
+    "name": "cubic",
+    "trans": [
+      "27.17",
+      "adj．立方体的"
+    ],
+    "ukphone": "ˋkju:bIk",
+    "usphone": "ˋkju:bIk"
+  },
+  {
+    "name": "circuitous",
+    "trans": [
+      "27.18",
+      "adj．迂回的（indirect, roundabout）",
+      "【记】 circuit（绕圈）+ous"
+    ],
+    "ukphone": "sərˋkju:Itəs",
+    "usphone": "sərˋkju:Itəs"
+  },
+  {
+    "name": "facet",
+    "trans": [
+      "27.19",
+      "n．平面"
+    ],
+    "ukphone": "ˋfæsIt",
+    "usphone": "ˋfæsIt"
+  },
+  {
+    "name": "sphere",
+    "trans": [
+      "27.20",
+      "n．球体（ball, globe）"
+    ],
+    "ukphone": "sfIr",
+    "usphone": "sfIr"
+  },
+  {
+    "name": "loop",
+    "trans": [
+      "27.21",
+      "n．圈，环，环孔（circle, ring）"
+    ],
+    "ukphone": "lu:p",
+    "usphone": "lu:p"
+  },
+  {
+    "name": "triangle",
+    "trans": [
+      "27.22",
+      "n．三角形"
+    ],
+    "ukphone": "ˋtraIæŋgl",
+    "usphone": "ˋtraIæŋgl"
+  },
+  {
+    "name": "circumference",
+    "trans": [
+      "27.23",
+      "n．圆周",
+      "【记】 circum（绕圈）+ference"
+    ],
+    "ukphone": "sərˋkʌmfərəns",
+    "usphone": "sərˋkʌmfərəns"
+  },
+  {
+    "name": "cone",
+    "trans": [
+      "27.24",
+      "n．圆锥"
+    ],
+    "ukphone": "koʊn",
+    "usphone": "koʊn"
+  },
+  {
+    "name": "caliber",
+    "trans": [
+      "27.25",
+      "n．口径"
+    ],
+    "ukphone": "ˋkælIbər",
+    "usphone": "ˋkælIbər"
+  },
+  {
+    "name": "diameter",
+    "trans": [
+      "27.26",
+      "n．直径",
+      "【记】 dia（对）+meter（量）→量到对面的线→直径"
+    ],
+    "ukphone": "daIˋæmItər",
+    "usphone": "daIˋæmItər"
+  },
+  {
+    "name": "figure",
+    "trans": [
+      "27.27",
+      "n．图形，形状（design, shape）"
+    ],
+    "ukphone": "ˋfIgjər",
+    "usphone": "ˋfIgjər"
+  },
+  {
+    "name": "circle",
+    "trans": [
+      "27.28",
+      "n．圆周，圆形物；派系；循环"
+    ],
+    "ukphone": "ˋsɜ:rkl",
+    "usphone": "ˋsɜ:rkl"
+  },
+  {
+    "name": "cube",
+    "trans": [
+      "27.29",
+      "n．立方体，立方"
+    ],
+    "ukphone": "kju:b",
+    "usphone": "kju:b"
+  },
+  {
+    "name": "column",
+    "trans": [
+      "27.30",
+      "n．圆柱，柱状物"
+    ],
+    "ukphone": "ˋkα:ləm",
+    "usphone": "ˋkα:ləm"
+  },
+  {
+    "name": "angle",
+    "trans": [
+      "27.31",
+      "n．角；角落"
+    ],
+    "ukphone": "ˋæŋgl",
+    "usphone": "ˋæŋgl"
+  },
+  {
+    "name": "area",
+    "trans": [
+      "27.32",
+      "n．范围，区域；面积；地区；空地"
+    ],
+    "ukphone": "ˋeriə",
+    "usphone": "ˋeriə"
+  },
+  {
+    "name": "ellipse",
+    "trans": [
+      "27.33",
+      "n．椭圆，椭圆形"
+    ],
+    "ukphone": "IˋlIps",
+    "usphone": "IˋlIps"
+  },
+  {
+    "name": "diagram",
+    "trans": [
+      "27.34",
+      "n．图表（sketch, drawing）",
+      "【记】 dia（交叉）+gram（画图）→交叉画图"
+    ],
+    "ukphone": "ˋdaIəgræm",
+    "usphone": "ˋdaIəgræm"
+  },
+  {
+    "name": "polygon",
+    "trans": [
+      "27.35",
+      "n．多角形，多边形"
+    ],
+    "ukphone": "ˋpα:ligα:n",
+    "usphone": "ˋpα:ligα:n"
+  },
+  {
+    "name": "intersect",
+    "trans": [
+      "27.36",
+      "vi．相交（cross, meet）",
+      "【记】 inter（中间）+sect（切，割）→从中间相切→相交"
+    ],
+    "ukphone": "ˌIntərˋsekt",
+    "usphone": "ˌIntərˋsekt"
+  },
+  {
+    "name": "radius",
+    "trans": [
+      "27.37",
+      "n．半径"
+    ],
+    "ukphone": "ˋreIdiəs",
+    "usphone": "ˋreIdiəs"
+  },
+  {
+    "name": "rectangle",
+    "trans": [
+      "27.38",
+      "n．长方形，矩形"
+    ],
+    "ukphone": "ˋrektæŋgl",
+    "usphone": "ˋrektæŋgl"
+  },
+  {
+    "name": "square",
+    "trans": [
+      "27.39",
+      "n．正方形；平方；直角尺；广场"
+    ],
+    "ukphone": "skwer",
+    "usphone": "skwer"
+  },
+  {
+    "name": "parallel",
+    "trans": [
+      "27.40",
+      "vt．与…平行 adj．平行的",
+      "【记】 para（旁边）+llel→旁边的→平行的"
+    ],
+    "ukphone": "ˋpærəlel",
+    "usphone": "ˋpærəlel"
+  },
+  {
+    "name": "deduction",
+    "trans": [
+      "27.41",
+      "n．扣除，扣除之量；推论，演绎法"
+    ],
+    "ukphone": "dIˋdʌkʃn",
+    "usphone": "dIˋdʌkʃn"
+  },
+  {
+    "name": "degree",
+    "trans": [
+      "27.42",
+      "n．度数，度；程度"
+    ],
+    "ukphone": "dIˋgri:",
+    "usphone": "dIˋgri:"
+  },
+  {
+    "name": "geometry",
+    "trans": [
+      "27.43",
+      "n．几何学",
+      "【记】 geo（地）+metry→测量地面→几何学"
+    ],
+    "ukphone": "dʒiˋα:mətri",
+    "usphone": "dʒiˋα:mətri"
+  },
+  {
+    "name": "mathematics",
+    "trans": [
+      "27.44",
+      "n．数学"
+    ],
+    "ukphone": "ˌmæθəˋmætIks",
+    "usphone": "ˌmæθəˋmætIks"
+  },
+  {
+    "name": "arithmetic",
+    "trans": [
+      "27.45",
+      "n．算术",
+      "【记】 arithm（数学）+etic"
+    ],
+    "ukphone": "əˋrIθmətIk",
+    "usphone": "əˋrIθmətIk"
+  },
+  {
+    "name": "statistics",
+    "trans": [
+      "27.46",
+      "n．统计学；统计表"
+    ],
+    "ukphone": "stəˋtIstIks",
+    "usphone": "stəˋtIstIks"
+  },
+  {
+    "name": "even",
+    "trans": [
+      "27.47",
+      "adj．平的；偶数的",
+      "【记】 比较odd（奇数）"
+    ],
+    "ukphone": "ˋi:vn",
+    "usphone": "ˋi:vn"
+  },
+  {
+    "name": "decimal",
+    "trans": [
+      "27.48",
+      "adj．十进制的 n．小数",
+      "【记】 decim（十分之一）+al"
+    ],
+    "ukphone": "ˋdesIml",
+    "usphone": "ˋdesIml"
+  },
+  {
+    "name": "ratio",
+    "trans": [
+      "27.49",
+      "n．比率（proportion, rate）"
+    ],
+    "ukphone": "ˋreIʃioʊ",
+    "usphone": "ˋreIʃioʊ"
+  },
+  {
+    "name": "estimate",
+    "trans": [
+      "27.50",
+      "vt．估计（gauge, compute）"
+    ],
+    "ukphone": "ˋestImeIt",
+    "usphone": "ˋestImeIt"
+  },
+  {
+    "name": "calculate",
+    "trans": [
+      "27.51",
+      "vt．计算，估计（count）；计划"
+    ],
+    "ukphone": "ˋkælkjuleIt",
+    "usphone": "ˋkælkjuleIt"
+  },
+  {
+    "name": "enumerate",
+    "trans": [
+      "27.52",
+      "vt．枚举；计数（count; numerate）",
+      "【记】 e（出）+numer（数字）+ate→按数列出→列举"
+    ],
+    "ukphone": "Iˋnu:məreIt",
+    "usphone": "Iˋnu:məreIt"
+  },
+  {
+    "name": "evaluate",
+    "trans": [
+      "27.53",
+      "vt．评价，估计（estimate, assess）",
+      "【记】 e+valu（价值）+ate"
+    ],
+    "ukphone": "IˋvæljueIt",
+    "usphone": "IˋvæljueIt"
+  },
+  {
+    "name": "variant",
+    "trans": [
+      "27.54",
+      "n．变量（variable）",
+      "【记】 vari（变化）+ant"
+    ],
+    "ukphone": "ˋveriənt",
+    "usphone": "ˋveriənt"
+  },
+  {
+    "name": "variable",
+    "trans": [
+      "27.55",
+      "n．变量"
+    ],
+    "ukphone": "ˋveriəbl",
+    "usphone": "ˋveriəbl"
+  },
+  {
+    "name": "abacus",
+    "trans": [
+      "27.56",
+      "n．算盘"
+    ],
+    "ukphone": "ˋæbəkəs",
+    "usphone": "ˋæbəkəs"
+  },
+  {
+    "name": "aggregate",
+    "trans": [
+      "27.57",
+      "n．合计，总计；集合体"
+    ],
+    "ukphone": "ˋægrIgət",
+    "usphone": "ˋægrIgət"
+  },
+  {
+    "name": "sum",
+    "trans": [
+      "27.58",
+      "n．总数，和；金额；算术题"
+    ],
+    "ukphone": "sʌm",
+    "usphone": "sʌm"
+  },
+  {
+    "name": "calculation",
+    "trans": [
+      "27.59",
+      "n．计算；考虑"
+    ],
+    "ukphone": "ˌkælkjuˋleIʃn",
+    "usphone": "ˌkælkjuˋleIʃn"
+  },
+  {
+    "name": "calculator",
+    "trans": [
+      "27.60",
+      "n．计算机，计算器"
+    ],
+    "ukphone": "ˋkælkjuleItər",
+    "usphone": "ˋkælkjuleItər"
+  },
+  {
+    "name": "calculus",
+    "trans": [
+      "27.61",
+      "n．微积分学"
+    ],
+    "ukphone": "ˋkælkjələs",
+    "usphone": "ˋkælkjələs"
+  },
+  {
+    "name": "digit",
+    "trans": [
+      "27.62",
+      "n．阿拉伯数字；手指或足趾；一指宽（约四分之三英寸）"
+    ],
+    "ukphone": "ˋdIdʒIt",
+    "usphone": "ˋdIdʒIt"
+  },
+  {
+    "name": "function",
+    "trans": [
+      "27.63",
+      "n．函数"
+    ],
+    "ukphone": "ˋfʌŋkʃn",
+    "usphone": "ˋfʌŋkʃn"
+  },
+  {
+    "name": "subtract",
+    "trans": [
+      "27.64",
+      "vt．减去（deduct）"
+    ],
+    "ukphone": "səbˋtrækt",
+    "usphone": "səbˋtrækt"
+  },
+  {
+    "name": "addition",
+    "trans": [
+      "27.65",
+      "n．加法"
+    ],
+    "ukphone": "əˋdIʃn",
+    "usphone": "əˋdIʃn"
+  },
+  {
+    "name": "minus",
+    "trans": [
+      "27.66",
+      "adj．负的；减的 prep．减去 n．负数"
+    ],
+    "ukphone": "ˋmaInəs",
+    "usphone": "ˋmaInəs"
+  },
+  {
+    "name": "multiply",
+    "trans": [
+      "27.67",
+      "v．乘；增加"
+    ],
+    "ukphone": "ˋmʌltIplaI",
+    "usphone": "ˋmʌltIplaI"
+  },
+  {
+    "name": "multiplication",
+    "trans": [
+      "27.68",
+      "n．乘法；增加"
+    ],
+    "ukphone": "ˌmʌltIplIˋkeIʃn",
+    "usphone": "ˌmʌltIplIˋkeIʃn"
+  },
+  {
+    "name": "numeral",
+    "trans": [
+      "27.69",
+      "n．数字"
+    ],
+    "ukphone": "ˋnju:mərəl",
+    "usphone": "ˋnju:mərəl"
+  },
+  {
+    "name": "percentage",
+    "trans": [
+      "27.70",
+      "n．百分数，百分率，百分比"
+    ],
+    "ukphone": "pərˋsentIdʒ",
+    "usphone": "pərˋsentIdʒ"
+  },
+  {
+    "name": "plus",
+    "trans": [
+      "27.71",
+      "prep．加上 adj．正的；加的"
+    ],
+    "ukphone": "plʌs",
+    "usphone": "plʌs"
+  },
+  {
+    "name": "equation",
+    "trans": [
+      "27.72",
+      "n．等式"
+    ],
+    "ukphone": "IˋkweIʒn",
+    "usphone": "IˋkweIʒn"
+  },
+  {
+    "name": "quarter",
+    "trans": [
+      "27.73",
+      "n．四分之一"
+    ],
+    "ukphone": "ˋkwɔ:rtər",
+    "usphone": "ˋkwɔ:rtər"
+  },
+  {
+    "name": "fraction",
+    "trans": [
+      "27.74",
+      "n．分数",
+      "【记】 fract（碎裂）+ion"
+    ],
+    "ukphone": "ˋfrækʃn",
+    "usphone": "ˋfrækʃn"
+  },
+  {
+    "name": "divide",
+    "trans": [
+      "27.75",
+      "vt．分割；除"
+    ],
+    "ukphone": "dIˋvaId",
+    "usphone": "dIˋvaId"
+  },
+  {
+    "name": "nanometer",
+    "trans": [
+      "27.76",
+      "n．［计量］ 纳米（即十亿分之一米）"
+    ],
+    "ukphone": "ˋnænoʊmi:tər",
+    "usphone": "ˋnænoʊmi:tər"
+  },
+  {
+    "name": "partial",
+    "trans": [
+      "28.1.1",
+      "adj．偏袒的",
+      "【记】 part（部分）+ial"
+    ],
+    "ukphone": "ˋpα:rʃl",
+    "usphone": "ˋpα:rʃl"
+  },
+  {
+    "name": "overbearing",
+    "trans": [
+      "28.1.2",
+      "adj．傲慢的（arrogant, haughty），专横的",
+      "【记】 over（过分）+bearing（忍受）→让别人过分忍受→傲慢的"
+    ],
+    "ukphone": "ˌoʊvərˋberIŋ",
+    "usphone": "ˌoʊvərˋberIŋ"
+  },
+  {
+    "name": "arrogant",
+    "trans": [
+      "28.1.3",
+      "adj．傲慢的（haughty, disdainful）"
+    ],
+    "ukphone": "ˋærəgənt",
+    "usphone": "ˋærəgənt"
+  },
+  {
+    "name": "haughty",
+    "trans": [
+      "28.1.4",
+      "adj．傲慢的，轻蔑的（disdainful, arrogant）"
+    ],
+    "ukphone": "ˋhɔ:ti",
+    "usphone": "ˋhɔ:ti"
+  },
+  {
+    "name": "insolent",
+    "trans": [
+      "28.1.5",
+      "adj．傲慢的；无礼的（haughty, arrogant; impudent）"
+    ],
+    "ukphone": "ˋInsələnt",
+    "usphone": "ˋInsələnt"
+  },
+  {
+    "name": "fussy",
+    "trans": [
+      "28.1.6",
+      "adj．过分挑剔的（finicky, fastidious）"
+    ],
+    "ukphone": "ˋfʌsi",
+    "usphone": "ˋfʌsi"
+  },
+  {
+    "name": "contemptuous",
+    "trans": [
+      "28.1.7",
+      "adj．藐视的；傲慢的（arrogant, haughty）",
+      "【记】 con+tempt（轻视，鄙视）+uous"
+    ],
+    "ukphone": "kənˋtemptʃuəs",
+    "usphone": "kənˋtemptʃuəs"
+  },
+  {
+    "name": "domineering",
+    "trans": [
+      "28.1.8",
+      "adj．盛气凌人的",
+      "【记】 domin（统治）+eering→统治者的→盛气凌人的"
+    ],
+    "ukphone": "ˌdα:məˋnIrIŋ",
+    "usphone": "ˌdα:məˋnIrIŋ"
+  },
+  {
+    "name": "presumptuous",
+    "trans": [
+      "28.1.9",
+      "adj．专横的（self-conceited, audacious）"
+    ],
+    "ukphone": "prIˋzʌmptʃuəs",
+    "usphone": "prIˋzʌmptʃuəs"
+  },
+  {
+    "name": "arrogance",
+    "trans": [
+      "28.1.10",
+      "n．傲慢",
+      "【记】 ar+rog（要求）+ance→一再要求→傲慢"
+    ],
+    "ukphone": "ˋærəgəns",
+    "usphone": "ˋærəgəns"
+  },
+  {
+    "name": "preference",
+    "trans": [
+      "28.1.11",
+      "n．偏爱",
+      "【记】 prefer（喜欢）+ence"
+    ],
+    "ukphone": "ˋprefrəns",
+    "usphone": "ˋprefrəns"
+  },
+  {
+    "name": "bias",
+    "trans": [
+      "28.1.12",
+      "n．偏见（prejudice, partiality）"
+    ],
+    "ukphone": "ˋbaIəs",
+    "usphone": "ˋbaIəs"
+  },
+  {
+    "name": "doleful",
+    "trans": [
+      "28.2.1",
+      "adj．悲哀的（mournful, sorrowful）",
+      "【记】 dole（悲哀）"
+    ],
+    "ukphone": "ˋdoʊlfl",
+    "usphone": "ˋdoʊlfl"
+  },
+  {
+    "name": "upset",
+    "trans": [
+      "28.2.2",
+      "adj．难过的（disturbed, distressed）"
+    ],
+    "ukphone": "ʌpˋset",
+    "usphone": "ʌpˋset"
+  },
+  {
+    "name": "trying",
+    "trans": [
+      "28.2.3",
+      "adj．难堪的，痛苦的（difficult, grueling）"
+    ],
+    "ukphone": "ˋtraIIŋ",
+    "usphone": "ˋtraIIŋ"
+  },
+  {
+    "name": "sentimental",
+    "trans": [
+      "28.2.4",
+      "adj．伤感的，多愁善感的（emotional）"
+    ],
+    "ukphone": "ˌsentIˋmentl",
+    "usphone": "ˌsentIˋmentl"
+  },
+  {
+    "name": "grieve",
+    "trans": [
+      "28.2.5",
+      "vi．悲伤（sorrow）"
+    ],
+    "ukphone": "gri:v",
+    "usphone": "gri:v"
+  },
+  {
+    "name": "grieved",
+    "trans": [
+      "28.2.6",
+      "adj．伤心的"
+    ],
+    "ukphone": "gri:vd",
+    "usphone": "gri:vd"
+  },
+  {
+    "name": "gloom",
+    "trans": [
+      "28.2.7",
+      "n．忧愁（sadness, depression）"
+    ],
+    "ukphone": "glu:m",
+    "usphone": "glu:m"
+  },
+  {
+    "name": "torturous",
+    "trans": [
+      "28.2.8",
+      "adj．痛苦的（tormenting）v．折磨",
+      "【记】 tort（扭）+urous→扭曲的→痛苦的"
+    ],
+    "ukphone": "ˋtɔ:rtʃərəs",
+    "usphone": "ˋtɔ:rtʃərəs"
+  },
+  {
+    "name": "misery",
+    "trans": [
+      "28.2.9",
+      "n．痛苦，苦恼"
+    ],
+    "ukphone": "ˋmIzəri",
+    "usphone": "ˋmIzəri"
+  },
+  {
+    "name": "miserable",
+    "trans": [
+      "28.2.10",
+      "adj．痛苦的；可怜的"
+    ],
+    "ukphone": "ˋmIzrəbl",
+    "usphone": "ˋmIzrəbl"
+  },
+  {
+    "name": "distressed",
+    "trans": [
+      "28.2.11",
+      "adj．痛苦的",
+      "【记】 dis+stress（压力，紧张）+ed"
+    ],
+    "ukphone": "dIˋstrest",
+    "usphone": "dIˋstrest"
+  },
+  {
+    "name": "pensive",
+    "trans": [
+      "28.2.12",
+      "adj．忧愁的，哀思的（thoughtful, contemplative）",
+      "【记】 pens（挂）+ive→心思挂在脸上→忧愁的"
+    ],
+    "ukphone": "ˋpensIv",
+    "usphone": "ˋpensIv"
+  },
+  {
+    "name": "lament",
+    "trans": [
+      "28.2.13",
+      "n．悲伤 vt．痛惜（mourn, grieve over）",
+      "【记】 联想lame（跛足的）加上“nt”"
+    ],
+    "ukphone": "ləˋment",
+    "usphone": "ləˋment"
+  },
+  {
+    "name": "torment",
+    "trans": [
+      "28.2.14",
+      "v．折磨"
+    ],
+    "ukphone": "ˋtɔ:rment］/［tɔ:rˋment",
+    "usphone": "ˋtɔ:rment］/［tɔ:rˋment"
+  },
+  {
+    "name": "deplore",
+    "trans": [
+      "28.2.15",
+      "vt．悲痛；深悔（grieve, mourn）"
+    ],
+    "ukphone": "dIˋplɔ:r",
+    "usphone": "dIˋplɔ:r"
+  },
+  {
+    "name": "overcast",
+    "trans": [
+      "28.2.16",
+      "adj．阴天的，愁闷的，阴暗的（cloudy, dismal）"
+    ],
+    "ukphone": "ˌoʊvərˋkæst",
+    "usphone": "ˌoʊvərˋkæst"
+  },
+  {
+    "name": "inconceivable",
+    "trans": [
+      "28.3.1",
+      "adj．不可思议的（unimaginable, unthinkable）",
+      "【记】 in（不）+conceivable（可以想像的）"
+    ],
+    "ukphone": "ˌInkənˋsi:vəbl",
+    "usphone": "ˌInkənˋsi:vəbl"
+  },
+  {
+    "name": "uncanny",
+    "trans": [
+      "28.3.2",
+      "adj．不可思议的，离奇的（odd, strange）",
+      "【记】 un（不）+canny（安静的，温和的）"
+    ],
+    "ukphone": "ʌnˋkæni",
+    "usphone": "ʌnˋkæni"
+  },
+  {
+    "name": "marvelous",
+    "trans": [
+      "28.3.3",
+      "adj．不可思议的；了不起的"
+    ],
+    "ukphone": "ˋmα:rvələs",
+    "usphone": "ˋmα:rvələs"
+  },
+  {
+    "name": "breathtaking",
+    "trans": [
+      "28.3.4",
+      "adj．惊人的，惊险的（stunning, exciting）"
+    ],
+    "ukphone": "ˋbreθteIkIŋ",
+    "usphone": "ˋbreθteIkIŋ"
+  },
+  {
+    "name": "astound",
+    "trans": [
+      "28.3.5",
+      "vt．使惊异（surprise, astonish）"
+    ],
+    "ukphone": "əˋstaʊnd",
+    "usphone": "əˋstaʊnd"
+  },
+  {
+    "name": "astonish",
+    "trans": [
+      "28.3.6",
+      "vt．使惊讶（amaze, astound, surprise）"
+    ],
+    "ukphone": "əˋstα:nIʃ",
+    "usphone": "əˋstα:nIʃ"
+  },
+  {
+    "name": "astonished",
+    "trans": [
+      "28.3.7",
+      "adj．惊讶的"
+    ],
+    "ukphone": "əˋstα:nIʃt",
+    "usphone": "əˋstα:nIʃt"
+  },
+  {
+    "name": "incredible",
+    "trans": [
+      "28.3.8",
+      "adj．难以相信的（unbelievable, improbable）",
+      "【记】 in（不）+cred（相信）+ible"
+    ],
+    "ukphone": "Inˋkredəbl",
+    "usphone": "Inˋkredəbl"
+  },
+  {
+    "name": "striking",
+    "trans": [
+      "28.3.9",
+      "adj．显著的，惊人的（prominent, outstanding, impressive）"
+    ],
+    "ukphone": "ˋstraIkIŋ",
+    "usphone": "ˋstraIkIŋ"
+  },
+  {
+    "name": "tremor",
+    "trans": [
+      "28.3.10",
+      "n．颤抖，战栗（tremble, shake）"
+    ],
+    "ukphone": "ˋtremər",
+    "usphone": "ˋtremər"
+  },
+  {
+    "name": "trepidation",
+    "trans": [
+      "28.3.11",
+      "n．惊恐，战栗（apprehension, alarm）"
+    ],
+    "ukphone": "ˌtrepIˋdeIʃn",
+    "usphone": "ˌtrepIˋdeIʃn"
+  },
+  {
+    "name": "petrify",
+    "trans": [
+      "28.3.12",
+      "vt．使发呆（stupefy, terrify）",
+      "【记】 petr（石头）+ify"
+    ],
+    "ukphone": "ˋpetrIfaI",
+    "usphone": "ˋpetrIfaI"
+  },
+  {
+    "name": "scare",
+    "trans": [
+      "28.3.13",
+      "vt．惊吓，使受惊（terrify）"
+    ],
+    "ukphone": "sker",
+    "usphone": "sker"
+  },
+  {
+    "name": "startle",
+    "trans": [
+      "28.3.14",
+      "vt．使大吃一惊（amaze, surprise）n．吃惊"
+    ],
+    "ukphone": "ˋstα:rtl",
+    "usphone": "ˋstα:rtl"
+  },
+  {
+    "name": "stun",
+    "trans": [
+      "28.3.15",
+      "vt．使昏晕，使目瞪口呆（astonish, daze, amaze）"
+    ],
+    "ukphone": "stʌn",
+    "usphone": "stʌn"
+  },
+  {
+    "name": "dismay",
+    "trans": [
+      "28.3.16",
+      "vt．使惊愕；使沮丧（disconcert, alarm）"
+    ],
+    "ukphone": "dIsˋmeI",
+    "usphone": "dIsˋmeI"
+  },
+  {
+    "name": "impetuous",
+    "trans": [
+      "28.4.1",
+      "adj．冲动的（impulsive）"
+    ],
+    "ukphone": "Imˋpetʃuəs",
+    "usphone": "Imˋpetʃuəs"
+  },
+  {
+    "name": "impulse",
+    "trans": [
+      "28.4.2",
+      "n．冲动；刺激",
+      "【记】 比较pulse（脉搏，跳动）"
+    ],
+    "ukphone": "ˋImpʌls",
+    "usphone": "ˋImpʌls"
+  },
+  {
+    "name": "impulsive",
+    "trans": [
+      "28.4.3",
+      "adj．易冲动的"
+    ],
+    "ukphone": "ImˋpʌlsIv",
+    "usphone": "ImˋpʌlsIv"
+  },
+  {
+    "name": "urge",
+    "trans": [
+      "28.4.4",
+      "n．冲动"
+    ],
+    "ukphone": "ɜ:rdʒ",
+    "usphone": "ɜ:rdʒ"
+  },
+  {
+    "name": "incentive",
+    "trans": [
+      "28.4.5",
+      "n．刺激；动机（motivation）"
+    ],
+    "ukphone": "InˋsentIv",
+    "usphone": "InˋsentIv"
+  },
+  {
+    "name": "motivation",
+    "trans": [
+      "28.4.6",
+      "n．动机（motive, incentive）",
+      "【记】 比较motive（动机）"
+    ],
+    "ukphone": "ˌmoʊtIˋveIʃn",
+    "usphone": "ˌmoʊtIˋveIʃn"
+  },
+  {
+    "name": "objective",
+    "trans": [
+      "28.4.7",
+      "n．目标（aim, goal）",
+      "【记】 object（客观）+ive"
+    ],
+    "ukphone": "əbˋdʒektIv",
+    "usphone": "əbˋdʒektIv"
+  },
+  {
+    "name": "grim",
+    "trans": [
+      "28.5.1",
+      "adj．不吉祥的"
+    ],
+    "ukphone": "grIm",
+    "usphone": "grIm"
+  },
+  {
+    "name": "sinister",
+    "trans": [
+      "28.5.2",
+      "adj．不祥的；邪恶的（wicked, evil）"
+    ],
+    "ukphone": "ˋsInIstər",
+    "usphone": "ˋsInIstər"
+  },
+  {
+    "name": "cruel",
+    "trans": [
+      "28.5.3",
+      "adj．残忍的（ferocious, ruthless）"
+    ],
+    "ukphone": "ˋkru:əl",
+    "usphone": "ˋkru:əl"
+  },
+  {
+    "name": "malevolent",
+    "trans": [
+      "28.5.4",
+      "adj．恶意的（malicious, spiteful）",
+      "【记】 male（坏）+vol（意念）+ent→恶意的"
+    ],
+    "ukphone": "məˋlevələnt",
+    "usphone": "məˋlevələnt"
+  },
+  {
+    "name": "malice",
+    "trans": [
+      "28.5.5",
+      "n．恶意（ill will, spite）"
+    ],
+    "ukphone": "ˋmælIs",
+    "usphone": "ˋmælIs"
+  },
+  {
+    "name": "malicious",
+    "trans": [
+      "28.5.6",
+      "adj．心毒的，怀恶意的（vicious, spiteful）"
+    ],
+    "ukphone": "məˋlIʃəs",
+    "usphone": "məˋlIʃəs"
+  },
+  {
+    "name": "ferocious",
+    "trans": [
+      "28.5.7",
+      "adj．凶猛的（fierce, savage, bestial）",
+      "【记】 feroc（凶猛）+ious"
+    ],
+    "ukphone": "fəˋroʊʃəs",
+    "usphone": "fəˋroʊʃəs"
+  },
+  {
+    "name": "gloomy",
+    "trans": [
+      "28.6.1",
+      "adj．忧郁的，烦闷的"
+    ],
+    "ukphone": "ˋglu:mi",
+    "usphone": "ˋglu:mi"
+  },
+  {
+    "name": "impatient",
+    "trans": [
+      "28.6.2",
+      "adj．不耐烦的",
+      "【记】 im（不）+patient（耐心的）"
+    ],
+    "ukphone": "ImˋpeIʃnt",
+    "usphone": "ImˋpeIʃnt"
+  },
+  {
+    "name": "stodgy",
+    "trans": [
+      "28.6.3",
+      "adj．枯燥乏味的（dull, boring）"
+    ],
+    "ukphone": "ˋstα:dʒi",
+    "usphone": "ˋstα:dʒi"
+  },
+  {
+    "name": "boring",
+    "trans": [
+      "28.6.4",
+      "adj．令人厌烦的"
+    ],
+    "ukphone": "ˋbɔ:rIŋ",
+    "usphone": "ˋbɔ:rIŋ"
+  },
+  {
+    "name": "bothersome",
+    "trans": [
+      "28.6.5",
+      "adj．令人厌烦的，令人烦恼的（irritating, annoying）"
+    ],
+    "ukphone": "ˋbα:ðərsəm",
+    "usphone": "ˋbα:ðərsəm"
+  },
+  {
+    "name": "boredom",
+    "trans": [
+      "28.6.6",
+      "n．烦恼，无聊（vexation, annoyance）",
+      "【记】 bore（厌烦）+dom"
+    ],
+    "ukphone": "ˋbɔ:rdəm",
+    "usphone": "ˋbɔ:rdəm"
+  },
+  {
+    "name": "tedious",
+    "trans": [
+      "28.6.7",
+      "adj．冗长乏味的，沉闷的（tiresome, boring）"
+    ],
+    "ukphone": "ˋti:diəs",
+    "usphone": "ˋti:diəs"
+  },
+  {
+    "name": "sicken",
+    "trans": [
+      "28.6.8",
+      "adj．使厌倦；使作呕"
+    ],
+    "ukphone": "ˋsIkən",
+    "usphone": "ˋsIkən"
+  },
+  {
+    "name": "uproar",
+    "trans": [
+      "28.6.9",
+      "n．扰乱，喧嚣（disturbance, commotion）",
+      "【记】 up（上）+roar（吼叫）"
+    ],
+    "ukphone": "ˋʌprɔ:r",
+    "usphone": "ˋʌprɔ:r"
+  },
+  {
+    "name": "intrude",
+    "trans": [
+      "28.6.10",
+      "v．侵扰（encroach, infringe）",
+      "【记】 in（进入）+trude（突出）→突进入→侵扰"
+    ],
+    "ukphone": "Inˋtru:d",
+    "usphone": "Inˋtru:d"
+  },
+  {
+    "name": "chafe",
+    "trans": [
+      "28.6.11",
+      "vt．烦扰（irritate）"
+    ],
+    "ukphone": "tʃeIf",
+    "usphone": "tʃeIf"
+  },
+  {
+    "name": "distract",
+    "trans": [
+      "28.6.12",
+      "vt．分散（心思），打扰（abstract, divert）",
+      "【记】 dis+tract（拉）→心被拉开→分散"
+    ],
+    "ukphone": "dIˋstrækt",
+    "usphone": "dIˋstrækt"
+  },
+  {
+    "name": "harass",
+    "trans": [
+      "28.6.13",
+      "vt．侵扰（bother）",
+      "【记】 参考ass（驴子）"
+    ],
+    "ukphone": "həˋræs",
+    "usphone": "həˋræs"
+  },
+  {
+    "name": "disarrange",
+    "trans": [
+      "28.6.14",
+      "vt．扰乱（disturb）",
+      "【记】 dis（不再）+arrange（排列）"
+    ],
+    "ukphone": "ˌdIsəˋreIndʒ",
+    "usphone": "ˌdIsəˋreIndʒ"
+  },
+  {
+    "name": "derange",
+    "trans": [
+      "28.6.15",
+      "vt．扰乱",
+      "【记】 de（坏）+range（排列）"
+    ],
+    "ukphone": "dIˋreIndʒ",
+    "usphone": "dIˋreIndʒ"
+  },
+  {
+    "name": "vex",
+    "trans": [
+      "28.6.16",
+      "vt．使烦恼（annoy, irritate）"
+    ],
+    "ukphone": "veks",
+    "usphone": "veks"
+  },
+  {
+    "name": "reluctant",
+    "trans": [
+      "28.6.17",
+      "adj．不情愿的，厌恶的，勉强的（unwilling, grudging）"
+    ],
+    "ukphone": "rIˋlʌktənt",
+    "usphone": "rIˋlʌktənt"
+  },
+  {
+    "name": "grouchy",
+    "trans": [
+      "28.7.1",
+      "adj．不悦的，愠怒的（bad-tempered, petulant）"
+    ],
+    "ukphone": "ˋgraʊtʃi",
+    "usphone": "ˋgraʊtʃi"
+  },
+  {
+    "name": "indignant",
+    "trans": [
+      "28.7.2",
+      "adj．愤慨的，义愤的（outraged）",
+      "【记】 in（不）+dign（礼貌）+ant→不礼貌→愤慨的"
+    ],
+    "ukphone": "InˋdIgnənt",
+    "usphone": "InˋdIgnənt"
+  },
+  {
+    "name": "furious",
+    "trans": [
+      "28.7.3",
+      "adj．狂怒的；狂暴的（frenzied, enraged）"
+    ],
+    "ukphone": "ˋfjʊriəs",
+    "usphone": "ˋfjʊriəs"
+  },
+  {
+    "name": "nervous",
+    "trans": [
+      "28.7.4",
+      "adj．易激动的",
+      "【记】 nerv（神经）+ous"
+    ],
+    "ukphone": "ˋnɜ:rvəs",
+    "usphone": "ˋnɜ:rvəs"
+  },
+  {
+    "name": "touchy",
+    "trans": [
+      "28.7.5",
+      "adj．易怒的；棘手的（annoyed, offended）"
+    ],
+    "ukphone": "ˋtʌtʃi",
+    "usphone": "ˋtʌtʃi"
+  },
+  {
+    "name": "fury",
+    "trans": [
+      "28.7.6",
+      "n．勃然大怒（rage, wrath）"
+    ],
+    "ukphone": "ˋfjʊri",
+    "usphone": "ˋfjʊri"
+  },
+  {
+    "name": "rage",
+    "trans": [
+      "28.7.7",
+      "n．激怒，愤怒（fury, anger）"
+    ],
+    "ukphone": "reIdʒ",
+    "usphone": "reIdʒ"
+  },
+  {
+    "name": "enrage",
+    "trans": [
+      "28.7.8",
+      "vt．激怒（infuriate, aggravate）",
+      "【记】 en+rage（暴怒）"
+    ],
+    "ukphone": "InˋreIdʒ",
+    "usphone": "InˋreIdʒ"
+  },
+  {
+    "name": "outrage",
+    "trans": [
+      "28.7.9",
+      "vt．激怒；侵犯（anger; offend）",
+      "【记】 out（出）+rage（愤怒）→出离愤怒"
+    ],
+    "ukphone": "ˋaʊtreIdʒ",
+    "usphone": "ˋaʊtreIdʒ"
+  },
+  {
+    "name": "exasperate",
+    "trans": [
+      "28.7.10",
+      "vt．激怒（annoy, irritate）",
+      "【记】 ex+asper（粗鲁）+ate→表现的粗鲁→发怒"
+    ],
+    "ukphone": "Igˋzα:spəreIt",
+    "usphone": "Igˋzα:spəreIt"
+  },
+  {
+    "name": "fret",
+    "trans": [
+      "28.7.11",
+      "vt．激怒（annoy, worry）"
+    ],
+    "ukphone": "fret",
+    "usphone": "fret"
+  },
+  {
+    "name": "provoke",
+    "trans": [
+      "28.7.12",
+      "vt．激怒，煽动（incite, stir up, cause, elicit）"
+    ],
+    "ukphone": "prəˋvoʊk",
+    "usphone": "prəˋvoʊk"
+  },
+  {
+    "name": "incense",
+    "trans": [
+      "28.7.13",
+      "vt．激怒",
+      "【记】 in（进入）+cense（光）→使怒火中烧"
+    ],
+    "ukphone": "Inˋsens",
+    "usphone": "Inˋsens"
+  },
+  {
+    "name": "indefatigable",
+    "trans": [
+      "28.8.1",
+      "adj．不疲倦的（tireless, dogged）",
+      "【记】 in（不）+de（表强调）+fatig（疲倦）+able"
+    ],
+    "ukphone": "ˌIndIˋfætIgəbl",
+    "usphone": "ˌIndIˋfætIgəbl"
+  },
+  {
+    "name": "sensuous",
+    "trans": [
+      "28.8.2",
+      "adj．感觉的，美感的"
+    ],
+    "ukphone": "ˋsenʃuəs",
+    "usphone": "ˋsenʃuəs"
+  },
+  {
+    "name": "faint",
+    "trans": [
+      "28.8.3",
+      "adj．昏晕的"
+    ],
+    "ukphone": "feInt",
+    "usphone": "feInt"
+  },
+  {
+    "name": "ravenous",
+    "trans": [
+      "28.8.4",
+      "adj．极饿的（famished, starving）"
+    ],
+    "ukphone": "ˋrævənəs",
+    "usphone": "ˋrævənəs"
+  },
+  {
+    "name": "listless",
+    "trans": [
+      "28.8.5",
+      "adj．倦怠的，没精打采的（sluggish, lifeless）",
+      "【记】 list（渴望）+less→倦怠的"
+    ],
+    "ukphone": "ˋlIstləs",
+    "usphone": "ˋlIstləs"
+  },
+  {
+    "name": "beat",
+    "trans": [
+      "28.8.6",
+      "adj．疲倦的（exhausted, tired, worn out）"
+    ],
+    "ukphone": "bi:t",
+    "usphone": "bi:t"
+  },
+  {
+    "name": "downhearted",
+    "trans": [
+      "28.8.7",
+      "adj．无精打采的（depressed, downcast）"
+    ],
+    "ukphone": "ˌdaʊnˋhα:rtId",
+    "usphone": "ˌdaʊnˋhα:rtId"
+  },
+  {
+    "name": "daze",
+    "trans": [
+      "28.8.8",
+      "n．昏晕 vt．使发昏，茫然（dazzle, confusion）"
+    ],
+    "ukphone": "deIz",
+    "usphone": "deIz"
+  },
+  {
+    "name": "intuition",
+    "trans": [
+      "28.8.9",
+      "n．直觉"
+    ],
+    "ukphone": "ˌIntjuˋIʃn",
+    "usphone": "ˌIntjuˋIʃn"
+  },
+  {
+    "name": "starve",
+    "trans": [
+      "28.8.10",
+      "v.（使）挨饿"
+    ],
+    "ukphone": "stα:rv",
+    "usphone": "stα:rv"
+  },
+  {
+    "name": "hunger",
+    "trans": [
+      "28.8.11",
+      "v./n．饥饿"
+    ],
+    "ukphone": "ˋhʌŋgər",
+    "usphone": "ˋhʌŋgər"
+  },
+  {
+    "name": "famish",
+    "trans": [
+      "28.8.12",
+      "vt．使挨饿"
+    ],
+    "ukphone": "ˋfæmIʃ",
+    "usphone": "ˋfæmIʃ"
+  },
+  {
+    "name": "exhaust",
+    "trans": [
+      "28.8.13",
+      "vt．使疲倦（use up, drain）",
+      "【记】 ex+haust（拉）→（用力）拉出→疲惫"
+    ],
+    "ukphone": "Igˋzɔ:st",
+    "usphone": "Igˋzɔ:st"
+  },
+  {
+    "name": "gorge",
+    "trans": [
+      "28.8.14",
+      "vt．塞饱"
+    ],
+    "ukphone": "gɔ:rdʒ",
+    "usphone": "gɔ:rdʒ"
+  },
+  {
+    "name": "exultant",
+    "trans": [
+      "28.9.1",
+      "adj．欢腾的；狂欢的（happy; jubilant）",
+      "【记】 ex+（s）ult（激动）+ant→出现激动→欢腾的"
+    ],
+    "ukphone": "Igˋzʌltənt",
+    "usphone": "Igˋzʌltənt"
+  },
+  {
+    "name": "brisk",
+    "trans": [
+      "28.9.2",
+      "adj．活泼的，轻快的（swift, energetic）"
+    ],
+    "ukphone": "brIsk",
+    "usphone": "brIsk"
+  },
+  {
+    "name": "gleeful",
+    "trans": [
+      "28.9.3",
+      "adj．极高兴的，兴奋的（delightful, exultant）"
+    ],
+    "ukphone": "ˋgli:fl",
+    "usphone": "ˋgli:fl"
+  },
+  {
+    "name": "joyous",
+    "trans": [
+      "28.9.4",
+      "adj．快乐的，高兴的",
+      "【记】 joy（高兴）+ous"
+    ],
+    "ukphone": "ˋdʒɔIəs",
+    "usphone": "ˋdʒɔIəs"
+  },
+  {
+    "name": "exalted",
+    "trans": [
+      "28.9.5",
+      "adj．兴奋的（exited）"
+    ],
+    "ukphone": "Igˋzɔ:ltId",
+    "usphone": "Igˋzɔ:ltId"
+  },
+  {
+    "name": "blessed",
+    "trans": [
+      "28.9.6",
+      "adj．愉快的（amused, blithe）"
+    ],
+    "ukphone": "ˋblesId",
+    "usphone": "ˋblesId"
+  },
+  {
+    "name": "pleasing",
+    "trans": [
+      "28.9.7",
+      "adj．愉快的（blithe, amusing）"
+    ],
+    "ukphone": "ˋpli:zIŋ",
+    "usphone": "ˋpli:zIŋ"
+  },
+  {
+    "name": "pleasure",
+    "trans": [
+      "28.9.8",
+      "n．快乐（enjoyment）"
+    ],
+    "ukphone": "ˋpleʒər",
+    "usphone": "ˋpleʒər"
+  },
+  {
+    "name": "elation",
+    "trans": [
+      "28.9.9",
+      "n．得意洋洋",
+      "【记】 elate+ion"
+    ],
+    "ukphone": "iˋleIʃn",
+    "usphone": "iˋleIʃn"
+  },
+  {
+    "name": "ecstasy",
+    "trans": [
+      "28.9.10",
+      "n．恍惚；狂喜"
+    ],
+    "ukphone": "ˋekstəsi",
+    "usphone": "ˋekstəsi"
+  },
+  {
+    "name": "excitement",
+    "trans": [
+      "28.9.11",
+      "n．激动，兴奋；刺激"
+    ],
+    "ukphone": "IkˋsaItmənt",
+    "usphone": "IkˋsaItmənt"
+  },
+  {
+    "name": "bliss",
+    "trans": [
+      "28.9.12",
+      "n．狂喜（ecstasy）"
+    ],
+    "ukphone": "blIs",
+    "usphone": "blIs"
+  },
+  {
+    "name": "rapture",
+    "trans": [
+      "28.9.13",
+      "n．狂喜（ecstasy, delight）",
+      "【记】 rapt（着迷）+ure"
+    ],
+    "ukphone": "ˋræptʃər",
+    "usphone": "ˋræptʃər"
+  },
+  {
+    "name": "tingle",
+    "trans": [
+      "28.9.14",
+      "vi.（因兴奋）激动"
+    ],
+    "ukphone": "ˋtIŋgl",
+    "usphone": "ˋtIŋgl"
+  },
+  {
+    "name": "brighten",
+    "trans": [
+      "28.9.15",
+      "vt．使快活",
+      "【记】 bright（光亮）+en"
+    ],
+    "ukphone": "ˋbraItn",
+    "usphone": "ˋbraItn"
+  },
+  {
+    "name": "enrapture",
+    "trans": [
+      "28.9.16",
+      "vt．使狂喜（delight, exult）",
+      "【记】 en+rapture（狂喜）"
+    ],
+    "ukphone": "Inˋræptʃər",
+    "usphone": "Inˋræptʃər"
+  },
+  {
+    "name": "ravish",
+    "trans": [
+      "28.9.17",
+      "vt．使陶醉；使狂喜"
+    ],
+    "ukphone": "ˋrævIʃ",
+    "usphone": "ˋrævIʃ"
+  },
+  {
+    "name": "curious",
+    "trans": [
+      "28.10.1",
+      "adj．好奇的（acquisitive）"
+    ],
+    "ukphone": "ˋkjʊriəs",
+    "usphone": "ˋkjʊriəs"
+  },
+  {
+    "name": "curiosity",
+    "trans": [
+      "28.10.2",
+      "n．好奇心"
+    ],
+    "ukphone": "ˌkjʊriˋα:səti",
+    "usphone": "ˌkjʊriˋα:səti"
+  },
+  {
+    "name": "inquisitive",
+    "trans": [
+      "28.10.3",
+      "adj．好奇的（nosy, curious）",
+      "【记】 in（进入）+quisit（询问）+ive→喜欢询问的→好奇的"
+    ],
+    "ukphone": "InˋkwIzətIv",
+    "usphone": "InˋkwIzətIv"
+  },
+  {
+    "name": "intriguing",
+    "trans": [
+      "28.10.4",
+      "adj．引起好奇心的，有迷惑力的（tantalizing, bewitching, captivating）"
+    ],
+    "ukphone": "Inˋtri:gIŋ",
+    "usphone": "Inˋtri:gIŋ"
+  },
+  {
+    "name": "concerned",
+    "trans": [
+      "28.11.1",
+      "adj．焦虑的"
+    ],
+    "ukphone": "kənˋsɜ:rnd",
+    "usphone": "kənˋsɜ:rnd"
+  },
+  {
+    "name": "intense",
+    "trans": [
+      "28.11.2",
+      "adj．紧张的"
+    ],
+    "ukphone": "Inˋtens",
+    "usphone": "Inˋtens"
+  },
+  {
+    "name": "suspense",
+    "trans": [
+      "28.11.3",
+      "n．焦虑（anticipation, uncertainty）；悬念",
+      "【记】 sus+pense（挂）→挂念→焦虑"
+    ],
+    "ukphone": "səˋspens",
+    "usphone": "səˋspens"
+  },
+  {
+    "name": "strain",
+    "trans": [
+      "28.11.4",
+      "n．紧张（stress, tension）"
+    ],
+    "ukphone": "streIn",
+    "usphone": "streIn"
+  },
+  {
+    "name": "fluster",
+    "trans": [
+      "28.11.5",
+      "vt．使慌乱（confuse, disconcert）"
+    ],
+    "ukphone": "ˋflʌstər",
+    "usphone": "ˋflʌstər"
+  },
+  {
+    "name": "tense",
+    "trans": [
+      "28.11.6",
+      "adj．紧张的（nervous, strained）"
+    ],
+    "ukphone": "tens",
+    "usphone": "tens"
+  },
+  {
+    "name": "abashed",
+    "trans": [
+      "28.11.7",
+      "adj．羞愧的，局促不安的（uneasy）",
+      "【记】 abash（羞愧）+ed；比较blush（脸红）"
+    ],
+    "ukphone": "əˋbæʃt",
+    "usphone": "əˋbæʃt"
+  },
+  {
+    "name": "languid",
+    "trans": [
+      "28.12.1",
+      "adj．精神不振的（sluggish, listless）",
+      "【记】 langu（松弛）+id→精神不振的"
+    ],
+    "ukphone": "ˋlæŋgwId",
+    "usphone": "ˋlæŋgwId"
+  },
+  {
+    "name": "downcast",
+    "trans": [
+      "28.12.2",
+      "adj．沮丧的（depressed, dejected）"
+    ],
+    "ukphone": "ˋdaʊnkæst",
+    "usphone": "ˋdaʊnkæst"
+  },
+  {
+    "name": "dismal",
+    "trans": [
+      "28.12.3",
+      "adj．沮丧的（gloomy, somber）"
+    ],
+    "ukphone": "ˋdIzməl",
+    "usphone": "ˋdIzməl"
+  },
+  {
+    "name": "dejected",
+    "trans": [
+      "28.12.4",
+      "adj．失望的，沮丧的（depressed, dispirited）",
+      "【记】 deject（失望）+ed"
+    ],
+    "ukphone": "dIˋdʒektId",
+    "usphone": "dIˋdʒektId"
+  },
+  {
+    "name": "depress",
+    "trans": [
+      "28.12.5",
+      "vt．使沮丧（deject, dispirit）",
+      "【记】 de（加强）+press（压）"
+    ],
+    "ukphone": "dIˋpres",
+    "usphone": "dIˋpres"
+  },
+  {
+    "name": "depression",
+    "trans": [
+      "28.12.6",
+      "n．沮丧"
+    ],
+    "ukphone": "dIˋpreʃn",
+    "usphone": "dIˋpreʃn"
+  },
+  {
+    "name": "dampen",
+    "trans": [
+      "28.12.7",
+      "vt．使沮丧（dismay, depress）"
+    ],
+    "ukphone": "ˋdæmpən",
+    "usphone": "ˋdæmpən"
+  },
+  {
+    "name": "cheerless",
+    "trans": [
+      "28.12.8",
+      "adj．不愉快的；阴郁的"
+    ],
+    "ukphone": "ˋtʃIrləs",
+    "usphone": "ˋtʃIrləs"
+  },
+  {
+    "name": "formidable",
+    "trans": [
+      "28.13.1",
+      "adj．可畏惧的，可怕的（dreadful, frightening）"
+    ],
+    "ukphone": "ˋfɔ:rmIdəbl",
+    "usphone": "ˋfɔ:rmIdəbl"
+  },
+  {
+    "name": "fright",
+    "trans": [
+      "28.13.2",
+      "n．惊吓，恐怖"
+    ],
+    "ukphone": "fraIt",
+    "usphone": "fraIt"
+  },
+  {
+    "name": "terror",
+    "trans": [
+      "28.13.3",
+      "n．恐怖"
+    ],
+    "ukphone": "ˋterər",
+    "usphone": "ˋterər"
+  },
+  {
+    "name": "terrify",
+    "trans": [
+      "28.13.4",
+      "vt．使恐怖，使惊吓"
+    ],
+    "ukphone": "ˋterIfaI",
+    "usphone": "ˋterIfaI"
+  },
+  {
+    "name": "panic",
+    "trans": [
+      "28.13.5",
+      "n．恐慌（fear, scare）"
+    ],
+    "ukphone": "ˋpænIk",
+    "usphone": "ˋpænIk"
+  },
+  {
+    "name": "horror",
+    "trans": [
+      "28.13.6",
+      "n．恐惧"
+    ],
+    "ukphone": "ˋhɔ:rər",
+    "usphone": "ˋhɔ:rər"
+  },
+  {
+    "name": "dread",
+    "trans": [
+      "28.13.7",
+      "n．畏惧，恐怖 v．畏惧（fear）"
+    ],
+    "ukphone": "dred",
+    "usphone": "dred"
+  },
+  {
+    "name": "cower",
+    "trans": [
+      "28.13.8",
+      "vi．畏缩（recoil）"
+    ],
+    "ukphone": "ˋkaʊər",
+    "usphone": "ˋkaʊər"
+  },
+  {
+    "name": "intimidate",
+    "trans": [
+      "28.13.9",
+      "vt．恐吓（frighten, threaten）",
+      "【记】 in（进入）+timid（害怕）+ate→使害怕→恐吓"
+    ],
+    "ukphone": "InˋtImIdeIt",
+    "usphone": "InˋtImIdeIt"
+  },
+  {
+    "name": "menace",
+    "trans": [
+      "28.13.10",
+      "vt．威吓（threaten, intimidate）；胁迫",
+      "【记】 men（人）+ace（王牌）→用手中的一张王牌→胁迫"
+    ],
+    "ukphone": "ˋmenəs",
+    "usphone": "ˋmenəs"
+  },
+  {
+    "name": "insane",
+    "trans": [
+      "28.14.1",
+      "adj．发狂，精神错乱的（crazy）",
+      "【记】 in（不）+sane（清醒的）"
+    ],
+    "ukphone": "InˋseIn",
+    "usphone": "InˋseIn"
+  },
+  {
+    "name": "crazy",
+    "trans": [
+      "28.14.2",
+      "adj．狂热的"
+    ],
+    "ukphone": "ˋkreIzi",
+    "usphone": "ˋkreIzi"
+  },
+  {
+    "name": "radical",
+    "trans": [
+      "28.14.3",
+      "adj．激进的（severe, extreme）"
+    ],
+    "ukphone": "ˋrædIkl",
+    "usphone": "ˋrædIkl"
+  },
+  {
+    "name": "radically",
+    "trans": [
+      "28.14.4",
+      "adv．激进地（drastically）"
+    ],
+    "ukphone": "ˋrædIkli",
+    "usphone": "ˋrædIkli"
+  },
+  {
+    "name": "mania",
+    "trans": [
+      "28.14.5",
+      "n．癫狂，狂热",
+      "【记】 man（疯狂）+ia（病）"
+    ],
+    "ukphone": "ˋmeIniə",
+    "usphone": "ˋmeIniə"
+  },
+  {
+    "name": "frenzy",
+    "trans": [
+      "28.14.6",
+      "n．狂热（great excitement）",
+      "【记】 参考frantic（疯狂的）"
+    ],
+    "ukphone": "ˋfrenzi",
+    "usphone": "ˋfrenzi"
+  },
+  {
+    "name": "fanatic",
+    "trans": [
+      "28.14.7",
+      "adj．狂热的，狂热者的（frantic, fervent）",
+      "【记】 fan（迷）+atic→着迷的人→盲信者"
+    ],
+    "ukphone": "fəˋnætIk",
+    "usphone": "fəˋnætIk"
+  },
+  {
+    "name": "fanaticism",
+    "trans": [
+      "28.14.8",
+      "n．狂热；盲从"
+    ],
+    "ukphone": "fəˋnætIsIzəm",
+    "usphone": "fəˋnætIsIzəm"
+  },
+  {
+    "name": "relieved",
+    "trans": [
+      "28.15.1",
+      "adj．放心的",
+      "【记】 名词relief（宽慰）"
+    ],
+    "ukphone": "rIˋli:vd",
+    "usphone": "rIˋli:vd"
+  },
+  {
+    "name": "satisfactory",
+    "trans": [
+      "28.15.2",
+      "adj．令人满意的（appealing）"
+    ],
+    "ukphone": "ˌsætIsˋfæktəri",
+    "usphone": "ˌsætIsˋfæktəri"
+  },
+  {
+    "name": "content",
+    "trans": [
+      "28.15.3",
+      "adj．满足的（satisfied, complacent）"
+    ],
+    "ukphone": "ˋkα:ntent",
+    "usphone": "ˋkα:ntent"
+  },
+  {
+    "name": "satiate",
+    "trans": [
+      "28.15.4",
+      "vt．使饱享；使满足",
+      "【记】 sat（满）+iate"
+    ],
+    "ukphone": "ˋseIʃieIt",
+    "usphone": "ˋseIʃieIt"
+  },
+  {
+    "name": "gratify",
+    "trans": [
+      "28.15.5",
+      "vt．使满意（satisfy）",
+      "【记】 grat（满意）+ify→满足，高兴"
+    ],
+    "ukphone": "ˋgrætIfaI",
+    "usphone": "ˋgrætIfaI"
+  },
+  {
+    "name": "reliance",
+    "trans": [
+      "28.15.6",
+      "n．信赖；信心；受信赖的人或物"
+    ],
+    "ukphone": "rIˋlaIəns",
+    "usphone": "rIˋlaIəns"
+  },
+  {
+    "name": "solicitous",
+    "trans": [
+      "28.16.1",
+      "adj．渴望的；焦虑的（avid; concerned）"
+    ],
+    "ukphone": "səˋlIsItəs",
+    "usphone": "səˋlIsItəs"
+  },
+  {
+    "name": "desire",
+    "trans": [
+      "28.16.2",
+      "vt．想要 n．欲望"
+    ],
+    "ukphone": "dIˋzaIər",
+    "usphone": "dIˋzaIər"
+  },
+  {
+    "name": "desirous",
+    "trans": [
+      "28.16.3",
+      "adj．渴望的"
+    ],
+    "ukphone": "dIˋzaIərəs",
+    "usphone": "dIˋzaIərəs"
+  },
+  {
+    "name": "desirable",
+    "trans": [
+      "28.16.4",
+      "adj．理想的，如意的"
+    ],
+    "ukphone": "dIˋzaIərəbl",
+    "usphone": "dIˋzaIərəbl"
+  },
+  {
+    "name": "aspire",
+    "trans": [
+      "28.16.5",
+      "vi．热望（crave, yearn）"
+    ],
+    "ukphone": "əˋspaIər",
+    "usphone": "əˋspaIər"
+  },
+  {
+    "name": "aspiration",
+    "trans": [
+      "28.16.6",
+      "n．热望，渴望（avidity）",
+      "【记】 a+spir（呼吸）+ation"
+    ],
+    "ukphone": "ˌæspəˋreIʃn",
+    "usphone": "ˌæspəˋreIʃn"
+  },
+  {
+    "name": "hunger",
+    "trans": [
+      "28.16.7",
+      "v./n．渴望"
+    ],
+    "ukphone": "ˋhʌŋgər",
+    "usphone": "ˋhʌŋgər"
+  },
+  {
+    "name": "long",
+    "trans": [
+      "28.16.8",
+      "vi．渴望（crave, yearn）"
+    ],
+    "ukphone": "lɔ:ŋ",
+    "usphone": "lɔ:ŋ"
+  },
+  {
+    "name": "crave",
+    "trans": [
+      "28.16.9",
+      "vt．渴求（desire, yearn）"
+    ],
+    "ukphone": "kreIv",
+    "usphone": "kreIv"
+  },
+  {
+    "name": "realize",
+    "trans": [
+      "28.16.10",
+      "vt．实现（implement, carry out）"
+    ],
+    "ukphone": "ˋri:əlaIz",
+    "usphone": "ˋri:əlaIz"
+  },
+  {
+    "name": "mean",
+    "trans": [
+      "28.16.11",
+      "vt．意欲（intend）"
+    ],
+    "ukphone": "mi:n",
+    "usphone": "mi:n"
+  },
+  {
+    "name": "yen",
+    "trans": [
+      "28.16.12",
+      "n./v．热望，渴望（yearn）"
+    ],
+    "ukphone": "jen",
+    "usphone": "jen"
+  },
+  {
+    "name": "court",
+    "trans": [
+      "28.16.13",
+      "v．追求（pursue）"
+    ],
+    "ukphone": "kɔ:rt",
+    "usphone": "kɔ:rt"
+  },
+  {
+    "name": "touching",
+    "trans": [
+      "28.17.1",
+      "adj．动人的，令人感伤的（moving, impressive）",
+      "【记】 touch（感动）+ing"
+    ],
+    "ukphone": "ˋtʌtʃIŋ",
+    "usphone": "ˋtʌtʃIŋ"
+  },
+  {
+    "name": "impassive",
+    "trans": [
+      "28.17.2",
+      "adj．无感情的（apathetic, indifferent）",
+      "【记】 im（不）+pass（感情）+ive"
+    ],
+    "ukphone": "ImˋpæsIv",
+    "usphone": "ImˋpæsIv"
+  },
+  {
+    "name": "cherish",
+    "trans": [
+      "28.17.3",
+      "vt．珍爱（care for）"
+    ],
+    "ukphone": "ˋtʃerIʃ",
+    "usphone": "ˋtʃerIʃ"
+  },
+  {
+    "name": "affection",
+    "trans": [
+      "28.17.4",
+      "n．友爱；爱情"
+    ],
+    "ukphone": "əˋfekʃn",
+    "usphone": "əˋfekʃn"
+  },
+  {
+    "name": "affectionate",
+    "trans": [
+      "28.17.5",
+      "adj．挚爱的，亲切的（kind, genial）",
+      "【记】 affection（感情）+ate"
+    ],
+    "ukphone": "əˋfekʃənət",
+    "usphone": "əˋfekʃənət"
+  },
+  {
+    "name": "emotional",
+    "trans": [
+      "28.17.6",
+      "adj．情绪的，情感的"
+    ],
+    "ukphone": "Iˋmoʊʃənl",
+    "usphone": "Iˋmoʊʃənl"
+  },
+  {
+    "name": "nostalgia",
+    "trans": [
+      "28.17.7",
+      "n．思家病，乡愁；向往过去，怀旧之情"
+    ],
+    "ukphone": "nəˋstældʒə",
+    "usphone": "nəˋstældʒə"
+  },
+  {
+    "name": "sentimental",
+    "trans": [
+      "28.17.8",
+      "adj．感伤性的，感情脆弱的"
+    ],
+    "ukphone": "ˌsentIˋmentl",
+    "usphone": "ˌsentIˋmentl"
+  },
+  {
+    "name": "emotive",
+    "trans": [
+      "28.17.9",
+      "adj．使感动的，感情的，动感情的"
+    ],
+    "ukphone": "iˋmoʊtIv",
+    "usphone": "iˋmoʊtIv"
+  },
+  {
+    "name": "lovelorn",
+    "trans": [
+      "28.17.10",
+      "a．失恋的"
+    ],
+    "ukphone": "ˋlʌvlɔ:rn",
+    "usphone": "ˋlʌvlɔ:rn"
+  },
+  {
+    "name": "passionate",
+    "trans": [
+      "28.17.11",
+      "adj．多情的，热情的（impassioned, fervent）",
+      "【记】 passion（激情）+ate"
+    ],
+    "ukphone": "ˋpæʃənət",
+    "usphone": "ˋpæʃənət"
+  },
+  {
+    "name": "unanticipated",
+    "trans": [
+      "28.17.12",
+      "adj．未预料到的，意料之外的（unexpected）",
+      "【记】 un-（否）+anticipate（预见）+ed"
+    ],
+    "ukphone": "ˌʌnænˋtIsIpeItId",
+    "usphone": "ˌʌnænˋtIsIpeItId"
+  },
+  {
+    "name": "unexpectedly",
+    "trans": [
+      "28.17.13",
+      "adv．出乎意料地；想不到地（circumstantially, surprisingly）",
+      "【记】 un-（否）+expect（期望）+ed+ly"
+    ],
+    "ukphone": "ˌʌnIkˋspektIdli",
+    "usphone": "ˌʌnIkˋspektIdli"
+  },
+  {
+    "name": "vigorous",
+    "trans": [
+      "28.18.1",
+      "adj．朝气蓬勃的"
+    ],
+    "ukphone": "ˋvIgərəs",
+    "usphone": "ˋvIgərəs"
+  },
+  {
+    "name": "hospitable",
+    "trans": [
+      "28.18.2",
+      "adj．好客的（sociable, companionable）"
+    ],
+    "ukphone": "hα:ˋspItəbl",
+    "usphone": "hα:ˋspItəbl"
+  },
+  {
+    "name": "positive",
+    "trans": [
+      "28.18.3",
+      "adj．积极的（active）",
+      "【记】 比较passive（消极的）"
+    ],
+    "ukphone": "ˋpα:zətIv",
+    "usphone": "ˋpα:zətIv"
+  },
+  {
+    "name": "energetic",
+    "trans": [
+      "28.18.4",
+      "adj．积极的，精力旺盛的（active）",
+      "【记】 energy（精力）"
+    ],
+    "ukphone": "ˌenərˋdʒetIk",
+    "usphone": "ˌenərˋdʒetIk"
+  },
+  {
+    "name": "ardor",
+    "trans": [
+      "28.18.5",
+      "n．热心（enthusiasm）"
+    ],
+    "ukphone": "ˋα:rdər",
+    "usphone": "ˋα:rdər"
+  },
+  {
+    "name": "ardent",
+    "trans": [
+      "28.18.6",
+      "adj．极热心的，热情的（passionate, enthusiastic, fervent, zealous）"
+    ],
+    "ukphone": "ˋα:rdnt",
+    "usphone": "ˋα:rdnt"
+  },
+  {
+    "name": "eager",
+    "trans": [
+      "28.18.7",
+      "adj．渴望的；热心的"
+    ],
+    "ukphone": "ˋi:gər",
+    "usphone": "ˋi:gər"
+  },
+  {
+    "name": "impassioned",
+    "trans": [
+      "28.18.8",
+      "adj．热烈的（emotional, ardent）",
+      "【记】 im（不）+passion（激情）+ed"
+    ],
+    "ukphone": "Imˋpæʃnd",
+    "usphone": "Imˋpæʃnd"
+  },
+  {
+    "name": "avid",
+    "trans": [
+      "28.18.9",
+      "adj．热切的（eager）"
+    ],
+    "ukphone": "ˋævId",
+    "usphone": "ˋævId"
+  },
+  {
+    "name": "devoted",
+    "trans": [
+      "28.18.10",
+      "adj．热心的（enthusiastic）"
+    ],
+    "ukphone": "dIˋvoʊtId",
+    "usphone": "dIˋvoʊtId"
+  },
+  {
+    "name": "readily",
+    "trans": [
+      "28.18.11",
+      "adv．愿意地（eagerly, willingly）"
+    ],
+    "ukphone": "ˋredIli",
+    "usphone": "ˋredIli"
+  },
+  {
+    "name": "enthusiasm",
+    "trans": [
+      "28.18.12",
+      "n．热情（passion）"
+    ],
+    "ukphone": "Inˋθu:ziæzəm",
+    "usphone": "Inˋθu:ziæzəm"
+  },
+  {
+    "name": "zeal",
+    "trans": [
+      "28.18.13",
+      "n．热心，热情，热忱（zest, enthusiasm）"
+    ],
+    "ukphone": "zi:l",
+    "usphone": "zi:l"
+  },
+  {
+    "name": "zealous",
+    "trans": [
+      "28.18.14",
+      "adj．热心的（enthusiastic, fervent）"
+    ],
+    "ukphone": "ˋzeləs",
+    "usphone": "ˋzeləs"
+  },
+  {
+    "name": "zest",
+    "trans": [
+      "28.18.15",
+      "n．浓烈的兴趣；热心（enthusiasm, interest）"
+    ],
+    "ukphone": "zest",
+    "usphone": "zest"
+  },
+  {
+    "name": "hail",
+    "trans": [
+      "28.18.16",
+      "vt．欢呼，欢迎（acclaim, applaud）"
+    ],
+    "ukphone": "heIl",
+    "usphone": "heIl"
+  },
+  {
+    "name": "jealous",
+    "trans": [
+      "28.19.1",
+      "adj．妒忌的（envious, resentful）；猜疑的"
+    ],
+    "ukphone": "ˋdʒeləs",
+    "usphone": "ˋdʒeləs"
+  },
+  {
+    "name": "indifferent",
+    "trans": [
+      "28.19.2",
+      "adj．冷漠的；不积极的（uninterested, nonchalant）",
+      "【记】 in（不）+different（不同的）"
+    ],
+    "ukphone": "InˋdIfrənt",
+    "usphone": "InˋdIfrənt"
+  },
+  {
+    "name": "profane",
+    "trans": [
+      "28.19.3",
+      "vt./adj．亵渎（的）（humiliate; disrespectful）",
+      "【记】 比较fane（神庙）"
+    ],
+    "ukphone": "prəˋfeIn",
+    "usphone": "prəˋfeIn"
+  },
+  {
+    "name": "flatter",
+    "trans": [
+      "28.19.4",
+      "vt．奉承，阿谀，谄媚"
+    ],
+    "ukphone": "ˋflætər",
+    "usphone": "ˋflætər"
+  },
+  {
+    "name": "begrudge",
+    "trans": [
+      "28.19.5",
+      "vt．羡慕；嫉妒（grudge, stint, envy, admire）",
+      "【记】 be+grudge（怨恨，吝啬）"
+    ],
+    "ukphone": "bIˋgrʌdʒ",
+    "usphone": "bIˋgrʌdʒ"
+  },
+  {
+    "name": "desperate",
+    "trans": [
+      "28.19.6",
+      "adj．不顾一切的；绝望的（extremely serious）"
+    ],
+    "ukphone": "ˋdespərət",
+    "usphone": "ˋdespərət"
+  },
+  {
+    "name": "contrite",
+    "trans": [
+      "28.19.7",
+      "adj．悔悟的（repentant, remorseful）",
+      "【记】 con+trite（摩擦）→（心灵）摩擦→悔悟的"
+    ],
+    "ukphone": "kənˋtraIt",
+    "usphone": "kənˋtraIt"
+  },
+  {
+    "name": "forlorn",
+    "trans": [
+      "28.19.8",
+      "adj．绝望的；被遗弃的（wretched, lonely）",
+      "【记】 for（出去）+lorn（被弃的）"
+    ],
+    "ukphone": "fərˋlɔ:rn",
+    "usphone": "fərˋlɔ:rn"
+  },
+  {
+    "name": "inadvertently",
+    "trans": [
+      "28.19.9",
+      "adv．不注意地（unintentionally）",
+      "【记】 in-（否）+advert（引起注意）+ent+ly"
+    ],
+    "ukphone": "ˌInədˋvɜ:rtəntli",
+    "usphone": "ˌInədˋvɜ:rtəntli"
+  },
+  {
+    "name": "unacceptable",
+    "trans": [
+      "28.19.10",
+      "adj．无法接受的，不受欢迎的",
+      "【记】 un-（否）+accept（接受）+able"
+    ],
+    "ukphone": "ˌʌnəkˋseptəbl",
+    "usphone": "ˌʌnəkˋseptəbl"
+  },
+  {
+    "name": "unambiguous",
+    "trans": [
+      "28.19.11",
+      "adj．不含糊的，明白的",
+      "【记】 un-（否）+ambiguous（模糊的）"
+    ],
+    "ukphone": "ˌʌnæmˋbIgjuəs",
+    "usphone": "ˌʌnæmˋbIgjuəs"
+  },
+  {
+    "name": "covert",
+    "trans": [
+      "28.19.12",
+      "adj．隐蔽的；隐密的；偷偷摸摸的"
+    ],
+    "ukphone": "ˋkoʊvɜ:rt",
+    "usphone": "ˋkoʊvɜ:rt"
+  },
+  {
+    "name": "dubious",
+    "trans": [
+      "28.20.1",
+      "adj．怀疑的（doubtful）"
+    ],
+    "ukphone": "ˋdju:biəs",
+    "usphone": "ˋdju:biəs"
+  },
+  {
+    "name": "skeptical",
+    "trans": [
+      "28.20.2",
+      "adj．怀疑的（dubious, incredulous）"
+    ],
+    "ukphone": "ˋskeptIkl",
+    "usphone": "ˋskeptIkl"
+  },
+  {
+    "name": "suspicion",
+    "trans": [
+      "28.20.3",
+      "n．怀疑（doubt, distrust）",
+      "【记】 sus=sub（下）+spic（看）+ion→从下面看→怀疑"
+    ],
+    "ukphone": "səˋspIʃn",
+    "usphone": "səˋspIʃn"
+  },
+  {
+    "name": "suspicious",
+    "trans": [
+      "28.20.4",
+      "adj．可疑的，猜疑的（dubious, fishy）"
+    ],
+    "ukphone": "səˋspIʃəs",
+    "usphone": "səˋspIʃəs"
+  },
+  {
+    "name": "fishy",
+    "trans": [
+      "28.20.5",
+      "adj．值得怀疑的（suspicious, dubious）"
+    ],
+    "ukphone": "ˋfIʃi",
+    "usphone": "ˋfIʃi"
+  },
+  {
+    "name": "incredulity",
+    "trans": [
+      "28.20.6",
+      "n．怀疑（suspicion, disbelief）"
+    ],
+    "ukphone": "ˌInkrəˋdju:ləti",
+    "usphone": "ˌInkrəˋdju:ləti"
+  },
+  {
+    "name": "misgiving",
+    "trans": [
+      "28.20.7",
+      "n．疑惧，疑虑"
+    ],
+    "ukphone": "ˌmIsˋgIvIŋ",
+    "usphone": "ˌmIsˋgIvIŋ"
+  },
+  {
+    "name": "poise",
+    "trans": [
+      "28.20.8",
+      "n．犹疑"
+    ],
+    "ukphone": "pɔIz",
+    "usphone": "pɔIz"
+  },
+  {
+    "name": "halt",
+    "trans": [
+      "28.20.9",
+      "v．踌躇；停止"
+    ],
+    "ukphone": "hɔ:lt",
+    "usphone": "hɔ:lt"
+  },
+  {
+    "name": "scruple",
+    "trans": [
+      "28.20.10",
+      "v./n．踌躇；顾忌（hesitation, scrupulousness）"
+    ],
+    "ukphone": "ˋskru:pl",
+    "usphone": "ˋskru:pl"
+  },
+  {
+    "name": "flounder",
+    "trans": [
+      "28.20.11",
+      "vi．踌躇",
+      "【记】 另一个意思是“比目鱼”"
+    ],
+    "ukphone": "ˋflaʊndər",
+    "usphone": "ˋflaʊndər"
+  },
+  {
+    "name": "demur",
+    "trans": [
+      "28.20.12",
+      "vi．踌躇"
+    ],
+    "ukphone": "dIˋmɜ:r",
+    "usphone": "dIˋmɜ:r"
+  },
+  {
+    "name": "hesitate",
+    "trans": [
+      "28.20.13",
+      "vi．犹豫，踌躇；含糊（falter, vacillate）"
+    ],
+    "ukphone": "ˋhezIteIt",
+    "usphone": "ˋhezIteIt"
+  },
+  {
+    "name": "doubt",
+    "trans": [
+      "28.20.14",
+      "vt./n．怀疑（suspect）"
+    ],
+    "ukphone": "daʊt",
+    "usphone": "daʊt"
+  },
+  {
+    "name": "suspect",
+    "trans": [
+      "28.20.15",
+      "vt．怀疑"
+    ],
+    "ukphone": "səˋspekt",
+    "usphone": "səˋspekt"
+  },
+  {
+    "name": "loath",
+    "trans": [
+      "28.21.1",
+      "adj．不喜欢的，不情愿的（reluctant, unwilling）"
+    ],
+    "ukphone": "loʊθ",
+    "usphone": "loʊθ"
+  },
+  {
+    "name": "loathe",
+    "trans": [
+      "28.21.2",
+      "vt．厌恶（hate, dislike）"
+    ],
+    "ukphone": "loʊð",
+    "usphone": "loʊð"
+  },
+  {
+    "name": "hideous",
+    "trans": [
+      "28.21.3",
+      "adj．骇人听闻的；丑恶的（ugly, ill-looking）"
+    ],
+    "ukphone": "ˋhIdiəs",
+    "usphone": "ˋhIdiəs"
+  },
+  {
+    "name": "sick",
+    "trans": [
+      "28.21.4",
+      "adj．厌恶的"
+    ],
+    "ukphone": "sIk",
+    "usphone": "sIk"
+  },
+  {
+    "name": "complaint",
+    "trans": [
+      "28.21.5",
+      "n．抱怨，怨言"
+    ],
+    "ukphone": "kəmˋpleInt",
+    "usphone": "kəmˋpleInt"
+  },
+  {
+    "name": "grievance",
+    "trans": [
+      "28.21.6",
+      "n．不满（dissatisfaction）",
+      "【记】 griev（悲伤）+ance→说悲伤的话→牢骚"
+    ],
+    "ukphone": "ˋgri:vəns",
+    "usphone": "ˋgri:vəns"
+  },
+  {
+    "name": "aversion",
+    "trans": [
+      "28.21.7",
+      "n．厌恶（dislike, distaste）",
+      "【记】 a+vers（转）+ion→转开→厌恶"
+    ],
+    "ukphone": "əˋvɜ:rʒn",
+    "usphone": "əˋvɜ:rʒn"
+  },
+  {
+    "name": "hatred",
+    "trans": [
+      "28.21.8",
+      "n．憎恶，憎恨（abomination）"
+    ],
+    "ukphone": "ˋheItrId",
+    "usphone": "ˋheItrId"
+  },
+  {
+    "name": "disgust",
+    "trans": [
+      "28.21.9",
+      "vt．厌恶"
+    ],
+    "ukphone": "dIsˋgʌst",
+    "usphone": "dIsˋgʌst"
+  },
+  {
+    "name": "grudge",
+    "trans": [
+      "28.21.10",
+      "vt．怨恨；妒忌；勉强给予"
+    ],
+    "ukphone": "grʌdʒ",
+    "usphone": "grʌdʒ"
+  },
+  {
+    "name": "detest",
+    "trans": [
+      "28.21.11",
+      "vt．憎恶（abhor, hate, loathe）"
+    ],
+    "ukphone": "dIˋtest",
+    "usphone": "dIˋtest"
+  },
+  {
+    "name": "resent",
+    "trans": [
+      "28.21.12",
+      "vt．憎恨（loathe, hate, detest）",
+      "【记】 re（反）+sent（感情）→相反的感情→憎恨"
+    ],
+    "ukphone": "rIˋzent",
+    "usphone": "rIˋzent"
+  },
+  {
+    "name": "abhor",
+    "trans": [
+      "28.21.13",
+      "vt．憎恶（detest, despise, loathe）",
+      "【记】 ab+hor（恨，怕）；比较horrible（可怕的）"
+    ],
+    "ukphone": "əbˋhɔ:r",
+    "usphone": "əbˋhɔ:r"
+  },
+  {
+    "name": "abhorrent",
+    "trans": [
+      "28.21.14",
+      "adj．可恶的，可恨的（detestable）"
+    ],
+    "ukphone": "əbˋhɔ:rənt",
+    "usphone": "əbˋhɔ:rənt"
+  },
+  {
+    "name": "benevolent",
+    "trans": [
+      "29.1.1",
+      "adj．慈善的（charitable, generous）",
+      "【记】 bene（好）+vol（心意）+ent"
+    ],
+    "ukphone": "biˋnevələnt",
+    "usphone": "biˋnevələnt"
+  },
+  {
+    "name": "munificent",
+    "trans": [
+      "29.1.2",
+      "adj．慷慨的（generous, liberal）",
+      "【记】 muni（礼物）+fic（做）+ent→做出来给大家→慷慨的"
+    ],
+    "ukphone": "mju:ˋnIfIsnt",
+    "usphone": "mju:ˋnIfIsnt"
+  },
+  {
+    "name": "charity",
+    "trans": [
+      "29.1.3",
+      "n．施舍（benevolence, altruism）；慈善事业"
+    ],
+    "ukphone": "ˋtʃærəti",
+    "usphone": "ˋtʃærəti"
+  },
+  {
+    "name": "charitable",
+    "trans": [
+      "29.1.4",
+      "adj．慷慨的，慈善的（generous, benevolent）"
+    ],
+    "ukphone": "ˋtʃærətəbl",
+    "usphone": "ˋtʃærətəbl"
+  },
+  {
+    "name": "generous",
+    "trans": [
+      "29.1.5",
+      "adj．慷慨的，大方的（lavish, handsome）",
+      "【记】 gener（产生）+ous→（不断）产生，丰富的→慷慨的"
+    ],
+    "ukphone": "ˋdʒenərəs",
+    "usphone": "ˋdʒenərəs"
+  },
+  {
+    "name": "generously",
+    "trans": [
+      "29.1.6",
+      "adv．宽大地"
+    ],
+    "ukphone": "ˋdʒenərəsli",
+    "usphone": "ˋdʒenərəsli"
+  },
+  {
+    "name": "obliging",
+    "trans": [
+      "29.1.7",
+      "adj．施恩的；愿帮忙的（helpful）"
+    ],
+    "ukphone": "əˋblaIdʒIŋ",
+    "usphone": "əˋblaIdʒIŋ"
+  },
+  {
+    "name": "sympathetic",
+    "trans": [
+      "29.1.8",
+      "adj．同情的；和谐的"
+    ],
+    "ukphone": "ˌsImpəˋθetIk",
+    "usphone": "ˌsImpəˋθetIk"
+  },
+  {
+    "name": "liberal",
+    "trans": [
+      "29.1.9",
+      "adj．心胸宽大的（lenient, broad-minded）；慷慨的",
+      "【记】 liber（自由）+al→心胸自由"
+    ],
+    "ukphone": "ˋlIbərəl",
+    "usphone": "ˋlIbərəl"
+  },
+  {
+    "name": "instrumental",
+    "trans": [
+      "29.1.10",
+      "adj．有帮助的（significant, useful）"
+    ],
+    "ukphone": "ˌInstrəˋmentl",
+    "usphone": "ˌInstrəˋmentl"
+  },
+  {
+    "name": "gainful",
+    "trans": [
+      "29.1.11",
+      "adj．有利的，有报酬的（profitable, lucrative）",
+      "【记】 gain（获得）+ful→有利的"
+    ],
+    "ukphone": "ˋgeInfl",
+    "usphone": "ˋgeInfl"
+  },
+  {
+    "name": "benefit",
+    "trans": [
+      "29.1.12",
+      "vt．对…有益处"
+    ],
+    "ukphone": "ˋbenIfIt",
+    "usphone": "ˋbenIfIt"
+  },
+  {
+    "name": "beneficial",
+    "trans": [
+      "29.1.13",
+      "adj．有益的（profitable, lucrative）"
+    ],
+    "ukphone": "ˌbenIˋfIʃl",
+    "usphone": "ˌbenIˋfIʃl"
+  },
+  {
+    "name": "prop",
+    "trans": [
+      "29.1.14",
+      "n./vt．支持（support, mainstay）"
+    ],
+    "ukphone": "prα:p",
+    "usphone": "prα:p"
+  },
+  {
+    "name": "redress",
+    "trans": [
+      "29.1.15",
+      "n．救济；赔偿"
+    ],
+    "ukphone": "rIˋdres",
+    "usphone": "rIˋdres"
+  },
+  {
+    "name": "compassion",
+    "trans": [
+      "29.1.16",
+      "n．怜悯，同情（sympathy）",
+      "【记】 com+pass（感情）+ion"
+    ],
+    "ukphone": "kəmˋpæʃn",
+    "usphone": "kəmˋpæʃn"
+  },
+  {
+    "name": "assist",
+    "trans": [
+      "29.1.17",
+      "vt．辅助（aid, help）"
+    ],
+    "ukphone": "əˋsIst",
+    "usphone": "əˋsIst"
+  },
+  {
+    "name": "extricate",
+    "trans": [
+      "29.1.18",
+      "vt．救出；使解脱（release, liberate）",
+      "【记】 ex+tric（复杂）+ate→从复杂中走出→解脱"
+    ],
+    "ukphone": "ˋekstrIkeIt",
+    "usphone": "ˋekstrIkeIt"
+  },
+  {
+    "name": "donate",
+    "trans": [
+      "29.1.19",
+      "vt．捐赠（contribute, present）"
+    ],
+    "ukphone": "ˋdoʊneIt",
+    "usphone": "ˋdoʊneIt"
+  },
+  {
+    "name": "raise",
+    "trans": [
+      "29.1.20",
+      "vt．募捐"
+    ],
+    "ukphone": "reIz",
+    "usphone": "reIz"
+  },
+  {
+    "name": "bestow",
+    "trans": [
+      "29.1.21",
+      "vt．赠予",
+      "【记】 be+stow（地方）→给予地方"
+    ],
+    "ukphone": "bIˋstoʊ",
+    "usphone": "bIˋstoʊ"
+  },
+  {
+    "name": "rescue",
+    "trans": [
+      "29.1.22",
+      "vt．拯救（save）"
+    ],
+    "ukphone": "ˋreskju:",
+    "usphone": "ˋreskju:"
+  },
+  {
+    "name": "champion",
+    "trans": [
+      "29.1.23",
+      "vt．支持（support）"
+    ],
+    "ukphone": "ˋtʃæmpiən",
+    "usphone": "ˋtʃæmpiən"
+  },
+  {
+    "name": "salvage",
+    "trans": [
+      "29.1.24",
+      "vt.（海上）救护，抢救（recover, rescue）"
+    ],
+    "ukphone": "ˋsælvIdʒ",
+    "usphone": "ˋsælvIdʒ"
+  },
+  {
+    "name": "save",
+    "trans": [
+      "29.1.25",
+      "v．拯救（rescue）"
+    ],
+    "ukphone": "seiv",
+    "usphone": "seiv"
+  },
+  {
+    "name": "adopt",
+    "trans": [
+      "29.1.26",
+      "vt．收养（introduce）"
+    ],
+    "ukphone": "əˋdα:pt",
+    "usphone": "əˋdα:pt"
+  },
+  {
+    "name": "proponent",
+    "trans": [
+      "29.1.27",
+      "n．支持者；建议者"
+    ],
+    "ukphone": "prəˋpoʊnənt",
+    "usphone": "prəˋpoʊnənt"
+  },
+  {
+    "name": "assert",
+    "trans": [
+      "29.2.1",
+      "vt．维护"
+    ],
+    "ukphone": "əˋsɜ:rt",
+    "usphone": "əˋsɜ:rt"
+  },
+  {
+    "name": "preserve",
+    "trans": [
+      "29.2.2",
+      "vt．保存（keep, save, maintain）",
+      "【记】 pre（预先）+serve（保存）"
+    ],
+    "ukphone": "prIˋzɜ:rv",
+    "usphone": "prIˋzɜ:rv"
+  },
+  {
+    "name": "retain",
+    "trans": [
+      "29.2.3",
+      "vt．保留（hold, reserve, withhold, keep）"
+    ],
+    "ukphone": "rIˋteIn",
+    "usphone": "rIˋteIn"
+  },
+  {
+    "name": "shield",
+    "trans": [
+      "29.2.4",
+      "vt．庇护，保护（protect）"
+    ],
+    "ukphone": "ʃi:ld",
+    "usphone": "ʃi:ld"
+  },
+  {
+    "name": "defend",
+    "trans": [
+      "29.2.5",
+      "vt．防护"
+    ],
+    "ukphone": "dIˋfend",
+    "usphone": "dIˋfend"
+  },
+  {
+    "name": "escort",
+    "trans": [
+      "29.2.6",
+      "vt．护送（accompany）"
+    ],
+    "ukphone": "ˋeskɔ:rt",
+    "usphone": "ˋeskɔ:rt"
+  },
+  {
+    "name": "convoy",
+    "trans": [
+      "29.2.7",
+      "vt．护送（accompany, escort）",
+      "【记】 con+voy（路，看）→照看一路→护送"
+    ],
+    "ukphone": "ˋkα:nvɔI",
+    "usphone": "ˋkα:nvɔI"
+  },
+  {
+    "name": "safeguard",
+    "trans": [
+      "29.2.8",
+      "vt．维护，保卫（protect）",
+      "【记】 联想 “舒肤佳”香皂"
+    ],
+    "ukphone": "ˋseIfgα:rd",
+    "usphone": "ˋseIfgα:rd"
+  },
+  {
+    "name": "behave",
+    "trans": [
+      "29.3.1",
+      "v．举止端正，表现"
+    ],
+    "ukphone": "bIˋheIv",
+    "usphone": "bIˋheIv"
+  },
+  {
+    "name": "behavior",
+    "trans": [
+      "29.3.2",
+      "n．行为（conduct, deed）"
+    ],
+    "ukphone": "bIˋheIvjər",
+    "usphone": "bIˋheIvjər"
+  },
+  {
+    "name": "conduct",
+    "trans": [
+      "29.3.3",
+      "v．行为（behave）"
+    ],
+    "ukphone": "kənˋdʌkt",
+    "usphone": "kənˋdʌkt"
+  },
+  {
+    "name": "deport",
+    "trans": [
+      "29.3.4",
+      "vt．举止"
+    ],
+    "ukphone": "dIˋpɔ:rt",
+    "usphone": "dIˋpɔ:rt"
+  },
+  {
+    "name": "abstract",
+    "trans": [
+      "29.3.5",
+      "adj．抽象的（theoretical, conceptual）"
+    ],
+    "ukphone": "ˋæbstrækt",
+    "usphone": "ˋæbstrækt"
+  },
+  {
+    "name": "abstraction",
+    "trans": [
+      "29.3.6",
+      "n．抽象概念"
+    ],
+    "ukphone": "æbˋstrækʃn",
+    "usphone": "æbˋstrækʃn"
+  },
+  {
+    "name": "action",
+    "trans": [
+      "29.3.7",
+      "n．行动（activity）"
+    ],
+    "ukphone": "ˋækʃn",
+    "usphone": "ˋækʃn"
+  },
+  {
+    "name": "shift",
+    "trans": [
+      "29.4.1",
+      "n./v．转移；替换（change, alteration）"
+    ],
+    "ukphone": "ʃIft",
+    "usphone": "ʃIft"
+  },
+  {
+    "name": "dissipate",
+    "trans": [
+      "29.4.2",
+      "v．驱散，消散（disappear）"
+    ],
+    "ukphone": "ˋdIsIpeIt",
+    "usphone": "ˋdIsIpeIt"
+  },
+  {
+    "name": "deal",
+    "trans": [
+      "29.4.3",
+      "vi．处理"
+    ],
+    "ukphone": "di:l",
+    "usphone": "di:l"
+  },
+  {
+    "name": "dispose",
+    "trans": [
+      "29.4.4",
+      "vi．处理；丢掉（deal with; get rid of）"
+    ],
+    "ukphone": "dIˋspoʊz",
+    "usphone": "dIˋspoʊz"
+  },
+  {
+    "name": "bestow",
+    "trans": [
+      "29.4.5",
+      "vt．应用，使用",
+      "【记】 be+stow（地方）→给予地方"
+    ],
+    "ukphone": "bIˋstoʊ",
+    "usphone": "bIˋstoʊ"
+  },
+  {
+    "name": "exert",
+    "trans": [
+      "29.4.6",
+      "vt．施加",
+      "【记】 ex+ert（力）→出力→施加"
+    ],
+    "ukphone": "Igˋzɜ:rt",
+    "usphone": "Igˋzɜ:rt"
+  },
+  {
+    "name": "displace",
+    "trans": [
+      "29.4.7",
+      "vt．转移，取代",
+      "【记】 dis+place（位置）→取代（位置）→转移"
+    ],
+    "ukphone": "dIsˋpleIs",
+    "usphone": "dIsˋpleIs"
+  },
+  {
+    "name": "tackle",
+    "trans": [
+      "29.4.8",
+      "vt．处理（deal, handle）"
+    ],
+    "ukphone": "ˋtækl",
+    "usphone": "ˋtækl"
+  },
+  {
+    "name": "transact",
+    "trans": [
+      "29.4.9",
+      "vt．处理（deal, manage）"
+    ],
+    "ukphone": "trænˋzækt",
+    "usphone": "trænˋzækt"
+  },
+  {
+    "name": "discard",
+    "trans": [
+      "29.4.10",
+      "vt．丢弃（reject）"
+    ],
+    "ukphone": "dIsˋkα:rd",
+    "usphone": "dIsˋkα:rd"
+  },
+  {
+    "name": "utilize",
+    "trans": [
+      "29.4.11",
+      "vt．利用（use, make use of）"
+    ],
+    "ukphone": "ˋju:təlaIz",
+    "usphone": "ˋju:təlaIz"
+  },
+  {
+    "name": "harness",
+    "trans": [
+      "29.4.12",
+      "vt．利用（utilize）"
+    ],
+    "ukphone": "ˋhα:rnIs",
+    "usphone": "ˋhα:rnIs"
+  },
+  {
+    "name": "arrange",
+    "trans": [
+      "29.4.13",
+      "vt．排列（put together, plan）",
+      "【记】 ar+range（列）"
+    ],
+    "ukphone": "əˋreIndʒ",
+    "usphone": "əˋreIndʒ"
+  },
+  {
+    "name": "reject",
+    "trans": [
+      "29.4.14",
+      "vt．抛弃",
+      "【记】 re（回）+ject（扔）→扔回来，拒绝"
+    ],
+    "ukphone": "rIˋdʒekt",
+    "usphone": "rIˋdʒekt"
+  },
+  {
+    "name": "cancel",
+    "trans": [
+      "29.4.15",
+      "vt．取消（call off, nullify）"
+    ],
+    "ukphone": "ˋkænsl",
+    "usphone": "ˋkænsl"
+  },
+  {
+    "name": "undo",
+    "trans": [
+      "29.4.16",
+      "vt．取消（cancel, annul）",
+      "【记】 un（不）+do（做）→取消"
+    ],
+    "ukphone": "ʌnˋdu:",
+    "usphone": "ʌnˋdu:"
+  },
+  {
+    "name": "delete",
+    "trans": [
+      "29.4.17",
+      "vt．删除（erase, remove from）"
+    ],
+    "ukphone": "dIˋli:t",
+    "usphone": "dIˋli:t"
+  },
+  {
+    "name": "contrive",
+    "trans": [
+      "29.4.18",
+      "vt．设计（plan）"
+    ],
+    "ukphone": "kənˋtraIv",
+    "usphone": "kənˋtraIv"
+  },
+  {
+    "name": "implement",
+    "trans": [
+      "29.4.19",
+      "vt．实现（carry out, fulfil, execute）",
+      "【记】 im（进入）+ple（满）+ment→使圆满→实现"
+    ],
+    "ukphone": "ˋImplIment",
+    "usphone": "ˋImplIment"
+  },
+  {
+    "name": "effectuate",
+    "trans": [
+      "29.4.20",
+      "vt．使实现",
+      "【记】 effect（效果）+uate（表示动词）"
+    ],
+    "ukphone": "IˋfektʃueIt",
+    "usphone": "IˋfektʃueIt"
+  },
+  {
+    "name": "glean",
+    "trans": [
+      "29.4.21",
+      "vt．收集（collect, gather）"
+    ],
+    "ukphone": "gli:n",
+    "usphone": "gli:n"
+  },
+  {
+    "name": "purge",
+    "trans": [
+      "29.4.22",
+      "vt．消除（clear, purify）",
+      "【记】 比较pure（纯的）"
+    ],
+    "ukphone": "pɜ:rdʒ",
+    "usphone": "pɜ:rdʒ"
+  },
+  {
+    "name": "erase",
+    "trans": [
+      "29.4.23",
+      "vt．消除（eliminate）",
+      "【记】 e+rase（擦）"
+    ],
+    "ukphone": "IˋreIs",
+    "usphone": "IˋreIs"
+  },
+  {
+    "name": "eradicate",
+    "trans": [
+      "29.4.24",
+      "vt．根除（eliminate, get rid of, remove）"
+    ],
+    "ukphone": "IˋrædIkeIt",
+    "usphone": "IˋrædIkeIt"
+  },
+  {
+    "name": "efface",
+    "trans": [
+      "29.4.25",
+      "vt．消除（erase）",
+      "【记】 ef+face（脸）→去掉表面→消除"
+    ],
+    "ukphone": "IˋfeIs",
+    "usphone": "IˋfeIs"
+  },
+  {
+    "name": "despatch",
+    "trans": [
+      "29.4.26",
+      "vt．迅速处理（dispose）"
+    ],
+    "ukphone": "dIˋspætʃ",
+    "usphone": "dIˋspætʃ"
+  },
+  {
+    "name": "forsake",
+    "trans": [
+      "29.4.27",
+      "vt．遗弃，抛弃，摒绝（abandon, desert）",
+      "【记】 for（god's）sake 看在上帝的份儿上，不要抛弃我。"
+    ],
+    "ukphone": "fərˋseIk",
+    "usphone": "fərˋseIk"
+  },
+  {
+    "name": "adopt",
+    "trans": [
+      "29.4.28",
+      "vt．采用（foster）",
+      "【记】 ad+opt（选择）→采用"
+    ],
+    "ukphone": "əˋdα:pt",
+    "usphone": "əˋdα:pt"
+  },
+  {
+    "name": "process",
+    "trans": [
+      "29.4.29",
+      "vt．处理（treat）"
+    ],
+    "ukphone": "ˋprα:ses",
+    "usphone": "ˋprα:ses"
+  },
+  {
+    "name": "scrap",
+    "trans": [
+      "29.4.30",
+      "vt．废弃"
+    ],
+    "ukphone": "skræp",
+    "usphone": "skræp"
+  },
+  {
+    "name": "abandon",
+    "trans": [
+      "29.4.31",
+      "vt．抛弃，放弃（discard, give up）",
+      "【记】 a（没）+bandon（权力）→不再有权力→抛弃"
+    ],
+    "ukphone": "əˋbændən",
+    "usphone": "əˋbændən"
+  },
+  {
+    "name": "jettison",
+    "trans": [
+      "29.4.32",
+      "vt．抛弃，丢弃（discard）"
+    ],
+    "ukphone": "ˋdʒetIsn",
+    "usphone": "ˋdʒetIsn"
+  },
+  {
+    "name": "offset",
+    "trans": [
+      "29.4.33",
+      "n./v．抵销（balance, compensate）；平版印刷；支派"
+    ],
+    "ukphone": "ˋɔ:fset",
+    "usphone": "ˋɔ:fset"
+  },
+  {
+    "name": "cobble",
+    "trans": [
+      "29.4.34",
+      "vt．修，拙劣地修补；铺鹅卵石，用圆石铺面"
+    ],
+    "ukphone": "ˋkα:bl",
+    "usphone": "ˋkα:bl"
+  },
+  {
+    "name": "impulsive",
+    "trans": [
+      "29.5.1",
+      "adj．推动的（propelling, driving）"
+    ],
+    "ukphone": "ImˋpʌlsIv",
+    "usphone": "ImˋpʌlsIv"
+  },
+  {
+    "name": "hasten",
+    "trans": [
+      "29.5.2",
+      "v．催促；赶紧（hurry; quicken）"
+    ],
+    "ukphone": "ˋheIsn",
+    "usphone": "ˋheIsn"
+  },
+  {
+    "name": "urge",
+    "trans": [
+      "29.5.3",
+      "v．推进；催促（advocate, encourage, impel, press）"
+    ],
+    "ukphone": "ɜ:rdʒ",
+    "usphone": "ɜ:rdʒ"
+  },
+  {
+    "name": "prod",
+    "trans": [
+      "29.5.4",
+      "vt．刺激（poke, spur）"
+    ],
+    "ukphone": "prα:d",
+    "usphone": "prα:d"
+  },
+  {
+    "name": "stimulate",
+    "trans": [
+      "29.5.5",
+      "（motivate, encourage, incite, actuate）",
+      "【记】 stimul（刺激）+ate"
+    ],
+    "ukphone": "ˋstImjuleIt",
+    "usphone": "ˋstImjuleIt"
+  },
+  {
+    "name": "promote",
+    "trans": [
+      "29.5.6",
+      "vt．促进",
+      "【记】 pro（前）+mote（动）→促进"
+    ],
+    "ukphone": "prəˋmoʊt",
+    "usphone": "prəˋmoʊt"
+  },
+  {
+    "name": "further",
+    "trans": [
+      "29.5.7",
+      "vt．促进，增进（advance, promote）"
+    ],
+    "ukphone": "ˋfɜ:rðər",
+    "usphone": "ˋfɜ:rðər"
+  },
+  {
+    "name": "elicit",
+    "trans": [
+      "29.5.8",
+      "vt．得出，引出（provoke）"
+    ],
+    "ukphone": "iˋlIsIt",
+    "usphone": "iˋlIsIt"
+  },
+  {
+    "name": "instigate",
+    "trans": [
+      "29.5.9",
+      "vt．鼓动（prompt）",
+      "【记】 in（进入）+stig（刺激）+ate→进入刺激→鼓动"
+    ],
+    "ukphone": "ˋInstIgeIt",
+    "usphone": "ˋInstIgeIt"
+  },
+  {
+    "name": "encourage",
+    "trans": [
+      "29.5.10",
+      "vt．鼓励（urge）"
+    ],
+    "ukphone": "Inˋkɜ:rIdʒ",
+    "usphone": "Inˋkɜ:rIdʒ"
+  },
+  {
+    "name": "inspire",
+    "trans": [
+      "29.5.11",
+      "vt．鼓舞，激发（fire the imagination, encourage）"
+    ],
+    "ukphone": "InˋspaIər",
+    "usphone": "InˋspaIər"
+  },
+  {
+    "name": "evoke",
+    "trans": [
+      "29.5.12",
+      "vt．唤起（arouse, produce）",
+      "【记】 e+voke（喊）→喊出→唤起"
+    ],
+    "ukphone": "Iˋvoʊk",
+    "usphone": "Iˋvoʊk"
+  },
+  {
+    "name": "arouse",
+    "trans": [
+      "29.5.13",
+      "vt．唤起（awake, evoke）",
+      "【记】 a+rouse（唤起）"
+    ],
+    "ukphone": "əˋraʊz",
+    "usphone": "əˋraʊz"
+  },
+  {
+    "name": "kindle",
+    "trans": [
+      "29.5.14",
+      "vt．激起",
+      "【记】 比较candle（蜡烛）"
+    ],
+    "ukphone": "ˋkIndl",
+    "usphone": "ˋkIndl"
+  },
+  {
+    "name": "intensify",
+    "trans": [
+      "29.5.15",
+      "vt．加强（enhance, strengthen）"
+    ],
+    "ukphone": "InˋtensIfaI",
+    "usphone": "InˋtensIfaI"
+  },
+  {
+    "name": "fortify",
+    "trans": [
+      "29.5.16",
+      "vt．加强（strengthen, reinforce）",
+      "【记】 fort（强）+ify→力量化→加强"
+    ],
+    "ukphone": "ˋfɔ:rtIfaI",
+    "usphone": "ˋfɔ:rtIfaI"
+  },
+  {
+    "name": "propel",
+    "trans": [
+      "29.5.17",
+      "vt．推进，促进（drive, push forward）",
+      "【记】 pro（前）+pel（推）→推进"
+    ],
+    "ukphone": "prəˋpel",
+    "usphone": "prəˋpel"
+  },
+  {
+    "name": "foment",
+    "trans": [
+      "29.5.18",
+      "vt．引发（incite, stir up）",
+      "【记】 比较ferment（酶，酝酿）"
+    ],
+    "ukphone": "foʊˋment",
+    "usphone": "foʊˋment"
+  },
+  {
+    "name": "incite",
+    "trans": [
+      "29.5.19",
+      "vt．引起；激动；煽动（arouse, provoke; stir）",
+      "【记】 in（进入）+cite（唤起）→激起"
+    ],
+    "ukphone": "InˋsaIt",
+    "usphone": "InˋsaIt"
+  },
+  {
+    "name": "impulse",
+    "trans": [
+      "29.5.20",
+      "v．推动（urge, momentum）",
+      "【记】 比较pulse（脉搏，跳动）"
+    ],
+    "ukphone": "ˋImpʌls",
+    "usphone": "ˋImpʌls"
+  },
+  {
+    "name": "spur",
+    "trans": [
+      "29.5.21",
+      "vt．刺激，鞭策（stimulate, provoke, urge）"
+    ],
+    "ukphone": "spɜ:r",
+    "usphone": "spɜ:r"
+  },
+  {
+    "name": "prompt",
+    "trans": [
+      "29.5.22",
+      "vt．鼓动，促使（stimulate, motivate）"
+    ],
+    "ukphone": "prα:mpt",
+    "usphone": "prα:mpt"
+  },
+  {
+    "name": "flourish",
+    "trans": [
+      "29.5.23",
+      "n./v．茂盛；兴旺，繁荣；活跃；装饰；炫耀，夸耀（bloom, prosper）"
+    ],
+    "ukphone": "ˋflɜ:rIʃ",
+    "usphone": "ˋflɜ:rIʃ"
+  },
+  {
+    "name": "interplay",
+    "trans": [
+      "29.5.24",
+      "n．互相作用，作用和反作用（interact）v．互相作用（interaction）",
+      "【记】 inter-（相互）+play"
+    ],
+    "ukphone": "ˋIntərpleI",
+    "usphone": "ˋIntərpleI"
+  },
+  {
+    "name": "foster",
+    "trans": [
+      "29.5.25",
+      "vt．培养；养育，抚育；抱（希望等）；促进"
+    ],
+    "ukphone": "ˋfɔ:stər",
+    "usphone": "ˋfɔ:stər"
+  },
+  {
+    "name": "due",
+    "trans": [
+      "29.6.1",
+      "adj．应得的 n．应得物"
+    ],
+    "ukphone": "dju:",
+    "usphone": "dju:"
+  },
+  {
+    "name": "attainment",
+    "trans": [
+      "29.6.2",
+      "n．成就（accomplishment, achievement）",
+      "【记】 at+tain（拿住）+ment→得到的→成就"
+    ],
+    "ukphone": "əˋteInmənt",
+    "usphone": "əˋteInmənt"
+  },
+  {
+    "name": "gain",
+    "trans": [
+      "29.6.3",
+      "v．得到，赚到（acquire, benefit, earn, profit, win）"
+    ],
+    "ukphone": "geIn",
+    "usphone": "geIn"
+  },
+  {
+    "name": "obtain",
+    "trans": [
+      "29.6.4",
+      "vt．得到（acquire, attain, gain）"
+    ],
+    "ukphone": "əbˋteIn",
+    "usphone": "əbˋteIn"
+  },
+  {
+    "name": "seize",
+    "trans": [
+      "29.6.5",
+      "vt．夺取，捕获（capture）"
+    ],
+    "ukphone": "si:z",
+    "usphone": "si:z"
+  },
+  {
+    "name": "redeem",
+    "trans": [
+      "29.6.6",
+      "vt．取回；赎回（rescue, save）",
+      "【记】 re（重新）+deem（买）→赎回"
+    ],
+    "ukphone": "rIˋdi:m",
+    "usphone": "rIˋdi:m"
+  },
+  {
+    "name": "procure",
+    "trans": [
+      "29.6.7",
+      "vt．获得，取得（acquire, obtain）"
+    ],
+    "ukphone": "prəˋkjʊr",
+    "usphone": "prəˋkjʊr"
+  },
+  {
+    "name": "acquire",
+    "trans": [
+      "29.6.8",
+      "vt．获得（obtain, attain）"
+    ],
+    "ukphone": "əˋkwaIər",
+    "usphone": "əˋkwaIər"
+  },
+  {
+    "name": "acquisitive",
+    "trans": [
+      "29.6.9",
+      "adj．可获得的",
+      "【记】 ac+quisit（得到）+ive→一再得到→可获得的"
+    ],
+    "ukphone": "əˋkwIzətIv",
+    "usphone": "əˋkwIzətIv"
+  },
+  {
+    "name": "derive",
+    "trans": [
+      "29.6.10",
+      "v．获得；起源（obtain, acquire）"
+    ],
+    "ukphone": "dIˑraIv",
+    "usphone": "dIˑraIv"
+  },
+  {
+    "name": "elude",
+    "trans": [
+      "29.7.1",
+      "vt．躲避（escape, evade）",
+      "【记】 e（出）+lude（玩）→玩出去→躲出去"
+    ],
+    "ukphone": "iˋlu:d",
+    "usphone": "iˋlu:d"
+  },
+  {
+    "name": "elusive",
+    "trans": [
+      "29.7.2",
+      "adj．躲避的",
+      "【记】 e（出）+lus（玩）+ive"
+    ],
+    "ukphone": "iˋlu:sIv",
+    "usphone": "iˋlu:sIv"
+  },
+  {
+    "name": "sly",
+    "trans": [
+      "29.7.3",
+      "adj．躲躲闪闪的（secret, furtive）"
+    ],
+    "ukphone": "slaI",
+    "usphone": "slaI"
+  },
+  {
+    "name": "evade",
+    "trans": [
+      "29.7.4",
+      "vt．逃避，回避（dodge, avoid）",
+      "【记】 e+vade（走）→逃跑"
+    ],
+    "ukphone": "IˋveId",
+    "usphone": "IˋveId"
+  },
+  {
+    "name": "evasive",
+    "trans": [
+      "29.7.5",
+      "adj．逃避的，推诿的（elusive, equivocating）"
+    ],
+    "ukphone": "IˋveIsIv",
+    "usphone": "IˋveIsIv"
+  },
+  {
+    "name": "evasion",
+    "trans": [
+      "29.7.6",
+      "n．逃避"
+    ],
+    "ukphone": "IˋveIʒn",
+    "usphone": "IˋveIʒn"
+  },
+  {
+    "name": "escape",
+    "trans": [
+      "29.7.7",
+      "v．避免；逃避；逃跑"
+    ],
+    "ukphone": "IˋskeIp",
+    "usphone": "IˋskeIp"
+  },
+  {
+    "name": "shun",
+    "trans": [
+      "29.7.8",
+      "vt．避开（avoid, eschew）"
+    ],
+    "ukphone": "ʃʌn",
+    "usphone": "ʃʌn"
+  },
+  {
+    "name": "eschew",
+    "trans": [
+      "29.7.9",
+      "vt．避开；远离（avoid; shun）"
+    ],
+    "ukphone": "Isˋtʃu:",
+    "usphone": "Isˋtʃu:"
+  },
+  {
+    "name": "avoid",
+    "trans": [
+      "29.7.10",
+      "vt．避免，回避，躲开（shun, escape）"
+    ],
+    "ukphone": "əˋvɔId",
+    "usphone": "əˋvɔId"
+  },
+  {
+    "name": "dodge",
+    "trans": [
+      "29.7.11",
+      "vt．躲开；逃避责任（avoid; evade）"
+    ],
+    "ukphone": "dα:dʒ",
+    "usphone": "dα:dʒ"
+  },
+  {
+    "name": "avert",
+    "trans": [
+      "29.7.12",
+      "vt．转移；避免，防止（shift; prevent, avoid）",
+      "【记】 a+vert（转）→转开→避免"
+    ],
+    "ukphone": "əˋvɜ:rt",
+    "usphone": "əˋvɜ:rt"
+  },
+  {
+    "name": "insubordinate",
+    "trans": [
+      "29.8.1",
+      "adj．不服从的（disobedient, rebellious）",
+      "【记】 in（不）+subordinate（服从的）"
+    ],
+    "ukphone": "ˌInsəˋbɔ:rdInət",
+    "usphone": "ˌInsəˋbɔ:rdInət"
+  },
+  {
+    "name": "defiant",
+    "trans": [
+      "29.8.2",
+      "adj．大胆反抗的（hostile, rebellious）"
+    ],
+    "ukphone": "dIˋfaIənt",
+    "usphone": "dIˋfaIənt"
+  },
+  {
+    "name": "opposed",
+    "trans": [
+      "29.8.3",
+      "adj．反对的",
+      "【记】 oppose（反对）+d"
+    ],
+    "ukphone": "əˋpoʊzd",
+    "usphone": "əˋpoʊzd"
+  },
+  {
+    "name": "rebellion",
+    "trans": [
+      "29.8.4",
+      "n．反抗（revolt, opposition）",
+      "【记】 re（反）+bell（打斗）+ion→反抗"
+    ],
+    "ukphone": "rIˋbeljən",
+    "usphone": "rIˋbeljən"
+  },
+  {
+    "name": "resist",
+    "trans": [
+      "29.8.5",
+      "v．抵抗（oppose）",
+      "【记】 re（始终）+sist（坐）→始终以静坐抵抗"
+    ],
+    "ukphone": "rIˋzIst",
+    "usphone": "rIˋzIst"
+  },
+  {
+    "name": "demur",
+    "trans": [
+      "29.8.6",
+      "vi．抗议（protest, object）"
+    ],
+    "ukphone": "dIˋmɜ:r",
+    "usphone": "dIˋmɜ:r"
+  },
+  {
+    "name": "traverse",
+    "trans": [
+      "29.8.7",
+      "vt．反对",
+      "【记】 tra（横）+verse（转）→横过"
+    ],
+    "ukphone": "trəˋvɜ:rs",
+    "usphone": "trəˋvɜ:rs"
+  },
+  {
+    "name": "defy",
+    "trans": [
+      "29.8.8",
+      "vt．蔑视，反抗"
+    ],
+    "ukphone": "dIˋfaI",
+    "usphone": "dIˋfaI"
+  },
+  {
+    "name": "suppress",
+    "trans": [
+      "29.8.9",
+      "v．镇压，平定；查禁；压制；废止（repress, subdue）"
+    ],
+    "ukphone": "səˋpres",
+    "usphone": "səˋpres"
+  },
+  {
+    "name": "combat",
+    "trans": [
+      "29.8.10",
+      "vt．反对；与…战斗 n．战斗；争论"
+    ],
+    "ukphone": "ˋkα:mbæt",
+    "usphone": "ˋkα:mbæt"
+  },
+  {
+    "name": "outrageous",
+    "trans": [
+      "29.9.1",
+      "adj．暴乱的（offensive, disgraceful）"
+    ],
+    "ukphone": "aʊtˋreIdʒəs",
+    "usphone": "aʊtˋreIdʒəs"
+  },
+  {
+    "name": "turbulent",
+    "trans": [
+      "29.9.2",
+      "adj．骚动的，骚乱的（violent）"
+    ],
+    "ukphone": "ˋtɜ:rbjələnt",
+    "usphone": "ˋtɜ:rbjələnt"
+  },
+  {
+    "name": "riot",
+    "trans": [
+      "29.9.3",
+      "n．暴乱，骚动（disturbance, disorder, chaos）"
+    ],
+    "ukphone": "ˋraIət",
+    "usphone": "ˋraIət"
+  },
+  {
+    "name": "defection",
+    "trans": [
+      "29.9.4",
+      "n．背叛，缺陷",
+      "【记】 de（坏）+fect（做）+ion→做坏事→背叛"
+    ],
+    "ukphone": "dIˋfekʃn",
+    "usphone": "dIˋfekʃn"
+  },
+  {
+    "name": "uprising",
+    "trans": [
+      "29.9.5",
+      "n．叛乱",
+      "【记】 来自rise up（起义）"
+    ],
+    "ukphone": "ˋʌpraIzIŋ",
+    "usphone": "ˋʌpraIzIŋ"
+  },
+  {
+    "name": "uproar",
+    "trans": [
+      "29.9.6",
+      "n．骚动",
+      "【记】 up（上）+roar（吼叫）"
+    ],
+    "ukphone": "ˋʌprɔ:r",
+    "usphone": "ˋʌprɔ:r"
+  },
+  {
+    "name": "turmoil",
+    "trans": [
+      "29.9.7",
+      "n．骚动；混乱（disorder, chaos）",
+      "【记】 tur+moil（喧闹）→混乱"
+    ],
+    "ukphone": "ˋtɜ:rmɔIl",
+    "usphone": "ˋtɜ:rmɔIl"
+  },
+  {
+    "name": "treason",
+    "trans": [
+      "29.9.8",
+      "n．通敌，叛国罪（treachery）"
+    ],
+    "ukphone": "ˋtri:zn",
+    "usphone": "ˋtri:zn"
+  },
+  {
+    "name": "rebel",
+    "trans": [
+      "29.9.9",
+      "vi．谋反，反抗"
+    ],
+    "ukphone": "rIˋbel",
+    "usphone": "rIˋbel"
+  },
+  {
+    "name": "betray",
+    "trans": [
+      "29.9.10",
+      "vt．背叛",
+      "【记】 be+tray（盘子）→和盘托出→背叛"
+    ],
+    "ukphone": "bIˋtreI",
+    "usphone": "bIˋtreI"
+  },
+  {
+    "name": "subvert",
+    "trans": [
+      "29.9.11",
+      "vt．颠覆，推翻（destroy, undermine）",
+      "【记】 sub（下面）+vert（转）→下面转变→颠覆"
+    ],
+    "ukphone": "səbˋvɜ:rt",
+    "usphone": "səbˋvɜ:rt"
+  },
+  {
+    "name": "plot",
+    "trans": [
+      "29.9.12",
+      "vt．密谋，策划（plan, map out, outline）"
+    ],
+    "ukphone": "plα:t",
+    "usphone": "plα:t"
+  },
+  {
+    "name": "overturn",
+    "trans": [
+      "29.9.13",
+      "v．推翻，颠倒"
+    ],
+    "ukphone": "ˌoʊvərˋtɜ:rn",
+    "usphone": "ˌoʊvərˋtɜ:rn"
+  },
+  {
+    "name": "exclusion",
+    "trans": [
+      "29.10.1",
+      "n．拒绝（rejection）"
+    ],
+    "ukphone": "Ikˋsklu:ʒn",
+    "usphone": "Ikˋsklu:ʒn"
+  },
+  {
+    "name": "decline",
+    "trans": [
+      "29.10.2",
+      "v．拒绝（refuse）"
+    ],
+    "ukphone": "dIˋklaIn",
+    "usphone": "dIˋklaIn"
+  },
+  {
+    "name": "relinquish",
+    "trans": [
+      "29.10.3",
+      "vt．放弃（abandon, give up, quit）",
+      "【记】 re（再次）+linqu（离开）+ish→再次离开→放弃"
+    ],
+    "ukphone": "rIˋlIŋkwIʃ",
+    "usphone": "rIˋlIŋkwIʃ"
+  },
+  {
+    "name": "renounce",
+    "trans": [
+      "29.10.4",
+      "vt．放弃，否认（abandon, reject）",
+      "【记】 re（反）+nounce（说）→否认"
+    ],
+    "ukphone": "rIˋnaʊns",
+    "usphone": "rIˋnaʊns"
+  },
+  {
+    "name": "gainsay",
+    "trans": [
+      "29.10.5",
+      "vt./n．否认（deny）",
+      "【记】 gain=against（反对）+say（说）→否认"
+    ],
+    "ukphone": "ˌgeInˋseI",
+    "usphone": "ˌgeInˋseI"
+  },
+  {
+    "name": "deny",
+    "trans": [
+      "29.10.6",
+      "vt．否认"
+    ],
+    "ukphone": "dIˋnaI",
+    "usphone": "dIˋnaI"
+  },
+  {
+    "name": "disclaim",
+    "trans": [
+      "29.10.7",
+      "vt．拒绝承认，否认（refuse）",
+      "【记】 dis+claim（喊）"
+    ],
+    "ukphone": "dIsˋkleIm",
+    "usphone": "dIsˋkleIm"
+  },
+  {
+    "name": "reject",
+    "trans": [
+      "29.10.8",
+      "vt．拒收（refuse, turn down）",
+      "【记】 re（回）+ject（扔）→扔回来→拒收"
+    ],
+    "ukphone": "rIˋdʒekt",
+    "usphone": "rIˋdʒekt"
+  },
+  {
+    "name": "submit",
+    "trans": [
+      "29.11.1",
+      "vi．服从（give in, yield）"
+    ],
+    "ukphone": "səbˋmIt",
+    "usphone": "səbˋmIt"
+  },
+  {
+    "name": "submissive",
+    "trans": [
+      "29.11.2",
+      "adj．顺从的（obedient, meek）"
+    ],
+    "ukphone": "səbˋmIsIv",
+    "usphone": "səbˋmIsIv"
+  },
+  {
+    "name": "submission",
+    "trans": [
+      "29.11.3",
+      "n．屈服；服从",
+      "【记】 sub（下面）+miss（放）+ion→放在下面→屈服"
+    ],
+    "ukphone": "səbˋmIʃn",
+    "usphone": "səbˋmIʃn"
+  },
+  {
+    "name": "subjection",
+    "trans": [
+      "29.11.4",
+      "n．服从（subjugation, subduing）"
+    ],
+    "ukphone": "səbˋdʒekʃn",
+    "usphone": "səbˋdʒekʃn"
+  },
+  {
+    "name": "obedience",
+    "trans": [
+      "29.11.5",
+      "n．服从，顺从（deference, submission）",
+      "【记】 动词obey（服从）"
+    ],
+    "ukphone": "əˋbi:diəns",
+    "usphone": "əˋbi:diəns"
+  },
+  {
+    "name": "succumb",
+    "trans": [
+      "29.11.6",
+      "vi．屈服（submit, yield）"
+    ],
+    "ukphone": "səˋkʌm",
+    "usphone": "səˋkʌm"
+  },
+  {
+    "name": "enthrall",
+    "trans": [
+      "29.11.7",
+      "vt．使服从",
+      "【记】 en+thrall（奴隶）→使服从"
+    ],
+    "ukphone": "Inˋθrɔ:l",
+    "usphone": "Inˋθrɔ:l"
+  },
+  {
+    "name": "defer",
+    "trans": [
+      "29.11.8",
+      "vi．服从，屈从（yield）",
+      "【记】 de（坏）+fer（带来）"
+    ],
+    "ukphone": "dIˋfɜ:r",
+    "usphone": "dIˋfɜ:r"
+  },
+  {
+    "name": "lash",
+    "trans": [
+      "29.12.1",
+      "v．鞭打（whip, flog）"
+    ],
+    "ukphone": "læʃ",
+    "usphone": "læʃ"
+  },
+  {
+    "name": "sustain",
+    "trans": [
+      "29.12.2",
+      "vt．遭受（suffer）"
+    ],
+    "ukphone": "səˋsteIn",
+    "usphone": "səˋsteIn"
+  },
+  {
+    "name": "pervert",
+    "trans": [
+      "29.12.3",
+      "vt．导入邪途；曲解（deviate, distort）",
+      "【记】 per（全部）+vert（转）→全都转到邪道"
+    ],
+    "ukphone": "pərˋvɜ:rt",
+    "usphone": "pərˋvɜ:rt"
+  },
+  {
+    "name": "coddle",
+    "trans": [
+      "29.12.4",
+      "vt．娇养，溺爱"
+    ],
+    "ukphone": "ˋkα:dl",
+    "usphone": "ˋkα:dl"
+  },
+  {
+    "name": "entail",
+    "trans": [
+      "29.12.5",
+      "vt．惹起；使负担（require; involve）"
+    ],
+    "ukphone": "InˋteIl",
+    "usphone": "InˋteIl"
+  },
+  {
+    "name": "inflict",
+    "trans": [
+      "29.12.6",
+      "vt．使遭受（损伤、苦痛等）（incur, impose）",
+      "【记】 in（进入）+flict（打斗）→导致痛苦"
+    ],
+    "ukphone": "InˋflIkt",
+    "usphone": "InˋflIkt"
+  },
+  {
+    "name": "distort",
+    "trans": [
+      "29.12.7",
+      "vt．歪曲（misrepresent, twist）"
+    ],
+    "ukphone": "dIˋstɔ:rt",
+    "usphone": "dIˋstɔ:rt"
+  },
+  {
+    "name": "abuse",
+    "trans": [
+      "29.12.8",
+      "vt．滥用",
+      "【记】 ab（不）+use（使用）→不正当使用→滥用"
+    ],
+    "ukphone": "əˋbju:s",
+    "usphone": "əˋbju:s"
+  },
+  {
+    "name": "correct",
+    "trans": [
+      "29.13.1",
+      "adj．正确的 vt．纠正（ratify）",
+      "【记】 cor+rect（直，正）"
+    ],
+    "ukphone": "kəˋrekt",
+    "usphone": "kəˋrekt"
+  },
+  {
+    "name": "innovation",
+    "trans": [
+      "29.13.2",
+      "n．改革，革新（reformation）",
+      "【记】 innovate（革新）+ion"
+    ],
+    "ukphone": "ˌInəˋveIʃn",
+    "usphone": "ˌInəˋveIʃn"
+  },
+  {
+    "name": "modify",
+    "trans": [
+      "29.13.3",
+      "vt．修改（change, adapt）",
+      "【记】 mod（方式，规范）+ify→规范化→修改"
+    ],
+    "ukphone": "ˋmα:dIfaI",
+    "usphone": "ˋmα:dIfaI"
+  },
+  {
+    "name": "modification",
+    "trans": [
+      "29.13.4",
+      "n．更改，修改（change）"
+    ],
+    "ukphone": "ˌmα:dIfIˋkeIʃn",
+    "usphone": "ˌmα:dIfIˋkeIʃn"
+  },
+  {
+    "name": "ornament",
+    "trans": [
+      "29.13.5",
+      "n．装饰物；装修（decoration, embellishment）",
+      "【记】 orn（装饰）+ament"
+    ],
+    "ukphone": "ˋɔ:rnəmənt",
+    "usphone": "ˋɔ:rnəmənt"
+  },
+  {
+    "name": "coax",
+    "trans": [
+      "29.13.6",
+      "vt．耐心调理"
+    ],
+    "ukphone": "koʊks",
+    "usphone": "koʊks"
+  },
+  {
+    "name": "gild",
+    "trans": [
+      "29.13.7",
+      "vt．虚饰（embellish）"
+    ],
+    "ukphone": "gIld",
+    "usphone": "gIld"
+  },
+  {
+    "name": "modulate",
+    "trans": [
+      "29.13.8",
+      "vt．调整（change, modify）",
+      "【记】 mod（方式，模式）+ulate→对模式进行调整→调整"
+    ],
+    "ukphone": "ˋmα:dʒəleIt",
+    "usphone": "ˋmα:dʒəleIt"
+  },
+  {
+    "name": "mend",
+    "trans": [
+      "29.13.9",
+      "vt．改正，修正（revise, correct）；改进"
+    ],
+    "ukphone": "mend",
+    "usphone": "mend"
+  },
+  {
+    "name": "renovate",
+    "trans": [
+      "29.13.10",
+      "vt．革新（renew, restore）",
+      "【记】 re（重新）+nov（新）+ate→重新翻新→革新"
+    ],
+    "ukphone": "ˋrenəveIt",
+    "usphone": "ˋrenəveIt"
+  },
+  {
+    "name": "substantiate",
+    "trans": [
+      "29.13.11",
+      "vt．加强（corroborate, verify）"
+    ],
+    "ukphone": "səbˋstænʃieIt",
+    "usphone": "səbˋstænʃieIt"
+  },
+  {
+    "name": "strengthen",
+    "trans": [
+      "29.13.12",
+      "v．加强，巩固（reinforce）"
+    ],
+    "ukphone": "ˋstreŋθn",
+    "usphone": "ˋstreŋθn"
+  },
+  {
+    "name": "reinforce",
+    "trans": [
+      "29.13.13",
+      "vt．加强，加固（increase, strengthen）",
+      "【记】 re（再次）+in+force（力量）→再次增加力量"
+    ],
+    "ukphone": "ˌri:Inˋfɔ:rs",
+    "usphone": "ˌri:Inˋfɔ:rs"
+  },
+  {
+    "name": "garnish",
+    "trans": [
+      "29.13.14",
+      "vt．加装饰（adorn, decorate）",
+      "【记】 garn=gar（花）+ish→用花来装饰"
+    ],
+    "ukphone": "ˋgα:rnIʃ",
+    "usphone": "ˋgα:rnIʃ"
+  },
+  {
+    "name": "embellish",
+    "trans": [
+      "29.13.15",
+      "vt．装饰，修饰（decorate, adorn）",
+      "【记】 em+bell（美）+ish→使美"
+    ],
+    "ukphone": "ImˋbelIʃ",
+    "usphone": "ImˋbelIʃ"
+  },
+  {
+    "name": "embroider",
+    "trans": [
+      "29.13.16",
+      "vt．装饰",
+      "【记】 em+broider（刺绣）→用刺绣来装饰"
+    ],
+    "ukphone": "ImˋbrɔIdər",
+    "usphone": "ImˋbrɔIdər"
+  },
+  {
+    "name": "temper",
+    "trans": [
+      "29.13.17",
+      "v．缓和，调节（modify, modulate）"
+    ],
+    "ukphone": "ˋtempər",
+    "usphone": "ˋtempər"
+  },
+  {
+    "name": "adjust",
+    "trans": [
+      "29.13.18",
+      "vt．调节；使适于（adapt）",
+      "【记】 ad+just（合适的）"
+    ],
+    "ukphone": "əˋdʒʌst",
+    "usphone": "əˋdʒʌst"
+  },
+  {
+    "name": "refine",
+    "trans": [
+      "29.13.19",
+      "vt．精炼，精制"
+    ],
+    "ukphone": "rIˋfaIn",
+    "usphone": "rIˋfaIn"
+  },
+  {
+    "name": "progressive",
+    "trans": [
+      "29.13.20",
+      "n．改革论者，进步论者 adj．前进的，进步的，累进的（increasing）"
+    ],
+    "ukphone": "prəˋgresIv",
+    "usphone": "prəˋgresIv"
+  },
+  {
+    "name": "conciliatory",
+    "trans": [
+      "29.14.1",
+      "adj．善于调解的（reconciling）",
+      "【记】 concil（协商）+iatory"
+    ],
+    "ukphone": "kənˋsIliətɔ:ri",
+    "usphone": "kənˋsIliətɔ:ri"
+  },
+  {
+    "name": "hurdle",
+    "trans": [
+      "29.14.2",
+      "n．障碍（barrier, obstacle）"
+    ],
+    "ukphone": "ˋhɜ:rdl",
+    "usphone": "ˋhɜ:rdl"
+  },
+  {
+    "name": "barrier",
+    "trans": [
+      "29.14.3",
+      "n．栅栏，屏障；障碍（obstacle, block, barricade）"
+    ],
+    "ukphone": "ˋbæriər",
+    "usphone": "ˋbæriər"
+  },
+  {
+    "name": "barricade",
+    "trans": [
+      "29.14.4",
+      "n．障碍物（barrier, impediment）",
+      "【记】 barric（阻止）+ade"
+    ],
+    "ukphone": "ˌbærIˋkeId",
+    "usphone": "ˌbærIˋkeId"
+  },
+  {
+    "name": "obstacle",
+    "trans": [
+      "29.14.5",
+      "n．障碍（barrier, impediment）"
+    ],
+    "ukphone": "ˋα:bstəkl",
+    "usphone": "ˋα:bstəkl"
+  },
+  {
+    "name": "snag",
+    "trans": [
+      "29.14.6",
+      "n．障碍（disadvantage, obstacle）"
+    ],
+    "ukphone": "snæg",
+    "usphone": "snæg"
+  },
+  {
+    "name": "forestall",
+    "trans": [
+      "29.14.7",
+      "v．预先阻止（prevent, preempt）"
+    ],
+    "ukphone": "fɔ:rˋstɔ:l",
+    "usphone": "fɔ:rˋstɔ:l"
+  },
+  {
+    "name": "intercede",
+    "trans": [
+      "29.14.8",
+      "vi．调停，求情（intervene, mediate）",
+      "【记】 inter（中间）+cede（走）→在中间奔走→调停"
+    ],
+    "ukphone": "ˌIntərˋsi:d",
+    "usphone": "ˌIntərˋsi:d"
+  },
+  {
+    "name": "intercept",
+    "trans": [
+      "29.14.9",
+      "vt．中途拦截；阻止（hold back, stop）",
+      "【记】 inter（中间）+cept（拿）→拦截"
+    ],
+    "ukphone": "ˌIntərˋsept",
+    "usphone": "ˌIntərˋsept"
+  },
+  {
+    "name": "intervene",
+    "trans": [
+      "29.14.10",
+      "vi．干涉（interfere, influence）",
+      "【记】 inter（中间）+vene（来）→来到中间→干涉"
+    ],
+    "ukphone": "ˌIntərˋvi:n",
+    "usphone": "ˌIntərˋvi:n"
+  },
+  {
+    "name": "interfere",
+    "trans": [
+      "29.14.11",
+      "vi．干涉，干预（intervene, meddle）；妨碍"
+    ],
+    "ukphone": "ˌIntərˋfIr",
+    "usphone": "ˌIntərˋfIr"
+  },
+  {
+    "name": "meddle",
+    "trans": [
+      "29.14.12",
+      "vi．干预（interfere, intervene）"
+    ],
+    "ukphone": "ˋmedl",
+    "usphone": "ˋmedl"
+  },
+  {
+    "name": "tamper",
+    "trans": [
+      "29.14.13",
+      "vi．干预（interfere, intervene）"
+    ],
+    "ukphone": "ˋtæmpər",
+    "usphone": "ˋtæmpər"
+  },
+  {
+    "name": "mediate",
+    "trans": [
+      "29.14.14",
+      "vt．调停（intercede, intervene）",
+      "【记】 medi（中间）+ate→在中间（走）→调停"
+    ],
+    "ukphone": "ˋmi:dieIt",
+    "usphone": "ˋmi:dieIt"
+  },
+  {
+    "name": "balk",
+    "trans": [
+      "29.14.15",
+      "vt．妨碍（block, hinder, stall）"
+    ],
+    "ukphone": "bɔ:k",
+    "usphone": "bɔ:k"
+  },
+  {
+    "name": "hinder",
+    "trans": [
+      "29.14.16",
+      "vt．妨碍（hamper, impede, retard）"
+    ],
+    "ukphone": "ˋhIndər",
+    "usphone": "ˋhIndər"
+  },
+  {
+    "name": "hamper",
+    "trans": [
+      "29.14.17",
+      "vt．妨碍（hinder, impede, handicap）"
+    ],
+    "ukphone": "ˋhæmpər",
+    "usphone": "ˋhæmpər"
+  },
+  {
+    "name": "handicap",
+    "trans": [
+      "29.14.18",
+      "vt．妨碍；使不利（hamper, impede, obstruct）"
+    ],
+    "ukphone": "ˋhændikæp",
+    "usphone": "ˋhændikæp"
+  },
+  {
+    "name": "incapacitate",
+    "trans": [
+      "29.14.19",
+      "vt．使不能（disable, handicap）",
+      "【记】 比较capacity（能力）"
+    ],
+    "ukphone": "ˌInkəˋpæsIteIt",
+    "usphone": "ˌInkəˋpæsIteIt"
+  },
+  {
+    "name": "prevent",
+    "trans": [
+      "29.14.20",
+      "vt．阻碍（block, cumber, hinder, obstruct）"
+    ],
+    "ukphone": "prIˋvent",
+    "usphone": "prIˋvent"
+  },
+  {
+    "name": "clog",
+    "trans": [
+      "29.14.21",
+      "vt．阻碍（block, jam）",
+      "【记】 分割记忆c+log（圆木头）"
+    ],
+    "ukphone": "klα:g",
+    "usphone": "klα:g"
+  },
+  {
+    "name": "stunt",
+    "trans": [
+      "29.14.22",
+      "vt．阻碍（hinder, impede）"
+    ],
+    "ukphone": "stʌnt",
+    "usphone": "stʌnt"
+  },
+  {
+    "name": "encumber",
+    "trans": [
+      "29.14.23",
+      "vt．阻碍，妨碍（burden, hamper）",
+      "【记】 en+cumber（躺）→躺着不动→阻碍"
+    ],
+    "ukphone": "Inˋkʌmbər",
+    "usphone": "Inˋkʌmbər"
+  },
+  {
+    "name": "obstruct",
+    "trans": [
+      "29.14.24",
+      "vt．阻碍，妨碍（hinder, impede）",
+      "【记】 ob（反）+struct（建造）→违规建造→妨碍"
+    ],
+    "ukphone": "əbˋstrʌkt",
+    "usphone": "əbˋstrʌkt"
+  },
+  {
+    "name": "foil",
+    "trans": [
+      "29.14.25",
+      "vt．阻止（defeat, frustrate）"
+    ],
+    "ukphone": "fɔIl",
+    "usphone": "fɔIl"
+  },
+  {
+    "name": "block",
+    "trans": [
+      "29.14.26",
+      "vt．阻碍（hinder, obstruct）"
+    ],
+    "ukphone": "blα:k",
+    "usphone": "blα:k"
+  },
+  {
+    "name": "trace",
+    "trans": [
+      "29.15.1",
+      "n．痕迹（remnant, residue）vt．跟踪，追溯（detect）"
+    ],
+    "ukphone": "treIs",
+    "usphone": "treIs"
+  },
+  {
+    "name": "vestige",
+    "trans": [
+      "29.15.2",
+      "n．痕迹，遗迹（remnant, trace）"
+    ],
+    "ukphone": "ˋvestIdʒ",
+    "usphone": "ˋvestIdʒ"
+  },
+  {
+    "name": "stalk",
+    "trans": [
+      "29.15.3",
+      "v．跟踪（猎物）（trace）"
+    ],
+    "ukphone": "stɔ:k",
+    "usphone": "stɔ:k"
+  },
+  {
+    "name": "entrap",
+    "trans": [
+      "29.15.4",
+      "vt．以网或陷阱捕捉（trick, entice）",
+      "【记】 en+trap（陷阱）"
+    ],
+    "ukphone": "Inˋtræp",
+    "usphone": "Inˋtræp"
+  },
+  {
+    "name": "stationary",
+    "trans": [
+      "29.16.1",
+      "adj．固定的（fixed, immobile, static）"
+    ],
+    "ukphone": "ˋsteIʃəneri",
+    "usphone": "ˋsteIʃəneri"
+  },
+  {
+    "name": "immobile",
+    "trans": [
+      "29.16.2",
+      "adj．固定的（fixed, stationary）",
+      "【记】 im（不）+mobile（能动的）；比较mobile phone（移动电话）"
+    ],
+    "ukphone": "Iˋmoʊbl",
+    "usphone": "Iˋmoʊbl"
+  },
+  {
+    "name": "fix",
+    "trans": [
+      "29.16.3",
+      "v．固定（set, determine）"
+    ],
+    "ukphone": "fIks",
+    "usphone": "fIks"
+  },
+  {
+    "name": "fixed",
+    "trans": [
+      "29.16.4",
+      "adj．固定的（stationary）",
+      "【记】 fix（固定）+ed"
+    ],
+    "ukphone": "fIkst",
+    "usphone": "fIkst"
+  },
+  {
+    "name": "solidly",
+    "trans": [
+      "29.16.5",
+      "adv．牢固地（squarely, firmly）"
+    ],
+    "ukphone": "ˋsα:lIdli",
+    "usphone": "ˋsα:lIdli"
+  },
+  {
+    "name": "locate",
+    "trans": [
+      "29.16.6",
+      "vt．设置，使位于（situate, set）",
+      "【记】 loc（地方）+ate→（找出）地方所在→使位于"
+    ],
+    "ukphone": "ˋloʊkeIt",
+    "usphone": "ˋloʊkeIt"
+  },
+  {
+    "name": "bear",
+    "trans": [
+      "29.16.7",
+      "vt．支撑（support, stand）"
+    ],
+    "ukphone": "ber",
+    "usphone": "ber"
+  },
+  {
+    "name": "install",
+    "trans": [
+      "29.16.8",
+      "vt．安装，设置（set up, equip）",
+      "【记】 in（进入）+stall（停止）→停放在里面→安装"
+    ],
+    "ukphone": "Inˋstɔ:l",
+    "usphone": "Inˋstɔ:l"
+  },
+  {
+    "name": "set",
+    "trans": [
+      "29.16.9",
+      "vt．放置（situate）adj．固定的（prescribed, fixed）"
+    ],
+    "ukphone": "set",
+    "usphone": "set"
+  },
+  {
+    "name": "sustain",
+    "trans": [
+      "29.16.10",
+      "vt．支撑，维持（stand, keep, maintain）"
+    ],
+    "ukphone": "səˋsteIn",
+    "usphone": "səˋsteIn"
+  },
+  {
+    "name": "brace",
+    "trans": [
+      "29.16.11",
+      "vt．支持，使固定（strengthen, support）n．支撑物"
+    ],
+    "ukphone": "breIs",
+    "usphone": "breIs"
+  },
+  {
+    "name": "perceive",
+    "trans": [
+      "29.17.1",
+      "vt．察觉到，看见（discern, see）",
+      "【记】 per（全部）+ceive（拿到）→觉察"
+    ],
+    "ukphone": "pərˋsi:v",
+    "usphone": "pərˋsi:v"
+  },
+  {
+    "name": "perceptive",
+    "trans": [
+      "29.17.2",
+      "adj．感觉敏锐的，观察入微的（discerning, penetrating）",
+      "【记】 per（全部）+cept（知道）+ive"
+    ],
+    "ukphone": "pərˋseptIv",
+    "usphone": "pərˋseptIv"
+  },
+  {
+    "name": "detect",
+    "trans": [
+      "29.17.3",
+      "vt．探测，发觉（explore, discover）"
+    ],
+    "ukphone": "dIˋtekt",
+    "usphone": "dIˋtekt"
+  },
+  {
+    "name": "detectable",
+    "trans": [
+      "29.17.4",
+      "adj．可发觉的，可看穿的（apparent, measurable）"
+    ],
+    "ukphone": "dIˋtektəbl",
+    "usphone": "dIˋtektəbl"
+  },
+  {
+    "name": "discernible",
+    "trans": [
+      "29.17.5",
+      "adj．可觉察的"
+    ],
+    "ukphone": "dIˋsɜ:rnəbl",
+    "usphone": "dIˋsɜ:rnəbl"
+  },
+  {
+    "name": "inquiry",
+    "trans": [
+      "29.17.6",
+      "n．调查研究（investigation, quest）"
+    ],
+    "ukphone": "ˋInkwəri",
+    "usphone": "ˋInkwəri"
+  },
+  {
+    "name": "observe",
+    "trans": [
+      "29.17.7",
+      "vt．看到（watch）",
+      "【记】 TOEFL常考词义为“遵守”"
+    ],
+    "ukphone": "əbˋzɜ:rv",
+    "usphone": "əbˋzɜ:rv"
+  },
+  {
+    "name": "observation",
+    "trans": [
+      "29.17.8",
+      "n．观察",
+      "【记】 动词observe（观，看）"
+    ],
+    "ukphone": "ˌα:bzərˋveIʃn",
+    "usphone": "ˌα:bzərˋveIʃn"
+  },
+  {
+    "name": "perspective",
+    "trans": [
+      "29.17.9",
+      "n．透视；观点（view, outlook）",
+      "【记】 per（全部）+spect（看）+ive→远景"
+    ],
+    "ukphone": "pərˋspektIv",
+    "usphone": "pərˋspektIv"
+  },
+  {
+    "name": "insight",
+    "trans": [
+      "29.17.10",
+      "n．洞察力，见识（understanding）"
+    ],
+    "ukphone": "ˋInsaIt",
+    "usphone": "ˋInsaIt"
+  },
+  {
+    "name": "investigate",
+    "trans": [
+      "29.17.11",
+      "v．调查，研究（research, survey）"
+    ],
+    "ukphone": "InˋvestIgeIt",
+    "usphone": "InˋvestIgeIt"
+  },
+  {
+    "name": "pierce",
+    "trans": [
+      "29.17.12",
+      "vt．洞察"
+    ],
+    "ukphone": "pIrs",
+    "usphone": "pIrs"
+  },
+  {
+    "name": "survey",
+    "trans": [
+      "29.17.13",
+      "vt．调查（review, research）；遵守"
+    ],
+    "ukphone": "ˋsɜ:rveI",
+    "usphone": "ˋsɜ:rveI"
+  },
+  {
+    "name": "scan",
+    "trans": [
+      "29.17.14",
+      "vt．浏览，扫描（browse）"
+    ],
+    "ukphone": "skæn",
+    "usphone": "skæn"
+  },
+  {
+    "name": "skim",
+    "trans": [
+      "29.17.15",
+      "vt．略读（scan）"
+    ],
+    "ukphone": "skIm",
+    "usphone": "skIm"
+  },
+  {
+    "name": "spot",
+    "trans": [
+      "29.17.16",
+      "vt．认出（notice, see, sight）"
+    ],
+    "ukphone": "spα:t",
+    "usphone": "spα:t"
+  },
+  {
+    "name": "identify",
+    "trans": [
+      "29.17.17",
+      "vt．认出（recognize）",
+      "【记】 iden（相同）+tify→和（记忆中）相同→认出"
+    ],
+    "ukphone": "aIˋdentIfaI",
+    "usphone": "aIˋdentIfaI"
+  },
+  {
+    "name": "realize",
+    "trans": [
+      "29.17.18",
+      "vt．认识到"
+    ],
+    "ukphone": "ˋri:əlaIz",
+    "usphone": "ˋri:əlaIz"
+  },
+  {
+    "name": "scrutinize",
+    "trans": [
+      "29.17.19",
+      "vt．细察（examine, inspect）",
+      "【记】 scrutin（检查）+ize"
+    ],
+    "ukphone": "ˋskru:tənaIz",
+    "usphone": "ˋskru:tənaIz"
+  },
+  {
+    "name": "locate",
+    "trans": [
+      "29.17.20",
+      "vt．找出（find）",
+      "【记】 loc（地方）+ate→找出地方所在"
+    ],
+    "ukphone": "ˋloʊkeIt",
+    "usphone": "ˋloʊkeIt"
+  },
+  {
+    "name": "oversee",
+    "trans": [
+      "29.17.21",
+      "vt．监督；审查；俯瞰；偷看到，无意中看到"
+    ],
+    "ukphone": "ˌoʊvərˋsi:",
+    "usphone": "ˌoʊvərˋsi:"
+  },
+  {
+    "name": "supervise",
+    "trans": [
+      "29.17.22",
+      "v．监督，管理；指导"
+    ],
+    "ukphone": "ˋsju:pəvaIz",
+    "usphone": "ˋsju:pəvaIz"
+  },
+  {
+    "name": "irreconcilable",
+    "trans": [
+      "29.18.1",
+      "adj．不能妥协的（unconformable, incompatible）",
+      "【记】 ir（不）+reconcilable（可以和解的）"
+    ],
+    "ukphone": "IˋrekənsaIləbl",
+    "usphone": "IˋrekənsaIləbl"
+  },
+  {
+    "name": "indomitable",
+    "trans": [
+      "29.18.2",
+      "adj．不屈不挠的（invincible, relentless）",
+      "【记】 in（不）+domit（支配，统治）+able→不可支配的"
+    ],
+    "ukphone": "Inˋdα:mItəbl",
+    "usphone": "Inˋdα:mItəbl"
+  },
+  {
+    "name": "sturdy",
+    "trans": [
+      "29.18.3",
+      "adj．不屈的，顽强的（strong, stout）"
+    ],
+    "ukphone": "ˋstɜ:rdi",
+    "usphone": "ˋstɜ:rdi"
+  },
+  {
+    "name": "obstinate",
+    "trans": [
+      "29.18.4",
+      "adj．固执的（stubborn）",
+      "【记】 ob+stin（站）+ate→坚决站着→固执的"
+    ],
+    "ukphone": "ˋα:bstInət",
+    "usphone": "ˋα:bstInət"
+  },
+  {
+    "name": "bigoted",
+    "trans": [
+      "29.18.5",
+      "adj．固执己见的（narrow-minded, intolerant）"
+    ],
+    "ukphone": "ˋbIgətId",
+    "usphone": "ˋbIgətId"
+  },
+  {
+    "name": "persistent",
+    "trans": [
+      "29.18.6",
+      "adj．坚持不懈的（dogged）",
+      "【记】 per（始终）+sist（坐）+ent→始终坐着→坚持不懈地（背单词）"
+    ],
+    "ukphone": "pərˋsIstənt",
+    "usphone": "pərˋsIstənt"
+  },
+  {
+    "name": "inflexible",
+    "trans": [
+      "29.18.7",
+      "adj．坚定的（rigid, unbending）",
+      "【记】 in（不）+flexible（灵活的）"
+    ],
+    "ukphone": "Inˋfleksəbl",
+    "usphone": "Inˋfleksəbl"
+  },
+  {
+    "name": "steadfast",
+    "trans": [
+      "29.18.8",
+      "adj．坚决，坚定，不变的（firm, unchanging）"
+    ],
+    "ukphone": "ˋstedfæst",
+    "usphone": "ˋstedfæst"
+  },
+  {
+    "name": "unshaken",
+    "trans": [
+      "29.18.9",
+      "adj．坚决的，不动摇的",
+      "【记】 un（不）+shaken（动摇）"
+    ],
+    "ukphone": "ˌʌnˋʃeIkən",
+    "usphone": "ˌʌnˋʃeIkən"
+  },
+  {
+    "name": "durable",
+    "trans": [
+      "29.18.10",
+      "adj．耐久的，耐用的（lasting, enduring）",
+      "【记】 dur（持续）+able"
+    ],
+    "ukphone": "ˋdjʊrəbl",
+    "usphone": "ˋdjʊrəbl"
+  },
+  {
+    "name": "tough",
+    "trans": [
+      "29.18.11",
+      "adj．强硬的，坚韧的（strong, hard）；粗暴的"
+    ],
+    "ukphone": "tʌf",
+    "usphone": "tʌf"
+  },
+  {
+    "name": "headstrong",
+    "trans": [
+      "29.18.12",
+      "adj．顽固的（obstinate, stubborn）"
+    ],
+    "ukphone": "ˋhedstrɔ:ŋ",
+    "usphone": "ˋhedstrɔ:ŋ"
+  },
+  {
+    "name": "stubborn",
+    "trans": [
+      "29.18.13",
+      "adj．顽固的"
+    ],
+    "ukphone": "ˋstʌbərn",
+    "usphone": "ˋstʌbərn"
+  },
+  {
+    "name": "tenacious",
+    "trans": [
+      "29.18.14",
+      "adj．抓住不放的，顽强的（stubborn, resolute）",
+      "【记】 ten（拿）+acious"
+    ],
+    "ukphone": "təˋneIʃəs",
+    "usphone": "təˋneIʃəs"
+  },
+  {
+    "name": "resolute",
+    "trans": [
+      "29.18.15",
+      "adj．坚决的（firm, determined, steadfast）"
+    ],
+    "ukphone": "ˋrezəlu:t",
+    "usphone": "ˋrezəlu:t"
+  },
+  {
+    "name": "hardheaded",
+    "trans": [
+      "29.18.16",
+      "adj．顽固的（stubborn, obstinate）",
+      "【记】 hard（硬的）+head（想法）+ed→铁石心肠的"
+    ],
+    "ukphone": "ˌhα:rdˋhedId",
+    "usphone": "ˌhα:rdˋhedId"
+  },
+  {
+    "name": "stoically",
+    "trans": [
+      "29.18.17",
+      "adv．坚韧地"
+    ],
+    "ukphone": "ˋstoʊIkli",
+    "usphone": "ˋstoʊIkli"
+  },
+  {
+    "name": "fortitude",
+    "trans": [
+      "29.18.18",
+      "n．坚忍，刚毅（endurance, courage）",
+      "【记】 fort（强）+itude表示状态→强的状态"
+    ],
+    "ukphone": "ˋfɔ:rtətju:d",
+    "usphone": "ˋfɔ:rtətju:d"
+  },
+  {
+    "name": "resist",
+    "trans": [
+      "29.18.19",
+      "v．坚持（withstand）",
+      "【记】 re（始终）+sist（坐）→始终坐着→坚持"
+    ],
+    "ukphone": "rIˋzIst",
+    "usphone": "rIˋzIst"
+  },
+  {
+    "name": "remain",
+    "trans": [
+      "29.18.20",
+      "vi．保持，逗留（stay）"
+    ],
+    "ukphone": "rIˋmeIn",
+    "usphone": "rIˋmeIn"
+  },
+  {
+    "name": "persevere",
+    "trans": [
+      "29.18.21",
+      "vi．坚持，不屈不挠",
+      "【记】 比较severe（严重）"
+    ],
+    "ukphone": "ˌpɜ:rsəˋvIr",
+    "usphone": "ˌpɜ:rsəˋvIr"
+  },
+  {
+    "name": "perseverance",
+    "trans": [
+      "29.18.22",
+      "n．坚定不移（persistence, endurance）"
+    ],
+    "ukphone": "ˌpɜ:rsəˋvIrəns",
+    "usphone": "ˌpɜ:rsəˋvIrəns"
+  },
+  {
+    "name": "maintain",
+    "trans": [
+      "29.18.23",
+      "vt．坚持（认为）（keep, sustain, persist, insist）",
+      "【记】 main=man（手）+tain（拿）→用手拿住→保持"
+    ],
+    "ukphone": "meInˋteIn",
+    "usphone": "meInˋteIn"
+  },
+  {
+    "name": "insist",
+    "trans": [
+      "29.18.24",
+      "vt．主张；坚持说（claim; adhere）"
+    ],
+    "ukphone": "InˋsIst",
+    "usphone": "InˋsIst"
+  },
+  {
+    "name": "allege",
+    "trans": [
+      "29.18.25",
+      "v．主张，申述，宣称（declare, state）"
+    ],
+    "ukphone": "əˋledʒ",
+    "usphone": "əˋledʒ"
+  },
+  {
+    "name": "implicit",
+    "trans": [
+      "29.19.1",
+      "adj．暗示的（inferred, implied）",
+      "【记】 im（进入）+plic（重叠）+it→重叠状态→含蓄的"
+    ],
+    "ukphone": "ImˋplIsIt",
+    "usphone": "ImˋplIsIt"
+  },
+  {
+    "name": "reflection",
+    "trans": [
+      "29.19.2",
+      "n．反映（indication, revelation）"
+    ],
+    "ukphone": "rIˋflekʃn",
+    "usphone": "rIˋflekʃn"
+  },
+  {
+    "name": "expose",
+    "trans": [
+      "29.19.3",
+      "vt．使暴露，受到，揭露（uncover, subject to）"
+    ],
+    "ukphone": "Ikˋspoʊz",
+    "usphone": "Ikˋspoʊz"
+  },
+  {
+    "name": "exposure",
+    "trans": [
+      "29.19.4",
+      "n．曝光（disclosure, uncovering）"
+    ],
+    "ukphone": "Ikˋspoʊʒər",
+    "usphone": "Ikˋspoʊʒər"
+  },
+  {
+    "name": "reveal",
+    "trans": [
+      "29.19.5",
+      "vt．展现；揭露（exhibit, expose, disclose）"
+    ],
+    "ukphone": "rIˋvi:l",
+    "usphone": "rIˋvi:l"
+  },
+  {
+    "name": "revelation",
+    "trans": [
+      "29.19.6",
+      "n．显示；揭露（disclosure）"
+    ],
+    "ukphone": "ˌrevəˋleIʃn",
+    "usphone": "ˌrevəˋleIʃn"
+  },
+  {
+    "name": "unveil",
+    "trans": [
+      "29.19.7",
+      "v．揭露，显露（disclose, reveal）",
+      "【记】 un（不）+veil（罩面纱）→揭开"
+    ],
+    "ukphone": "ˌʌnˋveIl",
+    "usphone": "ˌʌnˋveIl"
+  },
+  {
+    "name": "show",
+    "trans": [
+      "29.19.8",
+      "v．展示（demonstrate）"
+    ],
+    "ukphone": "ʃoʊ",
+    "usphone": "ʃoʊ"
+  },
+  {
+    "name": "transpire",
+    "trans": [
+      "29.19.9",
+      "vt．泄露"
+    ],
+    "ukphone": "trænˋspaIər",
+    "usphone": "trænˋspaIər"
+  },
+  {
+    "name": "profess",
+    "trans": [
+      "29.19.10",
+      "vt．表示（allege, claim, state）"
+    ],
+    "ukphone": "prəˋfes",
+    "usphone": "prəˋfes"
+  },
+  {
+    "name": "signify",
+    "trans": [
+      "29.19.11",
+      "vt．表示，意味着（indicate, mean）"
+    ],
+    "ukphone": "ˋsIgnIfaI",
+    "usphone": "ˋsIgnIfaI"
+  },
+  {
+    "name": "bare",
+    "trans": [
+      "29.19.12",
+      "vt．露出（expose）"
+    ],
+    "ukphone": "ber",
+    "usphone": "ber"
+  },
+  {
+    "name": "exhibit",
+    "trans": [
+      "29.19.13",
+      "vt．显示（show）",
+      "【记】 ex（出）+hibit（拿）→拿出→展览"
+    ],
+    "ukphone": "IgˋzIbIt",
+    "usphone": "IgˋzIbIt"
+  },
+  {
+    "name": "leak",
+    "trans": [
+      "29.19.14",
+      "vt．泄漏（seep, escape）"
+    ],
+    "ukphone": "li:k",
+    "usphone": "li:k"
+  },
+  {
+    "name": "divulge",
+    "trans": [
+      "29.19.15",
+      "vt．泄露（disclose; reveal）"
+    ],
+    "ukphone": "daIˋvʌldʒ",
+    "usphone": "daIˋvʌldʒ"
+  },
+  {
+    "name": "denote",
+    "trans": [
+      "29.19.16",
+      "vt．指示；表示（indicate, show）",
+      "【记】 de（加强）+note（注意）→加强注意→指示"
+    ],
+    "ukphone": "dIˋnoʊt",
+    "usphone": "dIˋnoʊt"
+  },
+  {
+    "name": "indicate",
+    "trans": [
+      "29.19.17",
+      "vt．指示；表示（show, suggest, hint）",
+      "【记】 in+dic（言，说）+ate→表示"
+    ],
+    "ukphone": "ˋIndIkeIt",
+    "usphone": "ˋIndIkeIt"
+  },
+  {
+    "name": "betray",
+    "trans": [
+      "29.19.18",
+      "vt．泄漏（expose）",
+      "【记】 be+tray（盘子）→和盘托出→泄漏"
+    ],
+    "ukphone": "bIˋtreI",
+    "usphone": "bIˋtreI"
+  },
+  {
+    "name": "allusion",
+    "trans": [
+      "29.19.19",
+      "n．暗示；提及；间接提到"
+    ],
+    "ukphone": "əˋlu:ʒn",
+    "usphone": "əˋlu:ʒn"
+  },
+  {
+    "name": "emergence",
+    "trans": [
+      "29.19.20",
+      "n．出现；露头；浮现（appear）"
+    ],
+    "ukphone": "iˋmɜ:rdʒəns",
+    "usphone": "iˋmɜ:rdʒəns"
+  },
+  {
+    "name": "manifestation",
+    "trans": [
+      "29.19.21",
+      "n．表现；显示；示威运动"
+    ],
+    "ukphone": "ˌmænIfeˋsteIʃn",
+    "usphone": "ˌmænIfeˋsteIʃn"
+  },
+  {
+    "name": "indication",
+    "trans": [
+      "29.19.22",
+      "n．指出；迹象；指示（denotation, indicant）"
+    ],
+    "ukphone": "ˌIndIˋkeIʃn",
+    "usphone": "ˌIndIˋkeIʃn"
+  },
+  {
+    "name": "irrepressible",
+    "trans": [
+      "29.20.1",
+      "adj．不可压制的，难以征服的（insuppressible, uncon-trolled）",
+      "【记】 ir（不）+repressible（可以压制的）；比较press（压，按）"
+    ],
+    "ukphone": "ˌIrIˋpresəbl",
+    "usphone": "ˌIrIˋpresəbl"
+  },
+  {
+    "name": "unruly",
+    "trans": [
+      "29.20.2",
+      "adj．难控制的（uncontrollable）",
+      "【记】 un（不）+rul（e）（法）+y"
+    ],
+    "ukphone": "ʌnˋru:li",
+    "usphone": "ʌnˋru:li"
+  },
+  {
+    "name": "operate",
+    "trans": [
+      "29.20.3",
+      "vt．操纵（manipulate, navigate, steer）"
+    ],
+    "ukphone": "ˋα:pəreIt",
+    "usphone": "ˋα:pəreIt"
+  },
+  {
+    "name": "handle",
+    "trans": [
+      "29.20.4",
+      "vt．操纵",
+      "【记】 hand（手）+le→操纵"
+    ],
+    "ukphone": "ˋhændl",
+    "usphone": "ˋhændl"
+  },
+  {
+    "name": "intelligible",
+    "trans": [
+      "29.21.1",
+      "adj．可理解的（apprehensible）"
+    ],
+    "ukphone": "InˋtelIdʒəbl",
+    "usphone": "InˋtelIdʒəbl"
+  },
+  {
+    "name": "evident",
+    "trans": [
+      "29.21.2",
+      "adj．明白的（obvious, manifest）",
+      "【记】 e+vid=vis（看）+ent"
+    ],
+    "ukphone": "ˋevIdənt",
+    "usphone": "ˋevIdənt"
+  },
+  {
+    "name": "explicit",
+    "trans": [
+      "29.21.3",
+      "adj．明确的；清楚的（straightforward）"
+    ],
+    "ukphone": "IkˋsplIsIt",
+    "usphone": "IkˋsplIsIt"
+  },
+  {
+    "name": "elusive",
+    "trans": [
+      "29.21.4",
+      "adj．难懂的（elusory, intangible）",
+      "【记】 e（出）+lus（玩）+ive→耍人→让人难懂的"
+    ],
+    "ukphone": "iˋlu:sIv",
+    "usphone": "iˋlu:sIv"
+  },
+  {
+    "name": "mysterious",
+    "trans": [
+      "29.21.5",
+      "adj．神秘的；难以理解的（cryptic; undecipherable）"
+    ],
+    "ukphone": "mIˋstIriəs",
+    "usphone": "mIˋstIriəs"
+  },
+  {
+    "name": "ignorant",
+    "trans": [
+      "29.21.6",
+      "adj．无知的，不了解的（unaware）"
+    ],
+    "ukphone": "ˋIgnərənt",
+    "usphone": "ˋIgnərənt"
+  },
+  {
+    "name": "ignorance",
+    "trans": [
+      "29.21.7",
+      "n．无知",
+      "【记】 ig（不）+nor（知道）+ance"
+    ],
+    "ukphone": "ˋIgnərəns",
+    "usphone": "ˋIgnərəns"
+  },
+  {
+    "name": "grasp",
+    "trans": [
+      "29.21.8",
+      "n./v．领会，理解（understanding, comprehension）"
+    ],
+    "ukphone": "græsp",
+    "usphone": "græsp"
+  },
+  {
+    "name": "comprehend",
+    "trans": [
+      "29.21.9",
+      "vt．理解（understand）"
+    ],
+    "ukphone": "ˌkα:mprIˋhend",
+    "usphone": "ˌkα:mprIˋhend"
+  },
+  {
+    "name": "comprehensive",
+    "trans": [
+      "29.21.10",
+      "adj．综合的；有理解力的"
+    ],
+    "ukphone": "ˌkα:mprIˋhensIv",
+    "usphone": "ˌkα:mprIˋhensIv"
+  },
+  {
+    "name": "rapacious",
+    "trans": [
+      "29.22.1",
+      "adj．强夺的",
+      "【记】 rap（抓，夺）+acious"
+    ],
+    "ukphone": "rəˋpeIʃəs",
+    "usphone": "rəˋpeIʃəs"
+  },
+  {
+    "name": "strip",
+    "trans": [
+      "29.22.2",
+      "vt．剥，夺去（deprive, take off）"
+    ],
+    "ukphone": "strIp",
+    "usphone": "strIp"
+  },
+  {
+    "name": "bereave",
+    "trans": [
+      "29.22.3",
+      "vt．剥夺（deprive, be devoid of）",
+      "【记】 be+reave（抢夺）"
+    ],
+    "ukphone": "bIˋri:v",
+    "usphone": "bIˋri:v"
+  },
+  {
+    "name": "loot",
+    "trans": [
+      "29.22.4",
+      "vt．掠夺（plunder, seize）"
+    ],
+    "ukphone": "lu:t",
+    "usphone": "lu:t"
+  },
+  {
+    "name": "harry",
+    "trans": [
+      "29.22.5",
+      "vt．掠夺；折磨（harass, pester）"
+    ],
+    "ukphone": "ˋhæri",
+    "usphone": "ˋhæri"
+  },
+  {
+    "name": "ravage",
+    "trans": [
+      "29.22.6",
+      "vt．掠夺"
+    ],
+    "ukphone": "ˋrævIdʒ",
+    "usphone": "ˋrævIdʒ"
+  },
+  {
+    "name": "grind",
+    "trans": [
+      "29.22.7",
+      "vt．折磨；压榨（crush, mill）"
+    ],
+    "ukphone": "graInd",
+    "usphone": "graInd"
+  },
+  {
+    "name": "torment",
+    "trans": [
+      "29.22.8",
+      "vt．折磨（anguish, agony）"
+    ],
+    "ukphone": "tɔ:rˋment",
+    "usphone": "tɔ:rˋment"
+  },
+  {
+    "name": "equivocal",
+    "trans": [
+      "29.23.1",
+      "adj．模棱两可的，意义不清的（ambiguous）",
+      "【记】 equi（平的）+voc（声音）+al→用平平的声音→意义不清的"
+    ],
+    "ukphone": "IˋkwIvəkl",
+    "usphone": "IˋkwIvəkl"
+  },
+  {
+    "name": "enigma",
+    "trans": [
+      "29.23.2",
+      "n．谜（mystery）"
+    ],
+    "ukphone": "IˋnIgmə",
+    "usphone": "IˋnIgmə"
+  },
+  {
+    "name": "enigmatic",
+    "trans": [
+      "29.23.3",
+      "adj．像谜般的，神秘的（mysterious, secretive）"
+    ],
+    "ukphone": "ˌenIgˋmætIk",
+    "usphone": "ˌenIgˋmætIk"
+  },
+  {
+    "name": "maze",
+    "trans": [
+      "29.23.4",
+      "n．迷宫；迷惑（complexity, labyrinth）",
+      "【记】 比较maize（玉米）"
+    ],
+    "ukphone": "meIz",
+    "usphone": "meIz"
+  },
+  {
+    "name": "labyrinth",
+    "trans": [
+      "29.23.5",
+      "n．迷宫；错综复杂之事件"
+    ],
+    "ukphone": "ˋlæbərInθ",
+    "usphone": "ˋlæbərInθ"
+  },
+  {
+    "name": "riddle",
+    "trans": [
+      "29.23.6",
+      "n．谜（puzzle, mystery）"
+    ],
+    "ukphone": "ˋrIdl",
+    "usphone": "ˋrIdl"
+  },
+  {
+    "name": "puzzle",
+    "trans": [
+      "29.23.7",
+      "n．难题，谜（mystery）v.（使）迷惑"
+    ],
+    "ukphone": "ˋpʌzl",
+    "usphone": "ˋpʌzl"
+  },
+  {
+    "name": "elude",
+    "trans": [
+      "29.23.8",
+      "vt．困惑",
+      "【记】 e（出）+lude（玩）→玩出去→躲出去"
+    ],
+    "ukphone": "iˋlu:d",
+    "usphone": "iˋlu:d"
+  },
+  {
+    "name": "captivate",
+    "trans": [
+      "29.23.9",
+      "vt．迷惑（attract, fascinate, enamour）"
+    ],
+    "ukphone": "ˋkæptIveIt",
+    "usphone": "ˋkæptIveIt"
+  },
+  {
+    "name": "enthrall",
+    "trans": [
+      "29.23.10",
+      "vt．迷惑（captivate）",
+      "【记】 en+thrall（奴隶）"
+    ],
+    "ukphone": "Inˋθrɔ:l",
+    "usphone": "Inˋθrɔ:l"
+  },
+  {
+    "name": "bewilder",
+    "trans": [
+      "29.23.11",
+      "vt．迷惑，把…弄糊涂（befuddle, confuse）"
+    ],
+    "ukphone": "bIˋwIldər",
+    "usphone": "bIˋwIldər"
+  },
+  {
+    "name": "perplex",
+    "trans": [
+      "29.23.12",
+      "vt．迷惑，困惑，难住（puzzle, confuse）",
+      "【记】 per（全部）+plex（交错重叠）→困惑"
+    ],
+    "ukphone": "pərˋpleks",
+    "usphone": "pərˋpleks"
+  },
+  {
+    "name": "tangle",
+    "trans": [
+      "29.23.13",
+      "vt．使缠结，使纠缠（knot, snarl）"
+    ],
+    "ukphone": "ˋtæŋgl",
+    "usphone": "ˋtæŋgl"
+  },
+  {
+    "name": "confound",
+    "trans": [
+      "29.23.14",
+      "vt．使糊涂，迷惑（confuse, puzzle）"
+    ],
+    "ukphone": "kənˋfaʊnd",
+    "usphone": "kənˋfaʊnd"
+  },
+  {
+    "name": "entangle",
+    "trans": [
+      "29.23.15",
+      "vt．使纠缠；使迷惑（embroil; involve）",
+      "【记】 en+tangle（纠缠）"
+    ],
+    "ukphone": "Inˋtæŋgl",
+    "usphone": "Inˋtæŋgl"
+  },
+  {
+    "name": "fascinate",
+    "trans": [
+      "29.23.16",
+      "vt．使迷惑（enchant, enthrall, intrigue）"
+    ],
+    "ukphone": "ˋfæsIneIt",
+    "usphone": "ˋfæsIneIt"
+  },
+  {
+    "name": "blur",
+    "trans": [
+      "29.23.17",
+      "vt．使模糊（become indistinct）"
+    ],
+    "ukphone": "blɜ:r",
+    "usphone": "blɜ:r"
+  },
+  {
+    "name": "dazzle",
+    "trans": [
+      "29.23.18",
+      "vt．使目眩；使迷惑（blind, bewilder）"
+    ],
+    "ukphone": "ˋdæzl",
+    "usphone": "ˋdæzl"
+  },
+  {
+    "name": "dogmatic",
+    "trans": [
+      "29.24.1",
+      "adj．教条的；武断的（opinionated; arbitrary）"
+    ],
+    "ukphone": "dɔ:gˋmætIk",
+    "usphone": "dɔ:gˋmætIk"
+  },
+  {
+    "name": "illegible",
+    "trans": [
+      "29.24.2",
+      "adj．难辨认的（unreadable）",
+      "【记】 il（不）+legible（可读的）→不能读的"
+    ],
+    "ukphone": "Iˋledʒəbl",
+    "usphone": "Iˋledʒəbl"
+  },
+  {
+    "name": "pending",
+    "trans": [
+      "29.24.3",
+      "adj．未决的（suspending）",
+      "【记】 pend（挂）+ing"
+    ],
+    "ukphone": "ˋpendIŋ",
+    "usphone": "ˋpendIŋ"
+  },
+  {
+    "name": "resolve",
+    "trans": [
+      "29.24.4",
+      "vt．决定（determine）"
+    ],
+    "ukphone": "rIˋzα:lv",
+    "usphone": "rIˋzα:lv"
+  },
+  {
+    "name": "resolved",
+    "trans": [
+      "29.24.5",
+      "adj．下定决心的"
+    ],
+    "ukphone": "rIˋzα:lvd",
+    "usphone": "rIˋzα:lvd"
+  },
+  {
+    "name": "determine",
+    "trans": [
+      "29.24.6",
+      "vt．决定（fix, calculate, evaluate）"
+    ],
+    "ukphone": "dIˋtɜ:rmIn",
+    "usphone": "dIˋtɜ:rmIn"
+  },
+  {
+    "name": "determination",
+    "trans": [
+      "29.24.7",
+      "n．决定，决心"
+    ],
+    "ukphone": "dIˌtɜ:rmIˋneIʃn",
+    "usphone": "dIˌtɜ:rmIˋneIʃn"
+  },
+  {
+    "name": "discretion",
+    "trans": [
+      "29.24.8",
+      "n．判断力"
+    ],
+    "ukphone": "dIˋskreʃn",
+    "usphone": "dIˋskreʃn"
+  },
+  {
+    "name": "decide",
+    "trans": [
+      "29.24.9",
+      "v．决定（determine）"
+    ],
+    "ukphone": "dIˋsaId",
+    "usphone": "dIˋsaId"
+  },
+  {
+    "name": "deem",
+    "trans": [
+      "29.24.10",
+      "v．认为（think, consider）"
+    ],
+    "ukphone": "di:m",
+    "usphone": "di:m"
+  },
+  {
+    "name": "vindicate",
+    "trans": [
+      "29.24.11",
+      "vt．辨明"
+    ],
+    "ukphone": "ˋvIndIkeIt",
+    "usphone": "ˋvIndIkeIt"
+  },
+  {
+    "name": "discern",
+    "trans": [
+      "29.24.12",
+      "vt．辨明（detect, distinguish）"
+    ],
+    "ukphone": "dIˋsɜ:rn",
+    "usphone": "dIˋsɜ:rn"
+  },
+  {
+    "name": "assert",
+    "trans": [
+      "29.24.13",
+      "vt．断言，宣称（declare）"
+    ],
+    "ukphone": "əˋsɜ:rt",
+    "usphone": "əˋsɜ:rt"
+  },
+  {
+    "name": "conclude",
+    "trans": [
+      "29.24.14",
+      "vt．推断出，断定"
+    ],
+    "ukphone": "kənˋklu:d",
+    "usphone": "kənˋklu:d"
+  },
+  {
+    "name": "affirm",
+    "trans": [
+      "29.24.15",
+      "vt．断言",
+      "【记】 af（一再）+firm（肯定）→断言"
+    ],
+    "ukphone": "əˋfɜ:rm",
+    "usphone": "əˋfɜ:rm"
+  },
+  {
+    "name": "breakdown",
+    "trans": [
+      "29.25.1",
+      "n．崩溃，倒塌；失败"
+    ],
+    "ukphone": "ˋbreIkdaʊn",
+    "usphone": "ˋbreIkdaʊn"
+  },
+  {
+    "name": "collapse",
+    "trans": [
+      "29.25.2",
+      "n./v．倒塌，崩溃（crash）",
+      "【记】 col（共同）+lapse（滑下）→倒塌"
+    ],
+    "ukphone": "kəˋlæps",
+    "usphone": "kəˋlæps"
+  },
+  {
+    "name": "breach",
+    "trans": [
+      "29.25.3",
+      "n．破裂（opening, break）"
+    ],
+    "ukphone": "bri:tʃ",
+    "usphone": "bri:tʃ"
+  },
+  {
+    "name": "shatter",
+    "trans": [
+      "29.25.4",
+      "n．碎片（fragment）v．粉碎（break）"
+    ],
+    "ukphone": "ˋʃætər",
+    "usphone": "ˋʃætər"
+  },
+  {
+    "name": "scrap",
+    "trans": [
+      "29.25.5",
+      "n．碎片，废料"
+    ],
+    "ukphone": "skræp",
+    "usphone": "skræp"
+  },
+  {
+    "name": "fragment",
+    "trans": [
+      "29.25.6",
+      "n．碎片，破片（piece, scrap）",
+      "【记】 frag（随）+ment"
+    ],
+    "ukphone": "ˋfrægmənt",
+    "usphone": "ˋfrægmənt"
+  },
+  {
+    "name": "fracture",
+    "trans": [
+      "29.25.7",
+      "n./v．断裂（break）",
+      "【记】 fract（碎裂）+ure→碎的状态→骨折"
+    ],
+    "ukphone": "ˋfræktʃər",
+    "usphone": "ˋfræktʃər"
+  },
+  {
+    "name": "rupture",
+    "trans": [
+      "29.25.8",
+      "n./v．破裂，决裂（burst, breach）",
+      "【记】 rupt（断）+ure"
+    ],
+    "ukphone": "ˋrʌptʃər",
+    "usphone": "ˋrʌptʃər"
+  },
+  {
+    "name": "crumble",
+    "trans": [
+      "29.25.9",
+      "v．粉碎，崩溃（collapse, crash）",
+      "【记】 比较crumb（面包屑，小量）"
+    ],
+    "ukphone": "ˋkrʌmbl",
+    "usphone": "ˋkrʌmbl"
+  },
+  {
+    "name": "squash",
+    "trans": [
+      "29.25.10",
+      "v．压碎（flatten, squeeze）"
+    ],
+    "ukphone": "skwα:ʃ",
+    "usphone": "skwα:ʃ"
+  },
+  {
+    "name": "crash",
+    "trans": [
+      "29.25.11",
+      "v．撞碎（crumble, shatter）"
+    ],
+    "ukphone": "kræʃ",
+    "usphone": "kræʃ"
+  },
+  {
+    "name": "ravage",
+    "trans": [
+      "29.25.12",
+      "vt．破坏（devastate, ruin）"
+    ],
+    "ukphone": "ˋrævIdʒ",
+    "usphone": "ˋrævIdʒ"
+  },
+  {
+    "name": "raze",
+    "trans": [
+      "29.25.13",
+      "vt．摧毁（damage, bulldoze, demolish）"
+    ],
+    "ukphone": "reIz",
+    "usphone": "reIz"
+  },
+  {
+    "name": "demolish",
+    "trans": [
+      "29.25.14",
+      "vt．破坏（destroy, raze）",
+      "【记】 demol（破坏）+ish"
+    ],
+    "ukphone": "dIˋmα:lIʃ",
+    "usphone": "dIˋmα:lIʃ"
+  },
+  {
+    "name": "disfigure",
+    "trans": [
+      "29.25.15",
+      "vt．破坏（destroy, wreck）",
+      "【记】 dis+figure（形象）→破坏（形象）"
+    ],
+    "ukphone": "dIsˋfIgjər",
+    "usphone": "dIsˋfIgjər"
+  },
+  {
+    "name": "frustrate",
+    "trans": [
+      "29.25.16",
+      "vt．破坏；挫败（baffle, thwart）"
+    ],
+    "ukphone": "ˋfrʌstreIt",
+    "usphone": "ˋfrʌstreIt"
+  },
+  {
+    "name": "smash",
+    "trans": [
+      "29.25.17",
+      "vt．破碎（shatter, destroy）"
+    ],
+    "ukphone": "smæʃ",
+    "usphone": "smæʃ"
+  },
+  {
+    "name": "devastate",
+    "trans": [
+      "29.25.18",
+      "vt．使荒废；破坏（destroy, demolish）",
+      "【记】 de+vast（大量）+ate→大量弄坏"
+    ],
+    "ukphone": "ˋdevəsteIt",
+    "usphone": "ˋdevəsteIt"
+  },
+  {
+    "name": "devastation",
+    "trans": [
+      "29.25.19",
+      "n．毁坏"
+    ],
+    "ukphone": "ˌdevəˋsteIʃn",
+    "usphone": "ˌdevəˋsteIʃn"
+  },
+  {
+    "name": "disrupt",
+    "trans": [
+      "29.25.20",
+      "vt．使中断，使分裂（disturb, disorder）",
+      "【记】 比较rupture（破裂）"
+    ],
+    "ukphone": "dIsˋrʌpt",
+    "usphone": "dIsˋrʌpt"
+  },
+  {
+    "name": "mangle",
+    "trans": [
+      "29.25.21",
+      "vt．撕裂，毁坏（mutilate）",
+      "【记】 比较mingle（混合）"
+    ],
+    "ukphone": "ˋmæŋgl",
+    "usphone": "ˋmæŋgl"
+  },
+  {
+    "name": "spoil",
+    "trans": [
+      "29.25.22",
+      "vt．损坏，糟蹋（decay, ruin, rot, go bad）；宠坏"
+    ],
+    "ukphone": "spɔIl",
+    "usphone": "spɔIl"
+  },
+  {
+    "name": "engulf",
+    "trans": [
+      "29.25.23",
+      "vt．吞没，吞食（devour, swallow）",
+      "【记】 en+gulf（沟）→使入沟→吞没"
+    ],
+    "ukphone": "Inˋgʌlf",
+    "usphone": "Inˋgʌlf"
+  },
+  {
+    "name": "devour",
+    "trans": [
+      "29.25.24",
+      "vt．吞食，吞没；毁灭（eat up, consume）",
+      "【记】 de+vour（吞食）"
+    ],
+    "ukphone": "dIˋvaʊər",
+    "usphone": "dIˋvaʊər"
+  },
+  {
+    "name": "crumple",
+    "trans": [
+      "29.25.25",
+      "vt．压皱（rumple, wrinkle）"
+    ],
+    "ukphone": "ˋkrʌmpl",
+    "usphone": "ˋkrʌmpl"
+  },
+  {
+    "name": "crush",
+    "trans": [
+      "29.25.26",
+      "vt．榨，挤，压碎（crunch）"
+    ],
+    "ukphone": "krʌʃ",
+    "usphone": "krʌʃ"
+  },
+  {
+    "name": "disintegration",
+    "trans": [
+      "29.25.27",
+      "n．瓦解"
+    ],
+    "ukphone": "dIsˌIntIˋgreIʃn",
+    "usphone": "dIsˌIntIˋgreIʃn"
+  },
+  {
+    "name": "rift",
+    "trans": [
+      "29.25.28",
+      "n．裂缝，裂口，断裂"
+    ],
+    "ukphone": "rIft",
+    "usphone": "rIft"
+  },
+  {
+    "name": "ruins",
+    "trans": [
+      "29.25.29",
+      "n．毁灭；废墟，遗迹"
+    ],
+    "ukphone": "ˋru:Inz",
+    "usphone": "ˋru:Inz"
+  },
+  {
+    "name": "destroy",
+    "trans": [
+      "29.25.30",
+      "vt．破坏；消灭；毁坏"
+    ],
+    "ukphone": "dIˋstrɔI",
+    "usphone": "dIˋstrɔI"
+  },
+  {
+    "name": "annihilate",
+    "trans": [
+      "29.25.31",
+      "vt．歼灭；战胜；废止"
+    ],
+    "ukphone": "əˋnaIəleIt",
+    "usphone": "əˋnaIəleIt"
+  },
+  {
+    "name": "compromise",
+    "trans": [
+      "29.25.32",
+      "v./n．妥协；危害，折中"
+    ],
+    "ukphone": "ˋkα:mprəmaIz",
+    "usphone": "ˋkα:mprəmaIz"
+  },
+  {
+    "name": "compulsive",
+    "trans": [
+      "29.26.1",
+      "adj．强迫的（irresistible, obsessive, obsessed）"
+    ],
+    "ukphone": "kəmˋpʌlsIv",
+    "usphone": "kəmˋpʌlsIv"
+  },
+  {
+    "name": "pressure",
+    "trans": [
+      "29.26.2",
+      "n．压迫（tension）",
+      "【记】 press（压）+ure"
+    ],
+    "ukphone": "ˋpreʃər",
+    "usphone": "ˋpreʃər"
+  },
+  {
+    "name": "tease",
+    "trans": [
+      "29.26.3",
+      "vt．强求"
+    ],
+    "ukphone": "ti:z",
+    "usphone": "ti:z"
+  },
+  {
+    "name": "compel",
+    "trans": [
+      "29.26.4",
+      "vt．强迫（coerce, force）"
+    ],
+    "ukphone": "kəmˋpel",
+    "usphone": "kəmˋpel"
+  },
+  {
+    "name": "constrain",
+    "trans": [
+      "29.26.5",
+      "vt．强迫（compel）"
+    ],
+    "ukphone": "kənˋstreIn",
+    "usphone": "kənˋstreIn"
+  },
+  {
+    "name": "laborious",
+    "trans": [
+      "29.27.1",
+      "adj．勤劳的",
+      "【记】 labor（劳动）+ious→劳动的，勤劳的"
+    ],
+    "ukphone": "ləˋbɔ:riəs",
+    "usphone": "ləˋbɔ:riəs"
+  },
+  {
+    "name": "industrious",
+    "trans": [
+      "29.27.2",
+      "adj．勤勉的（assiduous, diligent, sedulous）"
+    ],
+    "ukphone": "Inˋdʌstriəs",
+    "usphone": "Inˋdʌstriəs"
+  },
+  {
+    "name": "assiduous",
+    "trans": [
+      "29.27.3",
+      "adj．勤勉的（diligent, industrious）",
+      "【记】 as+sid（坐）+uous→一直坐着（工作）→勤勉的"
+    ],
+    "ukphone": "əˋsIdʒuəs",
+    "usphone": "əˋsIdʒuəs"
+  },
+  {
+    "name": "diligent",
+    "trans": [
+      "29.27.4",
+      "adj．勤勉的，勤奋的（industrious, assiduous）"
+    ],
+    "ukphone": "ˋdIlIdʒənt",
+    "usphone": "ˋdIlIdʒənt"
+  },
+  {
+    "name": "serious",
+    "trans": [
+      "29.27.5",
+      "adj．认真的（careful）"
+    ],
+    "ukphone": "ˋsIriəs",
+    "usphone": "ˋsIriəs"
+  },
+  {
+    "name": "cordial",
+    "trans": [
+      "29.27.6",
+      "adj．真诚的，诚恳的（friendly）",
+      "【记】 cord（心）+ial→以心相对→真诚的"
+    ],
+    "ukphone": "ˋkɔ:rdʒəl",
+    "usphone": "ˋkɔ:rdʒəl"
+  },
+  {
+    "name": "deliberate",
+    "trans": [
+      "29.27.7",
+      "adj．认真的；故意的（careful; intentional, purposive）",
+      "【记】 de+liber（自由）+ate"
+    ],
+    "ukphone": "dIˋlIbərət",
+    "usphone": "dIˋlIbərət"
+  },
+  {
+    "name": "attempt",
+    "trans": [
+      "29.27.8",
+      "n．努力，尝试（effort）vt．尝试（try, endeavor）"
+    ],
+    "ukphone": "əˋtempt",
+    "usphone": "əˋtempt"
+  },
+  {
+    "name": "effort",
+    "trans": [
+      "29.27.9",
+      "n．努力，成就（attempt, exertion, endeavor）"
+    ],
+    "ukphone": "ˋefərt",
+    "usphone": "ˋefərt"
+  },
+  {
+    "name": "endeavor",
+    "trans": [
+      "29.27.10",
+      "vi．努力（strive, struggle, try）"
+    ],
+    "ukphone": "Inˋdevər",
+    "usphone": "Inˋdevər"
+  },
+  {
+    "name": "strive",
+    "trans": [
+      "29.27.11",
+      "vi．努力，奋斗；力求（endeavor, struggle）"
+    ],
+    "ukphone": "straIv",
+    "usphone": "straIv"
+  },
+  {
+    "name": "reluctant",
+    "trans": [
+      "29.28.1",
+      "adj．不情愿的，勉强的（unwilling）"
+    ],
+    "ukphone": "rIˋlʌktənt",
+    "usphone": "rIˋlʌktənt"
+  },
+  {
+    "name": "tolerate",
+    "trans": [
+      "29.28.2",
+      "vt．忍受，容忍；宽恕（bear, put up with）"
+    ],
+    "ukphone": "ˋtα:ləreIt",
+    "usphone": "ˋtα:ləreIt"
+  },
+  {
+    "name": "tolerable",
+    "trans": [
+      "29.28.3",
+      "adj．可容忍的（bearable, endurable）"
+    ],
+    "ukphone": "ˋtα:lərəbl",
+    "usphone": "ˋtα:lərəbl"
+  },
+  {
+    "name": "insufferable",
+    "trans": [
+      "29.28.4",
+      "adj．难以忍受的（unbearable）",
+      "【记】 in（不）+sufferable（忍受的）"
+    ],
+    "ukphone": "Inˋsʌfrəbl",
+    "usphone": "Inˋsʌfrəbl"
+  },
+  {
+    "name": "undergo",
+    "trans": [
+      "29.28.5",
+      "vt．经历，忍受（experience）"
+    ],
+    "ukphone": "ˌʌndərˋgoʊ",
+    "usphone": "ˌʌndərˋgoʊ"
+  },
+  {
+    "name": "stand",
+    "trans": [
+      "29.28.6",
+      "vt．忍受（bear, tolerate）"
+    ],
+    "ukphone": "stænd",
+    "usphone": "stænd"
+  },
+  {
+    "name": "endure",
+    "trans": [
+      "29.28.7",
+      "vt．忍受，容忍（bear, tolerate）"
+    ],
+    "ukphone": "Inˋdʊr",
+    "usphone": "Inˋdʊr"
+  },
+  {
+    "name": "abide",
+    "trans": [
+      "29.28.8",
+      "vt．忍受",
+      "【记】 abide by（遵守）"
+    ],
+    "ukphone": "əˋbaId",
+    "usphone": "əˋbaId"
+  },
+  {
+    "name": "permit",
+    "trans": [
+      "29.29.1",
+      "vt．允许（allow, consent）"
+    ],
+    "ukphone": "pərˋmIt",
+    "usphone": "pərˋmIt"
+  },
+  {
+    "name": "permissible",
+    "trans": [
+      "29.29.2",
+      "adj．可容许的（allowable）",
+      "【记】 per（全部）+miss（放开）+ible→容许的"
+    ],
+    "ukphone": "pərˋmIsəbl",
+    "usphone": "pərˋmIsəbl"
+  },
+  {
+    "name": "permissive",
+    "trans": [
+      "29.29.3",
+      "adj．许可的"
+    ],
+    "ukphone": "pərˋmIsIv",
+    "usphone": "pərˋmIsIv"
+  },
+  {
+    "name": "tacit",
+    "trans": [
+      "29.29.4",
+      "adj．心照不宣的，默许的（unspoken, implicit）"
+    ],
+    "ukphone": "ˋtæsIt",
+    "usphone": "ˋtæsIt"
+  },
+  {
+    "name": "reception",
+    "trans": [
+      "29.29.5",
+      "n．接受（acceptance, admission）"
+    ],
+    "ukphone": "rIˋsepʃn",
+    "usphone": "rIˋsepʃn"
+  },
+  {
+    "name": "connive",
+    "trans": [
+      "29.29.6",
+      "vi．纵容，默许"
+    ],
+    "ukphone": "kəˋnaIv",
+    "usphone": "kəˋnaIv"
+  },
+  {
+    "name": "connivance",
+    "trans": [
+      "29.29.7",
+      "n．默许"
+    ],
+    "ukphone": "kəˋnaIvəns",
+    "usphone": "kəˋnaIvəns"
+  },
+  {
+    "name": "concede",
+    "trans": [
+      "29.29.8",
+      "vi．让步；承认（admit, accept）",
+      "【记】 con+cede（让）"
+    ],
+    "ukphone": "kənˋsi:d",
+    "usphone": "kənˋsi:d"
+  },
+  {
+    "name": "concession",
+    "trans": [
+      "29.29.9",
+      "n．让步，迁就（compromise, bargain）",
+      "【记】 concede（让步）的名词"
+    ],
+    "ukphone": "kənˋseʃn",
+    "usphone": "kənˋseʃn"
+  },
+  {
+    "name": "recognize",
+    "trans": [
+      "29.29.10",
+      "vt．认识；认出；承认（acknowledge）"
+    ],
+    "ukphone": "ˋrekəgnaIz",
+    "usphone": "ˋrekəgnaIz"
+  },
+  {
+    "name": "recognition",
+    "trans": [
+      "29.29.11",
+      "nod ［nα:d］ n./vi．点头，首肯（consent, approve）"
+    ],
+    "ukphone": "ˌrekəgˋnIʃn",
+    "usphone": "ˌrekəgˋnIʃn"
+  },
+  {
+    "name": "confess",
+    "trans": [
+      "29.29.12",
+      "v．忏悔，坦白（confide, disclose）"
+    ],
+    "ukphone": "kənˋfes",
+    "usphone": "kənˋfes"
+  },
+  {
+    "name": "approve",
+    "trans": [
+      "29.29.13",
+      "v．赞成，称许；批准（agree, assent）",
+      "【记】 ap+prove（证明）"
+    ],
+    "ukphone": "əˋpru:v",
+    "usphone": "əˋpru:v"
+  },
+  {
+    "name": "comply",
+    "trans": [
+      "29.29.14",
+      "vi．顺从（obey），应允"
+    ],
+    "ukphone": "kəmˋplaI",
+    "usphone": "kəmˋplaI"
+  },
+  {
+    "name": "concur",
+    "trans": [
+      "29.29.15",
+      "vi．同意（consent）"
+    ],
+    "ukphone": "kənˋkɜ:r",
+    "usphone": "kənˋkɜ:r"
+  },
+  {
+    "name": "avow",
+    "trans": [
+      "29.29.16",
+      "vt．公开承认（acknowledge, declare, admit）",
+      "【记】 a+vow（誓言）"
+    ],
+    "ukphone": "əˋvaʊ",
+    "usphone": "əˋvaʊ"
+  },
+  {
+    "name": "ratify",
+    "trans": [
+      "29.29.17",
+      "vt．批准（approve, endorse）"
+    ],
+    "ukphone": "ˋrætIfaI",
+    "usphone": "ˋrætIfaI"
+  },
+  {
+    "name": "guarantee",
+    "trans": [
+      "29.29.18",
+      "vt．确保（secure, assure）"
+    ],
+    "ukphone": "ˌgærənˋti:",
+    "usphone": "ˌgærənˋti:"
+  },
+  {
+    "name": "endorse",
+    "trans": [
+      "29.29.19",
+      "vt．确认；赞同，支持（support, ratify, certify）"
+    ],
+    "ukphone": "Inˋdɔ:rs",
+    "usphone": "Inˋdɔ:rs"
+  },
+  {
+    "name": "corroborate",
+    "trans": [
+      "29.29.20",
+      "vt．确证（confirm, substantiate）",
+      "【记】 cor+robor（力量）+ate→强化"
+    ],
+    "ukphone": "kəˋrα:bəreIt",
+    "usphone": "kəˋrα:bəreIt"
+  },
+  {
+    "name": "grant",
+    "trans": [
+      "29.29.21",
+      "vt．准予"
+    ],
+    "ukphone": "grænt",
+    "usphone": "grænt"
+  },
+  {
+    "name": "admit",
+    "trans": [
+      "29.29.22",
+      "vt．承认（acknowledge, accept）"
+    ],
+    "ukphone": "ədˋmIt",
+    "usphone": "ədˋmIt"
+  },
+  {
+    "name": "acknowledge",
+    "trans": [
+      "29.29.23",
+      "vt．承认（admit, accept）"
+    ],
+    "ukphone": "əkˋnα:lIdʒ",
+    "usphone": "əkˋnα:lIdʒ"
+  },
+  {
+    "name": "affirm",
+    "trans": [
+      "29.29.24",
+      "vt．肯定，断言",
+      "【记】 af（一再）+firm（肯定）→断言"
+    ],
+    "ukphone": "əˋfɜ:rm",
+    "usphone": "əˋfɜ:rm"
+  },
+  {
+    "name": "pardon",
+    "trans": [
+      "29.29.25",
+      "vt．原谅，宽恕"
+    ],
+    "ukphone": "ˋpα:rdn",
+    "usphone": "ˋpα:rdn"
+  },
+  {
+    "name": "innocent",
+    "trans": [
+      "29.30.1",
+      "adj．幼稚的",
+      "【记】 in（无）+noc（害）+ent→无害的"
+    ],
+    "ukphone": "ˋInəsnt",
+    "usphone": "ˋInəsnt"
+  },
+  {
+    "name": "regardless",
+    "trans": [
+      "29.30.2",
+      "adv．不管，不顾（despite, whatever, notwithstanding）"
+    ],
+    "ukphone": "rIˋgα:rdləs",
+    "usphone": "rIˋgα:rdləs"
+  },
+  {
+    "name": "heedless",
+    "trans": [
+      "29.30.3",
+      "adj．不留心的"
+    ],
+    "ukphone": "ˋhi:dləs",
+    "usphone": "ˋhi:dləs"
+  },
+  {
+    "name": "erroneous",
+    "trans": [
+      "29.30.4",
+      "adj．错误的（incorrect, mistaken）"
+    ],
+    "ukphone": "Iˋroʊniəs",
+    "usphone": "Iˋroʊniəs"
+  },
+  {
+    "name": "neglect",
+    "trans": [
+      "29.30.5",
+      "vt．疏忽（ignore, overlook）；忘记",
+      "【记】 neg（不）+lect（选择）→不选择→忽视"
+    ],
+    "ukphone": "nIˋglekt",
+    "usphone": "nIˋglekt"
+  },
+  {
+    "name": "negligent",
+    "trans": [
+      "29.30.6",
+      "adj．忽略的"
+    ],
+    "ukphone": "ˋneglIdʒənt",
+    "usphone": "ˋneglIdʒənt"
+  },
+  {
+    "name": "negligence",
+    "trans": [
+      "29.30.7",
+      "n．过失；疏忽"
+    ],
+    "ukphone": "ˋneglIdʒəns",
+    "usphone": "ˋneglIdʒəns"
+  },
+  {
+    "name": "ridiculous",
+    "trans": [
+      "29.30.8",
+      "adj．荒谬的"
+    ],
+    "ukphone": "rIˋdIkjələs",
+    "usphone": "rIˋdIkjələs"
+  },
+  {
+    "name": "slovenly",
+    "trans": [
+      "29.30.9",
+      "adj．马虎的"
+    ],
+    "ukphone": "ˋslʌvnli",
+    "usphone": "ˋslʌvnli"
+  },
+  {
+    "name": "credulous",
+    "trans": [
+      "29.30.10",
+      "adj．轻信的",
+      "【记】 cred（相信）+ulous"
+    ],
+    "ukphone": "ˋkredʒələs",
+    "usphone": "ˋkredʒələs"
+  },
+  {
+    "name": "useless",
+    "trans": [
+      "29.30.11",
+      "adj．无效的（invalid, futile）"
+    ],
+    "ukphone": "ˋju:sləs",
+    "usphone": "ˋju:sləs"
+  },
+  {
+    "name": "futile",
+    "trans": [
+      "29.30.12",
+      "adj．无益的；徒劳的（useless; vain）"
+    ],
+    "ukphone": "ˋfju:tl",
+    "usphone": "ˋfju:tl"
+  },
+  {
+    "name": "offhand",
+    "trans": [
+      "29.30.13",
+      "adj．无准备的（unprepared, impromptu）"
+    ],
+    "ukphone": "ˌɔ:fˋhænd",
+    "usphone": "ˌɔ:fˋhænd"
+  },
+  {
+    "name": "fallible",
+    "trans": [
+      "29.30.14",
+      "adj．易错的",
+      "【记】 fall（错误）+ible→犯错误的"
+    ],
+    "ukphone": "ˋfæləbl",
+    "usphone": "ˋfæləbl"
+  },
+  {
+    "name": "defect",
+    "trans": [
+      "29.30.15",
+      "n．缺陷（fault, shortcomings, imperfection）",
+      "【记】 de（坏）+fect（做）→做坏了→缺陷"
+    ],
+    "ukphone": "ˋdi:fekt",
+    "usphone": "ˋdi:fekt"
+  },
+  {
+    "name": "defective",
+    "trans": [
+      "29.30.16",
+      "adj．有缺陷的"
+    ],
+    "ukphone": "dIˋfektIv",
+    "usphone": "dIˋfektIv"
+  },
+  {
+    "name": "drawback",
+    "trans": [
+      "29.30.17",
+      "n．弊端（disadvantage, defect, demerit）"
+    ],
+    "ukphone": "ˋdrɔ:bæk",
+    "usphone": "ˋdrɔ:bæk"
+  },
+  {
+    "name": "flaw",
+    "trans": [
+      "29.30.18",
+      "n．缺点，瑕疵（fault, defect）"
+    ],
+    "ukphone": "flɔ:",
+    "usphone": "flɔ:"
+  },
+  {
+    "name": "oblivion",
+    "trans": [
+      "29.30.19",
+      "n．忘却，遗忘",
+      "【记】 ob（离开）+liv（活）+ion→忘却"
+    ],
+    "ukphone": "əˋblIviən",
+    "usphone": "əˋblIviən"
+  },
+  {
+    "name": "blunder",
+    "trans": [
+      "29.30.20",
+      "v．犯大错（make foolish mistakes, bungle）"
+    ],
+    "ukphone": "ˋblʌndər",
+    "usphone": "ˋblʌndər"
+  },
+  {
+    "name": "expire",
+    "trans": [
+      "29.30.21",
+      "vi．失效（terminate）",
+      "【记】 ex+pire（呼吸）→离开呼吸→断气"
+    ],
+    "ukphone": "IkˋspaIər",
+    "usphone": "IkˋspaIər"
+  },
+  {
+    "name": "overlook",
+    "trans": [
+      "29.30.22",
+      "vt．忽略（ignore, neglect）；疏忽",
+      "【记】 来自 look over（忽视）"
+    ],
+    "ukphone": "ˌoʊvərˋlʊk",
+    "usphone": "ˌoʊvərˋlʊk"
+  },
+  {
+    "name": "ignore",
+    "trans": [
+      "29.30.23",
+      "vt．忽视（disregard, neglect）",
+      "【记】 i（不）+gnore（知道）→不知道→不理睬"
+    ],
+    "ukphone": "Igˋnɔ:r",
+    "usphone": "Igˋnɔ:r"
+  },
+  {
+    "name": "omit",
+    "trans": [
+      "29.30.24",
+      "vt．省略，省去；遗漏（exclude, leave out）"
+    ],
+    "ukphone": "əˋmIt",
+    "usphone": "əˋmIt"
+  },
+  {
+    "name": "absurd",
+    "trans": [
+      "29.30.25",
+      "adj．荒谬的（ridiculous）",
+      "【记】 ab（离开）+surd（合理的）→不合理的→荒谬的"
+    ],
+    "ukphone": "əbˋsɜ:rd",
+    "usphone": "əbˋsɜ:rd"
+  },
+  {
+    "name": "abortive",
+    "trans": [
+      "29.30.26",
+      "adj．失败的（unsuccessful）",
+      "【记】 abort（放弃）+ive→失败的"
+    ],
+    "ukphone": "əˋbɔ:rtIv",
+    "usphone": "əˋbɔ:rtIv"
+  },
+  {
+    "name": "err",
+    "trans": [
+      "29.30.27",
+      "vi．犯错（make foolish mistakes）"
+    ],
+    "ukphone": "er",
+    "usphone": "er"
+  },
+  {
+    "name": "consider",
+    "trans": [
+      "29.31.1",
+      "vt．考虑"
+    ],
+    "ukphone": "kənˋsIdər",
+    "usphone": "kənˋsIdər"
+  },
+  {
+    "name": "considerate",
+    "trans": [
+      "29.31.2",
+      "adj．考虑周到的（thoughtful）"
+    ],
+    "ukphone": "kənˋsIdərət",
+    "usphone": "kənˋsIdərət"
+  },
+  {
+    "name": "meditative",
+    "trans": [
+      "29.31.3",
+      "adj．深思的（thoughtful）",
+      "【记】 动词meditate（思考）"
+    ],
+    "ukphone": "ˋmedIteItIv",
+    "usphone": "ˋmedIteItIv"
+  },
+  {
+    "name": "tender",
+    "trans": [
+      "29.31.4",
+      "adj．细心的；考虑周到的"
+    ],
+    "ukphone": "ˋtendər",
+    "usphone": "ˋtendər"
+  },
+  {
+    "name": "conscious",
+    "trans": [
+      "29.31.5",
+      "adj．有意识的"
+    ],
+    "ukphone": "ˋkα:nʃəs",
+    "usphone": "ˋkα:nʃəs"
+  },
+  {
+    "name": "recollection",
+    "trans": [
+      "29.31.6",
+      "n．记起，回想（remembrance, memory）"
+    ],
+    "ukphone": "ˌrekəˋlekʃn",
+    "usphone": "ˌrekəˋlekʃn"
+  },
+  {
+    "name": "ruminate",
+    "trans": [
+      "29.31.7",
+      "v．沉思（meditate）"
+    ],
+    "ukphone": "ˋru:mIneIt",
+    "usphone": "ˋru:mIneIt"
+  },
+  {
+    "name": "speculate",
+    "trans": [
+      "29.31.8",
+      "v．推测；沉思（hypothesize, conjecture）"
+    ],
+    "ukphone": "ˋspekjuleIt",
+    "usphone": "ˋspekjuleIt"
+  },
+  {
+    "name": "ponder",
+    "trans": [
+      "29.31.9",
+      "vt．考虑 vi．沉思（meditate）",
+      "【记】 pond（重量）+er→掂重量→考虑"
+    ],
+    "ukphone": "ˋpα:ndər",
+    "usphone": "ˋpα:ndər"
+  },
+  {
+    "name": "embalm",
+    "trans": [
+      "29.31.10",
+      "vt．铭记"
+    ],
+    "ukphone": "Imˋbα:m",
+    "usphone": "Imˋbα:m"
+  },
+  {
+    "name": "contemplate",
+    "trans": [
+      "29.31.11",
+      "vt．凝视；沉思（muse, ponder）"
+    ],
+    "ukphone": "ˋkα:ntəmpleIt",
+    "usphone": "ˋkα:ntəmpleIt"
+  },
+  {
+    "name": "elevate",
+    "trans": [
+      "29.31.12",
+      "vt．提高（思想）",
+      "【记】 e（出）+lev（举）+ate→举出→升高"
+    ],
+    "ukphone": "ˋelIveIt",
+    "usphone": "ˋelIveIt"
+  },
+  {
+    "name": "recall",
+    "trans": [
+      "29.31.13",
+      "vt．忆起，记忆（recollect, remember）"
+    ],
+    "ukphone": "rIˋkɔ:l",
+    "usphone": "rIˋkɔ:l"
+  },
+  {
+    "name": "haunt",
+    "trans": [
+      "29.31.14",
+      "vt．萦绕于心"
+    ],
+    "ukphone": "hɔ:nt",
+    "usphone": "hɔ:nt"
+  },
+  {
+    "name": "venture",
+    "trans": [
+      "29.32.1",
+      "n./vi．冒险（risk），冒昧"
+    ],
+    "ukphone": "ˋventʃər",
+    "usphone": "ˋventʃər"
+  },
+  {
+    "name": "risk",
+    "trans": [
+      "29.32.2",
+      "n./vt．冒险"
+    ],
+    "ukphone": "rIsk",
+    "usphone": "rIsk"
+  },
+  {
+    "name": "probe",
+    "trans": [
+      "29.32.3",
+      "v．探查（investigate, inspect）"
+    ],
+    "ukphone": "proʊb",
+    "usphone": "proʊb"
+  },
+  {
+    "name": "explore",
+    "trans": [
+      "29.32.4",
+      "v．探险，探索（search）",
+      "【记】 ex+plore（大喊）→喊出来→探索"
+    ],
+    "ukphone": "Ikˋsplɔ:r",
+    "usphone": "Ikˋsplɔ:r"
+  },
+  {
+    "name": "seek",
+    "trans": [
+      "29.32.5",
+      "v．寻找，探求（endeavor, try, campaign for, search for）"
+    ],
+    "ukphone": "si:k",
+    "usphone": "si:k"
+  },
+  {
+    "name": "grope",
+    "trans": [
+      "29.32.6",
+      "vi．摸索（fumble, search）"
+    ],
+    "ukphone": "groʊp",
+    "usphone": "groʊp"
+  },
+  {
+    "name": "ferret",
+    "trans": [
+      "29.32.7",
+      "vt．搜索（search）"
+    ],
+    "ukphone": "ˋferIt",
+    "usphone": "ˋferIt"
+  },
+  {
+    "name": "quest",
+    "trans": [
+      "29.32.8",
+      "n．寻找；探索；追求 v．寻找；跟踪搜寻；寻求（explore, search, seek）"
+    ],
+    "ukphone": "kwest",
+    "usphone": "kwest"
+  },
+  {
+    "name": "tardy",
+    "trans": [
+      "29.33.1",
+      "adj．延迟的（late, slow）",
+      "【记】 tard（迟缓）+y"
+    ],
+    "ukphone": "ˋtα:rdi",
+    "usphone": "ˋtα:rdi"
+  },
+  {
+    "name": "perpetuate",
+    "trans": [
+      "29.33.2",
+      "vt．使…永恒，使…延续"
+    ],
+    "ukphone": "pərˋpetʃueIt",
+    "usphone": "pərˋpetʃueIt"
+  },
+  {
+    "name": "detain",
+    "trans": [
+      "29.33.3",
+      "vt．使延迟（delay, retard）",
+      "【记】 de+tain（拿，抓）→拘留"
+    ],
+    "ukphone": "dIˋteIn",
+    "usphone": "dIˋteIn"
+  },
+  {
+    "name": "delay",
+    "trans": [
+      "29.33.4",
+      "vt．推迟，耽搁，延误（detain, postpone）"
+    ],
+    "ukphone": "dIˋleI",
+    "usphone": "dIˋleI"
+  },
+  {
+    "name": "prolong",
+    "trans": [
+      "29.33.5",
+      "vt．拖长，延长（extend, lengthen）",
+      "【记】 pro（向前）+long（长）→延长"
+    ],
+    "ukphone": "prəˋlɔ:ŋ",
+    "usphone": "prəˋlɔ:ŋ"
+  },
+  {
+    "name": "protract",
+    "trans": [
+      "29.33.6",
+      "vt．延长（lengthen, prolong）",
+      "【记】 pro（前）+tract（拉）→延长"
+    ],
+    "ukphone": "prəˋtrækt",
+    "usphone": "prəˋtrækt"
+  },
+  {
+    "name": "retard",
+    "trans": [
+      "29.33.7",
+      "vt．延迟（detain）",
+      "【记】 re（使）+tard（迟缓）→延迟"
+    ],
+    "ukphone": "rIˋtα:rd",
+    "usphone": "rIˋtα:rd"
+  },
+  {
+    "name": "postpone",
+    "trans": [
+      "29.33.8",
+      "vt．延搁（delay, put off）",
+      "【记】 post（后）+pone→推后"
+    ],
+    "ukphone": "poʊˋspoʊn",
+    "usphone": "poʊˋspoʊn"
+  },
+  {
+    "name": "defer",
+    "trans": [
+      "29.33.9",
+      "vt．延期（delay, postpone）",
+      "【记】 de（坏）+fer（带来）"
+    ],
+    "ukphone": "dIˋfɜ:r",
+    "usphone": "dIˋfɜ:r"
+  },
+  {
+    "name": "adjourn",
+    "trans": [
+      "29.33.10",
+      "vt．延期（defer, delay）"
+    ],
+    "ukphone": "əˋdʒɜ:rn",
+    "usphone": "əˋdʒɜ:rn"
+  },
+  {
+    "name": "inclined",
+    "trans": [
+      "29.34.1",
+      "adj．倾向…的（liable）",
+      "【记】 in（内）+clin（倾斜）+ed→内心的倾向"
+    ],
+    "ukphone": "InˋklaInd",
+    "usphone": "InˋklaInd"
+  },
+  {
+    "name": "prone",
+    "trans": [
+      "29.34.2",
+      "adj．倾向于（liable）"
+    ],
+    "ukphone": "proʊn",
+    "usphone": "proʊn"
+  },
+  {
+    "name": "habitually",
+    "trans": [
+      "29.34.3",
+      "adv．习惯地",
+      "【记】 habit（习惯）+ually"
+    ],
+    "ukphone": "həˋbItʃuəli",
+    "usphone": "həˋbItʃuəli"
+  },
+  {
+    "name": "bent",
+    "trans": [
+      "29.34.4",
+      "n．爱好；倾向"
+    ],
+    "ukphone": "bent",
+    "usphone": "bent"
+  },
+  {
+    "name": "aptitude",
+    "trans": [
+      "29.34.5",
+      "n．自然倾向；天资",
+      "【记】 apti（能力）+tude"
+    ],
+    "ukphone": "ˋæptItju:d",
+    "usphone": "ˋæptItju:d"
+  },
+  {
+    "name": "propensity",
+    "trans": [
+      "29.34.6",
+      "n．倾向（inclination）"
+    ],
+    "ukphone": "prəˋpensəti",
+    "usphone": "prəˋpensəti"
+  },
+  {
+    "name": "trend",
+    "trans": [
+      "29.34.7",
+      "n．倾向，趋势（tendency, propensity）"
+    ],
+    "ukphone": "trend",
+    "usphone": "trend"
+  },
+  {
+    "name": "penchant",
+    "trans": [
+      "29.34.8",
+      "n．倾向；爱好（inclination; preference）",
+      "【记】 pen（笔）+chant（咏唱）→用笔“歌唱”→爱好"
+    ],
+    "ukphone": "ˋpentʃənt",
+    "usphone": "ˋpentʃənt"
+  },
+  {
+    "name": "custom",
+    "trans": [
+      "29.34.9",
+      "n．习惯"
+    ],
+    "ukphone": "ˋkʌstəm",
+    "usphone": "ˋkʌstəm"
+  },
+  {
+    "name": "accustomed",
+    "trans": [
+      "29.34.10",
+      "adj．习惯的（habitual, conventional）",
+      "【记】 be accustomed to 习惯于"
+    ],
+    "ukphone": "əˋkʌstəmd",
+    "usphone": "əˋkʌstəmd"
+  },
+  {
+    "name": "interest",
+    "trans": [
+      "29.34.11",
+      "n．兴趣"
+    ],
+    "ukphone": "ˋIntrəst",
+    "usphone": "ˋIntrəst"
+  },
+  {
+    "name": "tend",
+    "trans": [
+      "29.34.12",
+      "vi．趋向，往往是（be prone to）"
+    ],
+    "ukphone": "tend",
+    "usphone": "tend"
+  },
+  {
+    "name": "inure",
+    "trans": [
+      "29.34.13",
+      "vt．使习惯（accustom）"
+    ],
+    "ukphone": "Iˋnjʊr",
+    "usphone": "Iˋnjʊr"
+  },
+  {
+    "name": "temperance",
+    "trans": [
+      "29.35.1",
+      "n．节制，自制（self-control, moderation）；戒酒"
+    ],
+    "ukphone": "ˋtempərəns",
+    "usphone": "ˋtempərəns"
+  },
+  {
+    "name": "bondage",
+    "trans": [
+      "29.35.2",
+      "n．束缚"
+    ],
+    "ukphone": "ˋbα:ndIdʒ",
+    "usphone": "ˋbα:ndIdʒ"
+  },
+  {
+    "name": "deterrent",
+    "trans": [
+      "29.35.3",
+      "n．制止物，威慑物",
+      "【记】 de+ter（吓唬）+rent"
+    ],
+    "ukphone": "dIˋtɜ:rənt",
+    "usphone": "dIˋtɜ:rənt"
+  },
+  {
+    "name": "neutralize",
+    "trans": [
+      "29.35.4",
+      "v．压制"
+    ],
+    "ukphone": "ˋnju:trəlaIz",
+    "usphone": "ˋnju:trəlaIz"
+  },
+  {
+    "name": "check",
+    "trans": [
+      "29.35.5",
+      "v．抑制（restrain, stop）"
+    ],
+    "ukphone": "tʃek",
+    "usphone": "tʃek"
+  },
+  {
+    "name": "circumscribe",
+    "trans": [
+      "29.35.6",
+      "vt．划界限；限制（encompass, encircle）",
+      "【记】 circum（绕圈）+scribe（画）→画圈"
+    ],
+    "ukphone": "ˋsɜ:rkəmskraIb",
+    "usphone": "ˋsɜ:rkəmskraIb"
+  },
+  {
+    "name": "shackle",
+    "trans": [
+      "29.35.7",
+      "vt．加桎梏，束缚（chain, fetter）"
+    ],
+    "ukphone": "ˋʃækl",
+    "usphone": "ˋʃækl"
+  },
+  {
+    "name": "fetter",
+    "trans": [
+      "29.35.8",
+      "vt．束缚，羁绊（restrict, inhibit）"
+    ],
+    "ukphone": "ˋfetər",
+    "usphone": "ˋfetər"
+  },
+  {
+    "name": "restrict",
+    "trans": [
+      "29.35.9",
+      "vt．限制（restrain, limit）"
+    ],
+    "ukphone": "rIˋstrIkt",
+    "usphone": "rIˋstrIkt"
+  },
+  {
+    "name": "restrain",
+    "trans": [
+      "29.35.10",
+      "vt．限制（restrict, limit）",
+      "【记】 re+stain（拉紧）→限制"
+    ],
+    "ukphone": "rIˋstreIn",
+    "usphone": "rIˋstreIn"
+  },
+  {
+    "name": "confine",
+    "trans": [
+      "29.35.11",
+      "vt．限制",
+      "【记】 con（全部）+fine（限制）→全限制"
+    ],
+    "ukphone": "kənˋfaIn",
+    "usphone": "kənˋfaIn"
+  },
+  {
+    "name": "quell",
+    "trans": [
+      "29.35.12",
+      "vt．压制（quash, suppress）"
+    ],
+    "ukphone": "kwel",
+    "usphone": "kwel"
+  },
+  {
+    "name": "curb",
+    "trans": [
+      "29.35.13",
+      "vt．抑制（check, control）"
+    ],
+    "ukphone": "kɜ:rb",
+    "usphone": "kɜ:rb"
+  },
+  {
+    "name": "bound",
+    "trans": [
+      "29.35.14",
+      "n．限制"
+    ],
+    "ukphone": "baʊnd",
+    "usphone": "baʊnd"
+  },
+  {
+    "name": "leash",
+    "trans": [
+      "29.35.15",
+      "n./v．束缚"
+    ],
+    "ukphone": "li:ʃ",
+    "usphone": "li:ʃ"
+  },
+  {
+    "name": "constraint",
+    "trans": [
+      "29.35.16",
+      "n．约束；强迫；限制；强制（limit）"
+    ],
+    "ukphone": "kənˋstreInt",
+    "usphone": "kənˋstreInt"
+  },
+  {
+    "name": "cramp",
+    "trans": [
+      "29.35.17",
+      "n．铁夹钳；铁箍；约束物 v．用夹钳夹紧；约束；限制；妨碍；使痉挛（confine）"
+    ],
+    "ukphone": "kræmp",
+    "usphone": "kræmp"
+  },
+  {
+    "name": "impediment",
+    "trans": [
+      "29.35.18",
+      "n．妨碍，阻碍；障碍物（obstruction, hindrance）"
+    ],
+    "ukphone": "ImˋpedImənt",
+    "usphone": "ImˋpedImənt"
+  },
+  {
+    "name": "inhibit",
+    "trans": [
+      "29.35.19",
+      "v．禁止，抑制（subdue, suppress）"
+    ],
+    "ukphone": "InˋhIbIt",
+    "usphone": "InˋhIbIt"
+  },
+  {
+    "name": "subdue",
+    "trans": [
+      "29.35.20",
+      "vt．征服；抑制；减轻"
+    ],
+    "ukphone": "səbˋdju:",
+    "usphone": "səbˋdju:"
+  },
+  {
+    "name": "literate",
+    "trans": [
+      "29.36.1",
+      "adj．有文化的，能读写的",
+      "【记】 liter（文学）+ate"
+    ],
+    "ukphone": "ˋlItərət",
+    "usphone": "ˋlItərət"
+  },
+  {
+    "name": "chalk",
+    "trans": [
+      "29.36.2",
+      "n．白垩，粉笔 vt．用粉笔写"
+    ],
+    "ukphone": "tʃɔ:k",
+    "usphone": "tʃɔ:k"
+  },
+  {
+    "name": "transcript",
+    "trans": [
+      "29.36.3",
+      "n．成绩单"
+    ],
+    "ukphone": "ˋtrænskrIpt",
+    "usphone": "ˋtrænskrIpt"
+  },
+  {
+    "name": "scholarship",
+    "trans": [
+      "29.36.4",
+      "n．奖学金"
+    ],
+    "ukphone": "ˋskα:lərʃIp",
+    "usphone": "ˋskα:lərʃIp"
+  },
+  {
+    "name": "article",
+    "trans": [
+      "29.36.5",
+      "n．论文，文章"
+    ],
+    "ukphone": "ˋα:rtIkl",
+    "usphone": "ˋα:rtIkl"
+  },
+  {
+    "name": "ken",
+    "trans": [
+      "29.36.6",
+      "n．视野；知识（knowledge）",
+      "【记】 比较kin（亲戚）"
+    ],
+    "ukphone": "ken",
+    "usphone": "ken"
+  },
+  {
+    "name": "stationery",
+    "trans": [
+      "29.36.7",
+      "n．文具"
+    ],
+    "ukphone": "ˋsteIʃəneri",
+    "usphone": "ˋsteIʃəneri"
+  },
+  {
+    "name": "brochure",
+    "trans": [
+      "29.36.8",
+      "n．小册子（pamphlet）"
+    ],
+    "ukphone": "broʊˋʃʊr",
+    "usphone": "broʊˋʃʊr"
+  },
+  {
+    "name": "pamphlet",
+    "trans": [
+      "29.36.9",
+      "n．小册子"
+    ],
+    "ukphone": "ˋpæmflət",
+    "usphone": "ˋpæmflət"
+  },
+  {
+    "name": "credit",
+    "trans": [
+      "29.36.10",
+      "n．学分"
+    ],
+    "ukphone": "ˋkredIt",
+    "usphone": "ˋkredIt"
+  },
+  {
+    "name": "semester",
+    "trans": [
+      "29.36.11",
+      "n．学期（term）"
+    ],
+    "ukphone": "sIˋmestər",
+    "usphone": "sIˋmestər"
+  },
+  {
+    "name": "thesis",
+    "trans": [
+      "29.36.12",
+      "n．学位论文"
+    ],
+    "ukphone": "ˋθi:sIs",
+    "usphone": "ˋθi:sIs"
+  },
+  {
+    "name": "discourse",
+    "trans": [
+      "29.36.13",
+      "n．演讲（lecture）；论文（disquisition）"
+    ],
+    "ukphone": "ˋdIskɔ:rs",
+    "usphone": "ˋdIskɔ:rs"
+  },
+  {
+    "name": "margin",
+    "trans": [
+      "29.36.14",
+      "n．页边的空白（edge, rim）；栏外"
+    ],
+    "ukphone": "ˋmα:rdʒən",
+    "usphone": "ˋmα:rdʒən"
+  },
+  {
+    "name": "term",
+    "trans": [
+      "29.36.15",
+      "n．学期；专用名词"
+    ],
+    "ukphone": "tɜ:rm",
+    "usphone": "tɜ:rm"
+  },
+  {
+    "name": "discipline",
+    "trans": [
+      "29.36.16",
+      "v．训练（manage）；学科，纪律"
+    ],
+    "ukphone": "ˋdIsəplIn",
+    "usphone": "ˋdIsəplIn"
+  },
+  {
+    "name": "commence",
+    "trans": [
+      "29.36.17",
+      "vi．获得学位"
+    ],
+    "ukphone": "kəˋmens",
+    "usphone": "kəˋmens"
+  },
+  {
+    "name": "cram",
+    "trans": [
+      "29.36.18",
+      "vt．仓促用功"
+    ],
+    "ukphone": "kræm",
+    "usphone": "kræm"
+  },
+  {
+    "name": "academic",
+    "trans": [
+      "29.36.19",
+      "adj．学院的（collegiate）；理论的"
+    ],
+    "ukphone": "ˌækəˋdemIk",
+    "usphone": "ˌækəˋdemIk"
+  },
+  {
+    "name": "heredity",
+    "trans": [
+      "29.37.1",
+      "n．遗传"
+    ],
+    "ukphone": "həˋredəti",
+    "usphone": "həˋredəti"
+  },
+  {
+    "name": "heritage",
+    "trans": [
+      "29.37.2",
+      "n．遗产（legacy, bequest）"
+    ],
+    "ukphone": "ˋherItIdʒ",
+    "usphone": "ˋherItIdʒ"
+  },
+  {
+    "name": "bequest",
+    "trans": [
+      "29.37.3",
+      "n．遗产（legacy, heritage），遗传"
+    ],
+    "ukphone": "bIˋkwest",
+    "usphone": "bIˋkwest"
+  },
+  {
+    "name": "legacy",
+    "trans": [
+      "29.37.4",
+      "n．遗产（bequest, heritage），遗物"
+    ],
+    "ukphone": "ˋlegəsi",
+    "usphone": "ˋlegəsi"
+  },
+  {
+    "name": "relic",
+    "trans": [
+      "29.37.5",
+      "n．遗物，遗迹；废墟；纪念物"
+    ],
+    "ukphone": "ˋrelIk",
+    "usphone": "ˋrelIk"
+  },
+  {
+    "name": "remains",
+    "trans": [
+      "29.37.6",
+      "n．残余；遗迹；遗体"
+    ],
+    "ukphone": "rIˋmeInz",
+    "usphone": "rIˋmeInz"
+  },
+  {
+    "name": "stray",
+    "trans": [
+      "29.38.1",
+      "adj．漂泊的（wandering, random）；走失的"
+    ],
+    "ukphone": "streI",
+    "usphone": "streI"
+  },
+  {
+    "name": "roam",
+    "trans": [
+      "29.38.2",
+      "n./v．漫步（wander）"
+    ],
+    "ukphone": "roʊm",
+    "usphone": "roʊm"
+  },
+  {
+    "name": "stalk",
+    "trans": [
+      "29.38.3",
+      "v．阔步"
+    ],
+    "ukphone": "stɔ:k",
+    "usphone": "stɔ:k"
+  },
+  {
+    "name": "rumble",
+    "trans": [
+      "29.38.4",
+      "v．隆隆行驶（grumble, roar）"
+    ],
+    "ukphone": "ˋrʌmbl",
+    "usphone": "ˋrʌmbl"
+  },
+  {
+    "name": "scale",
+    "trans": [
+      "29.38.5",
+      "n./v．攀登（climb, raise）"
+    ],
+    "ukphone": "skeIl",
+    "usphone": "skeIl"
+  },
+  {
+    "name": "ascend",
+    "trans": [
+      "29.38.6",
+      "v．攀登，登高（climb）",
+      "【记】 a+scend（爬）→爬上→攀登"
+    ],
+    "ukphone": "əˋsend",
+    "usphone": "əˋsend"
+  },
+  {
+    "name": "budge",
+    "trans": [
+      "29.38.7",
+      "v．移动（move）"
+    ],
+    "ukphone": "bʌdʒ",
+    "usphone": "bʌdʒ"
+  },
+  {
+    "name": "locomote",
+    "trans": [
+      "29.38.8",
+      "vi．移动，行动（move）"
+    ],
+    "ukphone": "ˌloʊkəˋmoʊt",
+    "usphone": "ˌloʊkəˋmoʊt"
+  },
+  {
+    "name": "traverse",
+    "trans": [
+      "29.38.9",
+      "vt．走过（span, stretch across）",
+      "【记】 tra（横）+verse（转）→横过"
+    ],
+    "ukphone": "trəˋvɜ:rs",
+    "usphone": "trəˋvɜ:rs"
+  },
+  {
+    "name": "stroll",
+    "trans": [
+      "29.38.10",
+      "vt．漫步（walk, ramble）"
+    ],
+    "ukphone": "stroʊl",
+    "usphone": "stroʊl"
+  },
+  {
+    "name": "insinuate",
+    "trans": [
+      "29.38.11",
+      "vt．迂回进入",
+      "【记】 in（进入）+sinu（弯曲）+ate→绕着弯进入→迂回进入"
+    ],
+    "ukphone": "InˋsInjueIt",
+    "usphone": "InˋsInjueIt"
+  },
+  {
+    "name": "zigzag",
+    "trans": [
+      "29.38.12",
+      "n．Z字形，锯齿形；蜿蜒曲折"
+    ],
+    "ukphone": "ˋzIgzæg",
+    "usphone": "ˋzIgzæg"
+  },
+  {
+    "name": "motion",
+    "trans": [
+      "29.38.13",
+      "n．运动，动作 v．运动",
+      "【记】 mot（动）+ion"
+    ],
+    "ukphone": "ˋmoʊʃn",
+    "usphone": "ˋmoʊʃn"
+  },
+  {
+    "name": "retreat",
+    "trans": [
+      "29.38.14",
+      "n．撤退；休息寓所"
+    ],
+    "ukphone": "rIˑtri:t",
+    "usphone": "rIˑtri:t"
+  },
+  {
+    "name": "unquenchable",
+    "trans": [
+      "29.39.1",
+      "adj．不可熄灭的，不能遏制的（insatiable）"
+    ],
+    "ukphone": "ʌnˋkwentʃəbl",
+    "usphone": "ʌnˋkwentʃəbl"
+  },
+  {
+    "name": "lag",
+    "trans": [
+      "29.39.2",
+      "n./vi．落后（drag, trail）"
+    ],
+    "ukphone": "læg",
+    "usphone": "læg"
+  },
+  {
+    "name": "subjection",
+    "trans": [
+      "29.39.3",
+      "n．征服"
+    ],
+    "ukphone": "səbˋdʒekʃn",
+    "usphone": "səbˋdʒekʃn"
+  },
+  {
+    "name": "overcome",
+    "trans": [
+      "29.39.4",
+      "v．战胜，胜过（defeat, surmount）"
+    ],
+    "ukphone": "ˌoʊvərˋkʌm ",
+    "usphone": "ˌoʊvərˋkʌm "
+  },
+  {
+    "name": "surpass",
+    "trans": [
+      "29.39.5",
+      "vt．超过，超越，胜过（exceed, surmount）",
+      "【记】 比较pass（通过）"
+    ],
+    "ukphone": "sərˋpæs",
+    "usphone": "sərˋpæs"
+  },
+  {
+    "name": "transcend",
+    "trans": [
+      "29.39.6",
+      "vt．超越（surpass, go beyond）",
+      "【记】 tran（超过）+scend（爬）"
+    ],
+    "ukphone": "trænˋsend",
+    "usphone": "trænˋsend"
+  },
+  {
+    "name": "surmount",
+    "trans": [
+      "29.39.7",
+      "vt．克服；登上；越过（conquer, overcome, exceed, surpass）",
+      "【记】 sur（超过）+mount（山）→登上（山顶）→超越困难"
+    ],
+    "ukphone": "sərˋmaʊnt",
+    "usphone": "sərˋmaʊnt"
+  },
+  {
+    "name": "precede",
+    "trans": [
+      "29.39.8",
+      "vt．先于 vi．领先（come before）",
+      "【记】 pre（前）+cede（走）→领先"
+    ],
+    "ukphone": "prIˋsi:d",
+    "usphone": "prIˋsi:d"
+  },
+  {
+    "name": "vanquish",
+    "trans": [
+      "29.39.9",
+      "左列单词在右列中有一个或多个同义词，请画线连接。"
+    ],
+    "ukphone": "ˋvæŋkwIʃ",
+    "usphone": "ˋvæŋkwIʃ"
+  },
+  {
+    "name": "despicable",
+    "trans": [
+      "30.1.1",
+      "adj．可鄙的（detestable, contemptible）"
+    ],
+    "ukphone": "dIˋspIkəbl",
+    "usphone": "dIˋspIkəbl"
+  },
+  {
+    "name": "contemptible",
+    "trans": [
+      "30.1.2",
+      "adj．可鄙的（mean, despicable）"
+    ],
+    "ukphone": "kənˋtemptəbl",
+    "usphone": "kənˋtemptəbl"
+  },
+  {
+    "name": "ignominious",
+    "trans": [
+      "30.1.3",
+      "adj．可耻的；不光彩的（disgraceful, humiliating）",
+      "【记】 ig（不）+nomin（名字）+ious→不好的名字→不光彩的"
+    ],
+    "ukphone": "ˌIgnəˋmIniəs",
+    "usphone": "ˌIgnəˋmIniəs"
+  },
+  {
+    "name": "menial",
+    "trans": [
+      "30.1.4",
+      "adj．奴仆的；卑贱的（humble, mean）"
+    ],
+    "ukphone": "ˋmi:niəl",
+    "usphone": "ˋmi:niəl"
+  },
+  {
+    "name": "scornful",
+    "trans": [
+      "30.1.5",
+      "adj．轻蔑的（disdainful, contemptuous）"
+    ],
+    "ukphone": "ˋskɔ:rnfl",
+    "usphone": "ˋskɔ:rnfl"
+  },
+  {
+    "name": "filthy",
+    "trans": [
+      "30.1.6",
+      "adj．污秽的；卑鄙的（dirty; squalid）",
+      "【记】 filth（脏）+y→污秽的"
+    ],
+    "ukphone": "ˋfIlθi",
+    "usphone": "ˋfIlθi"
+  },
+  {
+    "name": "shameless",
+    "trans": [
+      "30.1.7",
+      "adj．无耻的"
+    ],
+    "ukphone": "ˋʃeImləs",
+    "usphone": "ˋʃeImləs"
+  },
+  {
+    "name": "disrespectful",
+    "trans": [
+      "30.1.8",
+      "adj．无礼的，轻视的"
+    ],
+    "ukphone": "ˌdIsrIˋspektfl",
+    "usphone": "ˌdIsrIˋspektfl"
+  },
+  {
+    "name": "discrimination",
+    "trans": [
+      "30.1.9",
+      "n．歧视（prejudice）",
+      "【记】 dis+crimin（罪行）+ation"
+    ],
+    "ukphone": "dIˌskrImIˋneIʃn",
+    "usphone": "dIˌskrImIˋneIʃn"
+  },
+  {
+    "name": "contemn",
+    "trans": [
+      "30.1.10",
+      "vt．蔑视（disdain, scorn）"
+    ],
+    "ukphone": "kənˋtem",
+    "usphone": "kənˋtem"
+  },
+  {
+    "name": "belittle",
+    "trans": [
+      "30.1.11",
+      "vt．轻视（depreciate, despise）",
+      "【记】 be+litter（小）→小看→轻视"
+    ],
+    "ukphone": "bIˋlItl",
+    "usphone": "bIˋlItl"
+  },
+  {
+    "name": "disdain",
+    "trans": [
+      "30.1.12",
+      "vt．轻视，不屑（despise, scorn）n．轻蔑",
+      "【记】 dis（不）+dain=deign（俯就）→不俯就"
+    ],
+    "ukphone": "dIsˋdeIn",
+    "usphone": "dIsˋdeIn"
+  },
+  {
+    "name": "despise",
+    "trans": [
+      "30.1.13",
+      "vt．轻视，蔑视（belittle, disdain, contemn）",
+      "【记】 de（坏）+spi（看）+se→蔑视"
+    ],
+    "ukphone": "dIˋspaIz",
+    "usphone": "dIˋspaIz"
+  },
+  {
+    "name": "mean",
+    "trans": [
+      "30.1.14",
+      "adj．卑鄙的（inferior）"
+    ],
+    "ukphone": "mi:n",
+    "usphone": "mi:n"
+  },
+  {
+    "name": "awkward",
+    "trans": [
+      "30.2.1",
+      "adj．笨拙的，尴尬的（clumsy, inept）"
+    ],
+    "ukphone": "ˋɔ:kwərd",
+    "usphone": "ˋɔ:kwərd"
+  },
+  {
+    "name": "clumsy",
+    "trans": [
+      "30.2.2",
+      "adj．笨拙的；愚笨的（awkward）"
+    ],
+    "ukphone": "ˋklʌmzi",
+    "usphone": "ˋklʌmzi"
+  },
+  {
+    "name": "inert",
+    "trans": [
+      "30.2.3",
+      "adj．不活泼的（immobile, inactive）；迟钝的",
+      "【记】 in（不）+ert（动）→迟钝的"
+    ],
+    "ukphone": "Iˋnɜ:rt",
+    "usphone": "Iˋnɜ:rt"
+  },
+  {
+    "name": "blunt",
+    "trans": [
+      "30.2.4",
+      "adj．迟钝的 v．使变钝"
+    ],
+    "ukphone": "blʌnt",
+    "usphone": "blʌnt"
+  },
+  {
+    "name": "torpid",
+    "trans": [
+      "30.2.5",
+      "adj．迟钝的；不活泼的（lethargic, sluggish）"
+    ],
+    "ukphone": "ˋtɔ:rpId",
+    "usphone": "ˋtɔ:rpId"
+  },
+  {
+    "name": "silly",
+    "trans": [
+      "30.2.6",
+      "adj．傻的，糊涂的"
+    ],
+    "ukphone": "ˋsIli",
+    "usphone": "ˋsIli"
+  },
+  {
+    "name": "idiotic",
+    "trans": [
+      "30.2.7",
+      "adj．愚蠢的"
+    ],
+    "ukphone": "ˌIdiˋα:tIk",
+    "usphone": "ˌIdiˋα:tIk"
+  },
+  {
+    "name": "fatuous",
+    "trans": [
+      "30.2.8",
+      "adj．愚昧的（foolish, stupid, indolent）",
+      "【记】 fatu（笨）+ous→愚昧的"
+    ],
+    "ukphone": "ˋfætʃuəs",
+    "usphone": "ˋfætʃuəs"
+  },
+  {
+    "name": "hoax",
+    "trans": [
+      "30.2.9",
+      "n./vt．愚弄（trick, prank）",
+      "【记】 比较coax（哄骗）"
+    ],
+    "ukphone": "hoʊks",
+    "usphone": "hoʊks"
+  },
+  {
+    "name": "curt",
+    "trans": [
+      "30.3.1",
+      "adj．简短的，草率的（abrupt, blunt）"
+    ],
+    "ukphone": "kɜ:rt",
+    "usphone": "kɜ:rt"
+  },
+  {
+    "name": "reckless",
+    "trans": [
+      "30.3.2",
+      "adj．鲁莽的（rash）",
+      "【记】 reck（顾虑）+less→没有顾虑→鲁莽的"
+    ],
+    "ukphone": "ˋrekləs",
+    "usphone": "ˋrekləs"
+  },
+  {
+    "name": "impudent",
+    "trans": [
+      "30.3.3",
+      "adj．鲁莽的（rude, rash）",
+      "【记】 im（不）+pud（谦虚，小心）+ent→不小心的→鲁莽的"
+    ],
+    "ukphone": "ˋImpjədənt",
+    "usphone": "ˋImpjədənt"
+  },
+  {
+    "name": "rashly",
+    "trans": [
+      "30.3.4",
+      "adv．鲁莽地，匆忙地",
+      "【记】 rash（匆忙的）+ly→匆忙地"
+    ],
+    "ukphone": "ˋræʃli",
+    "usphone": "ˋræʃli"
+  },
+  {
+    "name": "imprudent",
+    "trans": [
+      "30.3.5",
+      "adj．轻率的，不谨慎的（rash）",
+      "【记】 im（不）+prudent（小心的）→轻率的"
+    ],
+    "ukphone": "Imˋpru:dnt",
+    "usphone": "Imˋpru:dnt"
+  },
+  {
+    "name": "blunt",
+    "trans": [
+      "30.3.6",
+      "adj．直率的，粗鲁的"
+    ],
+    "ukphone": "blʌnt",
+    "usphone": "blʌnt"
+  },
+  {
+    "name": "intelligent",
+    "trans": [
+      "30.4.1",
+      "adj．聪明的（ingenious, wise）"
+    ],
+    "ukphone": "InˋtelIdʒənt",
+    "usphone": "InˋtelIdʒənt"
+  },
+  {
+    "name": "smart",
+    "trans": [
+      "30.4.2",
+      "adj．聪明的，敏捷的（clever, intelligent）"
+    ],
+    "ukphone": "smα:rt",
+    "usphone": "smα:rt"
+  },
+  {
+    "name": "versatile",
+    "trans": [
+      "30.4.3",
+      "adj．多才多艺的（many-sided, talented, all-around）"
+    ],
+    "ukphone": "ˋvɜ:rsətl",
+    "usphone": "ˋvɜ:rsətl"
+  },
+  {
+    "name": "astute",
+    "trans": [
+      "30.4.4",
+      "adj．机敏的，狡猾的（shrewd, canny）"
+    ],
+    "ukphone": "əˋstju:t",
+    "usphone": "əˋstju:t"
+  },
+  {
+    "name": "shrewd",
+    "trans": [
+      "30.4.5",
+      "adj．精明的（clever, smart）"
+    ],
+    "ukphone": "ʃru:d",
+    "usphone": "ʃru:d"
+  },
+  {
+    "name": "sensible",
+    "trans": [
+      "30.4.6",
+      "adj．理智的（wise, rational）",
+      "【记】 sens（感觉）+ible→理智的"
+    ],
+    "ukphone": "ˋsensəbl",
+    "usphone": "ˋsensəbl"
+  },
+  {
+    "name": "sane",
+    "trans": [
+      "30.4.7",
+      "adj．理智的；健全的（sensible, reasonable）"
+    ],
+    "ukphone": "seIn",
+    "usphone": "seIn"
+  },
+  {
+    "name": "flexible",
+    "trans": [
+      "30.4.8",
+      "adj．灵活的，变通的（agile）",
+      "【记】 flex（弯曲）+ible→易弯曲的→灵活的"
+    ],
+    "ukphone": "ˋfleksəbl",
+    "usphone": "ˋfleksəbl"
+  },
+  {
+    "name": "exquisite",
+    "trans": [
+      "30.4.9",
+      "adj．灵敏的"
+    ],
+    "ukphone": "IkˋskwIzIt",
+    "usphone": "IkˋskwIzIt"
+  },
+  {
+    "name": "expeditious",
+    "trans": [
+      "30.4.10",
+      "adj．敏捷的；迅速的（prompt; speedy）"
+    ],
+    "ukphone": "ˌekspəˋdIʃəs",
+    "usphone": "ˌekspəˋdIʃəs"
+  },
+  {
+    "name": "nimble",
+    "trans": [
+      "30.4.11",
+      "adj．轻快的；灵敏的（agile, brisk）",
+      "【记】 比较nim（偷窃）"
+    ],
+    "ukphone": "ˋnImbl",
+    "usphone": "ˋnImbl"
+  },
+  {
+    "name": "knowledgeable",
+    "trans": [
+      "30.4.12",
+      "adj．有见识的"
+    ],
+    "ukphone": "ˋnα:lIdʒəbl",
+    "usphone": "ˋnα:lIdʒəbl"
+  },
+  {
+    "name": "capable",
+    "trans": [
+      "30.4.13",
+      "adj．有能力的"
+    ],
+    "ukphone": "ˋkeIpəbl",
+    "usphone": "ˋkeIpəbl"
+  },
+  {
+    "name": "tact",
+    "trans": [
+      "30.4.14",
+      "n．老练；机智（diplomacy, thoughtfulness）"
+    ],
+    "ukphone": "tækt",
+    "usphone": "tækt"
+  },
+  {
+    "name": "sharpen",
+    "trans": [
+      "30.4.15",
+      "vt．使敏锐"
+    ],
+    "ukphone": "ˋʃα:rpən",
+    "usphone": "ˋʃα:rpən"
+  },
+  {
+    "name": "adroit",
+    "trans": [
+      "30.4.16",
+      "adj．机巧的（skillful, adept, deft）",
+      "【记】 a+droit（灵巧）→机巧的"
+    ],
+    "ukphone": "əˋdrɔIt",
+    "usphone": "əˋdrɔIt"
+  },
+  {
+    "name": "acute",
+    "trans": [
+      "30.4.17",
+      "adj．敏锐的（sharp）"
+    ],
+    "ukphone": "əˋkju:t",
+    "usphone": "əˋkju:t"
+  },
+  {
+    "name": "acumen",
+    "trans": [
+      "30.4.18",
+      "n．敏锐（acuteness）",
+      "【记】 acu（尖端）+men→敏锐"
+    ],
+    "ukphone": "ˋækjəmən",
+    "usphone": "ˋækjəmən"
+  },
+  {
+    "name": "gauche",
+    "trans": [
+      "30.5.1",
+      "adj．笨拙的；粗鲁的（awkward, clumsy, unapt）"
+    ],
+    "ukphone": "goʊʃ",
+    "usphone": "goʊʃ"
+  },
+  {
+    "name": "rough",
+    "trans": [
+      "30.5.2",
+      "adj．粗暴的（rude）"
+    ],
+    "ukphone": "rʌf",
+    "usphone": "rʌf"
+  },
+  {
+    "name": "rugged",
+    "trans": [
+      "30.5.3",
+      "adj．粗俗的（coarse, rough）"
+    ],
+    "ukphone": "ˋrʌgId",
+    "usphone": "ˋrʌgId"
+  },
+  {
+    "name": "coarse",
+    "trans": [
+      "30.5.4",
+      "adj．粗糙的，粗野的（rough, crude）"
+    ],
+    "ukphone": "kɔ:rs",
+    "usphone": "kɔ:rs"
+  },
+  {
+    "name": "rustic",
+    "trans": [
+      "30.5.5",
+      "adj．粗俗的",
+      "【记】 rust（乡村）+ic→粗俗的"
+    ],
+    "ukphone": "ˋrʌstIk",
+    "usphone": "ˋrʌstIk"
+  },
+  {
+    "name": "grumpy",
+    "trans": [
+      "30.5.6",
+      "adj．坏脾气的，性情暴躁的（ill-tempered）"
+    ],
+    "ukphone": "ˋgrʌmpi",
+    "usphone": "ˋgrʌmpi"
+  },
+  {
+    "name": "brutal",
+    "trans": [
+      "30.5.7",
+      "adj．野蛮的"
+    ],
+    "ukphone": "ˋbru:tl",
+    "usphone": "ˋbru:tl"
+  },
+  {
+    "name": "spineless",
+    "trans": [
+      "30.6.1",
+      "adj．没骨气的（weak, feeble）"
+    ],
+    "ukphone": "ˋspaInləs",
+    "usphone": "ˋspaInləs"
+  },
+  {
+    "name": "timid",
+    "trans": [
+      "30.6.2",
+      "adj．胆怯的，羞怯的"
+    ],
+    "ukphone": "ˋtImId",
+    "usphone": "ˋtImId"
+  },
+  {
+    "name": "bashful",
+    "trans": [
+      "30.6.3",
+      "adj．害羞的，胆小的（coy, shy, timid）",
+      "【记】 bash（羞）+ful→害羞的"
+    ],
+    "ukphone": "ˋbæʃfl",
+    "usphone": "ˋbæʃfl"
+  },
+  {
+    "name": "shy",
+    "trans": [
+      "30.6.4",
+      "adj．害羞的；胆小的（coy, timid）"
+    ],
+    "ukphone": "ʃaI",
+    "usphone": "ʃaI"
+  },
+  {
+    "name": "pitiful",
+    "trans": [
+      "30.7.1",
+      "adj．慈悲的",
+      "【记】 名词pity（可怜）"
+    ],
+    "ukphone": "ˋpItIfl",
+    "usphone": "ˋpItIfl"
+  },
+  {
+    "name": "genial",
+    "trans": [
+      "30.7.2",
+      "adj．和蔼的（kindly, good-natured）",
+      "【记】 gen（产生）+ial→产生（感情）的→和蔼的"
+    ],
+    "ukphone": "ˋdʒi:niəl",
+    "usphone": "ˋdʒi:niəl"
+  },
+  {
+    "name": "modest",
+    "trans": [
+      "30.7.3",
+      "adj．谦虚的；适度的（humble, unassuming）",
+      "【记】 mod（方式）+est→做事有规矩→礼貌的"
+    ],
+    "ukphone": "ˋmα:dIst",
+    "usphone": "ˋmα:dIst"
+  },
+  {
+    "name": "benign",
+    "trans": [
+      "30.7.4",
+      "adj．亲切的，良好的（kind, benevolent）"
+    ],
+    "ukphone": "bIˋnaIn",
+    "usphone": "bIˋnaIn"
+  },
+  {
+    "name": "facile",
+    "trans": [
+      "30.7.5",
+      "adj．轻而易举的（easy, effortless）；随和的",
+      "【记】 fac（做）+ile→能做得出的→轻而易举的"
+    ],
+    "ukphone": "ˋfæsl",
+    "usphone": "ˋfæsl"
+  },
+  {
+    "name": "merciful",
+    "trans": [
+      "30.7.6",
+      "adj．仁慈的，宽大的",
+      "【记】 名词mercy（仁慈）"
+    ],
+    "ukphone": "ˋmɜ:rsIfl",
+    "usphone": "ˋmɜ:rsIfl"
+  },
+  {
+    "name": "humane",
+    "trans": [
+      "30.7.7",
+      "adj．仁慈的，亲切的（sympathetic, kind）",
+      "【记】 human（人）+e→有人情味的→仁慈的"
+    ],
+    "ukphone": "hju:ˋmeIn",
+    "usphone": "hju:ˋmeIn"
+  },
+  {
+    "name": "ductile",
+    "trans": [
+      "30.7.8",
+      "adj．柔软的；驯良的（plastic; malleable）"
+    ],
+    "ukphone": "ˋdʌktaIl",
+    "usphone": "ˋdʌktaIl"
+  },
+  {
+    "name": "frank",
+    "trans": [
+      "30.7.9",
+      "adj．坦白的，直率的（direct, honest）"
+    ],
+    "ukphone": "fræŋk",
+    "usphone": "fræŋk"
+  },
+  {
+    "name": "outspoken",
+    "trans": [
+      "30.7.10",
+      "adj．坦率直言的（forthright, straight-forward）",
+      "【记】 来自speak out（说出）"
+    ],
+    "ukphone": "aʊtˋspoʊkən",
+    "usphone": "aʊtˋspoʊkən"
+  },
+  {
+    "name": "moderate",
+    "trans": [
+      "30.7.11",
+      "adj．温和的；适度的（average, reasonable）",
+      "【记】 moder=mod（方式）+ate→方式正确→适度的"
+    ],
+    "ukphone": "ˋmα:dərət",
+    "usphone": "ˋmα:dərət"
+  },
+  {
+    "name": "meek",
+    "trans": [
+      "30.7.12",
+      "adj．温顺的（docile, submissive）；柔和的"
+    ],
+    "ukphone": "mi:k",
+    "usphone": "mi:k"
+  },
+  {
+    "name": "tractable",
+    "trans": [
+      "30.7.13",
+      "adj．易驾驭的；温顺的（obedient）",
+      "【记】 tract（拉）+able→能拉得动的→易驾驭的"
+    ],
+    "ukphone": "ˋtræktəbl",
+    "usphone": "ˋtræktəbl"
+  },
+  {
+    "name": "facetious",
+    "trans": [
+      "30.7.14",
+      "adj．幽默的，滑稽的（amusing, jesting）"
+    ],
+    "ukphone": "fəˋsi:ʃəs",
+    "usphone": "fəˋsi:ʃəs"
+  },
+  {
+    "name": "humorous",
+    "trans": [
+      "30.7.15",
+      "adj．幽默的"
+    ],
+    "ukphone": "ˋhju:mərəs",
+    "usphone": "ˋhju:mərəs"
+  },
+  {
+    "name": "sociable",
+    "trans": [
+      "30.7.16",
+      "adj．友善的，好交际的（gregarious, friendly）"
+    ],
+    "ukphone": "ˋsoʊʃəbl",
+    "usphone": "ˋsoʊʃəbl"
+  },
+  {
+    "name": "courteous",
+    "trans": [
+      "30.7.17",
+      "adj．有礼貌的；谦恭的（polite, gracious）"
+    ],
+    "ukphone": "ˋkɜ:rtiəs",
+    "usphone": "ˋkɜ:rtiəs"
+  },
+  {
+    "name": "gracious",
+    "trans": [
+      "30.7.18",
+      "adj．有礼貌的；仁慈的（affable）",
+      "【记】 grac（优雅，讲究礼仪）+ious→有礼貌的"
+    ],
+    "ukphone": "ˋgreIʃəs",
+    "usphone": "ˋgreIʃəs"
+  },
+  {
+    "name": "gregarious",
+    "trans": [
+      "30.7.19",
+      "adj．合群的（social, sociable）",
+      "【记】 greg（群体）+arious→爱群体的"
+    ],
+    "ukphone": "grIˋgeriəs",
+    "usphone": "grIˋgeriəs"
+  },
+  {
+    "name": "gentility",
+    "trans": [
+      "30.7.20",
+      "n．有教养；文雅"
+    ],
+    "ukphone": "dʒenˋtIləti",
+    "usphone": "dʒenˋtIləti"
+  },
+  {
+    "name": "affable",
+    "trans": [
+      "30.7.21",
+      "adj．和蔼可亲的（genial, benevolent）",
+      "【记】 af+fable（说，讲）→可以说话的→和蔼的"
+    ],
+    "ukphone": "ˋæfəbl",
+    "usphone": "ˋæfəbl"
+  },
+  {
+    "name": "crooked",
+    "trans": [
+      "30.8.1",
+      "adj．狡诈的（bent, twisted）",
+      "【记】 crook（弯曲）+ed→拐弯抹角的→狡诈的"
+    ],
+    "ukphone": "ˋkrʊkId",
+    "usphone": "ˋkrʊkId"
+  },
+  {
+    "name": "sly",
+    "trans": [
+      "30.8.2",
+      "adj．狡猾的"
+    ],
+    "ukphone": "slaI",
+    "usphone": "slaI"
+  },
+  {
+    "name": "cunning",
+    "trans": [
+      "30.8.3",
+      "adj．狡猾的（sly, tricky）"
+    ],
+    "ukphone": "ˋkʌnIŋ",
+    "usphone": "ˋkʌnIŋ"
+  },
+  {
+    "name": "designing",
+    "trans": [
+      "30.8.4",
+      "adj．狡猾的；蓄意的（cunning）"
+    ],
+    "ukphone": "dIˋzaInIŋ",
+    "usphone": "dIˋzaInIŋ"
+  },
+  {
+    "name": "frugal",
+    "trans": [
+      "30.9.1",
+      "adj．节约的（thrifty, economical）"
+    ],
+    "ukphone": "ˋfru:gl",
+    "usphone": "ˋfru:gl"
+  },
+  {
+    "name": "economize",
+    "trans": [
+      "30.9.2",
+      "vi．节俭（save, cut costs）"
+    ],
+    "ukphone": "Iˋkα:nəmaIz",
+    "usphone": "Iˋkα:nəmaIz"
+  },
+  {
+    "name": "economical",
+    "trans": [
+      "30.9.3",
+      "adj．节约的，经济的（thrifty）"
+    ],
+    "ukphone": "ˌi:kəˋnα:mIkl",
+    "usphone": "ˌi:kəˋnα:mIkl"
+  },
+  {
+    "name": "canny",
+    "trans": [
+      "30.9.4",
+      "adj．精明的；节俭的（shrewd, cunning）"
+    ],
+    "ukphone": "ˋkæni",
+    "usphone": "ˋkæni"
+  },
+  {
+    "name": "stoically",
+    "trans": [
+      "30.9.5",
+      "adv．淡泊地（impassively）"
+    ],
+    "ukphone": "ˋstoʊIkli",
+    "usphone": "ˋstoʊIkli"
+  },
+  {
+    "name": "austerity",
+    "trans": [
+      "30.9.6",
+      "n．节俭"
+    ],
+    "ukphone": "ɔ:ˋsterəti",
+    "usphone": "ɔ:ˋsterəti"
+  },
+  {
+    "name": "thrift",
+    "trans": [
+      "30.9.7",
+      "n．节约（economy, frugality）"
+    ],
+    "ukphone": "θrIft",
+    "usphone": "θrIft"
+  },
+  {
+    "name": "conservative",
+    "trans": [
+      "30.10.1",
+      "adj．保守的（modest; cautious）"
+    ],
+    "ukphone": "kənˋsɜ:rvətIv",
+    "usphone": "kənˋsɜ:rvətIv"
+  },
+  {
+    "name": "composed",
+    "trans": [
+      "30.10.2",
+      "adj．沉着的",
+      "【记】 比较pose（姿态）"
+    ],
+    "ukphone": "kəmˋpoʊzd",
+    "usphone": "kəmˋpoʊzd"
+  },
+  {
+    "name": "composure",
+    "trans": [
+      "30.10.3",
+      "n．镇静（calmness, self-control）"
+    ],
+    "ukphone": "kəmˋpoʊʒər",
+    "usphone": "kəmˋpoʊʒər"
+  },
+  {
+    "name": "prudent",
+    "trans": [
+      "30.10.4",
+      "adj．谨慎的（cautious）",
+      "【记】 prud（小心）+ent→谨慎的"
+    ],
+    "ukphone": "ˋpru:dnt",
+    "usphone": "ˋpru:dnt"
+  },
+  {
+    "name": "vigilant",
+    "trans": [
+      "30.10.5",
+      "adj．警惕的，清醒的（watchful, alert）"
+    ],
+    "ukphone": "ˋvIdʒIlənt",
+    "usphone": "ˋvIdʒIlənt"
+  },
+  {
+    "name": "hardheaded",
+    "trans": [
+      "30.10.6",
+      "adj．冷静的",
+      "【记】 hard（硬的）+head（想法）+ed"
+    ],
+    "ukphone": "ˋhα:rdˋhedId",
+    "usphone": "ˋhα:rdˋhedId"
+  },
+  {
+    "name": "sober",
+    "trans": [
+      "30.10.7",
+      "adj．清醒的"
+    ],
+    "ukphone": "ˋsoʊbər",
+    "usphone": "ˋsoʊbər"
+  },
+  {
+    "name": "discreet",
+    "trans": [
+      "30.10.8",
+      "adj．慎重的，谨慎的（prudent, cautious）"
+    ],
+    "ukphone": "dIˋskri:t",
+    "usphone": "dIˋskri:t"
+  },
+  {
+    "name": "discretion",
+    "trans": [
+      "30.10.9",
+      "n．慎重（caution, prudence）"
+    ],
+    "ukphone": "dIˋskreʃn",
+    "usphone": "dIˋskreʃn"
+  },
+  {
+    "name": "circumspect",
+    "trans": [
+      "30.10.10",
+      "adj．慎重的，小心的（prudent, cautious）",
+      "【记】 circum（绕圈）+spect（看）→四处看→小心的"
+    ],
+    "ukphone": "ˋsɜ:rkəmspekt",
+    "usphone": "ˋsɜ:rkəmspekt"
+  },
+  {
+    "name": "cautious",
+    "trans": [
+      "30.10.11",
+      "adj．小心的，谨慎的"
+    ],
+    "ukphone": "ˋkɔ:ʃəs",
+    "usphone": "ˋkɔ:ʃəs"
+  },
+  {
+    "name": "meticulously",
+    "trans": [
+      "30.10.12",
+      "adv．很仔细地（carefully, scrupulously）",
+      "【记】 metic（害怕）+ulously→害怕出错地→细心地"
+    ],
+    "ukphone": "məˋtIkjələsli",
+    "usphone": "məˋtIkjələsli"
+  },
+  {
+    "name": "sanity",
+    "trans": [
+      "30.10.13",
+      "n．神志清楚（saneness, rationality）"
+    ],
+    "ukphone": "ˋsænəti",
+    "usphone": "ˋsænəti"
+  },
+  {
+    "name": "sluggish",
+    "trans": [
+      "30.11.1",
+      "adj．怠惰的（lethargic, listless, slow）"
+    ],
+    "ukphone": "ˋslʌgIʃ",
+    "usphone": "ˋslʌgIʃ"
+  },
+  {
+    "name": "indolent",
+    "trans": [
+      "30.11.2",
+      "adj．懒惰的（lazy, slothful）"
+    ],
+    "ukphone": "ˋIndələnt",
+    "usphone": "ˋIndələnt"
+  },
+  {
+    "name": "inertia",
+    "trans": [
+      "30.11.3",
+      "n．惯性；惰性（laziness, indolence）"
+    ],
+    "ukphone": "Iˋnɜ:rʃə",
+    "usphone": "Iˋnɜ:rʃə"
+  },
+  {
+    "name": "slug",
+    "trans": [
+      "30.11.4",
+      "n．慢吞吞的人（或物）"
+    ],
+    "ukphone": "slʌg",
+    "usphone": "slʌg"
+  },
+  {
+    "name": "sloth",
+    "trans": [
+      "30.11.5",
+      "n．怠惰，懒惰"
+    ],
+    "ukphone": "sloʊθ",
+    "usphone": "sloʊθ"
+  },
+  {
+    "name": "slothful",
+    "trans": [
+      "30.11.6",
+      "adj．偷懒的"
+    ],
+    "ukphone": "ˋsloʊθfl",
+    "usphone": "ˋsloʊθfl"
+  },
+  {
+    "name": "stout",
+    "trans": [
+      "30.12.1",
+      "adj．健壮的（strong, sturdy）"
+    ],
+    "ukphone": "staʊt",
+    "usphone": "staʊt"
+  },
+  {
+    "name": "firm",
+    "trans": [
+      "30.12.2",
+      "adj．坚挺的；结实的（hard）"
+    ],
+    "ukphone": "fɜ:rm",
+    "usphone": "fɜ:rm"
+  },
+  {
+    "name": "stocky",
+    "trans": [
+      "30.12.3",
+      "adj．结实的，粗短的（sturdy）"
+    ],
+    "ukphone": "ˋstα:ki",
+    "usphone": "ˋstα:ki"
+  },
+  {
+    "name": "robust",
+    "trans": [
+      "30.12.4",
+      "adj．强壮的（strong, sturdy）",
+      "【记】 也就是谐音“乐百氏”"
+    ],
+    "ukphone": "roʊˋbʌst",
+    "usphone": "roʊˋbʌst"
+  },
+  {
+    "name": "hardy",
+    "trans": [
+      "30.12.5",
+      "adj．强壮的（tough, rugged）；耐劳的"
+    ],
+    "ukphone": "ˋhα:rdi",
+    "usphone": "ˋhα:rdi"
+  },
+  {
+    "name": "lusty",
+    "trans": [
+      "30.12.6",
+      "adj．强壮的；有精神的（vigorous, energetic）",
+      "【记】 lust（光亮）+y→人满面红光→有精神的"
+    ],
+    "ukphone": "ˋlʌsti",
+    "usphone": "ˋlʌsti"
+  },
+  {
+    "name": "stiff",
+    "trans": [
+      "30.12.7",
+      "adj．硬的，僵直的"
+    ],
+    "ukphone": "stIf",
+    "usphone": "stIf"
+  },
+  {
+    "name": "prodigal",
+    "trans": [
+      "30.13.1",
+      "adj．浪费的（extravagant, wasteful）"
+    ],
+    "ukphone": "ˋprα:dIgl",
+    "usphone": "ˋprα:dIgl"
+  },
+  {
+    "name": "improvident",
+    "trans": [
+      "30.13.2",
+      "adj．浪费的（thriftless, wasteful）",
+      "【记】 im（无）+provident（前瞻性的）"
+    ],
+    "ukphone": "Imˋprα:vIdənt",
+    "usphone": "Imˋprα:vIdənt"
+  },
+  {
+    "name": "lavish",
+    "trans": [
+      "30.13.3",
+      "adj．浪费的，奢侈的（wasteful）",
+      "【记】 lav（洗）+ish→冲掉→浪费的"
+    ],
+    "ukphone": "ˋlævIʃ",
+    "usphone": "ˋlævIʃ"
+  },
+  {
+    "name": "luxurious",
+    "trans": [
+      "30.13.4",
+      "adj．奢侈的（expensive, costly）"
+    ],
+    "ukphone": "lʌgˋʒʊriəs",
+    "usphone": "lʌgˋʒʊriəs"
+  },
+  {
+    "name": "extravagant",
+    "trans": [
+      "30.13.5",
+      "adj．奢侈的，浪费的（wasteful）",
+      "【记】 extra+vag（走）+ant→游走外面的世界→奢侈的"
+    ],
+    "ukphone": "Ikˋstrævəgənt",
+    "usphone": "Ikˋstrævəgənt"
+  },
+  {
+    "name": "squander",
+    "trans": [
+      "30.13.6",
+      "vt．浪费（dissipate, waste）"
+    ],
+    "ukphone": "ˋskwα:ndər",
+    "usphone": "ˋskwα:ndər"
+  },
+  {
+    "name": "flamboyant",
+    "trans": [
+      "30.13.7",
+      "adj．华丽的，浮夸的（dazzling, showy）"
+    ],
+    "ukphone": "flæmˋbɔIənt",
+    "usphone": "flæmˋbɔIənt"
+  },
+  {
+    "name": "deft",
+    "trans": [
+      "30.14.1",
+      "adj．灵巧的，熟练的（skillful, adroit）"
+    ],
+    "ukphone": "deft",
+    "usphone": "deft"
+  },
+  {
+    "name": "adept",
+    "trans": [
+      "30.14.2",
+      "adj．擅长的（adroit, apt）"
+    ],
+    "ukphone": "əˋdept",
+    "usphone": "əˋdept"
+  },
+  {
+    "name": "skillful",
+    "trans": [
+      "30.14.3",
+      "adj．熟练的（adroit）"
+    ],
+    "ukphone": "ˋskIlfl",
+    "usphone": "ˋskIlfl"
+  },
+  {
+    "name": "experienced",
+    "trans": [
+      "30.14.4",
+      "adj．有经验的",
+      "【记】 比较experience（经验）"
+    ],
+    "ukphone": "IkˋspIriənst",
+    "usphone": "IkˋspIriənst"
+  },
+  {
+    "name": "stunt",
+    "trans": [
+      "30.14.5",
+      "n．惊人的技艺（trick, feat）"
+    ],
+    "ukphone": "stʌnt",
+    "usphone": "stʌnt"
+  },
+  {
+    "name": "craft",
+    "trans": [
+      "30.14.6",
+      "n．手艺（workmanship）",
+      "【记】 craftsman（手艺人）"
+    ],
+    "ukphone": "kræft",
+    "usphone": "kræft"
+  },
+  {
+    "name": "facility",
+    "trans": [
+      "30.14.7",
+      "n．熟练（proficiency）；（复数）工具"
+    ],
+    "ukphone": "fəˋsIləti",
+    "usphone": "fəˋsIləti"
+  },
+  {
+    "name": "familiarize",
+    "trans": [
+      "30.14.8",
+      "vt．熟悉",
+      "【记】 familiar（熟悉的）+ize（动词词尾）→熟悉"
+    ],
+    "ukphone": "fəˋmIliəraIz",
+    "usphone": "fəˋmIliəraIz"
+  },
+  {
+    "name": "accomplished",
+    "trans": [
+      "30.14.9",
+      "adj．熟练的（experienced, skillful）"
+    ],
+    "ukphone": "əˋkα:mplIʃt",
+    "usphone": "əˋkα:mplIʃt"
+  },
+  {
+    "name": "aptitude",
+    "trans": [
+      "30.15.1",
+      "n．才能（talent, knack）",
+      "【记】 apti（能力）+tude→才能"
+    ],
+    "ukphone": "ˋæptItju:d",
+    "usphone": "ˋæptItju:d"
+  },
+  {
+    "name": "vigor",
+    "trans": [
+      "30.15.2",
+      "n．精力（energy, enthusiasm）"
+    ],
+    "ukphone": "ˋvIgər",
+    "usphone": "ˋvIgər"
+  },
+  {
+    "name": "caliber",
+    "trans": [
+      "30.15.3",
+      "n．品质（quality, capacity, ability）"
+    ],
+    "ukphone": "ˋkælIbər",
+    "usphone": "ˋkælIbər"
+  },
+  {
+    "name": "quality",
+    "trans": [
+      "30.15.4",
+      "n．品质（trait, calibre）"
+    ],
+    "ukphone": "ˋkwα:ləti",
+    "usphone": "ˋkwα:ləti"
+  },
+  {
+    "name": "temperament",
+    "trans": [
+      "30.15.5",
+      "n．气质，性情（disposition, nature）",
+      "【记】 tempera（脾气）+ment→性情"
+    ],
+    "ukphone": "ˋtemprəmənt",
+    "usphone": "ˋtemprəmənt"
+  },
+  {
+    "name": "stamina",
+    "trans": [
+      "30.15.6",
+      "n．体力，精力（endurance）"
+    ],
+    "ukphone": "ˋstæmInə",
+    "usphone": "ˋstæmInə"
+  },
+  {
+    "name": "talent",
+    "trans": [
+      "30.15.7",
+      "n．天才；才能；人才（gift, aptitude, knack）"
+    ],
+    "ukphone": "ˋtælənt",
+    "usphone": "ˋtælənt"
+  },
+  {
+    "name": "confidence",
+    "trans": [
+      "30.15.8",
+      "n．信心",
+      "【记】 con+fid（相信）+ence→信心"
+    ],
+    "ukphone": "ˋkα:nfIdəns",
+    "usphone": "ˋkα:nfIdəns"
+  },
+  {
+    "name": "disposition",
+    "trans": [
+      "30.15.9",
+      "n．性情（temperament, nature）"
+    ],
+    "ukphone": "ˌdIspəˋzIʃn",
+    "usphone": "ˌdIspəˋzIʃn"
+  },
+  {
+    "name": "mass",
+    "trans": [
+      "30.15.10",
+      "n．质量"
+    ],
+    "ukphone": "mæs",
+    "usphone": "mæs"
+  },
+  {
+    "name": "ability",
+    "trans": [
+      "30.15.11",
+      "n．能力（capability）"
+    ],
+    "ukphone": "əˋbIləti",
+    "usphone": "əˋbIləti"
+  },
+  {
+    "name": "versatile",
+    "trans": [
+      "30.15.12",
+      "adj．通用的，万能的，多才多艺的，多面手的"
+    ],
+    "ukphone": "ˋvɜ:rsətl",
+    "usphone": "ˋvɜ:rsətl"
+  },
+  {
+    "name": "power",
+    "trans": [
+      "30.15.13",
+      "n．能力，力量"
+    ],
+    "ukphone": "ˋpaʊər",
+    "usphone": "ˋpaʊər"
+  },
+  {
+    "name": "avid",
+    "trans": [
+      "30.16.1",
+      "adj．贪婪的（greedy）"
+    ],
+    "ukphone": "ˋævId",
+    "usphone": "ˋævId"
+  },
+  {
+    "name": "ravenous",
+    "trans": [
+      "30.16.2",
+      "adj．贪婪的"
+    ],
+    "ukphone": "ˋrævənəs",
+    "usphone": "ˋrævənəs"
+  },
+  {
+    "name": "rapacious",
+    "trans": [
+      "30.16.3",
+      "adj．贪婪的（avaricious, covetous）",
+      "【记】 rap（抓，夺）+acious→贪婪的"
+    ],
+    "ukphone": "rəˋpeIʃəs",
+    "usphone": "rəˋpeIʃəs"
+  },
+  {
+    "name": "greedy",
+    "trans": [
+      "30.16.4",
+      "adj．贪婪的（voracious, insatiable）"
+    ],
+    "ukphone": "ˋgri:di",
+    "usphone": "ˋgri:di"
+  },
+  {
+    "name": "covetous",
+    "trans": [
+      "30.16.5",
+      "adj．贪心的（desirous, avaricious）",
+      "【记】 动词covet（贪心）"
+    ],
+    "ukphone": "ˋkʌvətəs",
+    "usphone": "ˋkʌvətəs"
+  },
+  {
+    "name": "avarice",
+    "trans": [
+      "30.16.6",
+      "n．贪婪（greed, lust）",
+      "【记】 参考avid（渴望的）"
+    ],
+    "ukphone": "ˋævərIs",
+    "usphone": "ˋævərIs"
+  },
+  {
+    "name": "avaricious",
+    "trans": [
+      "30.16.7",
+      "adj．贪婪的，贪心的（greedy）"
+    ],
+    "ukphone": "ˌævəˋrIʃəs",
+    "usphone": "ˌævəˋrIʃəs"
+  },
+  {
+    "name": "acquisitive",
+    "trans": [
+      "30.16.8",
+      "adj．贪得无厌的（covetous, greedy）",
+      "【记】 ac+quisit（得到）+ive→一再要得到→贪婪的"
+    ],
+    "ukphone": "əˋkwIzətIv",
+    "usphone": "əˋkwIzətIv"
+  },
+  {
+    "name": "exacting",
+    "trans": [
+      "30.17.1",
+      "adj．费力的，严格的（demanding, rigorous）",
+      "【记】 比较exact（一丝不差的）"
+    ],
+    "ukphone": "IgˋzæktIŋ",
+    "usphone": "IgˋzæktIŋ"
+  },
+  {
+    "name": "ascetic",
+    "trans": [
+      "30.17.2",
+      "adj．苦行的（austere, rigorous, strict）"
+    ],
+    "ukphone": "əˋsetIk",
+    "usphone": "əˋsetIk"
+  },
+  {
+    "name": "grim",
+    "trans": [
+      "30.17.3",
+      "adj．冷酷的（cruel, merciless）"
+    ],
+    "ukphone": "grIm",
+    "usphone": "grIm"
+  },
+  {
+    "name": "relentless",
+    "trans": [
+      "30.17.4",
+      "adj．无情的（merciless, ruthless）",
+      "【记】 relent（怜悯的）+less→无怜悯的"
+    ],
+    "ukphone": "rIˋlentləs",
+    "usphone": "rIˋlentləs"
+  },
+  {
+    "name": "ruthless",
+    "trans": [
+      "30.17.5",
+      "adj．无情的，冷酷的（merciless, pitiless）"
+    ],
+    "ukphone": "ˋru:θləs",
+    "usphone": "ˋru:θləs"
+  },
+  {
+    "name": "rigid",
+    "trans": [
+      "30.17.6",
+      "adj．严格的，僵化的（strict, fixed）"
+    ],
+    "ukphone": "ˋrIdʒId",
+    "usphone": "ˋrIdʒId"
+  },
+  {
+    "name": "stern",
+    "trans": [
+      "30.17.7",
+      "adj．严格的；僵化的（harsh, hard, strict）"
+    ],
+    "ukphone": "stɜ:rn",
+    "usphone": "stɜ:rn"
+  },
+  {
+    "name": "stringent",
+    "trans": [
+      "30.17.8",
+      "adj．严格的；迫切的（strict, rigid）"
+    ],
+    "ukphone": "ˋstrIndʒənt",
+    "usphone": "ˋstrIndʒənt"
+  },
+  {
+    "name": "scrupulous",
+    "trans": [
+      "30.17.9",
+      "adj．严谨的，讲究的（prudent, meticulous）"
+    ],
+    "ukphone": "ˋskru:pjələs",
+    "usphone": "ˋskru:pjələs"
+  },
+  {
+    "name": "drastic",
+    "trans": [
+      "30.17.10",
+      "adj．严厉的（severe）"
+    ],
+    "ukphone": "ˋdrα:stIk",
+    "usphone": "ˋdrα:stIk"
+  },
+  {
+    "name": "harsh",
+    "trans": [
+      "30.17.11",
+      "adj．严厉的（severe）"
+    ],
+    "ukphone": "hα:rʃ",
+    "usphone": "hα:rʃ"
+  },
+  {
+    "name": "rigor",
+    "trans": [
+      "30.17.12",
+      "n．严格，严厉（rigidity, hardship）"
+    ],
+    "ukphone": "rIgər",
+    "usphone": "rIgər"
+  },
+  {
+    "name": "rigorous",
+    "trans": [
+      "30.17.13",
+      "adj．严厉的，严峻的（strict, rigid）",
+      "【记】 rig（严厉的）+orous→严厉的"
+    ],
+    "ukphone": "ˋrIgərəs",
+    "usphone": "ˋrIgərəs"
+  },
+  {
+    "name": "serious",
+    "trans": [
+      "30.17.14",
+      "adj．严肃的"
+    ],
+    "ukphone": "ˋsIriəs",
+    "usphone": "ˋsIriəs"
+  },
+  {
+    "name": "severe",
+    "trans": [
+      "30.17.15",
+      "adj．严重的，严肃的（grave, grievous）"
+    ],
+    "ukphone": "sIˋvIr",
+    "usphone": "sIˋvIr"
+  },
+  {
+    "name": "austerity",
+    "trans": [
+      "30.17.16",
+      "n．严峻",
+      "【记】 au+ster（冷）+ity→冷冰冰→严峻"
+    ],
+    "ukphone": "ɔ:ˋsterəti",
+    "usphone": "ɔ:ˋsterəti"
+  },
+  {
+    "name": "ordeal",
+    "trans": [
+      "30.17.17",
+      "n．严酷的考验（difficult experience, trial）"
+    ],
+    "ukphone": "ɔ:rˋdi:l",
+    "usphone": "ɔ:rˋdi:l"
+  },
+  {
+    "name": "bold",
+    "trans": [
+      "30.18.1",
+      "adj．大胆的（daring, brave）"
+    ],
+    "ukphone": "boʊld",
+    "usphone": "boʊld"
+  },
+  {
+    "name": "daring",
+    "trans": [
+      "30.18.2",
+      "adj．大胆的，勇敢的（bold, audacious）",
+      "【记】 比较dare（胆敢）"
+    ],
+    "ukphone": "ˋderIŋ",
+    "usphone": "ˋderIŋ"
+  },
+  {
+    "name": "undaunted",
+    "trans": [
+      "30.18.3",
+      "adj．无畏的，勇敢的（intrepid, fearless）"
+    ],
+    "ukphone": "ˌʌnˋdɔ:ntId",
+    "usphone": "ˌʌnˋdɔ:ntId"
+  },
+  {
+    "name": "dauntless",
+    "trans": [
+      "30.18.4",
+      "adj．勇敢的",
+      "【记】 daunt（害怕）+less→不害怕的→勇敢的"
+    ],
+    "ukphone": "ˋdɔ:ntləs",
+    "usphone": "ˋdɔ:ntləs"
+  },
+  {
+    "name": "valiant",
+    "trans": [
+      "30.18.5",
+      "adj．英勇的（courageous, dauntless, intrepid）"
+    ],
+    "ukphone": "ˋvæliənt",
+    "usphone": "ˋvæliənt"
+  },
+  {
+    "name": "gallant",
+    "trans": [
+      "30.18.6",
+      "adj．英勇的（courageous, heroic）",
+      "【记】 gall（胆）+ant→有胆的→英勇的"
+    ],
+    "ukphone": "ˋgælənt",
+    "usphone": "ˋgælənt"
+  },
+  {
+    "name": "intrepid",
+    "trans": [
+      "30.18.7",
+      "adj．勇敢的（fearless, dauntless）",
+      "【记】 in（不）+trepid（害怕）→勇敢的"
+    ],
+    "ukphone": "InˋtrepId",
+    "usphone": "InˋtrepId"
+  },
+  {
+    "name": "valor",
+    "trans": [
+      "30.18.8",
+      "n．勇气（bravery, courage）",
+      "【记】 val（强大）+or"
+    ],
+    "ukphone": "ˋvælər",
+    "usphone": "ˋvælər"
+  },
+  {
+    "name": "flighty",
+    "trans": [
+      "30.19.1",
+      "adj．不负责任的；轻浮的（fickle, capricious）",
+      "【记】 flight（飞）+y→轻浮的"
+    ],
+    "ukphone": "ˋflaIti",
+    "usphone": "ˋflaIti"
+  },
+  {
+    "name": "skimpy",
+    "trans": [
+      "30.19.2",
+      "adj．吝啬的"
+    ],
+    "ukphone": "ˋskImpi",
+    "usphone": "ˋskImpi"
+  },
+  {
+    "name": "stingy",
+    "trans": [
+      "30.19.3",
+      "adj．吝啬的（miserly, ungenerous）"
+    ],
+    "ukphone": "ˋstIndʒi",
+    "usphone": "ˋstIndʒi"
+  },
+  {
+    "name": "miserly",
+    "trans": [
+      "30.19.4",
+      "adj．吝啬的（stingy）"
+    ],
+    "ukphone": "ˋmaIzərli",
+    "usphone": "ˋmaIzərli"
+  },
+  {
+    "name": "snobbish",
+    "trans": [
+      "30.19.5",
+      "adj．势利的，谄上欺下的",
+      "【记】 snob（势利）+bish→势利的"
+    ],
+    "ukphone": "ˋsnα:bIʃ",
+    "usphone": "ˋsnα:bIʃ"
+  },
+  {
+    "name": "selfish",
+    "trans": [
+      "30.19.6",
+      "左列单词在右列中有一个或多个同义词，请画线连接。"
+    ],
+    "ukphone": "ˋselfIʃ",
+    "usphone": "ˋselfIʃ"
+  },
+  {
+    "name": "diverse",
+    "trans": [
+      "31.1.1",
+      "adj．不同的（different, various）"
+    ],
+    "ukphone": "daIˋvɜ:rs",
+    "usphone": "daIˋvɜ:rs"
+  },
+  {
+    "name": "diversify",
+    "trans": [
+      "31.1.2",
+      "vt．使多样化（vary）"
+    ],
+    "ukphone": "daIˋvɜ:rsIfaI",
+    "usphone": "daIˋvɜ:rsIfaI"
+  },
+  {
+    "name": "fickle",
+    "trans": [
+      "31.1.3",
+      "adj．多变的（changeable, capricious）"
+    ],
+    "ukphone": "ˋfIkl",
+    "usphone": "ˋfIkl"
+  },
+  {
+    "name": "manifold",
+    "trans": [
+      "31.1.4",
+      "adj．多样的（various, many）；多方面的",
+      "【记】 mani（许多）+fold（层次）→繁多的"
+    ],
+    "ukphone": "ˋmænIfoʊld",
+    "usphone": "ˋmænIfoʊld"
+  },
+  {
+    "name": "lavish",
+    "trans": [
+      "31.1.5",
+      "adj．丰富的（liberal）",
+      "【记】 lav（洗）+ish→冲掉→浪费的"
+    ],
+    "ukphone": "ˋlævIʃ",
+    "usphone": "ˋlævIʃ"
+  },
+  {
+    "name": "profuse",
+    "trans": [
+      "31.1.6",
+      "adj．极其丰富的（abundant, exuberant）",
+      "【记】 pro（向前）+fuse（流）→表示充足，丰富的"
+    ],
+    "ukphone": "prəˋfju:s",
+    "usphone": "prəˋfju:s"
+  },
+  {
+    "name": "vary",
+    "trans": [
+      "31.1.7",
+      "vt．改变（differ, deviate from, range）"
+    ],
+    "ukphone": "ˋveri",
+    "usphone": "ˋveri"
+  },
+  {
+    "name": "various",
+    "trans": [
+      "31.1.8",
+      "adj．各种的（diversified）"
+    ],
+    "ukphone": "ˋveriəs",
+    "usphone": "ˋveriəs"
+  },
+  {
+    "name": "variation",
+    "trans": [
+      "31.1.9",
+      "n．变化（alteration, change）",
+      "【记】 vari（变化）+ation"
+    ],
+    "ukphone": "ˌveriˋeIʃn",
+    "usphone": "ˌveriˋeIʃn"
+  },
+  {
+    "name": "variant",
+    "trans": [
+      "31.1.10",
+      "adj．不同的（different）",
+      "【记】 vari（变化）+ant"
+    ],
+    "ukphone": "ˋveriənt",
+    "usphone": "ˋveriənt"
+  },
+  {
+    "name": "mutation",
+    "trans": [
+      "31.1.11",
+      "n．变化（transformation）",
+      "【记】 mut（变）+ation"
+    ],
+    "ukphone": "mju:ˋteIʃn",
+    "usphone": "mju:ˋteIʃn"
+  },
+  {
+    "name": "transition",
+    "trans": [
+      "31.1.12",
+      "n．转变，变迁；过渡（change, shift）",
+      "【记】 trans（交换）+it（走）+ion→转变"
+    ],
+    "ukphone": "trænˋzIʃn",
+    "usphone": "trænˋzIʃn"
+  },
+  {
+    "name": "transform",
+    "trans": [
+      "31.1.13",
+      "vt．变换（change, transmute）",
+      "【记】 trans（变）+form（形）→变形"
+    ],
+    "ukphone": "trænsˋfɔ:rm",
+    "usphone": "trænsˋfɔ:rm"
+  },
+  {
+    "name": "enrich",
+    "trans": [
+      "31.1.14",
+      "vt．丰富（make rich, enhance）",
+      "【记】 en+rich（富）"
+    ],
+    "ukphone": "InˋrItʃ",
+    "usphone": "InˋrItʃ"
+  },
+  {
+    "name": "convert",
+    "trans": [
+      "31.1.15",
+      "vt．转换（change, transform）",
+      "【记】 con+vert（转）"
+    ],
+    "ukphone": "kənˋvɜ:rt",
+    "usphone": "kənˋvɜ:rt"
+  },
+  {
+    "name": "copious",
+    "trans": [
+      "31.1.16",
+      "adj．丰富的（plentiful）"
+    ],
+    "ukphone": "ˋkoʊpiəs",
+    "usphone": "ˋkoʊpiəs"
+  },
+  {
+    "name": "alteration",
+    "trans": [
+      "31.1.17",
+      "n．修改，改变；变更"
+    ],
+    "ukphone": "ˌɔ:ltəˋreIʃn",
+    "usphone": "ˌɔ:ltəˋreIʃn"
+  },
+  {
+    "name": "replacement",
+    "trans": [
+      "31.1.18",
+      "n．更换；复位；代替者；补充兵员"
+    ],
+    "ukphone": "rIˑpleIsmənt",
+    "usphone": "rIˑpleIsmənt"
+  },
+  {
+    "name": "hostile",
+    "trans": [
+      "31.2.1",
+      "adj．敌对的，不友好的（antagonistic, unfriendly）"
+    ],
+    "ukphone": "ˋhα:stl",
+    "usphone": "ˋhα:stl"
+  },
+  {
+    "name": "diverge",
+    "trans": [
+      "31.2.2",
+      "vt．分歧，差异（differ, deviate）",
+      "【记】 di+verge（转）→转开→分歧"
+    ],
+    "ukphone": "daIˋvɜ:rdʒ",
+    "usphone": "daIˋvɜ:rdʒ"
+  },
+  {
+    "name": "divergent",
+    "trans": [
+      "31.2.3",
+      "adj．分叉的；分歧的（different）"
+    ],
+    "ukphone": "daIˋvɜ:rdʒənt",
+    "usphone": "daIˋvɜ:rdʒənt"
+  },
+  {
+    "name": "belligerent",
+    "trans": [
+      "31.2.4",
+      "adj．好战的；交战的（hostile, aggressive）"
+    ],
+    "ukphone": "bəˋlIdʒərənt",
+    "usphone": "bəˋlIdʒərənt"
+  },
+  {
+    "name": "repulsive",
+    "trans": [
+      "31.2.5",
+      "adj．排斥的（revolting, disgusting）"
+    ],
+    "ukphone": "rIˋpʌlsIv",
+    "usphone": "rIˋpʌlsIv"
+  },
+  {
+    "name": "offensive",
+    "trans": [
+      "31.2.6",
+      "adj．无礼的；攻击性的（aggressive）",
+      "【记】 动词offend（进攻，冒犯）"
+    ],
+    "ukphone": "əˋfensIv",
+    "usphone": "əˋfensIv"
+  },
+  {
+    "name": "strife",
+    "trans": [
+      "31.2.7",
+      "n．冲突；竞争（squabble, conflict）"
+    ],
+    "ukphone": "straIf",
+    "usphone": "straIf"
+  },
+  {
+    "name": "feud",
+    "trans": [
+      "31.2.8",
+      "n．世仇 vi．不合"
+    ],
+    "ukphone": "fju:d",
+    "usphone": "fju:d"
+  },
+  {
+    "name": "struggle",
+    "trans": [
+      "31.2.9",
+      "n./vi．竞争，奋斗（fight）"
+    ],
+    "ukphone": "ˋstrʌgl",
+    "usphone": "ˋstrʌgl"
+  },
+  {
+    "name": "strike",
+    "trans": [
+      "31.2.10",
+      "v．打击（hit）"
+    ],
+    "ukphone": "straIk",
+    "usphone": "straIk"
+  },
+  {
+    "name": "contend",
+    "trans": [
+      "31.2.11",
+      "v．争斗（compete, rival）"
+    ],
+    "ukphone": "kənˋtend",
+    "usphone": "kənˋtend"
+  },
+  {
+    "name": "compete",
+    "trans": [
+      "31.2.12",
+      "vi．竞争"
+    ],
+    "ukphone": "kəmˋpi:t",
+    "usphone": "kəmˋpi:t"
+  },
+  {
+    "name": "frown",
+    "trans": [
+      "31.2.13",
+      "vi．皱眉；反对"
+    ],
+    "ukphone": "fraʊn",
+    "usphone": "fraʊn"
+  },
+  {
+    "name": "parallel",
+    "trans": [
+      "31.2.14",
+      "vt．匹敌（match, rival）"
+    ],
+    "ukphone": "ˋpærəlel",
+    "usphone": "ˋpærəlel"
+  },
+  {
+    "name": "tantalize",
+    "trans": [
+      "31.2.15",
+      "vt．逗惹，使…着急（provoke, tease）"
+    ],
+    "ukphone": "ˋtæntəlaIz",
+    "usphone": "ˋtæntəlaIz"
+  },
+  {
+    "name": "rival",
+    "trans": [
+      "31.2.16",
+      "vt．竞争，匹敌（compete, match）"
+    ],
+    "ukphone": "ˋraIvl",
+    "usphone": "ˋraIvl"
+  },
+  {
+    "name": "assail",
+    "trans": [
+      "31.2.17",
+      "vt．猛击；决然面对（attack, assault）",
+      "【记】 as+sail（跳上去）→跳上去打→猛打"
+    ],
+    "ukphone": "əˋseIl",
+    "usphone": "əˋseIl"
+  },
+  {
+    "name": "fulminate",
+    "trans": [
+      "31.2.18",
+      "vi．猛烈爆发（explode）",
+      "【记】 fulmin（闪电，雷声）+ate→像雷声一般发作→猛烈爆发"
+    ],
+    "ukphone": "ˋfʌlmIneIt",
+    "usphone": "ˋfʌlmIneIt"
+  },
+  {
+    "name": "baste",
+    "trans": [
+      "31.2.19",
+      "vt．殴打；公开责骂（lash, beat）"
+    ],
+    "ukphone": "beIst",
+    "usphone": "beIst"
+  },
+  {
+    "name": "repulse",
+    "trans": [
+      "31.2.20",
+      "vt．排斥",
+      "【记】 re（反）+pulse（推）→排斥"
+    ],
+    "ukphone": "rIˋpʌls",
+    "usphone": "rIˋpʌls"
+  },
+  {
+    "name": "repel",
+    "trans": [
+      "31.2.21",
+      "vt．排斥（resist, reject）",
+      "【记】 re（反）+pel（推）→排斥"
+    ],
+    "ukphone": "rIˋpel",
+    "usphone": "rIˋpel"
+  },
+  {
+    "name": "emulate",
+    "trans": [
+      "31.2.22",
+      "vt．努力赶上或超过"
+    ],
+    "ukphone": "ˋemjuleIt",
+    "usphone": "ˋemjuleIt"
+  },
+  {
+    "name": "punch",
+    "trans": [
+      "31.2.23",
+      "vt．重击（blow, hit）"
+    ],
+    "ukphone": "pʌntʃ",
+    "usphone": "pʌntʃ"
+  },
+  {
+    "name": "thump",
+    "trans": [
+      "31.2.24",
+      "vt．重击（strike, pound）"
+    ],
+    "ukphone": "θʌmp",
+    "usphone": "θʌmp"
+  },
+  {
+    "name": "adverse",
+    "trans": [
+      "31.2.25",
+      "adj．敌对的；不利的（hostile, unfavorable, negative）"
+    ],
+    "ukphone": "ˋædvɜ:rs",
+    "usphone": "ˋædvɜ:rs"
+  },
+  {
+    "name": "impact",
+    "trans": [
+      "31.2.26",
+      "v．冲击（affect, influence）"
+    ],
+    "ukphone": "ˋImpækt",
+    "usphone": "ˋImpækt"
+  },
+  {
+    "name": "admonish",
+    "trans": [
+      "31.2.27",
+      "vt．警告（warn）",
+      "【记】 ad（加强）+mon（警告）+ish→加强警告"
+    ],
+    "ukphone": "ədˋmα:nIʃ",
+    "usphone": "ədˋmα:nIʃ"
+  },
+  {
+    "name": "stab",
+    "trans": [
+      "31.3.1",
+      "v./n．刺，戳（jab, injure）"
+    ],
+    "ukphone": "stæb",
+    "usphone": "stæb"
+  },
+  {
+    "name": "sheathe",
+    "trans": [
+      "31.3.2",
+      "vt.（将刀剑）入鞘（cover, encase）"
+    ],
+    "ukphone": "ʃi:ð",
+    "usphone": "ʃi:ð"
+  },
+  {
+    "name": "insert",
+    "trans": [
+      "31.3.3",
+      "vt．插入（put in, add）",
+      "【记】 in（进入）+sert（插）"
+    ],
+    "ukphone": "Inˋsɜ:rt",
+    "usphone": "Inˋsɜ:rt"
+  },
+  {
+    "name": "pierce",
+    "trans": [
+      "31.3.4",
+      "vt．穿透，戳穿（penetrate, puncture）"
+    ],
+    "ukphone": "pIrs",
+    "usphone": "pIrs"
+  },
+  {
+    "name": "transfix",
+    "trans": [
+      "31.3.5",
+      "vt．刺穿（pierce, impale）"
+    ],
+    "ukphone": "trænsˋfIks",
+    "usphone": "trænsˋfIks"
+  },
+  {
+    "name": "impale",
+    "trans": [
+      "31.3.6",
+      "vt．刺穿，刺住（pierce, penetrate）",
+      "【记】 im（进入）+pale（尖木）→刺穿"
+    ],
+    "ukphone": "ImˋpeIl",
+    "usphone": "ImˋpeIl"
+  },
+  {
+    "name": "penetrate",
+    "trans": [
+      "31.3.7",
+      "vt．刺穿，进入（pierce）",
+      "【记】 pen（全部）+etr（进入）+ate"
+    ],
+    "ukphone": "ˋpenətreIt",
+    "usphone": "ˋpenətreIt"
+  },
+  {
+    "name": "interject",
+    "trans": [
+      "31.3.8",
+      "vt．突然插入"
+    ],
+    "ukphone": "ˌIntərˋdʒekt",
+    "usphone": "ˌIntərˋdʒekt"
+  },
+  {
+    "name": "punch",
+    "trans": [
+      "31.3.9",
+      "vt．打孔"
+    ],
+    "ukphone": "pʌntʃ",
+    "usphone": "pʌntʃ"
+  },
+  {
+    "name": "successful",
+    "trans": [
+      "31.4.1",
+      "adj．成功的（fruitful）"
+    ],
+    "ukphone": "səkˋsesfl",
+    "usphone": "səkˋsesfl"
+  },
+  {
+    "name": "incipient",
+    "trans": [
+      "31.4.2",
+      "adj．初期的",
+      "【记】 in（进入）+cip（掉）+ient→掉进来→刚开始的"
+    ],
+    "ukphone": "InˋsIpiənt",
+    "usphone": "InˋsIpiənt"
+  },
+  {
+    "name": "initiate",
+    "trans": [
+      "31.4.3",
+      "vt．开始，创始（start, begin, commence）"
+    ],
+    "ukphone": "IˋnIʃieIt",
+    "usphone": "IˋnIʃieIt"
+  },
+  {
+    "name": "initial",
+    "trans": [
+      "31.4.4",
+      "adj．初始的（original, beginning, early, oldest）",
+      "【记】 in（进入）+it（走）+ial→走进→开始的"
+    ],
+    "ukphone": "IˋnIʃl",
+    "usphone": "IˋnIʃl"
+  },
+  {
+    "name": "foremost",
+    "trans": [
+      "31.4.5",
+      "adj．最初的（prime）",
+      "【记】 fore（前）+most（最）→最先的"
+    ],
+    "ukphone": "ˋfɔ:rmoʊst",
+    "usphone": "ˋfɔ:rmoʊst"
+  },
+  {
+    "name": "original",
+    "trans": [
+      "31.4.6",
+      "adj．最初的（earliest, initial）",
+      "【记】 origin（起源）+al"
+    ],
+    "ukphone": "əˋrIdʒənl",
+    "usphone": "əˋrIdʒənl"
+  },
+  {
+    "name": "originally",
+    "trans": [
+      "31.4.7",
+      "adv．本来；最初"
+    ],
+    "ukphone": "əˋrIdʒənəli",
+    "usphone": "əˋrIdʒənəli"
+  },
+  {
+    "name": "primary",
+    "trans": [
+      "31.4.8",
+      "adj．最初的（foremost, initial）",
+      "【记】 prim（最初的）+ary"
+    ],
+    "ukphone": "ˋpraImeri",
+    "usphone": "ˋpraImeri"
+  },
+  {
+    "name": "eventual",
+    "trans": [
+      "31.4.9",
+      "adj．最后的（final, ultimate）",
+      "【记】 比较event（事件）"
+    ],
+    "ukphone": "Iˋventʃuəl",
+    "usphone": "Iˋventʃuəl"
+  },
+  {
+    "name": "ultimate",
+    "trans": [
+      "31.4.10",
+      "adj．最后的（final, eventual）",
+      "【记】 ultim（最远）+ate"
+    ],
+    "ukphone": "ˋʌltImət",
+    "usphone": "ˋʌltImət"
+  },
+  {
+    "name": "final",
+    "trans": [
+      "31.4.11",
+      "adj．最后的（ultimate）"
+    ],
+    "ukphone": "ˋfaInl",
+    "usphone": "ˋfaInl"
+  },
+  {
+    "name": "progress",
+    "trans": [
+      "31.4.12",
+      "n./v．前进，发展",
+      "【记】 pro（向前）+gress（走）→前进"
+    ],
+    "ukphone": "ˋprα:gres",
+    "usphone": "ˋprα:gres"
+  },
+  {
+    "name": "triumph",
+    "trans": [
+      "31.4.13",
+      "n．成功（victory）"
+    ],
+    "ukphone": "ˋtraIʌmf",
+    "usphone": "ˋtraIʌmf"
+  },
+  {
+    "name": "culmination",
+    "trans": [
+      "31.4.14",
+      "n．顶点（climax, summit）"
+    ],
+    "ukphone": "ˌkʌlmIˋneIʃn",
+    "usphone": "ˌkʌlmIˋneIʃn"
+  },
+  {
+    "name": "peak",
+    "trans": [
+      "31.4.15",
+      "n．高峰；尖端（mountain top; summit, top）"
+    ],
+    "ukphone": "pi:k",
+    "usphone": "pi:k"
+  },
+  {
+    "name": "process",
+    "trans": [
+      "31.4.16",
+      "n．过程（procedure）vt．加工，处理"
+    ],
+    "ukphone": "ˋprα:ses",
+    "usphone": "ˋprα:ses"
+  },
+  {
+    "name": "phase",
+    "trans": [
+      "31.4.17",
+      "n．阶段，态（stage, period）"
+    ],
+    "ukphone": "feIz",
+    "usphone": "feIz"
+  },
+  {
+    "name": "condition",
+    "trans": [
+      "31.4.18",
+      "n．条件；状况"
+    ],
+    "ukphone": "kənˋdIʃn",
+    "usphone": "kənˋdIʃn"
+  },
+  {
+    "name": "status",
+    "trans": [
+      "31.4.19",
+      "n．状况"
+    ],
+    "ukphone": "ˋsteItəs",
+    "usphone": "ˋsteItəs"
+  },
+  {
+    "name": "result",
+    "trans": [
+      "31.4.20",
+      "n．结果（outcome）"
+    ],
+    "ukphone": "rIˋzʌlt",
+    "usphone": "rIˋzʌlt"
+  },
+  {
+    "name": "headway",
+    "trans": [
+      "31.4.21",
+      "n．进展（progress）"
+    ],
+    "ukphone": "ˋhedweI",
+    "usphone": "ˋhedweI"
+  },
+  {
+    "name": "onset",
+    "trans": [
+      "31.4.22",
+      "n．开始（beginning）",
+      "【记】 来自set on（攻击）"
+    ],
+    "ukphone": "ˋα:nset",
+    "usphone": "ˋα:nset"
+  },
+  {
+    "name": "halt",
+    "trans": [
+      "31.4.23",
+      "v．停止（stop, cease）"
+    ],
+    "ukphone": "hɔ:lt",
+    "usphone": "hɔ:lt"
+  },
+  {
+    "name": "develop",
+    "trans": [
+      "31.4.24",
+      "v．发展；产生；成长"
+    ],
+    "ukphone": "dIˋveləp",
+    "usphone": "dIˋveləp"
+  },
+  {
+    "name": "resume",
+    "trans": [
+      "31.4.25",
+      "v．继续（continue, take up）",
+      "【记】 re（重新）+sume（拿）→继续"
+    ],
+    "ukphone": "rIˋzju:m",
+    "usphone": "rIˋzju:m"
+  },
+  {
+    "name": "exit",
+    "trans": [
+      "31.4.26",
+      "v．退出",
+      "【记】 ex（出）+it（走）→走出→出口"
+    ],
+    "ukphone": "ˋeksIt",
+    "usphone": "ˋeksIt"
+  },
+  {
+    "name": "climax",
+    "trans": [
+      "31.4.27",
+      "v.（使）达到高潮 n．高峰，顶点（peak, culmination）"
+    ],
+    "ukphone": "ˋklaImæks",
+    "usphone": "ˋklaImæks"
+  },
+  {
+    "name": "emerge",
+    "trans": [
+      "31.4.28",
+      "vi．出现（appear, come into prominence）",
+      "【记】 e（出）+merge（沉）→沉的东西出现→浮现"
+    ],
+    "ukphone": "iˋmɜ:rdʒ",
+    "usphone": "iˋmɜ:rdʒ"
+  },
+  {
+    "name": "proceed",
+    "trans": [
+      "31.4.29",
+      "vi．进行（carry on, go on）",
+      "【记】 pro（向前）+ceed（走）→进行"
+    ],
+    "ukphone": "proʊˋsi:d",
+    "usphone": "proʊˋsi:d"
+  },
+  {
+    "name": "commence",
+    "trans": [
+      "31.4.30",
+      "vi．开始（begin）"
+    ],
+    "ukphone": "kəˋmens",
+    "usphone": "kəˋmens"
+  },
+  {
+    "name": "vanish",
+    "trans": [
+      "31.4.31",
+      "vi．消失（disappear, fade）",
+      "【记】 van（空）+ish→变空→消失"
+    ],
+    "ukphone": "ˋvænIʃ",
+    "usphone": "ˋvænIʃ"
+  },
+  {
+    "name": "launch",
+    "trans": [
+      "31.4.32",
+      "vt．发动（start, begin）"
+    ],
+    "ukphone": "lɔ:ntʃ",
+    "usphone": "lɔ:ntʃ"
+  },
+  {
+    "name": "engender",
+    "trans": [
+      "31.4.33",
+      "vt．产生（generate, produce）",
+      "【记】 en（使）+gender（产生）→使产生"
+    ],
+    "ukphone": "Inˋdʒendər",
+    "usphone": "Inˋdʒendər"
+  },
+  {
+    "name": "beget",
+    "trans": [
+      "31.4.34",
+      "vt．引起；产生（arise, bring）"
+    ],
+    "ukphone": "bIˋget",
+    "usphone": "bIˋget"
+  },
+  {
+    "name": "generate",
+    "trans": [
+      "31.4.35",
+      "vt．造成（produce, give rise to）",
+      "【记】 gener（产生）+ate"
+    ],
+    "ukphone": "ˋdʒenəreIt",
+    "usphone": "ˋdʒenəreIt"
+  },
+  {
+    "name": "terminate",
+    "trans": [
+      "31.4.36",
+      "vt．终止（end, finish, conclude, stop）",
+      "【记】 termin（结束）+ate"
+    ],
+    "ukphone": "ˋtɜ:rmIneIt",
+    "usphone": "ˋtɜ:rmIneIt"
+  },
+  {
+    "name": "accomplished",
+    "trans": [
+      "31.4.37",
+      "adj．完成的"
+    ],
+    "ukphone": "əˋkα:mplIʃt",
+    "usphone": "əˋkα:mplIʃt"
+  },
+  {
+    "name": "conclude",
+    "trans": [
+      "31.4.38",
+      "vi．结束"
+    ],
+    "ukphone": "kənˋklu:d",
+    "usphone": "kənˋklu:d"
+  },
+  {
+    "name": "conclusive",
+    "trans": [
+      "31.4.39",
+      "adj．决定性的；最后的（decisive, definitive, final）"
+    ],
+    "ukphone": "kənˋklu:sIv",
+    "usphone": "kənˋklu:sIv"
+  },
+  {
+    "name": "advance",
+    "trans": [
+      "31.4.40",
+      "vt．使前进（proceed）；提出（propose）"
+    ],
+    "ukphone": "ədˋvæns",
+    "usphone": "ədˋvæns"
+  },
+  {
+    "name": "achieve",
+    "trans": [
+      "31.4.41",
+      "vt．完成；实现；达到（accomplish, fulfil）"
+    ],
+    "ukphone": "əˋtʃi:v",
+    "usphone": "əˋtʃi:v"
+  },
+  {
+    "name": "circumstance",
+    "trans": [
+      "31.4.42",
+      "n．环境；事件；状况（condition, situation）"
+    ],
+    "ukphone": "ˋsɜ:rkəmstæns",
+    "usphone": "ˋsɜ:rkəmstæns"
+  },
+  {
+    "name": "escalate",
+    "trans": [
+      "31.4.43",
+      "v．逐步增强；逐步升高"
+    ],
+    "ukphone": "ˋeskəleIt",
+    "usphone": "ˋeskəleIt"
+  },
+  {
+    "name": "detach",
+    "trans": [
+      "31.5.1",
+      "vt．分开；分离（remove, separate）"
+    ],
+    "ukphone": "dIˋtætʃ",
+    "usphone": "dIˋtætʃ"
+  },
+  {
+    "name": "detached",
+    "trans": [
+      "31.5.2",
+      "adj．分离的（separated, disconnected）"
+    ],
+    "ukphone": "dIˋtætʃt",
+    "usphone": "dIˋtætʃt"
+  },
+  {
+    "name": "solitude",
+    "trans": [
+      "31.5.3",
+      "n．与外界隔绝（isolation, loneliness）"
+    ],
+    "ukphone": "ˋsα:lətju:d",
+    "usphone": "ˋsα:lətju:d"
+  },
+  {
+    "name": "sever",
+    "trans": [
+      "31.5.4",
+      "vt．分开，断绝（separate）"
+    ],
+    "ukphone": "ˋsevər",
+    "usphone": "ˋsevər"
+  },
+  {
+    "name": "rend",
+    "trans": [
+      "31.5.5",
+      "vt．分离（apart, seperate）"
+    ],
+    "ukphone": "rend",
+    "usphone": "rend"
+  },
+  {
+    "name": "segregate",
+    "trans": [
+      "31.5.6",
+      "vt．隔离，分离（alienate, separate）",
+      "【记】 se（分开）+greg（群体）+ate→和群体分开→隔离"
+    ],
+    "ukphone": "ˋsegrIgeIt",
+    "usphone": "ˋsegrIgeIt"
+  },
+  {
+    "name": "disunite",
+    "trans": [
+      "31.5.7",
+      "vt．使分离",
+      "【记】 dis（不）+unite（统一）→不统一→分离"
+    ],
+    "ukphone": "ˌdIsjuˋnaIt",
+    "usphone": "ˌdIsjuˋnaIt"
+  },
+  {
+    "name": "scatter",
+    "trans": [
+      "31.5.8",
+      "vt．使分散（disperse, spread）"
+    ],
+    "ukphone": "ˋskætər",
+    "usphone": "ˋskætər"
+  },
+  {
+    "name": "cushion",
+    "trans": [
+      "31.6.1",
+      "n．垫层 vt．缓解"
+    ],
+    "ukphone": "ˋkʊʃn",
+    "usphone": "ˋkʊʃn"
+  },
+  {
+    "name": "soothe",
+    "trans": [
+      "31.6.2",
+      "v．安慰；缓和；减轻（appease, relieve）"
+    ],
+    "ukphone": "su:ð",
+    "usphone": "su:ð"
+  },
+  {
+    "name": "relax",
+    "trans": [
+      "31.6.3",
+      "v.（使）松弛，放松（ease）"
+    ],
+    "ukphone": "rIˋlæks",
+    "usphone": "rIˋlæks"
+  },
+  {
+    "name": "placate",
+    "trans": [
+      "31.6.4",
+      "vt．安抚（appease, pacify）",
+      "【记】 plac（平静）+ate"
+    ],
+    "ukphone": "ˋpleIkeIt",
+    "usphone": "ˋpleIkeIt"
+  },
+  {
+    "name": "console",
+    "trans": [
+      "31.6.5",
+      "vt．安慰（conciliate, comfort）"
+    ],
+    "ukphone": "kənˋsoʊl",
+    "usphone": "kənˋsoʊl"
+  },
+  {
+    "name": "assuage",
+    "trans": [
+      "31.6.6",
+      "vt．缓和（alleviate, mitigate, soothe）",
+      "【记】 as+suage（甜）→变甜→缓和"
+    ],
+    "ukphone": "əˋsweIdʒ",
+    "usphone": "əˋsweIdʒ"
+  },
+  {
+    "name": "mollify",
+    "trans": [
+      "31.6.7",
+      "vt．缓和（appease, assuage）",
+      "【记】 moll（软）+ify→软化→缓和"
+    ],
+    "ukphone": "ˋmα:lIfaI",
+    "usphone": "ˋmα:lIfaI"
+  },
+  {
+    "name": "mitigate",
+    "trans": [
+      "31.6.8",
+      "vt．缓和；减轻（alleviate, relieve）",
+      "【记】 miti（小）+gate（做）→缓减"
+    ],
+    "ukphone": "ˋmItIgeIt",
+    "usphone": "ˋmItIgeIt"
+  },
+  {
+    "name": "slacken",
+    "trans": [
+      "31.6.9",
+      "vt．使松弛（loosen, slow down）",
+      "【记】 slack（松弛）+en"
+    ],
+    "ukphone": "ˋslækən",
+    "usphone": "ˋslækən"
+  },
+  {
+    "name": "pacify",
+    "trans": [
+      "31.6.10",
+      "vt．镇定；抚慰（appease, placate）",
+      "【记】 pac（和平，平静）+ify"
+    ],
+    "ukphone": "ˋpæsIfaI",
+    "usphone": "ˋpæsIfaI"
+  },
+  {
+    "name": "rally",
+    "trans": [
+      "31.7.1",
+      "n./v．恢复",
+      "【记】 比较ally（联盟）"
+    ],
+    "ukphone": "ˋræli",
+    "usphone": "ˋræli"
+  },
+  {
+    "name": "revive",
+    "trans": [
+      "31.7.2",
+      "v．复兴；复苏（revitalize）",
+      "【记】 re（重新）+vive（活）→复苏"
+    ],
+    "ukphone": "rIˋvaIv",
+    "usphone": "rIˋvaIv"
+  },
+  {
+    "name": "revert",
+    "trans": [
+      "31.7.3",
+      "v．回复（come back, return）"
+    ],
+    "ukphone": "rIˋvɜ:rt",
+    "usphone": "rIˋvɜ:rt"
+  },
+  {
+    "name": "retract",
+    "trans": [
+      "31.7.4",
+      "v．收回，撤回（take back, withdraw）",
+      "【记】 re（回）+tract（拉）→拉回→收回"
+    ],
+    "ukphone": "rIˋtrækt",
+    "usphone": "rIˋtrækt"
+  },
+  {
+    "name": "retrieve",
+    "trans": [
+      "31.7.5",
+      "v．重新找回（recover, save）",
+      "【记】 re（重新）+trieve（找到）→重新找到"
+    ],
+    "ukphone": "rIˋtri:v",
+    "usphone": "rIˋtri:v"
+  },
+  {
+    "name": "energize",
+    "trans": [
+      "31.7.6",
+      "vt．供给能量；使活跃"
+    ],
+    "ukphone": "ˋenərdʒaIz",
+    "usphone": "ˋenərdʒaIz"
+  },
+  {
+    "name": "restore",
+    "trans": [
+      "31.7.7",
+      "vt．恢复（recover, bring back）",
+      "【记】 re（回）+store（储存）→返回储存→恢复"
+    ],
+    "ukphone": "rIˋstɔ:r",
+    "usphone": "rIˋstɔ:r"
+  },
+  {
+    "name": "rehabilitate",
+    "trans": [
+      "31.7.8",
+      "vt．恢复（restore）",
+      "【记】 reh（重新）+abili（能力）+tate→重新获得能力→恢复"
+    ],
+    "ukphone": "ˌri:əˋbIlIteIt",
+    "usphone": "ˌri:əˋbIlIteIt"
+  },
+  {
+    "name": "recover",
+    "trans": [
+      "31.7.9",
+      "vt．恢复（resume）"
+    ],
+    "ukphone": "rIˋkʌvər",
+    "usphone": "rIˋkʌvər"
+  },
+  {
+    "name": "revoke",
+    "trans": [
+      "31.7.10",
+      "vt．取消，撤回（cancel, repeal）",
+      "【记】 re（反）+voke（喊）→喊反话→取消"
+    ],
+    "ukphone": "rIˋvoʊk",
+    "usphone": "rIˋvoʊk"
+  },
+  {
+    "name": "refresh",
+    "trans": [
+      "31.7.11",
+      "vt．使清新 vi．恢复精神（renew, revive）",
+      "【记】 re（重新）+fresh（新鲜的）"
+    ],
+    "ukphone": "rIˋfreʃ",
+    "usphone": "rIˋfreʃ"
+  },
+  {
+    "name": "intricate",
+    "trans": [
+      "31.8.1",
+      "adj．错综复杂的（complicated, entangled）；难懂的",
+      "【记】 in（进入）+tric（复杂）+ate"
+    ],
+    "ukphone": "ˋIntrIkət",
+    "usphone": "ˋIntrIkət"
+  },
+  {
+    "name": "complex",
+    "trans": [
+      "31.8.2",
+      "adj．复杂的（complicated, tangled）n．综合体",
+      "【记】 com+plex（交叉重叠）→复杂的"
+    ],
+    "ukphone": "kəmˋpleks",
+    "usphone": "kəmˋpleks"
+  },
+  {
+    "name": "disarray",
+    "trans": [
+      "31.8.3",
+      "n./vt．杂乱；混乱",
+      "【记】 dis+array（排列）"
+    ],
+    "ukphone": "ˌdIsəˋreI",
+    "usphone": "ˌdIsəˋreI"
+  },
+  {
+    "name": "confuse",
+    "trans": [
+      "31.8.4",
+      "vt．混淆",
+      "【记】 con（共同）+fuse（流）→流到一起→混合"
+    ],
+    "ukphone": "kənˋfju:z",
+    "usphone": "kənˋfju:z"
+  },
+  {
+    "name": "jumble",
+    "trans": [
+      "31.8.5",
+      "v．混杂（muddle, mix）"
+    ],
+    "ukphone": "ˋdʒʌmbl",
+    "usphone": "ˋdʒʌmbl"
+  },
+  {
+    "name": "shuffle",
+    "trans": [
+      "31.8.6",
+      "vt．搅乱，混合（mix, blend）"
+    ],
+    "ukphone": "ˋʃʌfl",
+    "usphone": "ˋʃʌfl"
+  },
+  {
+    "name": "complicate",
+    "trans": [
+      "31.8.7",
+      "vt．使复杂；使陷入"
+    ],
+    "ukphone": "ˋkα:mplIkeIt",
+    "usphone": "ˋkα:mplIkeIt"
+  },
+  {
+    "name": "befuddle",
+    "trans": [
+      "31.8.8",
+      "vt．使混乱（confuse）"
+    ],
+    "ukphone": "bIˋfʌdl",
+    "usphone": "bIˋfʌdl"
+  },
+  {
+    "name": "muddle",
+    "trans": [
+      "31.8.9",
+      "vt．使混乱（confuse, make into a mess）",
+      "【记】 mud（泥）+dle→混入泥→混乱"
+    ],
+    "ukphone": "ˋmʌdl",
+    "usphone": "ˋmʌdl"
+  },
+  {
+    "name": "assemble",
+    "trans": [
+      "31.9.1",
+      "vt．聚集（gather, congregate）"
+    ],
+    "ukphone": "əˋsembl",
+    "usphone": "əˋsembl"
+  },
+  {
+    "name": "assembly",
+    "trans": [
+      "31.9.2",
+      "n．集会"
+    ],
+    "ukphone": "əˋsembli",
+    "usphone": "əˋsembli"
+  },
+  {
+    "name": "party",
+    "trans": [
+      "31.9.3",
+      "n．团体；一伙"
+    ],
+    "ukphone": "ˋpα:rti",
+    "usphone": "ˋpα:rti"
+  },
+  {
+    "name": "association",
+    "trans": [
+      "31.9.4",
+      "n．协会（society）"
+    ],
+    "ukphone": "əˌsoʊʃiˋeIʃn",
+    "usphone": "əˌsoʊʃiˋeIʃn"
+  },
+  {
+    "name": "gather",
+    "trans": [
+      "31.9.5",
+      "v．聚集，集合（compile, collect）"
+    ],
+    "ukphone": "ˋgæðər",
+    "usphone": "ˋgæðər"
+  },
+  {
+    "name": "attend",
+    "trans": [
+      "31.9.6",
+      "vt．参加（join）"
+    ],
+    "ukphone": "əˋtend",
+    "usphone": "əˋtend"
+  },
+  {
+    "name": "convene",
+    "trans": [
+      "31.9.7",
+      "vt．集合（assemble, gather）",
+      "【记】 con（共同）+vene（走）→走到一起"
+    ],
+    "ukphone": "kənˋvi:n",
+    "usphone": "kənˋvi:n"
+  },
+  {
+    "name": "congregate",
+    "trans": [
+      "31.9.8",
+      "vt．聚集（assemble, gather）",
+      "【记】 con（共同）+greg（集会）+ate"
+    ],
+    "ukphone": "ˋkα:ŋgrIgeIt",
+    "usphone": "ˋkα:ŋgrIgeIt"
+  },
+  {
+    "name": "accompany",
+    "trans": [
+      "31.9.9",
+      "vt．伴随（travel with）",
+      "【记】 ac+company（伴侣）"
+    ],
+    "ukphone": "əˋkʌmpəni",
+    "usphone": "əˋkʌmpəni"
+  },
+  {
+    "name": "accumulation",
+    "trans": [
+      "31.9.10",
+      "n．堆积；积聚；累积物；堆积物（deposit）"
+    ],
+    "ukphone": "əˌkju:mjəˋleIʃn",
+    "usphone": "əˌkju:mjəˋleIʃn"
+  },
+  {
+    "name": "cumulative",
+    "trans": [
+      "31.9.11",
+      "adj．累积的"
+    ],
+    "ukphone": "ˋkju:mjəleItIv",
+    "usphone": "ˋkju:mjəleItIv"
+  },
+  {
+    "name": "soar",
+    "trans": [
+      "31.9.12",
+      "vi．高飞；高耸；往上飞舞 n．高飞；高涨"
+    ],
+    "ukphone": "sɔ:r",
+    "usphone": "sɔ:r"
+  },
+  {
+    "name": "sprawl",
+    "trans": [
+      "31.10.1",
+      "n．扩展 v．蔓延（spread）",
+      "【记】 比较crawl（爬）"
+    ],
+    "ukphone": "sprɔ:l",
+    "usphone": "sprɔ:l"
+  },
+  {
+    "name": "broaden",
+    "trans": [
+      "31.10.2",
+      "v．放宽，变阔",
+      "【记】 broad（宽）+en"
+    ],
+    "ukphone": "ˋbrɔ:dn",
+    "usphone": "ˋbrɔ:dn"
+  },
+  {
+    "name": "swell",
+    "trans": [
+      "31.10.3",
+      "v．膨胀（expand, inflate）"
+    ],
+    "ukphone": "swel",
+    "usphone": "swel"
+  },
+  {
+    "name": "expand",
+    "trans": [
+      "31.10.4",
+      "vi．扩张（outspread）",
+      "【记】 ex+pand（分散）→分散出去→扩张"
+    ],
+    "ukphone": "Ikˋspænd",
+    "usphone": "Ikˋspænd"
+  },
+  {
+    "name": "dilate",
+    "trans": [
+      "31.10.5",
+      "vt．使膨胀，使扩大（expand, widen）",
+      "【记】 di（分开）+late→扩大"
+    ],
+    "ukphone": "daIˋleIt",
+    "usphone": "daIˋleIt"
+  },
+  {
+    "name": "augment",
+    "trans": [
+      "31.10.6",
+      "vt．增大，增加（enlarge, increase）",
+      "【记】 aug（提高）+ment→增大"
+    ],
+    "ukphone": "ɔ:gˋment",
+    "usphone": "ɔ:gˋment"
+  },
+  {
+    "name": "proliferation",
+    "trans": [
+      "31.10.7",
+      "n．增殖；扩散；激增"
+    ],
+    "ukphone": "prəˌlIfəˋreIʃn",
+    "usphone": "prəˌlIfəˋreIʃn"
+  },
+  {
+    "name": "incorporate",
+    "trans": [
+      "31.10.8",
+      "v．包含，吸收；体现；把…合并 adj．合并的；一体化的；组成公司的"
+    ],
+    "ukphone": "Inˋkɔ:rpəreIt",
+    "usphone": "Inˋkɔ:rpəreIt"
+  },
+  {
+    "name": "stick",
+    "trans": [
+      "31.11.1",
+      "v．粘住，粘贴（cling, attach）"
+    ],
+    "ukphone": "stIk",
+    "usphone": "stIk"
+  },
+  {
+    "name": "sticky",
+    "trans": [
+      "31.11.2",
+      "adj．粘连的（adhesive）"
+    ],
+    "ukphone": "ˋstIki",
+    "usphone": "ˋstIki"
+  },
+  {
+    "name": "attachment",
+    "trans": [
+      "31.11.3",
+      "n．连接物，附件"
+    ],
+    "ukphone": "əˋtætʃmənt",
+    "usphone": "əˋtætʃmənt"
+  },
+  {
+    "name": "cohere",
+    "trans": [
+      "31.11.4",
+      "vi．附着，粘合（connect, fit）",
+      "【记】 co（共同）+here（粘）→共同粘→连贯"
+    ],
+    "ukphone": "koʊˋhIr",
+    "usphone": "koʊˋhIr"
+  },
+  {
+    "name": "cling",
+    "trans": [
+      "31.11.5",
+      "vi．黏附（adhere, stick）"
+    ],
+    "ukphone": "klIŋ",
+    "usphone": "klIŋ"
+  },
+  {
+    "name": "adhere",
+    "trans": [
+      "31.11.6",
+      "vi．黏着，坚持（stick, hold, cling）"
+    ],
+    "ukphone": "ədˋhIr",
+    "usphone": "ədˋhIr"
+  },
+  {
+    "name": "adherent",
+    "trans": [
+      "31.11.7",
+      "adj．依附的（adhesive, sticky）n．追随者，信徒"
+    ],
+    "ukphone": "ədˋhIrənt",
+    "usphone": "ədˋhIrənt"
+  },
+  {
+    "name": "constant",
+    "trans": [
+      "31.12.1",
+      "adj．不变的，持续的（invariable, continous）"
+    ],
+    "ukphone": "ˋkα:nstənt",
+    "usphone": "ˋkα:nstənt"
+  },
+  {
+    "name": "incessant",
+    "trans": [
+      "31.12.2",
+      "adj．不断的（ceaseless, continual）",
+      "【记】 in（不）+cess（停止）+ant"
+    ],
+    "ukphone": "Inˋsesnt",
+    "usphone": "Inˋsesnt"
+  },
+  {
+    "name": "coherent",
+    "trans": [
+      "31.12.3",
+      "adj．连贯的（logical, unified）"
+    ],
+    "ukphone": "koʊˋhIrənt",
+    "usphone": "koʊˋhIrənt"
+  },
+  {
+    "name": "incoherent",
+    "trans": [
+      "31.12.4",
+      "adj．不连贯的（disconnected）",
+      "【记】 in（不）+coherent（连贯的）"
+    ],
+    "ukphone": "ˌInkoʊˋhIrənt",
+    "usphone": "ˌInkoʊˋhIrənt"
+  },
+  {
+    "name": "ceaseless",
+    "trans": [
+      "31.12.5",
+      "adj．不停的（incessant, endless）",
+      "【记】 cease（停）+less（否定后缀）"
+    ],
+    "ukphone": "ˋsi:sləs",
+    "usphone": "ˋsi:sləs"
+  },
+  {
+    "name": "speedy",
+    "trans": [
+      "31.12.6",
+      "adj．快的，迅速的"
+    ],
+    "ukphone": "ˋspi:di",
+    "usphone": "ˋspi:di"
+  },
+  {
+    "name": "swift",
+    "trans": [
+      "31.12.7",
+      "adj．快速的（quick）"
+    ],
+    "ukphone": "swIft",
+    "usphone": "swIft"
+  },
+  {
+    "name": "successive",
+    "trans": [
+      "31.12.8",
+      "adj．连续的（consecutive）"
+    ],
+    "ukphone": "səkˋsesIv",
+    "usphone": "səkˋsesIv"
+  },
+  {
+    "name": "consecutive",
+    "trans": [
+      "31.12.9",
+      "adj．连续的（successive）"
+    ],
+    "ukphone": "kənˋsekjətIv",
+    "usphone": "kənˋsekjətIv"
+  },
+  {
+    "name": "prompt",
+    "trans": [
+      "31.12.10",
+      "adj．迅速的（quick）"
+    ],
+    "ukphone": "prα:mpt",
+    "usphone": "prα:mpt"
+  },
+  {
+    "name": "fitful",
+    "trans": [
+      "31.12.11",
+      "adj．一阵阵的；断断续续的",
+      "【记】 fit（一阵）+ful"
+    ],
+    "ukphone": "ˋfItfl",
+    "usphone": "ˋfItfl"
+  },
+  {
+    "name": "continually",
+    "trans": [
+      "31.12.12",
+      "adv．不断地（constantly, ceaselessly）"
+    ],
+    "ukphone": "kənˋtInjuəli",
+    "usphone": "kənˋtInjuəli"
+  },
+  {
+    "name": "gradually",
+    "trans": [
+      "31.12.13",
+      "adv．逐渐地（slowly, by degree, little by little）"
+    ],
+    "ukphone": "ˋgrædʒuəli",
+    "usphone": "ˋgrædʒuəli"
+  },
+  {
+    "name": "haunt",
+    "trans": [
+      "31.12.14",
+      "vt．常到（frequent）"
+    ],
+    "ukphone": "hɔ:nt",
+    "usphone": "hɔ:nt"
+  },
+  {
+    "name": "frequency",
+    "trans": [
+      "31.12.15",
+      "n．频率，发生次数"
+    ],
+    "ukphone": "ˋfri:kwənsi",
+    "usphone": "ˋfri:kwənsi"
+  },
+  {
+    "name": "infrequent",
+    "trans": [
+      "31.12.16",
+      "adj．稀少的，罕见的，珍贵的（uncommon, scarce）",
+      "【记】 in-（否）+frequent（经常）"
+    ],
+    "ukphone": "Inˋfri:kwənt",
+    "usphone": "Inˋfri:kwənt"
+  },
+  {
+    "name": "insufficient",
+    "trans": [
+      "31.13.1",
+      "adj．不足的，不够的（inadaquate）"
+    ],
+    "ukphone": "ˌInsəˋfIʃnt",
+    "usphone": "ˌInsəˋfIʃnt"
+  },
+  {
+    "name": "scanty",
+    "trans": [
+      "31.13.2",
+      "adj．贫乏的（sparse, meager）",
+      "【记】 scant（不足的）+y"
+    ],
+    "ukphone": "ˋskænti",
+    "usphone": "ˋskænti"
+  },
+  {
+    "name": "meager",
+    "trans": [
+      "31.13.3",
+      "adj．贫乏的，不足的（scanty）"
+    ],
+    "ukphone": "ˋmi:gər",
+    "usphone": "ˋmi:gər"
+  },
+  {
+    "name": "needy",
+    "trans": [
+      "31.13.4",
+      "adj．贫穷的（poor）",
+      "【记】 need（需要）+y→急需的→贫穷的"
+    ],
+    "ukphone": "ˋni:di",
+    "usphone": "ˋni:di"
+  },
+  {
+    "name": "stingy",
+    "trans": [
+      "31.13.5",
+      "adj．缺乏的"
+    ],
+    "ukphone": "ˋstIndʒi",
+    "usphone": "ˋstIndʒi"
+  },
+  {
+    "name": "devoid",
+    "trans": [
+      "31.13.6",
+      "adj．缺乏的（empty, lacking）",
+      "【记】 de+void（空）→缺乏的"
+    ],
+    "ukphone": "dIˋvɔId",
+    "usphone": "dIˋvɔId"
+  },
+  {
+    "name": "scarce",
+    "trans": [
+      "31.13.7",
+      "adj．缺乏的，不足的（sparse）"
+    ],
+    "ukphone": "skers",
+    "usphone": "skers"
+  },
+  {
+    "name": "forfeit",
+    "trans": [
+      "31.13.8",
+      "vt．丧失（sacrifice）adj．丧失了的（lost）"
+    ],
+    "ukphone": "ˋfɔ:rfət",
+    "usphone": "ˋfɔ:rfət"
+  },
+  {
+    "name": "degenerate",
+    "trans": [
+      "31.14.1",
+      "adj．堕落的 vi．退步（degrade, deteriorate）",
+      "【记】 de（坏）+gener（产生）+ate→往坏产生→堕落"
+    ],
+    "ukphone": "dIˋdʒenəreIt",
+    "usphone": "dIˋdʒenəreIt"
+  },
+  {
+    "name": "decadence",
+    "trans": [
+      "31.14.2",
+      "n．衰落，颓废",
+      "【记】 de+cad（落下）+ence"
+    ],
+    "ukphone": "ˋdekədəns",
+    "usphone": "ˋdekədəns"
+  },
+  {
+    "name": "decline",
+    "trans": [
+      "31.14.3",
+      "v．衰落（go down, drop）"
+    ],
+    "ukphone": "dIˋklaIn",
+    "usphone": "dIˋklaIn"
+  },
+  {
+    "name": "languish",
+    "trans": [
+      "31.14.4",
+      "vi．变衰弱（wither, fade）"
+    ],
+    "ukphone": "ˋlæŋgwIʃ",
+    "usphone": "ˋlæŋgwIʃ"
+  },
+  {
+    "name": "ebb",
+    "trans": [
+      "31.14.5",
+      "vi．衰退（decay）"
+    ],
+    "ukphone": "eb",
+    "usphone": "eb"
+  },
+  {
+    "name": "flag",
+    "trans": [
+      "31.14.6",
+      "vi．衰退，减弱（decline）"
+    ],
+    "ukphone": "flæg",
+    "usphone": "flæg"
+  },
+  {
+    "name": "deplete",
+    "trans": [
+      "31.14.7",
+      "vt．耗尽，使衰竭（exhaust）"
+    ],
+    "ukphone": "dIˋpli:t",
+    "usphone": "dIˋpli:t"
+  },
+  {
+    "name": "degrade",
+    "trans": [
+      "31.14.8",
+      "vt．使降级；使堕落（degenerate, lower）",
+      "【记】 de（向下）+grade（级）→向下降级"
+    ],
+    "ukphone": "dIˋgreId",
+    "usphone": "dIˋgreId"
+  },
+  {
+    "name": "enervate",
+    "trans": [
+      "31.14.9",
+      "vt．使衰弱（enfeeble, weaken）"
+    ],
+    "ukphone": "ˋenərveIt",
+    "usphone": "ˋenərveIt"
+  },
+  {
+    "name": "informal",
+    "trans": [
+      "31.15.1",
+      "adj．不拘礼节的，随便的"
+    ],
+    "ukphone": "Inˋfɔ:rml",
+    "usphone": "Inˋfɔ:rml"
+  },
+  {
+    "name": "indefinite",
+    "trans": [
+      "31.15.2",
+      "adj．不明确的；不定的（infinite, unlimited）",
+      "【记】 in（不）+definite（确定的）"
+    ],
+    "ukphone": "InˋdefInət",
+    "usphone": "InˋdefInət"
+  },
+  {
+    "name": "casual",
+    "trans": [
+      "31.15.3",
+      "adj．非正式的，随便的（informal）"
+    ],
+    "ukphone": "ˋkæʒuəl",
+    "usphone": "ˋkæʒuəl"
+  },
+  {
+    "name": "potential",
+    "trans": [
+      "31.15.4",
+      "adj．可能的；潜在的（possible, conceivable）"
+    ],
+    "ukphone": "pəˋtenʃl",
+    "usphone": "pəˋtenʃl"
+  },
+  {
+    "name": "contingent",
+    "trans": [
+      "31.15.5",
+      "adj．可能发生的（accidental, unforeseen）"
+    ],
+    "ukphone": "kənˋtIndʒənt",
+    "usphone": "kənˋtIndʒənt"
+  },
+  {
+    "name": "dispensable",
+    "trans": [
+      "31.15.6",
+      "adj．可有可无的（unnecessary, unimportant）"
+    ],
+    "ukphone": "dIˋspensəbl",
+    "usphone": "dIˋspensəbl"
+  },
+  {
+    "name": "occasional",
+    "trans": [
+      "31.15.7",
+      "adj．偶然的（accidental, haphazard）"
+    ],
+    "ukphone": "əˋkeIʒənl",
+    "usphone": "əˋkeIʒənl"
+  },
+  {
+    "name": "fortuitously",
+    "trans": [
+      "31.15.8",
+      "adv．偶然地，意外地（accidentally, coincidentally）"
+    ],
+    "ukphone": "fɔ:rˋtu:Itəsli",
+    "usphone": "fɔ:rˋtu:Itəsli"
+  },
+  {
+    "name": "haphazard",
+    "trans": [
+      "31.15.9",
+      "adj．偶然的；随便的（casual, random, indiscriminate）",
+      "【记】 hap+hazard（偶然，运气）→偶然的"
+    ],
+    "ukphone": "hæpˋhæzərd",
+    "usphone": "hæpˋhæzərd"
+  },
+  {
+    "name": "random",
+    "trans": [
+      "31.15.10",
+      "adj．任意的，随意的（patternless, unplanned）"
+    ],
+    "ukphone": "ˋrændəm",
+    "usphone": "ˋrændəm"
+  },
+  {
+    "name": "doubtful",
+    "trans": [
+      "31.15.11",
+      "adj．未确定的；不可靠的（treacherous）"
+    ],
+    "ukphone": "ˋdaʊtfl",
+    "usphone": "ˋdaʊtfl"
+  },
+  {
+    "name": "lottery",
+    "trans": [
+      "31.15.12",
+      "n．碰巧之事"
+    ],
+    "ukphone": "ˋlα:təri",
+    "usphone": "ˋlα:təri"
+  },
+  {
+    "name": "accidental",
+    "trans": [
+      "31.15.13",
+      "adj．偶然的（occasional）",
+      "【记】 ac+cid（落下）+ental→意外的"
+    ],
+    "ukphone": "ˌæksIˋdentl",
+    "usphone": "ˌæksIˋdentl"
+  },
+  {
+    "name": "constrict",
+    "trans": [
+      "31.16.1",
+      "v.（使）收紧，压缩（reduce, compress）",
+      "【记】 strict（严格的，精密的）"
+    ],
+    "ukphone": "kənˋstrIkt",
+    "usphone": "kənˋstrIkt"
+  },
+  {
+    "name": "dwindle",
+    "trans": [
+      "31.16.2",
+      "vi．减少（diminish, decrease）"
+    ],
+    "ukphone": "ˋdwIndl",
+    "usphone": "ˋdwIndl"
+  },
+  {
+    "name": "detract",
+    "trans": [
+      "31.16.3",
+      "vi．去掉；减损（lessen, derogate）",
+      "【记】 de+tract（拉）"
+    ],
+    "ukphone": "dIˋtrækt",
+    "usphone": "dIˋtrækt"
+  },
+  {
+    "name": "contract",
+    "trans": [
+      "31.16.4",
+      "vi．收缩（shrink, reduce）",
+      "【记】 con+tract（拉）→拉到一起→收缩"
+    ],
+    "ukphone": "kənˋtrækt",
+    "usphone": "kənˋtrækt"
+  },
+  {
+    "name": "reduce",
+    "trans": [
+      "31.16.5",
+      "vt．减少，简化（simplify）"
+    ],
+    "ukphone": "rIˋdju:s",
+    "usphone": "rIˋdju:s"
+  },
+  {
+    "name": "diminish",
+    "trans": [
+      "31.16.6",
+      "vt．减少；缩小（decrease, dwindle）",
+      "【记】 di（向下）+mini（小）+ish→小下去→缩小"
+    ],
+    "ukphone": "dIˋmInIʃ",
+    "usphone": "dIˋmInIʃ"
+  },
+  {
+    "name": "curtail",
+    "trans": [
+      "31.16.7",
+      "vt．缩减（cut back, reduce）",
+      "【记】 cur+tail（尾巴）→尾巴短了→减缩"
+    ],
+    "ukphone": "kɜ:rˋteIl",
+    "usphone": "kɜ:rˋteIl"
+  },
+  {
+    "name": "indent",
+    "trans": [
+      "31.16.8",
+      "vt．缩排，缩进"
+    ],
+    "ukphone": "Inˋdent",
+    "usphone": "Inˋdent"
+  },
+  {
+    "name": "subtraction",
+    "trans": [
+      "31.16.9",
+      "n．减少"
+    ],
+    "ukphone": "səbˋtrækʃn",
+    "usphone": "səbˋtrækʃn"
+  },
+  {
+    "name": "consumption",
+    "trans": [
+      "31.16.10",
+      "n．消费；消耗（utilization）"
+    ],
+    "ukphone": "kənˋsʌmpʃn",
+    "usphone": "kənˋsʌmpʃn"
+  },
+  {
+    "name": "erratic",
+    "trans": [
+      "31.17.1",
+      "adj．不稳定的（unpredictable）"
+    ],
+    "ukphone": "IˋrætIk",
+    "usphone": "IˋrætIk"
+  },
+  {
+    "name": "stable",
+    "trans": [
+      "31.17.2",
+      "adj．稳定的（immobile, steady）"
+    ],
+    "ukphone": "ˋsteIbl",
+    "usphone": "ˋsteIbl"
+  },
+  {
+    "name": "unstable",
+    "trans": [
+      "31.17.3",
+      "adj．不稳定的，不牢固的（variable, troubled, inconstant）"
+    ],
+    "ukphone": "ʌnˋsteIbl",
+    "usphone": "ʌnˋsteIbl"
+  },
+  {
+    "name": "steady",
+    "trans": [
+      "31.17.4",
+      "adj．稳固的 vt．使稳定"
+    ],
+    "ukphone": "ˋstedi",
+    "usphone": "ˋstedi"
+  },
+  {
+    "name": "steadily",
+    "trans": [
+      "31.17.5",
+      "adv．稳定地，有规则地（consistently）"
+    ],
+    "ukphone": "ˋstedəli",
+    "usphone": "ˋstedəli"
+  },
+  {
+    "name": "poise",
+    "trans": [
+      "31.17.6",
+      "n．平衡；稳定（balance）"
+    ],
+    "ukphone": "pɔIz",
+    "usphone": "pɔIz"
+  },
+  {
+    "name": "intact",
+    "trans": [
+      "31.17.7",
+      "adj．完整的；原封不动的；未受损伤的"
+    ],
+    "ukphone": "Inˋtækt",
+    "usphone": "Inˋtækt"
+  },
+  {
+    "name": "consistent",
+    "trans": [
+      "31.17.8",
+      "adj．始终如一的，一致的；坚持的"
+    ],
+    "ukphone": "kənˋsIstənt",
+    "usphone": "kənˋsIstənt"
+  },
+  {
+    "name": "ascent",
+    "trans": [
+      "31.18.1",
+      "n．上升"
+    ],
+    "ukphone": "əˋsent",
+    "usphone": "əˋsent"
+  },
+  {
+    "name": "descent",
+    "trans": [
+      "31.18.2",
+      "n．下降"
+    ],
+    "ukphone": "dIˋsent",
+    "usphone": "dIˋsent"
+  },
+  {
+    "name": "extend",
+    "trans": [
+      "31.18.3",
+      "v．扩充，延伸（stretch, increase）"
+    ],
+    "ukphone": "Ikˋstend",
+    "usphone": "Ikˋstend"
+  },
+  {
+    "name": "extension",
+    "trans": [
+      "31.18.4",
+      "n．延伸"
+    ],
+    "ukphone": "Ikˋstenʃn",
+    "usphone": "Ikˋstenʃn"
+  },
+  {
+    "name": "hike",
+    "trans": [
+      "31.18.5",
+      "v．上升"
+    ],
+    "ukphone": "haIk",
+    "usphone": "haIk"
+  },
+  {
+    "name": "hoist",
+    "trans": [
+      "31.18.6",
+      "v．升起（raise）n．起重机"
+    ],
+    "ukphone": "hɔIst",
+    "usphone": "hɔIst"
+  },
+  {
+    "name": "stretch",
+    "trans": [
+      "31.18.7",
+      "v．伸展，伸长（pull taut, expand）"
+    ],
+    "ukphone": "stretʃ",
+    "usphone": "stretʃ"
+  },
+  {
+    "name": "transform",
+    "trans": [
+      "31.18.8",
+      "vt．明显地改变…外观或形状",
+      "【记】 trans（变）+form（形）→变形"
+    ],
+    "ukphone": "trænsˋfɔ:rm",
+    "usphone": "trænsˋfɔ:rm"
+  },
+  {
+    "name": "deform",
+    "trans": [
+      "31.18.9",
+      "vt．使变形（disfigure, distort）",
+      "【记】 de（坏）+form（形状）→使变形"
+    ],
+    "ukphone": "dIˋfɔ:rm",
+    "usphone": "dIˋfɔ:rm"
+  },
+  {
+    "name": "elevate",
+    "trans": [
+      "31.18.10",
+      "vt．抬高",
+      "【记】 e（出）+lev（举）+ate→举出→升高"
+    ],
+    "ukphone": "ˋelIveIt",
+    "usphone": "ˋelIveIt"
+  },
+  {
+    "name": "sharpen",
+    "trans": [
+      "31.18.11",
+      "vt．削尖"
+    ],
+    "ukphone": "ˋʃα:rpən",
+    "usphone": "ˋʃα:rpən"
+  },
+  {
+    "name": "enhance",
+    "trans": [
+      "31.18.12",
+      "vt．增加（raise, improve, heighten）"
+    ],
+    "ukphone": "Inˋhæns",
+    "usphone": "Inˋhæns"
+  },
+  {
+    "name": "abate",
+    "trans": [
+      "31.18.13",
+      "v．减少（lessen, diminish, dwindle, subside）"
+    ],
+    "ukphone": "əˋbeIt",
+    "usphone": "əˋbeIt"
+  },
+  {
+    "name": "accumulate",
+    "trans": [
+      "31.18.14",
+      "vt．积聚（aggregate, amass, accrue）",
+      "【记】 ac+cumul（堆积）+ate→积累"
+    ],
+    "ukphone": "əˋkju:mjəleIt",
+    "usphone": "əˋkju:mjəleIt"
+  },
+  {
+    "name": "amplify",
+    "trans": [
+      "31.18.15",
+      "vt．放大，增强"
+    ],
+    "ukphone": "ˋæmplIfaI",
+    "usphone": "ˋæmplIfaI"
+  },
+  {
+    "name": "amplification",
+    "trans": [
+      "31.18.16",
+      "n．扩大"
+    ],
+    "ukphone": "ˌæmplIfIˋkeIʃn",
+    "usphone": "ˌæmplIfIˋkeIʃn"
+  },
+  {
+    "name": "inflate",
+    "trans": [
+      "31.18.17",
+      "v．使得意，使骄傲；使膨胀；使充气（enlarge, expand, swell）"
+    ],
+    "ukphone": "InˋfleIt",
+    "usphone": "InˋfleIt"
+  },
+  {
+    "name": "transport",
+    "trans": [
+      "31.18.18",
+      "vt．运输；流放；使狂喜"
+    ],
+    "ukphone": "ˋtrænspɔ:rt］/［træsˋpɔ:rt",
+    "usphone": "ˋtrænspɔ:rt］/［træsˋpɔ:rt"
+  },
+  {
+    "name": "stuffy",
+    "trans": [
+      "31.19.1",
+      "adj．闷热的，不通风的（airless, stale）"
+    ],
+    "ukphone": "ˋstʌfi",
+    "usphone": "ˋstʌfi"
+  },
+  {
+    "name": "tilted",
+    "trans": [
+      "31.19.2",
+      "v.（使）倾斜（slant）"
+    ],
+    "ukphone": "tIltId",
+    "usphone": "tIltId"
+  },
+  {
+    "name": "regularly",
+    "trans": [
+      "31.19.3",
+      "adv．有规律地，整齐地（routinely）"
+    ],
+    "ukphone": "ˋregjələrli",
+    "usphone": "ˋregjələrli"
+  },
+  {
+    "name": "coil",
+    "trans": [
+      "31.19.4",
+      "n．盘绕 v．卷（curl, wind）"
+    ],
+    "ukphone": "kɔIl",
+    "usphone": "kɔIl"
+  },
+  {
+    "name": "slope",
+    "trans": [
+      "31.19.5",
+      "n．倾斜，斜面 v．倾斜（slant, tilt, incline）"
+    ],
+    "ukphone": "sloʊp",
+    "usphone": "sloʊp"
+  },
+  {
+    "name": "slant",
+    "trans": [
+      "31.19.6",
+      "n．斜面 vt．使倾斜（tilt, slope）"
+    ],
+    "ukphone": "slænt",
+    "usphone": "slænt"
+  },
+  {
+    "name": "protrude",
+    "trans": [
+      "31.19.7",
+      "v.（使）突出（project, stick out）",
+      "【记】 pro（前）+trude（伸出）→突出"
+    ],
+    "ukphone": "proʊˋtru:d",
+    "usphone": "proʊˋtru:d"
+  },
+  {
+    "name": "rotate",
+    "trans": [
+      "31.19.8",
+      "v.（使）旋转（turn, alternate）"
+    ],
+    "ukphone": "ˋroʊteIt",
+    "usphone": "ˋroʊteIt"
+  },
+  {
+    "name": "roll",
+    "trans": [
+      "31.19.9",
+      "v．滚动（scroll）"
+    ],
+    "ukphone": "roʊl",
+    "usphone": "roʊl"
+  },
+  {
+    "name": "dangle",
+    "trans": [
+      "31.19.10",
+      "v．悬摆（suspend, hang）"
+    ],
+    "ukphone": "ˋdæŋgl",
+    "usphone": "ˋdæŋgl"
+  },
+  {
+    "name": "project",
+    "trans": [
+      "31.19.11",
+      "v．凸出，投射（protrude）"
+    ],
+    "ukphone": "prəˋdʒekt",
+    "usphone": "prəˋdʒekt"
+  },
+  {
+    "name": "encompass",
+    "trans": [
+      "31.19.12",
+      "vt．包围，环绕（encircle, cover）；包含",
+      "【记】 en+compass（包围）"
+    ],
+    "ukphone": "Inˋkʌmpəs",
+    "usphone": "Inˋkʌmpəs"
+  },
+  {
+    "name": "active",
+    "trans": [
+      "31.19.13",
+      "adj．活动的，活跃的"
+    ],
+    "ukphone": "ˋæktIv",
+    "usphone": "ˋæktIv"
+  },
+  {
+    "name": "hump",
+    "trans": [
+      "31.19.14",
+      "vi．隆起"
+    ],
+    "ukphone": "hʌmp",
+    "usphone": "hʌmp"
+  },
+  {
+    "name": "tower",
+    "trans": [
+      "31.19.15",
+      "vi．屹立，高耸"
+    ],
+    "ukphone": "ˋtaʊər",
+    "usphone": "ˋtaʊər"
+  },
+  {
+    "name": "spin",
+    "trans": [
+      "31.19.16",
+      "v．旋转"
+    ],
+    "ukphone": "spIn",
+    "usphone": "spIn"
+  },
+  {
+    "name": "concave",
+    "trans": [
+      "31.19.17",
+      "adj．凹的，凹入的 n．凹，凹面"
+    ],
+    "ukphone": "kα:nˋkeIv",
+    "usphone": "kα:nˋkeIv"
+  },
+  {
+    "name": "convex",
+    "trans": [
+      "31.19.18",
+      "adj．表面弯曲如球的外侧的，凸起的"
+    ],
+    "ukphone": "ˋkα:nveks",
+    "usphone": "ˋkα:nveks"
+  },
+  {
+    "name": "pitch",
+    "trans": [
+      "31.19.19",
+      "n．程度；斜度"
+    ],
+    "ukphone": "pItʃ",
+    "usphone": "pItʃ"
+  },
+  {
+    "name": "configuration",
+    "trans": [
+      "31.19.20",
+      "n．结构；形态；表面轮廓（shape, form）"
+    ],
+    "ukphone": "kənˌfIgjəˋreIʃn",
+    "usphone": "kənˌfIgjəˋreIʃn"
+  },
+  {
+    "name": "glamor",
+    "trans": [
+      "31.20.1",
+      "n．魅力（attraction, charm）"
+    ],
+    "ukphone": "ˋglæmər",
+    "usphone": "ˋglæmər"
+  },
+  {
+    "name": "glamorous",
+    "trans": [
+      "31.20.2",
+      "adj．富有魅力的（fascinating, charming）",
+      "【记】 参考glamour（魔力）"
+    ],
+    "ukphone": "ˋglæmərəs",
+    "usphone": "ˋglæmərəs"
+  },
+  {
+    "name": "catching",
+    "trans": [
+      "31.20.3",
+      "adj．迷人的（charming）",
+      "【记】 catch（抓）+ing→心被抓住→迷人的"
+    ],
+    "ukphone": "ˋkætʃIŋ",
+    "usphone": "ˋkætʃIŋ"
+  },
+  {
+    "name": "engross",
+    "trans": [
+      "31.20.4",
+      "vt．使全神贯注于；吸引（absorb, preoccupy）"
+    ],
+    "ukphone": "Inˋgroʊs",
+    "usphone": "Inˋgroʊs"
+  },
+  {
+    "name": "engrossed",
+    "trans": [
+      "31.20.5",
+      "adj．全神贯注的（absorbed）"
+    ],
+    "ukphone": "Inˋgroʊst",
+    "usphone": "Inˋgroʊst"
+  },
+  {
+    "name": "attractive",
+    "trans": [
+      "31.20.6",
+      "adj．吸引人的，有魅力的（pretty, appealing）"
+    ],
+    "ukphone": "əˋtræktIv",
+    "usphone": "əˋtræktIv"
+  },
+  {
+    "name": "conspicuous",
+    "trans": [
+      "31.20.7",
+      "adj．引人注目的（noticeable, obvious）",
+      "【记】 con+spic（看）+uous→大家都看→引人注目的"
+    ],
+    "ukphone": "kənˋspIkjuəs",
+    "usphone": "kənˋspIkjuəs"
+  },
+  {
+    "name": "inviting",
+    "trans": [
+      "31.20.8",
+      "adj．诱人的（attractive）；引人注目的"
+    ],
+    "ukphone": "InˋvaItIŋ",
+    "usphone": "InˋvaItIŋ"
+  },
+  {
+    "name": "bait",
+    "trans": [
+      "31.20.9",
+      "n．饵，引诱物（lure）"
+    ],
+    "ukphone": "beIt",
+    "usphone": "beIt"
+  },
+  {
+    "name": "charisma",
+    "trans": [
+      "31.20.10",
+      "n．魅力，感召力"
+    ],
+    "ukphone": "kəˋrIzmə",
+    "usphone": "kəˋrIzmə"
+  },
+  {
+    "name": "draw",
+    "trans": [
+      "31.20.11",
+      "v．吸引，拉（attact）"
+    ],
+    "ukphone": "drɔ:",
+    "usphone": "drɔ:"
+  },
+  {
+    "name": "enrapture",
+    "trans": [
+      "31.20.12",
+      "vt．使出神",
+      "【记】 en+rapture（狂喜）"
+    ],
+    "ukphone": "Inˋræptʃər",
+    "usphone": "Inˋræptʃər"
+  },
+  {
+    "name": "induce",
+    "trans": [
+      "31.20.13",
+      "vt．导致，诱使（cause, produce）",
+      "【记】 in（进入）+duce（引导）"
+    ],
+    "ukphone": "Inˋdju:s",
+    "usphone": "Inˋdju:s"
+  },
+  {
+    "name": "intoxicate",
+    "trans": [
+      "31.20.14",
+      "vt．使陶醉",
+      "【记】 in（进入）+toxic（毒）+ate→进入毒→使迷醉"
+    ],
+    "ukphone": "Inˋtα:ksIkeIt",
+    "usphone": "Inˋtα:ksIkeIt"
+  },
+  {
+    "name": "lure",
+    "trans": [
+      "31.20.15",
+      "vt．诱惑（entice, tempt）",
+      "【记】 比较allure（引诱）"
+    ],
+    "ukphone": "lʊr",
+    "usphone": "lʊr"
+  },
+  {
+    "name": "entice",
+    "trans": [
+      "31.20.16",
+      "vt．诱惑（lure, tempt）"
+    ],
+    "ukphone": "InˋtaIs",
+    "usphone": "InˋtaIs"
+  },
+  {
+    "name": "tempt",
+    "trans": [
+      "31.20.17",
+      "vt．诱使（lure, entice）"
+    ],
+    "ukphone": "tempt",
+    "usphone": "tempt"
+  },
+  {
+    "name": "addict",
+    "trans": [
+      "31.20.18",
+      "vt．对…有瘾"
+    ],
+    "ukphone": "əˋdIkt",
+    "usphone": "əˋdIkt"
+  },
+  {
+    "name": "addicted",
+    "trans": [
+      "31.20.19",
+      "adj．沉溺的，上瘾的"
+    ],
+    "ukphone": "əˋdIktId",
+    "usphone": "əˋdIktId"
+  },
+  {
+    "name": "absorb",
+    "trans": [
+      "31.20.20",
+      "vt．吸收，吸引（attract, allure）",
+      "【记】 ab+sorb（吸）"
+    ],
+    "ukphone": "əbˋzɔ:rb",
+    "usphone": "əbˋzɔ:rb"
+  },
+  {
+    "name": "absorbing",
+    "trans": [
+      "31.20.21",
+      "adj．引人入胜的（enchanting, fascinating）"
+    ],
+    "ukphone": "əbˋzɔ:rbIŋ",
+    "usphone": "əbˋzɔ:rbIŋ"
+  },
+  {
+    "name": "delicate",
+    "trans": [
+      "31.21.1",
+      "adj．脆弱的"
+    ],
+    "ukphone": "ˋdelIkət",
+    "usphone": "ˋdelIkət"
+  },
+  {
+    "name": "pitiful",
+    "trans": [
+      "31.21.2",
+      "adj．可怜的",
+      "【记】 名词pity（可怜）"
+    ],
+    "ukphone": "ˋpItIfl",
+    "usphone": "ˋpItIfl"
+  },
+  {
+    "name": "fragile",
+    "trans": [
+      "31.21.3",
+      "adj．脆的（breakable, brittle）",
+      "【记】 frag（碎）+ile→易碎的"
+    ],
+    "ukphone": "ˋfrædʒl",
+    "usphone": "ˋfrædʒl"
+  },
+  {
+    "name": "emaciate",
+    "trans": [
+      "31.21.4",
+      "vt．使瘦弱",
+      "【记】 e+maci（瘦）+ate"
+    ],
+    "ukphone": "IˋmeIʃieIt",
+    "usphone": "IˋmeIʃieIt"
+  },
+  {
+    "name": "emaciated",
+    "trans": [
+      "31.21.5",
+      "adj．瘦弱的；憔悴的（skinny; haggard）"
+    ],
+    "ukphone": "IˋmeIʃieItId",
+    "usphone": "IˋmeIʃieItId"
+  },
+  {
+    "name": "flimsy",
+    "trans": [
+      "31.21.6",
+      "adj．脆弱的；薄弱的（thin）",
+      "【记】 比较film（胶片）"
+    ],
+    "ukphone": "ˋflImzi",
+    "usphone": "ˋflImzi"
+  },
+  {
+    "name": "fragmentary",
+    "trans": [
+      "31.21.7",
+      "adj．碎片的；不连续的（discontinuous）"
+    ],
+    "ukphone": "ˋfrægmənteri",
+    "usphone": "ˋfrægmənteri"
+  },
+  {
+    "name": "frail",
+    "trans": [
+      "31.21.8",
+      "adj．虚弱的，脆弱的（fragile, flimsy）",
+      "【记】 frail=fract（打碎的）→脆弱的"
+    ],
+    "ukphone": "freIl",
+    "usphone": "freIl"
+  },
+  {
+    "name": "brittle",
+    "trans": [
+      "31.21.9",
+      "adj．易碎的（fragile）"
+    ],
+    "ukphone": "ˋbrItl",
+    "usphone": "ˋbrItl"
+  },
+  {
+    "name": "slender",
+    "trans": [
+      "31.21.10",
+      "adj．苗条的，微弱的（slim）"
+    ],
+    "ukphone": "ˋslendər",
+    "usphone": "ˋslendər"
+  },
+  {
+    "name": "impotence",
+    "trans": [
+      "31.21.11",
+      "n．无力；虚弱（powerlessness）",
+      "【记】 im（无）+potence（能力）→无能"
+    ],
+    "ukphone": "ˋImpətəns",
+    "usphone": "ˋImpətəns"
+  },
+  {
+    "name": "limp",
+    "trans": [
+      "31.21.12",
+      "adj．柔软的，无力的",
+      "【记】 比较limb（四肢）"
+    ],
+    "ukphone": "lImp",
+    "usphone": "lImp"
+  },
+  {
+    "name": "vulnerable",
+    "trans": [
+      "31.21.13",
+      "adj．易受攻击的；易受伤害的；有弱点的"
+    ],
+    "ukphone": "ˋvʌlnərəbl",
+    "usphone": "ˋvʌlnərəbl"
+  },
+  {
+    "name": "cryptic",
+    "trans": [
+      "31.22.1",
+      "adj．神秘的，隐藏的（mysterious）",
+      "【记】 crypt（神秘）+ic"
+    ],
+    "ukphone": "ˋkrIptIk",
+    "usphone": "ˋkrIptIk"
+  },
+  {
+    "name": "secluded",
+    "trans": [
+      "31.22.2",
+      "adj．隐蔽的，隐退的（remote, isolated）"
+    ],
+    "ukphone": "sIˋklu:dId",
+    "usphone": "sIˋklu:dId"
+  },
+  {
+    "name": "seclusion",
+    "trans": [
+      "31.22.3",
+      "n．归隐；隔离（solitude, isolation）",
+      "【记】 se（分开）+clus=clude（关闭）+ion→隔离"
+    ],
+    "ukphone": "sIˋklu:ʒn",
+    "usphone": "sIˋklu:ʒn"
+  },
+  {
+    "name": "dissemble",
+    "trans": [
+      "31.22.4",
+      "v．隐藏；伪装（disguise, dissimulate）",
+      "【记】 dis+semble（相似）→隐藏"
+    ],
+    "ukphone": "dIˋsembl",
+    "usphone": "dIˋsembl"
+  },
+  {
+    "name": "lurk",
+    "trans": [
+      "31.22.5",
+      "vi．躲藏（prowl, slink）"
+    ],
+    "ukphone": "lɜ:rk",
+    "usphone": "lɜ:rk"
+  },
+  {
+    "name": "sneak",
+    "trans": [
+      "31.22.6",
+      "vi．潜行（lurk, skulk）",
+      "【记】 比较snake（蛇）"
+    ],
+    "ukphone": "sni:k",
+    "usphone": "sni:k"
+  },
+  {
+    "name": "conceal",
+    "trans": [
+      "31.22.7",
+      "vt．把…隐藏起来（disguise, hide）"
+    ],
+    "ukphone": "kənˋsi:l",
+    "usphone": "kənˋsi:l"
+  },
+  {
+    "name": "feign",
+    "trans": [
+      "31.22.8",
+      "vt．假装（simulate, sham）",
+      "【记】 比较feint（佯攻）"
+    ],
+    "ukphone": "feIn",
+    "usphone": "feIn"
+  },
+  {
+    "name": "pretend",
+    "trans": [
+      "31.22.9",
+      "vt．伪装（camouflage, disguise）"
+    ],
+    "ukphone": "prIˋtend",
+    "usphone": "prIˋtend"
+  },
+  {
+    "name": "simulate",
+    "trans": [
+      "31.22.10",
+      "vt．伪装，模拟（feign, fake）"
+    ],
+    "ukphone": "ˋsImjuleIt",
+    "usphone": "ˋsImjuleIt"
+  },
+  {
+    "name": "hide",
+    "trans": [
+      "31.22.11",
+      "v．隐藏（conceal）"
+    ],
+    "ukphone": "haId",
+    "usphone": "haId"
+  },
+  {
+    "name": "obscure",
+    "trans": [
+      "31.22.12",
+      "vt．掩盖（hide, cloud）",
+      "【记】 ob（离开）+scure（跑）→跑开→掩盖"
+    ],
+    "ukphone": "əbˋskjʊr",
+    "usphone": "əbˋskjʊr"
+  },
+  {
+    "name": "screen",
+    "trans": [
+      "31.22.13",
+      "vt．遮蔽（veil, conceal）"
+    ],
+    "ukphone": "skri:n",
+    "usphone": "skri:n"
+  },
+  {
+    "name": "deceit",
+    "trans": [
+      "32.1.1",
+      "n．欺骗，欺诈（cheat, fraud）"
+    ],
+    "ukphone": "dIˋsi:t",
+    "usphone": "dIˋsi:t"
+  },
+  {
+    "name": "deceitful",
+    "trans": [
+      "32.1.2",
+      "adj．欺骗的（sly, dishonest）"
+    ],
+    "ukphone": "dIˋsi:tfl",
+    "usphone": "dIˋsi:tfl"
+  },
+  {
+    "name": "deceive",
+    "trans": [
+      "32.1.3",
+      "vt．欺骗，行骗"
+    ],
+    "ukphone": "dIˋsi:v",
+    "usphone": "dIˋsi:v"
+  },
+  {
+    "name": "deceptive",
+    "trans": [
+      "32.1.4",
+      "adj．虚伪的，骗人的（deceitful, misleading.）"
+    ],
+    "ukphone": "dIˋseptIv",
+    "usphone": "dIˋseptIv"
+  },
+  {
+    "name": "gangster",
+    "trans": [
+      "32.1.5",
+      "n．暴徒，歹徒（mobster, hoodlum）"
+    ],
+    "ukphone": "ˋgæŋstər",
+    "usphone": "ˋgæŋstər"
+  },
+  {
+    "name": "fraud",
+    "trans": [
+      "32.1.6",
+      "n．欺骗（fault, deception）"
+    ],
+    "ukphone": "frɔ:d",
+    "usphone": "frɔ:d"
+  },
+  {
+    "name": "fraudulent",
+    "trans": [
+      "32.1.7",
+      "adj．欺诈的，不诚实的（deceitful, dishonest）"
+    ],
+    "ukphone": "ˋfrɔ:dʒələnt",
+    "usphone": "ˋfrɔ:dʒələnt"
+  },
+  {
+    "name": "homicide",
+    "trans": [
+      "32.1.8",
+      "n．杀人（slaughter）"
+    ],
+    "ukphone": "ˋhα:mIsaId",
+    "usphone": "ˋhα:mIsaId"
+  },
+  {
+    "name": "theft",
+    "trans": [
+      "32.1.9",
+      "n．偷窃（stealing）"
+    ],
+    "ukphone": "θeft",
+    "usphone": "θeft"
+  },
+  {
+    "name": "pilferage",
+    "trans": [
+      "32.1.10",
+      "n．偷窃（stealing）",
+      "【记】 pilfer（偷）+age"
+    ],
+    "ukphone": "ˋpIlfərIdʒ",
+    "usphone": "ˋpIlfərIdʒ"
+  },
+  {
+    "name": "counterfeit",
+    "trans": [
+      "32.1.11",
+      "n．赝品 adj．伪造的，假冒的（fake, sham）"
+    ],
+    "ukphone": "ˋkaʊntərfIt",
+    "usphone": "ˋkaʊntərfIt"
+  },
+  {
+    "name": "conspire",
+    "trans": [
+      "32.1.12",
+      "vi．阴谋，密谋（intrigue, plot）"
+    ],
+    "ukphone": "kənˋspaIər",
+    "usphone": "kənˋspaIər"
+  },
+  {
+    "name": "conspiracy",
+    "trans": [
+      "32.1.13",
+      "n．阴谋（plot）"
+    ],
+    "ukphone": "kənˋspIrəsi",
+    "usphone": "kənˋspIrəsi"
+  },
+  {
+    "name": "sin",
+    "trans": [
+      "32.1.14",
+      "n．罪过，过失"
+    ],
+    "ukphone": "sIn",
+    "usphone": "sIn"
+  },
+  {
+    "name": "brew",
+    "trans": [
+      "32.1.15",
+      "v．酿造；图谋（ferment, plot）；酝酿，即将发生"
+    ],
+    "ukphone": "bru:",
+    "usphone": "bru:"
+  },
+  {
+    "name": "beguile",
+    "trans": [
+      "32.1.16",
+      "vi．欺骗（deceive）",
+      "【记】 be+guile（欺诈）"
+    ],
+    "ukphone": "bIˋgaIl",
+    "usphone": "bIˋgaIl"
+  },
+  {
+    "name": "despoil",
+    "trans": [
+      "32.1.17",
+      "vt．抢劫（rob）"
+    ],
+    "ukphone": "dIˋspɔIl",
+    "usphone": "dIˋspɔIl"
+  },
+  {
+    "name": "forge",
+    "trans": [
+      "32.1.18",
+      "vt．伪造（feign, fabricate）"
+    ],
+    "ukphone": "fɔ:rdʒ",
+    "usphone": "fɔ:rdʒ"
+  },
+  {
+    "name": "assassinate",
+    "trans": [
+      "32.1.19",
+      "vt．暗杀，行刺"
+    ],
+    "ukphone": "əˋsæsəneIt",
+    "usphone": "əˋsæsəneIt"
+  },
+  {
+    "name": "kidnap",
+    "trans": [
+      "32.1.20",
+      "vt．绑架（abduct）",
+      "【记】 kid（小孩）+nap（睡）→（小孩睡时被）绑架"
+    ],
+    "ukphone": "ˋkIdnæp",
+    "usphone": "ˋkIdnæp"
+  },
+  {
+    "name": "embezzle",
+    "trans": [
+      "32.1.21",
+      "vt．盗用（公款；公物）（misappropriate）"
+    ],
+    "ukphone": "Imˋbezl",
+    "usphone": "Imˋbezl"
+  },
+  {
+    "name": "extort",
+    "trans": [
+      "32.1.22",
+      "vt．勒索，强索（extract, squeeze）",
+      "【记】 ex+tort（扭）→扭出来→强索"
+    ],
+    "ukphone": "Ikˋstɔ:rt",
+    "usphone": "Ikˋstɔ:rt"
+  },
+  {
+    "name": "blackmail",
+    "trans": [
+      "32.1.23",
+      "vt．勒索",
+      "【记】 black（黑）+mail（信）"
+    ],
+    "ukphone": "ˋblækmeIl",
+    "usphone": "ˋblækmeIl"
+  },
+  {
+    "name": "delude",
+    "trans": [
+      "32.1.24",
+      "vt．欺骗，迷惑（beguile, deceive, hoax）",
+      "【记】 de（坏）+lude（玩）→使坏→欺骗"
+    ],
+    "ukphone": "dIˋlu:d",
+    "usphone": "dIˋlu:d"
+  },
+  {
+    "name": "defraud",
+    "trans": [
+      "32.1.25",
+      "vt．欺诈（deceive, beguile, cheat）",
+      "【记】 de+fraud（欺诈）"
+    ],
+    "ukphone": "dIˋfrɔ:d",
+    "usphone": "dIˋfrɔ:d"
+  },
+  {
+    "name": "fabricate",
+    "trans": [
+      "32.1.26",
+      "vt．伪造（forge, coin）",
+      "【记】 fabric（结构）+ate→使出现结构→伪造"
+    ],
+    "ukphone": "ˋfæbrIkeIt",
+    "usphone": "ˋfæbrIkeIt"
+  },
+  {
+    "name": "purge",
+    "trans": [
+      "32.1.27",
+      "vt．洗涤（罪等）",
+      "【记】 比较pure（纯的）"
+    ],
+    "ukphone": "pɜ:rdʒ",
+    "usphone": "pɜ:rdʒ"
+  },
+  {
+    "name": "belie",
+    "trans": [
+      "32.1.28",
+      "vt．掩饰（conceal, cover up）",
+      "【记】 be+lie（谎言）"
+    ],
+    "ukphone": "bIˋlaI",
+    "usphone": "bIˋlaI"
+  },
+  {
+    "name": "trap",
+    "trans": [
+      "32.1.29",
+      "vt．诱捕，陷害 n．陷阱（entrap）"
+    ],
+    "ukphone": "træp",
+    "usphone": "træp"
+  },
+  {
+    "name": "accomplice",
+    "trans": [
+      "32.1.30",
+      "n．从犯（accessory）",
+      "【记】 ac+com（共同）+plic（做）+e→一起干→同谋"
+    ],
+    "ukphone": "əˋkα:mplIs",
+    "usphone": "əˋkα:mplIs"
+  },
+  {
+    "name": "abduct",
+    "trans": [
+      "32.1.31",
+      "vt．绑架，诱拐（kidnap）",
+      "【记】 ab+duct（引导）→把人带走→绑架"
+    ],
+    "ukphone": "æbˋdʌkt",
+    "usphone": "æbˋdʌkt"
+  },
+  {
+    "name": "decimation",
+    "trans": [
+      "32.1.32",
+      "n．大批杀害；大量毁灭（destruction）"
+    ],
+    "ukphone": "ˌdesIˋmeIʃn",
+    "usphone": "ˌdesIˋmeIʃn"
+  },
+  {
+    "name": "convenient",
+    "trans": [
+      "32.2.1",
+      "adj．便利的，方便的"
+    ],
+    "ukphone": "kənˋvi:niənt",
+    "usphone": "kənˋvi:niənt"
+  },
+  {
+    "name": "grateful",
+    "trans": [
+      "32.2.2",
+      "adj．感谢的（thankful）",
+      "【记】 grate（高兴）+ful（多）"
+    ],
+    "ukphone": "ˋgreItfl",
+    "usphone": "ˋgreItfl"
+  },
+  {
+    "name": "gratitude",
+    "trans": [
+      "32.2.3",
+      "n．感谢，感激",
+      "【记】 grat（满意）+itude"
+    ],
+    "ukphone": "ˋgrætItju:d",
+    "usphone": "ˋgrætItju:d"
+  },
+  {
+    "name": "auspicious",
+    "trans": [
+      "32.2.4",
+      "adj．吉兆的，幸运的（promising, favorable）"
+    ],
+    "ukphone": "ɔ:ˋspIʃəs",
+    "usphone": "ɔ:ˋspIʃəs"
+  },
+  {
+    "name": "cozy",
+    "trans": [
+      "32.2.5",
+      "adj．舒适的（comfortable, snug）"
+    ],
+    "ukphone": "ˋkoʊzi",
+    "usphone": "ˋkoʊzi"
+  },
+  {
+    "name": "fortunate",
+    "trans": [
+      "32.2.6",
+      "adj．幸运的（lucky）",
+      "【记】 fortun（e）（财富）+ate→发财→幸运的"
+    ],
+    "ukphone": "ˋfɔ:rtʃənət",
+    "usphone": "ˋfɔ:rtʃənət"
+  },
+  {
+    "name": "readily",
+    "trans": [
+      "32.2.7",
+      "adv．容易地（easily, quickly）"
+    ],
+    "ukphone": "ˋredIli",
+    "usphone": "ˋredIli"
+  },
+  {
+    "name": "boon",
+    "trans": [
+      "32.2.8",
+      "n．恩惠（blessing, benefit）"
+    ],
+    "ukphone": "bu:n",
+    "usphone": "bu:n"
+  },
+  {
+    "name": "bonanza",
+    "trans": [
+      "32.2.9",
+      "n．幸运"
+    ],
+    "ukphone": "bəˋnænzə",
+    "usphone": "bəˋnænzə"
+  },
+  {
+    "name": "blessing",
+    "trans": [
+      "32.2.10",
+      "n．祝福"
+    ],
+    "ukphone": "ˋblesIŋ",
+    "usphone": "ˋblesIŋ"
+  },
+  {
+    "name": "thrive",
+    "trans": [
+      "32.2.11",
+      "vi．繁荣，旺盛（flourish, do well on）"
+    ],
+    "ukphone": "θraIv",
+    "usphone": "θraIv"
+  },
+  {
+    "name": "furrow",
+    "trans": [
+      "32.3.1",
+      "vt．犁，耕；弄绉"
+    ],
+    "ukphone": "ˋfɜ:roʊ",
+    "usphone": "ˋfɜ:roʊ"
+  },
+  {
+    "name": "instrument",
+    "trans": [
+      "32.3.2",
+      "n．工具"
+    ],
+    "ukphone": "ˋInstrəmənt",
+    "usphone": "ˋInstrəmənt"
+  },
+  {
+    "name": "implement",
+    "trans": [
+      "32.3.3",
+      "n．工具（device, instrument, facility）"
+    ],
+    "ukphone": "ˋImplIment",
+    "usphone": "ˋImplIment"
+  },
+  {
+    "name": "tool",
+    "trans": [
+      "32.3.4",
+      "n．工具，用具（instrument）"
+    ],
+    "ukphone": "tu:l",
+    "usphone": "tu:l"
+  },
+  {
+    "name": "shaft",
+    "trans": [
+      "32.3.5",
+      "n．轴，柄（handle, pole）"
+    ],
+    "ukphone": "ʃæft",
+    "usphone": "ʃæft"
+  },
+  {
+    "name": "pump",
+    "trans": [
+      "32.3.6",
+      "n．水泵 v．抽，吸（drive）"
+    ],
+    "ukphone": "pʌmp",
+    "usphone": "pʌmp"
+  },
+  {
+    "name": "snap",
+    "trans": [
+      "32.3.7",
+      "v.（使）猛然断裂（break）"
+    ],
+    "ukphone": "snæp",
+    "usphone": "snæp"
+  },
+  {
+    "name": "squeeze",
+    "trans": [
+      "32.3.8",
+      "v．挤（cram, press）"
+    ],
+    "ukphone": "skwi:z",
+    "usphone": "skwi:z"
+  },
+  {
+    "name": "prune",
+    "trans": [
+      "32.3.9",
+      "v．剪修（shear, trim）"
+    ],
+    "ukphone": "pru:n",
+    "usphone": "pru:n"
+  },
+  {
+    "name": "glaze",
+    "trans": [
+      "32.3.10",
+      "v．上釉 n．釉"
+    ],
+    "ukphone": "gleIz",
+    "usphone": "gleIz"
+  },
+  {
+    "name": "tug",
+    "trans": [
+      "32.3.11",
+      "v．拖，牵引（pull, haul）"
+    ],
+    "ukphone": "tʌg",
+    "usphone": "tʌg"
+  },
+  {
+    "name": "fix",
+    "trans": [
+      "32.3.12",
+      "v．修理（repair）"
+    ],
+    "ukphone": "fIks",
+    "usphone": "fIks"
+  },
+  {
+    "name": "maintain",
+    "trans": [
+      "32.3.13",
+      "vt．维修（repair）"
+    ],
+    "ukphone": "meInˋteIn",
+    "usphone": "meInˋteIn"
+  },
+  {
+    "name": "extract",
+    "trans": [
+      "32.3.14",
+      "vt．拔出，榨取（remove）"
+    ],
+    "ukphone": "Ikˋstrækt",
+    "usphone": "Ikˋstrækt"
+  },
+  {
+    "name": "flay",
+    "trans": [
+      "32.3.15",
+      "vt．剥…的皮"
+    ],
+    "ukphone": "fleI",
+    "usphone": "fleI"
+  },
+  {
+    "name": "flush",
+    "trans": [
+      "32.3.16",
+      "vt．冲洗（flow, pour）",
+      "【记】 比较blush（脸红）"
+    ],
+    "ukphone": "flʌʃ",
+    "usphone": "flʌʃ"
+  },
+  {
+    "name": "clinch",
+    "trans": [
+      "32.3.17",
+      "vt．钉牢，揪住"
+    ],
+    "ukphone": "klIntʃ",
+    "usphone": "klIntʃ"
+  },
+  {
+    "name": "gild",
+    "trans": [
+      "32.3.18",
+      "vt．镀金"
+    ],
+    "ukphone": "gIld",
+    "usphone": "gIld"
+  },
+  {
+    "name": "scratch",
+    "trans": [
+      "32.3.19",
+      "vt．刮擦 n．划痕（rub）"
+    ],
+    "ukphone": "skrætʃ",
+    "usphone": "skrætʃ"
+  },
+  {
+    "name": "clip",
+    "trans": [
+      "32.3.20",
+      "vt．夹住，修剪（cut, shear）n．夹子，钳子"
+    ],
+    "ukphone": "klIp",
+    "usphone": "klIp"
+  },
+  {
+    "name": "clamp",
+    "trans": [
+      "32.3.21",
+      "vt．夹"
+    ],
+    "ukphone": "klæmp",
+    "usphone": "klæmp"
+  },
+  {
+    "name": "hew",
+    "trans": [
+      "32.3.22",
+      "vt．砍，伐；削（cut, chop）"
+    ],
+    "ukphone": "hju:",
+    "usphone": "hju:"
+  },
+  {
+    "name": "rap",
+    "trans": [
+      "32.3.23",
+      "vt．敲击（tap, knock）"
+    ],
+    "ukphone": "ræp",
+    "usphone": "ræp"
+  },
+  {
+    "name": "cleanse",
+    "trans": [
+      "32.3.24",
+      "vt．使清洁（clean, purify）"
+    ],
+    "ukphone": "klenz",
+    "usphone": "klenz"
+  },
+  {
+    "name": "rend",
+    "trans": [
+      "32.3.25",
+      "vt．撕开（tear）；揪扯"
+    ],
+    "ukphone": "rend",
+    "usphone": "rend"
+  },
+  {
+    "name": "cram",
+    "trans": [
+      "32.3.26",
+      "vt．填塞"
+    ],
+    "ukphone": "kræm",
+    "usphone": "kræm"
+  },
+  {
+    "name": "smear",
+    "trans": [
+      "32.3.27",
+      "vt．涂"
+    ],
+    "ukphone": "smIr",
+    "usphone": "smIr"
+  },
+  {
+    "name": "efface",
+    "trans": [
+      "32.3.28",
+      "vt．涂抹（obliterate）"
+    ],
+    "ukphone": "IˋfeIs",
+    "usphone": "IˋfeIs"
+  },
+  {
+    "name": "remove",
+    "trans": [
+      "32.3.29",
+      "vt．移动，搬开；脱掉",
+      "【记】 re（再次）+move（动）→移动"
+    ],
+    "ukphone": "rIˋmu:v",
+    "usphone": "rIˋmu:v"
+  },
+  {
+    "name": "forge",
+    "trans": [
+      "32.3.30",
+      "vt．铸造（make）"
+    ],
+    "ukphone": "fɔ:rdʒ",
+    "usphone": "fɔ:rdʒ"
+  },
+  {
+    "name": "tow",
+    "trans": [
+      "32.3.31",
+      "vt./n．拖引，牵引（pull, haul）"
+    ],
+    "ukphone": "toʊ",
+    "usphone": "toʊ"
+  },
+  {
+    "name": "incise",
+    "trans": [
+      "32.3.32",
+      "vt．切割，切开（cut）"
+    ],
+    "ukphone": "InˋsaIz",
+    "usphone": "InˋsaIz"
+  },
+  {
+    "name": "chop",
+    "trans": [
+      "32.3.33",
+      "vt．砍（cut, hew）"
+    ],
+    "ukphone": "tʃα:p",
+    "usphone": "tʃα:p"
+  },
+  {
+    "name": "harrow",
+    "trans": [
+      "32.3.34",
+      "vt．耙掘"
+    ],
+    "ukphone": "ˋhæroʊ",
+    "usphone": "ˋhæroʊ"
+  },
+  {
+    "name": "pick",
+    "trans": [
+      "32.3.35",
+      "v．摘；掘，凿，挖；挑选"
+    ],
+    "ukphone": "pIk",
+    "usphone": "pIk"
+  },
+  {
+    "name": "shovel",
+    "trans": [
+      "32.3.36",
+      "n．铲，铁铲 v．铲"
+    ],
+    "ukphone": "ʃʌvl",
+    "usphone": "ʃʌvl"
+  },
+  {
+    "name": "sickle",
+    "trans": [
+      "32.3.37",
+      "n．镰刀"
+    ],
+    "ukphone": "ˋsIkl",
+    "usphone": "ˋsIkl"
+  },
+  {
+    "name": "spade",
+    "trans": [
+      "32.3.38",
+      "n．铲，铁锹 v．铲"
+    ],
+    "ukphone": "speId",
+    "usphone": "speId"
+  },
+  {
+    "name": "bore",
+    "trans": [
+      "32.3.39",
+      "v．钻孔"
+    ],
+    "ukphone": "bɔ:r",
+    "usphone": "bɔ:r"
+  },
+  {
+    "name": "hectic",
+    "trans": [
+      "32.4.1",
+      "adj．忙碌的（busy）",
+      "【记】 hect（许多）+ic→许多事要做→紧张兴奋的"
+    ],
+    "ukphone": "ˋhektIk",
+    "usphone": "ˋhektIk"
+  },
+  {
+    "name": "officially",
+    "trans": [
+      "32.4.2",
+      "adv．职务上；正式地（formally）"
+    ],
+    "ukphone": "əˋfIʃəli",
+    "usphone": "əˋfIʃəli"
+  },
+  {
+    "name": "entry",
+    "trans": [
+      "32.4.3",
+      "n．登记；入口"
+    ],
+    "ukphone": "ˋentri",
+    "usphone": "ˋentri"
+  },
+  {
+    "name": "role",
+    "trans": [
+      "32.4.4",
+      "n．任务"
+    ],
+    "ukphone": "roʊl",
+    "usphone": "roʊl"
+  },
+  {
+    "name": "log",
+    "trans": [
+      "32.4.5",
+      "n．日志（journal）"
+    ],
+    "ukphone": "lɔ:g",
+    "usphone": "lɔ:g"
+  },
+  {
+    "name": "draft",
+    "trans": [
+      "32.4.6",
+      "n．草案 v．起草，设计（formulate, draw up）"
+    ],
+    "ukphone": "dræft",
+    "usphone": "dræft"
+  },
+  {
+    "name": "sketch",
+    "trans": [
+      "32.4.7",
+      "n．草图（drawing, chart）v．勾画（compose, outline）"
+    ],
+    "ukphone": "sketʃ",
+    "usphone": "sketʃ"
+  },
+  {
+    "name": "assumption",
+    "trans": [
+      "32.4.8",
+      "n．就职"
+    ],
+    "ukphone": "əˋsʌmpʃn",
+    "usphone": "əˋsʌmpʃn"
+  },
+  {
+    "name": "drudgery",
+    "trans": [
+      "32.4.9",
+      "n．苦差事（tedium）"
+    ],
+    "ukphone": "ˋdrʌdʒəri",
+    "usphone": "ˋdrʌdʒəri"
+  },
+  {
+    "name": "chore",
+    "trans": [
+      "32.4.10",
+      "n．零工，杂务"
+    ],
+    "ukphone": "tʃɔ:r",
+    "usphone": "tʃɔ:r"
+  },
+  {
+    "name": "undertaking",
+    "trans": [
+      "32.4.11",
+      "n．任务，工作（endeavor, enterprise）"
+    ],
+    "ukphone": "ˌʌndərˋteIkIŋ",
+    "usphone": "ˌʌndərˋteIkIŋ"
+  },
+  {
+    "name": "task",
+    "trans": [
+      "32.4.12",
+      "n．任务，作业（chore, duty, job）"
+    ],
+    "ukphone": "tæsk",
+    "usphone": "tæsk"
+  },
+  {
+    "name": "career",
+    "trans": [
+      "32.4.13",
+      "n．生涯，职业（profession, pursuit, vocation）"
+    ],
+    "ukphone": "kəˋrIr",
+    "usphone": "kəˋrIr"
+  },
+  {
+    "name": "audition",
+    "trans": [
+      "32.4.14",
+      "n．试听；面试",
+      "【记】 audi（听）+ion"
+    ],
+    "ukphone": "ɔ:ˋdIʃn",
+    "usphone": "ɔ:ˋdIʃn"
+  },
+  {
+    "name": "vocation",
+    "trans": [
+      "32.4.15",
+      "n．职业，行业（occupation, profession）"
+    ],
+    "ukphone": "voʊˋkeIʃn",
+    "usphone": "voʊˋkeIʃn"
+  },
+  {
+    "name": "charge",
+    "trans": [
+      "32.4.16",
+      "n．职责"
+    ],
+    "ukphone": "tʃα:rdʒ",
+    "usphone": "tʃα:rdʒ"
+  },
+  {
+    "name": "major",
+    "trans": [
+      "32.4.17",
+      "n．专业"
+    ],
+    "ukphone": "ˋmeIdʒər",
+    "usphone": "ˋmeIdʒər"
+  },
+  {
+    "name": "resign",
+    "trans": [
+      "32.4.18",
+      "n./v．辞职（give up）"
+    ],
+    "ukphone": "rIˋzaIn",
+    "usphone": "rIˋzaIn"
+  },
+  {
+    "name": "solicit",
+    "trans": [
+      "32.4.19",
+      "v．拉客"
+    ],
+    "ukphone": "səˋlIsIt",
+    "usphone": "səˋlIsIt"
+  },
+  {
+    "name": "register",
+    "trans": [
+      "32.4.20",
+      "vt．登记（enroll, enlist）"
+    ],
+    "ukphone": "ˋredʒIstər",
+    "usphone": "ˋredʒIstər"
+  },
+  {
+    "name": "inaugurate",
+    "trans": [
+      "32.4.21",
+      "vt．开始（commence, initiate）；使就职",
+      "【记】 in（进入）+augur（开始）+ate"
+    ],
+    "ukphone": "Iˋnɔ:gjəreIt",
+    "usphone": "Iˋnɔ:gjəreIt"
+  },
+  {
+    "name": "promote",
+    "trans": [
+      "32.4.22",
+      "vt．升职；促进",
+      "【记】 pro（前）+mote（动）→促进"
+    ],
+    "ukphone": "prəˋmoʊt",
+    "usphone": "prəˋmoʊt"
+  },
+  {
+    "name": "officeholding",
+    "trans": [
+      "32.4.23",
+      "n．任职"
+    ],
+    "ukphone": "ˋɔ:fIsˌ hoʊldIŋ",
+    "usphone": "ˋɔ:fIsˌ hoʊldIŋ"
+  },
+  {
+    "name": "provide",
+    "trans": [
+      "32.5.1",
+      "vt．提供（supply, furnish, give）"
+    ],
+    "ukphone": "prəˋvaId",
+    "usphone": "prəˋvaId"
+  },
+  {
+    "name": "provision",
+    "trans": [
+      "32.5.2",
+      "n．供应（supply, furnishing）"
+    ],
+    "ukphone": "prəˋvIʒn",
+    "usphone": "prəˋvIʒn"
+  },
+  {
+    "name": "accommodate",
+    "trans": [
+      "32.5.3",
+      "vt．供给住宿"
+    ],
+    "ukphone": "əˋkα:mədeIt",
+    "usphone": "əˋkα:mədeIt"
+  },
+  {
+    "name": "furnish",
+    "trans": [
+      "32.5.4",
+      "vt．供应，供给（equip, supply，provide）"
+    ],
+    "ukphone": "ˋfɜ:rnIʃ",
+    "usphone": "ˋfɜ:rnIʃ"
+  },
+  {
+    "name": "render",
+    "trans": [
+      "32.5.5",
+      "vt．提供（provide）"
+    ],
+    "ukphone": "ˋrendər",
+    "usphone": "ˋrendər"
+  },
+  {
+    "name": "incompatible",
+    "trans": [
+      "32.6.1",
+      "adj．不兼容的（inconsistent, incongruous）",
+      "【记】 in（不）+compatible（和谐的，融合的）"
+    ],
+    "ukphone": "ˌInkəmˋpætəbl",
+    "usphone": "ˌInkəmˋpætəbl"
+  },
+  {
+    "name": "congruity",
+    "trans": [
+      "32.6.2",
+      "n．一致，协调",
+      "【记】 con+gru=agree（同意）+ity"
+    ],
+    "ukphone": "kα:nˋgru:əti",
+    "usphone": "kα:nˋgru:əti"
+  },
+  {
+    "name": "incongruity",
+    "trans": [
+      "32.6.3",
+      "n．不和谐（之物）"
+    ],
+    "ukphone": "ˌInkα:nˋgru:əti",
+    "usphone": "ˌInkα:nˋgru:əti"
+  },
+  {
+    "name": "incongruous",
+    "trans": [
+      "32.6.4",
+      "adj．不协调的（inconsistent）",
+      "【记】 in（不）+congruous（和谐的）"
+    ],
+    "ukphone": "Inˋkα:ŋgruəs",
+    "usphone": "Inˋkα:ŋgruəs"
+  },
+  {
+    "name": "respective",
+    "trans": [
+      "32.6.5",
+      "adj．分别的，各自的（individual）"
+    ],
+    "ukphone": "rIˋspektIv",
+    "usphone": "rIˋspektIv"
+  },
+  {
+    "name": "close",
+    "trans": [
+      "32.6.6",
+      "adj．亲密的 adv．紧密地"
+    ],
+    "ukphone": "kloʊz",
+    "usphone": "kloʊz"
+  },
+  {
+    "name": "mutual",
+    "trans": [
+      "32.6.7",
+      "adj．相互的；共同的（reciprocal; joint）",
+      "【记】 mut（变化）+ual→你变我也变→相互的"
+    ],
+    "ukphone": "ˋmju:tʃuəl",
+    "usphone": "ˋmju:tʃuəl"
+  },
+  {
+    "name": "concerted",
+    "trans": [
+      "32.6.8",
+      "adj．协定的；协调的（unisonous）"
+    ],
+    "ukphone": "kənˋsɜ:rtId",
+    "usphone": "kənˋsɜ:rtId"
+  },
+  {
+    "name": "fraternal",
+    "trans": [
+      "32.6.9",
+      "adj．兄弟的，兄弟般的；友爱的（brotherly; cordial）",
+      "【记】 fratern（兄弟）+al"
+    ],
+    "ukphone": "frəˋtɜ:rnl",
+    "usphone": "frəˋtɜ:rnl"
+  },
+  {
+    "name": "dependent",
+    "trans": [
+      "32.6.10",
+      "adj．依靠的，依赖的"
+    ],
+    "ukphone": "dIˋpendənt",
+    "usphone": "dIˋpendənt"
+  },
+  {
+    "name": "congenial",
+    "trans": [
+      "32.6.11",
+      "adj．意气相投的（compatible, agreeable, pleasant, pleasing）"
+    ],
+    "ukphone": "kənˋdʒi:niəl",
+    "usphone": "kənˋdʒi:niəl"
+  },
+  {
+    "name": "relevant",
+    "trans": [
+      "32.6.12",
+      "adj．有关的；贴切的（related, pertinent）"
+    ],
+    "ukphone": "ˋreləvənt",
+    "usphone": "ˋreləvənt"
+  },
+  {
+    "name": "bond",
+    "trans": [
+      "32.6.13",
+      "n．联结，联系（tie, link）"
+    ],
+    "ukphone": "bα:nd",
+    "usphone": "bα:nd"
+  },
+  {
+    "name": "complement",
+    "trans": [
+      "32.6.14",
+      "n．补足物 vt．补足",
+      "【记】 比较complete（完整的）"
+    ],
+    "ukphone": "ˋkα:mplIment",
+    "usphone": "ˋkα:mplIment"
+  },
+  {
+    "name": "complementary",
+    "trans": [
+      "32.6.15",
+      "adj．补充的（supplementary, subsidiary）"
+    ],
+    "ukphone": "ˌkα:mplIˋmentri",
+    "usphone": "ˌkα:mplIˋmentri"
+  },
+  {
+    "name": "discord",
+    "trans": [
+      "32.6.16",
+      "n．不和谐（disharmony, disagreement）",
+      "【记】 dis+cord（和谐）"
+    ],
+    "ukphone": "ˋdIskɔ:rd",
+    "usphone": "ˋdIskɔ:rd"
+  },
+  {
+    "name": "association",
+    "trans": [
+      "32.6.17",
+      "n．关联（relationship）"
+    ],
+    "ukphone": "əˌsoʊʃiˋeIʃn",
+    "usphone": "əˌsoʊʃiˋeIʃn"
+  },
+  {
+    "name": "associate",
+    "trans": [
+      "32.6.18",
+      "v．联合（unite, combine）n．伙伴（partner）"
+    ],
+    "ukphone": "əˋsoʊʃieIt",
+    "usphone": "əˋsoʊʃieIt"
+  },
+  {
+    "name": "cooperation",
+    "trans": [
+      "32.6.19",
+      "n．合作",
+      "【记】 co+operation（操作）→一起做→合作"
+    ],
+    "ukphone": "koʊˌα:pəˋreIʃn",
+    "usphone": "koʊˌα:pəˋreIʃn"
+  },
+  {
+    "name": "fusion",
+    "trans": [
+      "32.6.20",
+      "n．联合（association）"
+    ],
+    "ukphone": "ˋfju:ʒn",
+    "usphone": "ˋfju:ʒn"
+  },
+  {
+    "name": "intimate",
+    "trans": [
+      "32.6.21",
+      "adj．亲密的 ［ˋIntImeIt］ vt．暗示"
+    ],
+    "ukphone": "ˋIntImət",
+    "usphone": "ˋIntImət"
+  },
+  {
+    "name": "intimacy",
+    "trans": [
+      "32.6.22",
+      "n．熟悉；亲近（proximity）",
+      "【记】 intim（内部）+acy→内部的→熟悉"
+    ],
+    "ukphone": "ˋIntIməsi",
+    "usphone": "ˋIntIməsi"
+  },
+  {
+    "name": "substitute",
+    "trans": [
+      "32.6.23",
+      "n．替代品（replacement）v．替代（replace）"
+    ],
+    "ukphone": "ˋsʌbstItju:t",
+    "usphone": "ˋsʌbstItju:t"
+  },
+  {
+    "name": "consensus",
+    "trans": [
+      "32.6.24",
+      "n．一致（unanimity）"
+    ],
+    "ukphone": "kənˋsensəs",
+    "usphone": "kənˋsensəs"
+  },
+  {
+    "name": "concurrence",
+    "trans": [
+      "32.6.25",
+      "n．一致"
+    ],
+    "ukphone": "kənˋkɜ:rəns",
+    "usphone": "kənˋkɜ:rəns"
+  },
+  {
+    "name": "impact",
+    "trans": [
+      "32.6.26",
+      "n．影响，作用（collision, force）v．对…发生影响"
+    ],
+    "ukphone": "ˋImpækt",
+    "usphone": "ˋImpækt"
+  },
+  {
+    "name": "link",
+    "trans": [
+      "32.6.27",
+      "n./v．链接（connect）"
+    ],
+    "ukphone": "lIŋk",
+    "usphone": "lIŋk"
+  },
+  {
+    "name": "proximity",
+    "trans": [
+      "32.6.28",
+      "n．接近，邻近（nearness）",
+      "【记】 proxim（接近）+ity"
+    ],
+    "ukphone": "prα:kˋsIməti",
+    "usphone": "prα:kˋsIməti"
+  },
+  {
+    "name": "band",
+    "trans": [
+      "32.6.29",
+      "v．联合，结合（form，group）"
+    ],
+    "ukphone": "bænd",
+    "usphone": "bænd"
+  },
+  {
+    "name": "collaborate",
+    "trans": [
+      "32.6.30",
+      "vi．合作（cooperate, work together）",
+      "【记】 col（共同）+labor（劳动）+ate→共同劳动→合作"
+    ],
+    "ukphone": "kəˋlæbəreIt",
+    "usphone": "kəˋlæbəreIt"
+  },
+  {
+    "name": "hinge",
+    "trans": [
+      "32.6.31",
+      "vi．依…而定（depend, rely）"
+    ],
+    "ukphone": "hIndʒ",
+    "usphone": "hIndʒ"
+  },
+  {
+    "name": "replenish",
+    "trans": [
+      "32.6.32",
+      "vt．补充（fill up, refill）",
+      "【记】 re（重新）+plen=plenty（多）+ish→重新变多→补充"
+    ],
+    "ukphone": "rIˋplenIʃ",
+    "usphone": "rIˋplenIʃ"
+  },
+  {
+    "name": "supplant",
+    "trans": [
+      "32.6.33",
+      "vt．排挤；取代（replace）"
+    ],
+    "ukphone": "səˋplænt",
+    "usphone": "səˋplænt"
+  },
+  {
+    "name": "implicate",
+    "trans": [
+      "32.6.34",
+      "vt．牵连（involve）"
+    ],
+    "ukphone": "ˋImplIkeIt",
+    "usphone": "ˋImplIkeIt"
+  },
+  {
+    "name": "displace",
+    "trans": [
+      "32.6.35",
+      "vt．取代（replace, substitute）",
+      "【记】 dis+place（位置）→取代（位置）"
+    ],
+    "ukphone": "dIsˋpleIs",
+    "usphone": "dIsˋpleIs"
+  },
+  {
+    "name": "supersede",
+    "trans": [
+      "32.6.36",
+      "vt．替代（replace, substitute）",
+      "【记】 super（上面）+sede（坐）→坐上→替代"
+    ],
+    "ukphone": "ˌsju:pərˋsi:d",
+    "usphone": "ˌsju:pərˋsi:d"
+  },
+  {
+    "name": "correlate",
+    "trans": [
+      "32.6.37",
+      "vt．相关联（associate, relate）",
+      "【记】 cor+relate（关联）"
+    ],
+    "ukphone": "ˋkɔ:rəleIt",
+    "usphone": "ˋkɔ:rəleIt"
+  },
+  {
+    "name": "grant",
+    "trans": [
+      "32.6.38",
+      "vt．赠予（award, give）"
+    ],
+    "ukphone": "grænt",
+    "usphone": "grænt"
+  },
+  {
+    "name": "subsidiary",
+    "trans": [
+      "32.6.39",
+      "adj．辅助的；附属的（supplementary）",
+      "【记】 sub（下面）+sidi（坐）+ary→坐在下面辅助的"
+    ],
+    "ukphone": "səbˋsIdieri",
+    "usphone": "səbˋsIdieri"
+  },
+  {
+    "name": "affinity",
+    "trans": [
+      "32.6.40",
+      "n．密切关系（liking）",
+      "【记】 af（一再）+fin（范围）+ity→一再能进别人范围→亲密"
+    ],
+    "ukphone": "əˋfInəti",
+    "usphone": "əˋfInəti"
+  },
+  {
+    "name": "fitting",
+    "trans": [
+      "32.6.41",
+      "adj．适合的，相称的",
+      "【记】 fit（合适）+ting"
+    ],
+    "ukphone": "ˋfItIŋ",
+    "usphone": "ˋfItIŋ"
+  },
+  {
+    "name": "sway",
+    "trans": [
+      "32.6.42",
+      "v．影响（persuade）"
+    ],
+    "ukphone": "sweI",
+    "usphone": "sweI"
+  },
+  {
+    "name": "affect",
+    "trans": [
+      "32.6.43",
+      "vt．影响；感动（influence, impress）",
+      "【记】 af（使）+fect（做）→使人做→影响"
+    ],
+    "ukphone": "əˋfekt",
+    "usphone": "əˋfekt"
+  },
+  {
+    "name": "derivative",
+    "trans": [
+      "32.6.44",
+      "n．派生的事物"
+    ],
+    "ukphone": "dIˋrIvətIv",
+    "usphone": "dIˋrIvətIv"
+  },
+  {
+    "name": "patronage",
+    "trans": [
+      "32.6.45",
+      "n．保护人的身份，保护；赞助；光顾"
+    ],
+    "ukphone": "ˋpætrənIdʒ",
+    "usphone": "ˋpætrənIdʒ"
+  },
+  {
+    "name": "unionization",
+    "trans": [
+      "32.6.46",
+      "n．联合，结合"
+    ],
+    "ukphone": "ˌju:niənəˋzeIʃn",
+    "usphone": "ˌju:niənəˋzeIʃn"
+  },
+  {
+    "name": "supplementary",
+    "trans": [
+      "32.6.47",
+      "adj．补足的，追加的，补充的（auxiliary, subsidiary）"
+    ],
+    "ukphone": "ˌsʌplIˋmentri",
+    "usphone": "ˌsʌplIˋmentri"
+  },
+  {
+    "name": "apparent",
+    "trans": [
+      "32.6.48",
+      "adj．显然的；表面上的"
+    ],
+    "ukphone": "əˋpærənt",
+    "usphone": "əˋpærənt"
+  },
+  {
+    "name": "haven",
+    "trans": [
+      "32.7.1",
+      "n．港口；避难所（shelter, refuge）",
+      "【记】 比较heaven（天堂，天空）"
+    ],
+    "ukphone": "ˋheIvn",
+    "usphone": "ˋheIvn"
+  },
+  {
+    "name": "refuge",
+    "trans": [
+      "32.7.2",
+      "n．避难所（shelter, protection）",
+      "【记】 re（回）+fuge（逃）→逃回去的（地方）→避难所"
+    ],
+    "ukphone": "ˋrefju:dʒ",
+    "usphone": "ˋrefju:dʒ"
+  },
+  {
+    "name": "depot",
+    "trans": [
+      "32.7.3",
+      "n．仓库（house）vt．把…存放在仓库里（contain）"
+    ],
+    "ukphone": "ˋdi:poʊ",
+    "usphone": "ˋdi:poʊ"
+  },
+  {
+    "name": "auditorium",
+    "trans": [
+      "32.7.4",
+      "n．大礼堂",
+      "【记】 audi（听）+t+orium（名词字尾，表示场所、地点）"
+    ],
+    "ukphone": "ˌɔ:dIˋtɔ:riəm",
+    "usphone": "ˌɔ:dIˋtɔ:riəm"
+  },
+  {
+    "name": "vault",
+    "trans": [
+      "32.7.5",
+      "n．拱形圆屋顶；地窖"
+    ],
+    "ukphone": "vɔ:lt",
+    "usphone": "vɔ:lt"
+  },
+  {
+    "name": "block",
+    "trans": [
+      "32.7.6",
+      "n．街区"
+    ],
+    "ukphone": "blα:k",
+    "usphone": "blα:k"
+  },
+  {
+    "name": "stall",
+    "trans": [
+      "32.7.7",
+      "n．厩；摊位（stable, barn）"
+    ],
+    "ukphone": "stɔ:l",
+    "usphone": "stɔ:l"
+  },
+  {
+    "name": "dormitory",
+    "trans": [
+      "32.7.8",
+      "n．宿舍"
+    ],
+    "ukphone": "ˋdɔ:rmətɔ:ri",
+    "usphone": "ˋdɔ:rmətɔ:ri"
+  },
+  {
+    "name": "tower",
+    "trans": [
+      "32.7.9",
+      "n．塔 v．屹立，高耸"
+    ],
+    "ukphone": "ˋtaʊər",
+    "usphone": "ˋtaʊər"
+  },
+  {
+    "name": "dwelling",
+    "trans": [
+      "32.7.10",
+      "n．住所（residence, shelter, accommodation）"
+    ],
+    "ukphone": "ˋdwelIŋ",
+    "usphone": "ˋdwelIŋ"
+  },
+  {
+    "name": "forge",
+    "trans": [
+      "32.7.11",
+      "n．铁匠铺"
+    ],
+    "ukphone": "fɔ:rdʒ",
+    "usphone": "fɔ:rdʒ"
+  },
+  {
+    "name": "canopy",
+    "trans": [
+      "32.7.12",
+      "n．天篷，遮篷"
+    ],
+    "ukphone": "ˋkænəpi",
+    "usphone": "ˋkænəpi"
+  },
+  {
+    "name": "laborious",
+    "trans": [
+      "32.8.1",
+      "adj．费力的，艰难的（arduous, painstaking）",
+      "【记】 labor（劳动）+ious（的）→劳动的，苦的"
+    ],
+    "ukphone": "ləˋbɔ:riəs",
+    "usphone": "ləˋbɔ:riəs"
+  },
+  {
+    "name": "precipitous",
+    "trans": [
+      "32.8.2",
+      "adj．陡峭的（sheer, extremely steep）；急躁的"
+    ],
+    "ukphone": "prIˋsIpItəs",
+    "usphone": "prIˋsIpItəs"
+  },
+  {
+    "name": "devious",
+    "trans": [
+      "32.8.3",
+      "adj．曲折的（circuitous）"
+    ],
+    "ukphone": "ˋdi:viəs",
+    "usphone": "ˋdi:viəs"
+  },
+  {
+    "name": "arduous",
+    "trans": [
+      "32.8.4",
+      "adj．险峻的，困难的（difficult, strenuous, laborious, back-breaking）",
+      "【记】 ardu（高，险）+ous"
+    ],
+    "ukphone": "ˋα:rdʒuəs",
+    "usphone": "ˋα:rdʒuəs"
+  },
+  {
+    "name": "strenuous",
+    "trans": [
+      "32.8.5",
+      "adj．辛苦的（energetic, laborious）"
+    ],
+    "ukphone": "ˋstrenjuəs",
+    "usphone": "ˋstrenjuəs"
+  },
+  {
+    "name": "plight",
+    "trans": [
+      "32.8.6",
+      "n.（恶劣的）情势，困境（predicament, dilemma）"
+    ],
+    "ukphone": "plaIt",
+    "usphone": "plaIt"
+  },
+  {
+    "name": "strait",
+    "trans": [
+      "32.8.7",
+      "n．困难"
+    ],
+    "ukphone": "streIt",
+    "usphone": "streIt"
+  },
+  {
+    "name": "painstaking",
+    "trans": [
+      "32.8.8",
+      "n．辛劳 adj．劳苦的（careful, scrupulous）",
+      "【记】 pains（痛苦）+taking（花，费）→付出痛苦的→劳苦的"
+    ],
+    "ukphone": "ˋpeInzteIkIŋ",
+    "usphone": "ˋpeInzteIkIŋ"
+  },
+  {
+    "name": "dilemma",
+    "trans": [
+      "32.8.9",
+      "n．左右为难，困境"
+    ],
+    "ukphone": "dIˋlemə",
+    "usphone": "dIˋlemə"
+  },
+  {
+    "name": "flounder",
+    "trans": [
+      "32.8.10",
+      "vi．挣扎",
+      "【记】 另一个意思是“比目鱼”"
+    ],
+    "ukphone": "ˋflaʊndər",
+    "usphone": "ˋflaʊndər"
+  },
+  {
+    "name": "embarrass",
+    "trans": [
+      "32.8.11",
+      "vt．使困窘"
+    ],
+    "ukphone": "Imˋbærəs",
+    "usphone": "Imˋbærəs"
+  },
+  {
+    "name": "fashionable",
+    "trans": [
+      "32.9.1",
+      "adj．流行的，时髦的（popular）",
+      "【记】 fashion（时髦）+able"
+    ],
+    "ukphone": "ˋfæʃnəbl",
+    "usphone": "ˋfæʃnəbl"
+  },
+  {
+    "name": "prevail",
+    "trans": [
+      "32.9.2",
+      "vi．流行，盛行（dominate）"
+    ],
+    "ukphone": "prIˋveIl",
+    "usphone": "prIˋveIl"
+  },
+  {
+    "name": "prevalent",
+    "trans": [
+      "32.9.3",
+      "adj．普遍的，流行的（prevailing, widespread, popular）"
+    ],
+    "ukphone": "ˋprevələnt",
+    "usphone": "ˋprevələnt"
+  },
+  {
+    "name": "tide",
+    "trans": [
+      "32.9.4",
+      "n．潮流"
+    ],
+    "ukphone": "taId",
+    "usphone": "taId"
+  },
+  {
+    "name": "vogue",
+    "trans": [
+      "32.9.5",
+      "n．流行（fashion）"
+    ],
+    "ukphone": "voʊg",
+    "usphone": "voʊg"
+  },
+  {
+    "name": "novelty",
+    "trans": [
+      "32.9.6",
+      "n．新颖；新奇的事物（newness, unusualness）",
+      "【记】 novel（新）+ty"
+    ],
+    "ukphone": "ˋnα:vlti",
+    "usphone": "ˋnα:vlti"
+  },
+  {
+    "name": "gorgeous",
+    "trans": [
+      "32.10.1",
+      "adj．极好的",
+      "【记】 参考gorge（峡谷）"
+    ],
+    "ukphone": "ˋgɔ:rdʒəs",
+    "usphone": "ˋgɔ:rdʒəs"
+  },
+  {
+    "name": "outstanding",
+    "trans": [
+      "32.10.2",
+      "adj．杰出的",
+      "【记】 来自stand out（醒目，突出）"
+    ],
+    "ukphone": "aʊtˋstændIŋ",
+    "usphone": "aʊtˋstændIŋ"
+  },
+  {
+    "name": "obscure",
+    "trans": [
+      "32.10.3",
+      "adj．无名气的（unknown, inconspicuous）"
+    ],
+    "ukphone": "əbˋskjʊr",
+    "usphone": "əbˋskjʊr"
+  },
+  {
+    "name": "immortal",
+    "trans": [
+      "32.10.4",
+      "adj．不朽的（undying, everlasting）",
+      "【记】 im（不）+mort（死）+al"
+    ],
+    "ukphone": "Iˋmɔ:rtl",
+    "usphone": "Iˋmɔ:rtl"
+  },
+  {
+    "name": "notorious",
+    "trans": [
+      "32.10.5",
+      "adj．臭名昭著的（infamous）",
+      "【记】 not（知道）+orious（多）→臭名昭著的"
+    ],
+    "ukphone": "noʊˋtɔ:riəs",
+    "usphone": "noʊˋtɔ:riəs"
+  },
+  {
+    "name": "infamous",
+    "trans": [
+      "32.10.6",
+      "adj．臭名昭著的（notorious, disgraceful）",
+      "【记】 in（不）+famous（著名的）"
+    ],
+    "ukphone": "ˋInfəməs",
+    "usphone": "ˋInfəməs"
+  },
+  {
+    "name": "legendary",
+    "trans": [
+      "32.10.7",
+      "adj．传奇的（renowned, famed）",
+      "【记】 legend（传奇）+ary"
+    ],
+    "ukphone": "ˋledʒənderi",
+    "usphone": "ˋledʒənderi"
+  },
+  {
+    "name": "glorious",
+    "trans": [
+      "32.10.8",
+      "adj．光荣的"
+    ],
+    "ukphone": "ˋglɔ:riəs",
+    "usphone": "ˋglɔ:riəs"
+  },
+  {
+    "name": "illustrious",
+    "trans": [
+      "32.10.9",
+      "adj．辉煌的；著名的（famous, distinguished）",
+      "【记】 il（一再）+lustr（光）+ious→一再光明→辉煌的"
+    ],
+    "ukphone": "Iˋlʌstriəs",
+    "usphone": "Iˋlʌstriəs"
+  },
+  {
+    "name": "eminent",
+    "trans": [
+      "32.10.10",
+      "adj．杰出的（outstanding, distinguished）",
+      "【记】 e（出）+min（伸）+ent→伸出的→突出的"
+    ],
+    "ukphone": "ˋemInənt",
+    "usphone": "ˋemInənt"
+  },
+  {
+    "name": "deferential",
+    "trans": [
+      "32.10.11",
+      "adj．充满敬意的（respectful, dutiful）"
+    ],
+    "ukphone": "ˌdefəˋrenʃl",
+    "usphone": "ˌdefəˋrenʃl"
+  },
+  {
+    "name": "exemplary",
+    "trans": [
+      "32.10.12",
+      "adj．模范的，典范的"
+    ],
+    "ukphone": "Igˋzempləri",
+    "usphone": "Igˋzempləri"
+  },
+  {
+    "name": "matchless",
+    "trans": [
+      "32.10.13",
+      "adj．无与伦比的（unbeatable, incomparable）",
+      "【记】 match（相配的）+less"
+    ],
+    "ukphone": "ˋmætʃləs",
+    "usphone": "ˋmætʃləs"
+  },
+  {
+    "name": "excel",
+    "trans": [
+      "32.10.14",
+      "v．优秀，胜过他人（superior, surpass, exceed）"
+    ],
+    "ukphone": "Ikˋsel",
+    "usphone": "Ikˋsel"
+  },
+  {
+    "name": "excellent",
+    "trans": [
+      "32.10.15",
+      "adj．优秀的，杰出的（outstanding, preeminent）"
+    ],
+    "ukphone": "ˋeksələnt",
+    "usphone": "ˋeksələnt"
+  },
+  {
+    "name": "compliment",
+    "trans": [
+      "32.10.16",
+      "（praise, commend）vt．赞美，祝贺"
+    ],
+    "ukphone": "ˋkα:mplImənt",
+    "usphone": "ˋkα:mplImənt"
+  },
+  {
+    "name": "complimentary",
+    "trans": [
+      "32.10.17",
+      "adj．赞美的（praising）"
+    ],
+    "ukphone": "ˌkα:mplIˋmentri",
+    "usphone": "ˌkα:mplIˋmentri"
+  },
+  {
+    "name": "renowned",
+    "trans": [
+      "32.10.18",
+      "adj．知名的（acclaimed, distinguished, famous）",
+      "【记】 re（重新）+nown（名字）+ed→名字一再出现→知名的"
+    ],
+    "ukphone": "rIˋnaʊnd",
+    "usphone": "rIˋnaʊnd"
+  },
+  {
+    "name": "laudable",
+    "trans": [
+      "32.10.19",
+      "adj．值得赞美的（praiseworthy, commendable）"
+    ],
+    "ukphone": "ˋlɔ:dəbl",
+    "usphone": "ˋlɔ:dəbl"
+  },
+  {
+    "name": "supreme",
+    "trans": [
+      "32.10.20",
+      "adj．至高的（highest, greatest）"
+    ],
+    "ukphone": "su:ˋpri:m",
+    "usphone": "su:ˋpri:m"
+  },
+  {
+    "name": "celebrate",
+    "trans": [
+      "32.10.21",
+      "vt．赞扬，表扬（praise）"
+    ],
+    "ukphone": "ˋselIbreIt",
+    "usphone": "ˋselIbreIt"
+  },
+  {
+    "name": "celebrated",
+    "trans": [
+      "32.10.22",
+      "adj．著名的（distinguished, famous）"
+    ],
+    "ukphone": "ˋselIbreItId",
+    "usphone": "ˋselIbreItId"
+  },
+  {
+    "name": "notable",
+    "trans": [
+      "32.10.23",
+      "adj．著名的，显要的（distinguished, celebrated）",
+      "【记】 not（知道）+able→大家都知道的→著名的"
+    ],
+    "ukphone": "ˋnoʊtəbl",
+    "usphone": "ˋnoʊtəbl"
+  },
+  {
+    "name": "noted",
+    "trans": [
+      "32.10.24",
+      "adj．著名的，知名的（distinguished, celebrated）"
+    ],
+    "ukphone": "ˋnoʊtId",
+    "usphone": "ˋnoʊtId"
+  },
+  {
+    "name": "exceptional",
+    "trans": [
+      "32.10.25",
+      "adj．卓越的（extraordinary）"
+    ],
+    "ukphone": "Ikˋsepʃənl",
+    "usphone": "Ikˋsepʃənl"
+  },
+  {
+    "name": "preeminent",
+    "trans": [
+      "32.10.26",
+      "adj．卓越的（prominent, outstanding）",
+      "【记】 pre（前）+eminent（突出的）→向前突出→杰出的"
+    ],
+    "ukphone": "ˌpri:ˋemInənt",
+    "usphone": "ˌpri:ˋemInənt"
+  },
+  {
+    "name": "prominent",
+    "trans": [
+      "32.10.27",
+      "adj．卓越的，突出的（conspicuous, protruding）",
+      "【记】 pro（前）+minent（伸）→突出的"
+    ],
+    "ukphone": "ˋprα:mInənt",
+    "usphone": "ˋprα:mInənt"
+  },
+  {
+    "name": "dignify",
+    "trans": [
+      "32.10.28",
+      "vt．使尊荣，使显贵（ennoble, elevate）"
+    ],
+    "ukphone": "ˋdIgnIfaI",
+    "usphone": "ˋdIgnIfaI"
+  },
+  {
+    "name": "dignified",
+    "trans": [
+      "32.10.29",
+      "adj．尊严的；高贵的（noble）"
+    ],
+    "ukphone": "ˋdIgnIfaId",
+    "usphone": "ˋdIgnIfaId"
+  },
+  {
+    "name": "dignity",
+    "trans": [
+      "32.10.30",
+      "n．尊严"
+    ],
+    "ukphone": "ˋdIgnəti",
+    "usphone": "ˋdIgnəti"
+  },
+  {
+    "name": "lofty",
+    "trans": [
+      "32.10.31",
+      "adj．高尚的",
+      "【记】 loft（阁楼，顶楼）+y"
+    ],
+    "ukphone": "ˋlɔ:fti",
+    "usphone": "ˋlɔ:fti"
+  },
+  {
+    "name": "odor",
+    "trans": [
+      "32.10.32",
+      "n．名声（fame）"
+    ],
+    "ukphone": "ˋoʊdər",
+    "usphone": "ˋoʊdər"
+  },
+  {
+    "name": "credit",
+    "trans": [
+      "32.10.33",
+      "n．信誉（trust, credence）"
+    ],
+    "ukphone": "ˋkredIt",
+    "usphone": "ˋkredIt"
+  },
+  {
+    "name": "feat",
+    "trans": [
+      "32.10.34",
+      "n．功绩，壮举（achievement, accomplishment）"
+    ],
+    "ukphone": "fi:t",
+    "usphone": "fi:t"
+  },
+  {
+    "name": "homage",
+    "trans": [
+      "32.10.35",
+      "n．敬意（respect, reverence）",
+      "【记】 hom（人）+age→把对方当人看"
+    ],
+    "ukphone": "ˋhα:mIdʒ",
+    "usphone": "ˋhα:mIdʒ"
+  },
+  {
+    "name": "deference",
+    "trans": [
+      "32.10.36",
+      "n．敬意",
+      "【记】 defer（服从，敬意）+ence"
+    ],
+    "ukphone": "ˋdefərəns",
+    "usphone": "ˋdefərəns"
+  },
+  {
+    "name": "virtue",
+    "trans": [
+      "32.10.37",
+      "n．美德（morality, goodness）"
+    ],
+    "ukphone": "ˋvɜ:rtʃu:",
+    "usphone": "ˋvɜ:rtʃu:"
+  },
+  {
+    "name": "prestige",
+    "trans": [
+      "32.10.38",
+      "n．威望，声望（fame, reputation）"
+    ],
+    "ukphone": "preˋsti:ʒ",
+    "usphone": "preˋsti:ʒ"
+  },
+  {
+    "name": "grandeur",
+    "trans": [
+      "32.10.39",
+      "n．庄严，伟大（magnificence）"
+    ],
+    "ukphone": "ˋgrændʒər",
+    "usphone": "ˋgrændʒər"
+  },
+  {
+    "name": "reverence",
+    "trans": [
+      "32.10.40",
+      "n．尊敬（respect, veneration）"
+    ],
+    "ukphone": "ˋrevərəns",
+    "usphone": "ˋrevərəns"
+  },
+  {
+    "name": "awe",
+    "trans": [
+      "32.10.41",
+      "n./vt．敬畏（reverence, veneration; dread）"
+    ],
+    "ukphone": "ɔ:",
+    "usphone": "ɔ:"
+  },
+  {
+    "name": "esteem",
+    "trans": [
+      "32.10.42",
+      "n./vt．尊敬（respect）"
+    ],
+    "ukphone": "Iˋsti:m",
+    "usphone": "Iˋsti:m"
+  },
+  {
+    "name": "commend",
+    "trans": [
+      "32.10.43",
+      "v．赞扬（praise）",
+      "【记】 com+mend（相信）→都信→赞扬"
+    ],
+    "ukphone": "kəˋmend",
+    "usphone": "kəˋmend"
+  },
+  {
+    "name": "exalt",
+    "trans": [
+      "32.10.44",
+      "vt．称赞；提升（extol, laud; promote）",
+      "【记】 ex+alt（高）→使高出→赞扬"
+    ],
+    "ukphone": "Igˋzɔ:lt",
+    "usphone": "Igˋzɔ:lt"
+  },
+  {
+    "name": "exalted",
+    "trans": [
+      "32.10.45",
+      "adj．尊贵的（noble）"
+    ],
+    "ukphone": "Igˋzɔ:ltId",
+    "usphone": "Igˋzɔ:ltId"
+  },
+  {
+    "name": "venerate",
+    "trans": [
+      "32.10.46",
+      "vt．敬拜，崇拜（respect, revere）"
+    ],
+    "ukphone": "ˋvenəreIt",
+    "usphone": "ˋvenəreIt"
+  },
+  {
+    "name": "embalm",
+    "trans": [
+      "32.10.47",
+      "vt．使不朽"
+    ],
+    "ukphone": "Imˋbα:m",
+    "usphone": "Imˋbα:m"
+  },
+  {
+    "name": "tarnish",
+    "trans": [
+      "32.10.48",
+      "vt．使晦暗，败坏（名誉）（darken, lose luster）"
+    ],
+    "ukphone": "ˋtα:rnIʃ",
+    "usphone": "ˋtα:rnIʃ"
+  },
+  {
+    "name": "extol",
+    "trans": [
+      "32.10.49",
+      "vt．颂扬（exalt）",
+      "【记】 ex+tol（举）→推举出→颂扬"
+    ],
+    "ukphone": "Ikˋstoʊl",
+    "usphone": "Ikˋstoʊl"
+  },
+  {
+    "name": "laud",
+    "trans": [
+      "32.10.50",
+      "vt．赞美（compliment, praise）",
+      "【记】 比较laurel（桂冠，月桂树）"
+    ],
+    "ukphone": "lɔ:d",
+    "usphone": "lɔ:d"
+  },
+  {
+    "name": "revere",
+    "trans": [
+      "32.10.51",
+      "vt．尊敬（respect, worship）"
+    ],
+    "ukphone": "rIˋvIr",
+    "usphone": "rIˋvIr"
+  },
+  {
+    "name": "admirable",
+    "trans": [
+      "32.10.52",
+      "adj．可敬的，极好的（redoubted, wonderful）"
+    ],
+    "ukphone": "ˋædmərəbl",
+    "usphone": "ˋædmərəbl"
+  },
+  {
+    "name": "disreputable",
+    "trans": [
+      "32.10.53",
+      "adj．声名狼藉的（notorious）",
+      "【记】 dis+reputable（有声望的）"
+    ],
+    "ukphone": "dIsˋrepjətəbl",
+    "usphone": "dIsˋrepjətəbl"
+  },
+  {
+    "name": "classic",
+    "trans": [
+      "32.10.54",
+      "adj．第一流的"
+    ],
+    "ukphone": "ˋklæsIk",
+    "usphone": "ˋklæsIk"
+  },
+  {
+    "name": "respect",
+    "trans": [
+      "32.10.55",
+      "n./vt．尊重，敬重（admire, esteem, honor）"
+    ],
+    "ukphone": "rIˋspekt",
+    "usphone": "rIˋspekt"
+  },
+  {
+    "name": "adore",
+    "trans": [
+      "32.10.56",
+      "vt．敬爱，极喜爱（admire, love, esteem）",
+      "【记】 ad+ore（讲话）→说好听的话"
+    ],
+    "ukphone": "əˋdɔ:r",
+    "usphone": "əˋdɔ:r"
+  },
+  {
+    "name": "admire",
+    "trans": [
+      "32.10.57",
+      "vt．钦佩（respect）；赞美，夸奖",
+      "【记】 ad（一再）+mire（高兴）→一再让人惊喜"
+    ],
+    "ukphone": "ədˋmaIr",
+    "usphone": "ədˋmaIr"
+  },
+  {
+    "name": "advocate",
+    "trans": [
+      "32.10.58",
+      "vt．拥护（hold, maintain）"
+    ],
+    "ukphone": "ˋædvəkeIt",
+    "usphone": "ˋædvəkeIt"
+  },
+  {
+    "name": "hilarious",
+    "trans": [
+      "32.11.1",
+      "adj．热闹的"
+    ],
+    "ukphone": "hIˋleriəs",
+    "usphone": "hIˋleriəs"
+  },
+  {
+    "name": "sullen",
+    "trans": [
+      "32.11.2",
+      "adj．阴沉的（moody, bad-tempered）"
+    ],
+    "ukphone": "ˋsʌlən",
+    "usphone": "ˋsʌlən"
+  },
+  {
+    "name": "hilarity",
+    "trans": [
+      "32.11.3",
+      "n．欢闹"
+    ],
+    "ukphone": "hIˋlærəti",
+    "usphone": "hIˋlærəti"
+  },
+  {
+    "name": "aura",
+    "trans": [
+      "32.11.4",
+      "n．气氛（atmosphere, mood）"
+    ],
+    "ukphone": "ˋɔ:rə",
+    "usphone": "ˋɔ:rə"
+  },
+  {
+    "name": "formal",
+    "trans": [
+      "32.12.1",
+      "adj．正式的；礼仪上的",
+      "【记】 informal（非正式的）"
+    ],
+    "ukphone": "ˋfɔ:rml",
+    "usphone": "ˋfɔ:rml"
+  },
+  {
+    "name": "session",
+    "trans": [
+      "32.12.2",
+      "n．会议（meeting）"
+    ],
+    "ukphone": "ˋseʃn",
+    "usphone": "ˋseʃn"
+  },
+  {
+    "name": "conference",
+    "trans": [
+      "32.12.3",
+      "n．会议，讨论会"
+    ],
+    "ukphone": "ˋkα:nfərəns",
+    "usphone": "ˋkα:nfərəns"
+  },
+  {
+    "name": "reception",
+    "trans": [
+      "32.12.4",
+      "n．接待；招待会"
+    ],
+    "ukphone": "rIˋsepʃn",
+    "usphone": "rIˋsepʃn"
+  },
+  {
+    "name": "etiquette",
+    "trans": [
+      "32.12.5",
+      "n．礼节",
+      "【记】 e+tiquette=ticket（票）→凭票入场→礼仪"
+    ],
+    "ukphone": "ˋetIkət",
+    "usphone": "ˋetIkət"
+  },
+  {
+    "name": "decorum",
+    "trans": [
+      "32.12.6",
+      "n．礼仪（ceremony）",
+      "【记】 decor（美）+um"
+    ],
+    "ukphone": "dIˋkɔ:rəm",
+    "usphone": "dIˋkɔ:rəm"
+  },
+  {
+    "name": "banquet",
+    "trans": [
+      "32.12.7",
+      "n．宴会，盛会（feast）"
+    ],
+    "ukphone": "ˋbæŋkwIt",
+    "usphone": "ˋbæŋkwIt"
+  },
+  {
+    "name": "bidding",
+    "trans": [
+      "32.12.8",
+      "n．邀请"
+    ],
+    "ukphone": "ˋbIdIŋ",
+    "usphone": "ˋbIdIŋ"
+  },
+  {
+    "name": "ceremony",
+    "trans": [
+      "32.12.9",
+      "n．仪式"
+    ],
+    "ukphone": "ˋserəmoʊni",
+    "usphone": "ˋserəmoʊni"
+  },
+  {
+    "name": "ceremonial",
+    "trans": [
+      "32.12.10",
+      "n./adj．仪式；正式的"
+    ],
+    "ukphone": "ˌserIˋmoʊniəl",
+    "usphone": "ˌserIˋmoʊniəl"
+  },
+  {
+    "name": "ceremonious",
+    "trans": [
+      "32.12.11",
+      "adj．隆重的；正式的，恭敬的（formal, solemn）"
+    ],
+    "ukphone": "ˌserəˋmoʊniəs",
+    "usphone": "ˌserəˋmoʊniəs"
+  },
+  {
+    "name": "unveil",
+    "trans": [
+      "32.12.12",
+      "v．开幕",
+      "【记】 un（不）+veil（罩面纱）→揭开"
+    ],
+    "ukphone": "ˌʌnˋveIl",
+    "usphone": "ˌʌnˋveIl"
+  },
+  {
+    "name": "celebrate",
+    "trans": [
+      "32.12.13",
+      "vi．庆祝"
+    ],
+    "ukphone": "ˋselIbreIt",
+    "usphone": "ˋselIbreIt"
+  },
+  {
+    "name": "entertain",
+    "trans": [
+      "32.12.14",
+      "vt．招待；娱乐（amuse）"
+    ],
+    "ukphone": "ˌentərˋteIn",
+    "usphone": "ˌentərˋteIn"
+  },
+  {
+    "name": "sleigh",
+    "trans": [
+      "32.12.15",
+      "v．乘/驾雪橇 n．雪橇"
+    ],
+    "ukphone": "sleI",
+    "usphone": "sleI"
+  },
+  {
+    "name": "glaring",
+    "trans": [
+      "32.13.1",
+      "adj．瞪眼的",
+      "【记】 参考glare（瞪）"
+    ],
+    "ukphone": "ˋglerIŋ",
+    "usphone": "ˋglerIŋ"
+  },
+  {
+    "name": "grip",
+    "trans": [
+      "32.13.2",
+      "n．紧握（grasp, clasp）"
+    ],
+    "ukphone": "grIp",
+    "usphone": "grIp"
+  },
+  {
+    "name": "posture",
+    "trans": [
+      "32.13.3",
+      "n．人体的姿势（pose, bearing）"
+    ],
+    "ukphone": "ˋpα:stʃər",
+    "usphone": "ˋpα:stʃər"
+  },
+  {
+    "name": "grasp",
+    "trans": [
+      "32.13.4",
+      "n./v．抓紧"
+    ],
+    "ukphone": "græsp",
+    "usphone": "græsp"
+  },
+  {
+    "name": "jerk",
+    "trans": [
+      "32.13.5",
+      "n./v．急拉；抽搐"
+    ],
+    "ukphone": "dʒɜ:rk",
+    "usphone": "dʒɜ:rk"
+  },
+  {
+    "name": "chuckle",
+    "trans": [
+      "32.13.6",
+      "n./vi．咯咯的/地笑"
+    ],
+    "ukphone": "ˋtʃʌkl",
+    "usphone": "ˋtʃʌkl"
+  },
+  {
+    "name": "flip",
+    "trans": [
+      "32.13.7",
+      "v．翻滚（overturn）；（用手指）弹，投"
+    ],
+    "ukphone": "flIp",
+    "usphone": "flIp"
+  },
+  {
+    "name": "stagger",
+    "trans": [
+      "32.13.8",
+      "v.（使）蹒跚"
+    ],
+    "ukphone": "ˋstægər",
+    "usphone": "ˋstægər"
+  },
+  {
+    "name": "trudge",
+    "trans": [
+      "32.13.9",
+      "v．跋涉，吃力地走（plod, trek）"
+    ],
+    "ukphone": "trʌdʒ",
+    "usphone": "trʌdʒ"
+  },
+  {
+    "name": "fasten",
+    "trans": [
+      "32.13.10",
+      "v．扣牢，抓住（affix, attach）"
+    ],
+    "ukphone": "ˋfæsn",
+    "usphone": "ˋfæsn"
+  },
+  {
+    "name": "hurl",
+    "trans": [
+      "32.13.11",
+      "v．猛投；猛冲（throw, fling）"
+    ],
+    "ukphone": "hɜ:rl",
+    "usphone": "hɜ:rl"
+  },
+  {
+    "name": "face",
+    "trans": [
+      "32.13.12",
+      "v．面对（confront）"
+    ],
+    "ukphone": "feIs",
+    "usphone": "feIs"
+  },
+  {
+    "name": "leap",
+    "trans": [
+      "32.13.13",
+      "v．跳跃（jump）",
+      "【记】 hop 单脚跳，skip跨步跳，jump双脚跳，leap飞跃（多用于比喻义中的跳）"
+    ],
+    "ukphone": "li:p",
+    "usphone": "li:p"
+  },
+  {
+    "name": "bow",
+    "trans": [
+      "32.13.14",
+      "v．弯腰，屈服"
+    ],
+    "ukphone": "baʊ",
+    "usphone": "baʊ"
+  },
+  {
+    "name": "blink",
+    "trans": [
+      "32.13.15",
+      "v．眨眼（wink）"
+    ],
+    "ukphone": "blIŋk",
+    "usphone": "blIŋk"
+  },
+  {
+    "name": "erect",
+    "trans": [
+      "32.13.16",
+      "v．直立（straight）",
+      "【记】 e+rect（立，竖）"
+    ],
+    "ukphone": "Iˋrekt",
+    "usphone": "Iˋrekt"
+  },
+  {
+    "name": "trample",
+    "trans": [
+      "32.13.17",
+      "v./n．践踏，蹂躏（tread, crush）",
+      "【记】 tramp（踩踏）+le"
+    ],
+    "ukphone": "ˋtræmpl",
+    "usphone": "ˋtræmpl"
+  },
+  {
+    "name": "tremble",
+    "trans": [
+      "32.13.18",
+      "vi．发抖；摇晃（shake, shiver）"
+    ],
+    "ukphone": "ˋtrembl",
+    "usphone": "ˋtrembl"
+  },
+  {
+    "name": "glide",
+    "trans": [
+      "32.13.19",
+      "vi．滑动；溜走"
+    ],
+    "ukphone": "glaId",
+    "usphone": "glaId"
+  },
+  {
+    "name": "depart",
+    "trans": [
+      "32.13.20",
+      "vi．离开，出发（leave, set off）",
+      "【记】 de+part（离开）"
+    ],
+    "ukphone": "dIˋpα:rt",
+    "usphone": "dIˋpα:rt"
+  },
+  {
+    "name": "slump",
+    "trans": [
+      "32.13.21",
+      "vi．猛然落下（drop, lapse）"
+    ],
+    "ukphone": "slʌmp",
+    "usphone": "slʌmp"
+  },
+  {
+    "name": "gaze",
+    "trans": [
+      "32.13.22",
+      "vi．凝视（stare）"
+    ],
+    "ukphone": "geIz",
+    "usphone": "geIz"
+  },
+  {
+    "name": "creep",
+    "trans": [
+      "32.13.23",
+      "vi．爬，蹑手蹑脚（crawl, move slowly）"
+    ],
+    "ukphone": "kri:p",
+    "usphone": "kri:p"
+  },
+  {
+    "name": "limp",
+    "trans": [
+      "32.13.24",
+      "vi．蹒跚；瘸着走",
+      "【记】 比较limb（四肢）"
+    ],
+    "ukphone": "lImp",
+    "usphone": "lImp"
+  },
+  {
+    "name": "sigh",
+    "trans": [
+      "32.13.25",
+      "vi./n．叹息"
+    ],
+    "ukphone": "saI",
+    "usphone": "saI"
+  },
+  {
+    "name": "recoil",
+    "trans": [
+      "32.13.26",
+      "vi./n．后退，退缩（retreat, withdraw）"
+    ],
+    "ukphone": "rIˋkɔIl",
+    "usphone": "rIˋkɔIl"
+  },
+  {
+    "name": "uphold",
+    "trans": [
+      "32.13.27",
+      "vt．举起；支撑（support, sustain）",
+      "【记】 来自hold up（举起）"
+    ],
+    "ukphone": "ʌpˋhoʊld",
+    "usphone": "ʌpˋhoʊld"
+  },
+  {
+    "name": "grab",
+    "trans": [
+      "32.13.28",
+      "vt．攫取，抓住（snatch, rob）"
+    ],
+    "ukphone": "græb",
+    "usphone": "græb"
+  },
+  {
+    "name": "stride",
+    "trans": [
+      "32.13.29",
+      "vt．跨越（step, pace）"
+    ],
+    "ukphone": "straId",
+    "usphone": "straId"
+  },
+  {
+    "name": "thrust",
+    "trans": [
+      "32.13.30",
+      "vt．力推（push, shove）"
+    ],
+    "ukphone": "θrʌst",
+    "usphone": "θrʌst"
+  },
+  {
+    "name": "gnaw",
+    "trans": [
+      "32.13.31",
+      "vt．啮（bite）"
+    ],
+    "ukphone": "nɔ:",
+    "usphone": "nɔ:"
+  },
+  {
+    "name": "spew",
+    "trans": [
+      "32.13.32",
+      "vt．呕吐（eject, gush）"
+    ],
+    "ukphone": "spju:",
+    "usphone": "spju:"
+  },
+  {
+    "name": "dab",
+    "trans": [
+      "32.13.33",
+      "vt．轻拍"
+    ],
+    "ukphone": "dæb",
+    "usphone": "dæb"
+  },
+  {
+    "name": "plunge",
+    "trans": [
+      "32.13.34",
+      "v．投入（dive, sink）"
+    ],
+    "ukphone": "plʌndʒ",
+    "usphone": "plʌndʒ"
+  },
+  {
+    "name": "dart",
+    "trans": [
+      "32.13.35",
+      "vt．投掷（hurl, throw）"
+    ],
+    "ukphone": "dα:rt",
+    "usphone": "dα:rt"
+  },
+  {
+    "name": "shove",
+    "trans": [
+      "32.13.36",
+      "vt．推挤（push, jostle）"
+    ],
+    "ukphone": "ʃʌv",
+    "usphone": "ʃʌv"
+  },
+  {
+    "name": "drag",
+    "trans": [
+      "32.13.37",
+      "vt．拖动（tow）"
+    ],
+    "ukphone": "dræg",
+    "usphone": "dræg"
+  },
+  {
+    "name": "haul",
+    "trans": [
+      "32.13.38",
+      "vt．拖曳；拖运（drag, transport, pull）"
+    ],
+    "ukphone": "hɔ:l",
+    "usphone": "hɔ:l"
+  },
+  {
+    "name": "shake",
+    "trans": [
+      "32.13.39",
+      "vt．摇；震动"
+    ],
+    "ukphone": "ʃeIk",
+    "usphone": "ʃeIk"
+  },
+  {
+    "name": "jolt",
+    "trans": [
+      "32.13.40",
+      "vt．摇动（shake, jar）"
+    ],
+    "ukphone": "dʒoʊlt",
+    "usphone": "dʒoʊlt"
+  },
+  {
+    "name": "embrace",
+    "trans": [
+      "32.13.41",
+      "vt．拥抱（hug, cuddle）"
+    ],
+    "ukphone": "ImˋbreIs",
+    "usphone": "ImˋbreIs"
+  },
+  {
+    "name": "heave",
+    "trans": [
+      "32.13.42",
+      "vt．用力举起；拖（lift, fling）",
+      "【记】 参考heaven（天空）去掉“n”"
+    ],
+    "ukphone": "hi:v",
+    "usphone": "hi:v"
+  },
+  {
+    "name": "slap",
+    "trans": [
+      "32.13.43",
+      "vt．掌击，拍（clap, blow）"
+    ],
+    "ukphone": "slæp",
+    "usphone": "slæp"
+  },
+  {
+    "name": "clutch",
+    "trans": [
+      "32.13.44",
+      "vt．抓住 vi．掌握，攫（grab, grip）"
+    ],
+    "ukphone": "klʌtʃ",
+    "usphone": "klʌtʃ"
+  },
+  {
+    "name": "flush",
+    "trans": [
+      "32.13.45",
+      "n./v．脸红",
+      "【记】 比较blush（脸红）"
+    ],
+    "ukphone": "flʌʃ",
+    "usphone": "flʌʃ"
+  },
+  {
+    "name": "sprawl",
+    "trans": [
+      "32.13.46",
+      "v．伸开手脚（stretch）",
+      "【记】 比较crawl（爬）"
+    ],
+    "ukphone": "sprɔ:l",
+    "usphone": "sprɔ:l"
+  },
+  {
+    "name": "sway",
+    "trans": [
+      "32.13.47",
+      "v．摇摆"
+    ],
+    "ukphone": "sweI",
+    "usphone": "sweI"
+  },
+  {
+    "name": "spring",
+    "trans": [
+      "32.13.48",
+      "v．跳跃"
+    ],
+    "ukphone": "sprIŋ",
+    "usphone": "sprIŋ"
+  },
+  {
+    "name": "footbeat",
+    "trans": [
+      "32.13.49",
+      "n．跺脚"
+    ],
+    "ukphone": "ˋfʊtbi:t",
+    "usphone": "ˋfʊtbi:t"
+  },
+  {
+    "name": "industrial",
+    "trans": [
+      "32.14.1",
+      "adj．工业的"
+    ],
+    "ukphone": "Inˋdʌstriəl",
+    "usphone": "Inˋdʌstriəl"
+  },
+  {
+    "name": "practical",
+    "trans": [
+      "32.14.2",
+      "adj．实践的；实用的（pragmatic）"
+    ],
+    "ukphone": "ˋpræktIkl",
+    "usphone": "ˋpræktIkl"
+  },
+  {
+    "name": "instrument",
+    "trans": [
+      "32.14.3",
+      "n．仪器（device）"
+    ],
+    "ukphone": "ˋInstrəmənt",
+    "usphone": "ˋInstrəmənt"
+  },
+  {
+    "name": "instrumental",
+    "trans": [
+      "32.14.4",
+      "adj．仪器的，器械的"
+    ],
+    "ukphone": "ˌInstrəˋmentl",
+    "usphone": "ˌInstrəˋmentl"
+  },
+  {
+    "name": "textile",
+    "trans": [
+      "32.14.5",
+      "adj．纺织的 n．纺织品（fabric, fiber, cloth）",
+      "【记】 text（编织）+ile"
+    ],
+    "ukphone": "ˋtekstaIl",
+    "usphone": "ˋtekstaIl"
+  },
+  {
+    "name": "outfit",
+    "trans": [
+      "32.14.6",
+      "n．装备；用具（equipment）",
+      "【记】 来自 fit out（装备）"
+    ],
+    "ukphone": "ˋaʊtfIt",
+    "usphone": "ˋaʊtfIt"
+  },
+  {
+    "name": "mine",
+    "trans": [
+      "32.14.7",
+      "n./v．采矿"
+    ],
+    "ukphone": "maIn",
+    "usphone": "maIn"
+  },
+  {
+    "name": "gear",
+    "trans": [
+      "32.14.8",
+      "n．齿轮"
+    ],
+    "ukphone": "gIə",
+    "usphone": "gIə"
+  },
+  {
+    "name": "fixture",
+    "trans": [
+      "32.14.9",
+      "n．固定设备（apparatus, appliance, device）"
+    ],
+    "ukphone": "ˋfIkstʃər",
+    "usphone": "ˋfIkstʃər"
+  },
+  {
+    "name": "monitor",
+    "trans": [
+      "32.14.10",
+      "v．监视，监听",
+      "【记】 另一个词义是“班长”"
+    ],
+    "ukphone": "ˋmα:nItər",
+    "usphone": "ˋmα:nItər"
+  },
+  {
+    "name": "device",
+    "trans": [
+      "32.14.11",
+      "n．器械，装置；设计（equipment; scheme, ploy）"
+    ],
+    "ukphone": "dIˋvaIs",
+    "usphone": "dIˋvaIs"
+  },
+  {
+    "name": "equipment",
+    "trans": [
+      "32.14.12",
+      "n．设备（facility, fixture）"
+    ],
+    "ukphone": "IˋkwIpmənt",
+    "usphone": "IˋkwIpmənt"
+  },
+  {
+    "name": "cement",
+    "trans": [
+      "32.14.13",
+      "n．水泥，黏合物 vt．接合（stick, bond）"
+    ],
+    "ukphone": "sIˋment",
+    "usphone": "sIˋment"
+  },
+  {
+    "name": "pivot",
+    "trans": [
+      "32.14.14",
+      "n．轴（axis, axle）"
+    ],
+    "ukphone": "ˋpIvət",
+    "usphone": "ˋpIvət"
+  },
+  {
+    "name": "axis",
+    "trans": [
+      "32.14.15",
+      "n．轴（shaft）"
+    ],
+    "ukphone": "ˋæksIs",
+    "usphone": "ˋæksIs"
+  },
+  {
+    "name": "release",
+    "trans": [
+      "32.14.16",
+      "n./vt．发行"
+    ],
+    "ukphone": "rIˋli:s",
+    "usphone": "rIˋli:s"
+  },
+  {
+    "name": "load",
+    "trans": [
+      "32.14.17",
+      "n．负荷 v．装载（burden）"
+    ],
+    "ukphone": "loʊd",
+    "usphone": "loʊd"
+  },
+  {
+    "name": "behave",
+    "trans": [
+      "32.14.18",
+      "v．运转"
+    ],
+    "ukphone": "bIˋheIv",
+    "usphone": "bIˋheIv"
+  },
+  {
+    "name": "erect",
+    "trans": [
+      "32.14.19",
+      "v．建设（build, set up, establish）",
+      "【记】 e+rect（立，竖）"
+    ],
+    "ukphone": "Iˋrekt",
+    "usphone": "Iˋrekt"
+  },
+  {
+    "name": "raise",
+    "trans": [
+      "32.14.20",
+      "vt．养殖（breed）"
+    ],
+    "ukphone": "reIz",
+    "usphone": "reIz"
+  },
+  {
+    "name": "manipulate",
+    "trans": [
+      "32.14.21",
+      "vt．操作（handle, operate）；操纵"
+    ],
+    "ukphone": "məˋnIpjuleIt",
+    "usphone": "məˋnIpjuleIt"
+  },
+  {
+    "name": "construct",
+    "trans": [
+      "32.14.22",
+      "vt．建造，构造",
+      "【记】 con+struct（结构）"
+    ],
+    "ukphone": "kənˋstrʌkt",
+    "usphone": "kənˋstrʌkt"
+  },
+  {
+    "name": "convey",
+    "trans": [
+      "32.14.23",
+      "vt．运输（transport, deliver）"
+    ],
+    "ukphone": "kənˋveI",
+    "usphone": "kənˋveI"
+  },
+  {
+    "name": "fabricate",
+    "trans": [
+      "32.14.24",
+      "vt．制造（make）",
+      "【记】 fabric（结构）+ate→使出现结构→制造"
+    ],
+    "ukphone": "ˋfæbrIkeIt",
+    "usphone": "ˋfæbrIkeIt"
+  },
+  {
+    "name": "manufacture",
+    "trans": [
+      "32.14.25",
+      "vt．制造",
+      "【记】 manu（手）+fact（做）+ure→用手做→制造"
+    ],
+    "ukphone": "ˌmænjuˋfæktʃər",
+    "usphone": "ˌmænjuˋfæktʃər"
+  },
+  {
+    "name": "conserve",
+    "trans": [
+      "32.14.26",
+      "vt．贮藏（preserve, store, retain）"
+    ],
+    "ukphone": "kənˋsɜ:rv",
+    "usphone": "kənˋsɜ:rv"
+  },
+  {
+    "name": "hoist",
+    "trans": [
+      "32.14.27",
+      "n．吊车（lift）v．升起，提起"
+    ],
+    "ukphone": "hɔIst",
+    "usphone": "hɔIst"
+  },
+  {
+    "name": "concrete",
+    "trans": [
+      "32.14.28",
+      "n．水泥"
+    ],
+    "ukphone": "ˋkα:ŋkri:t",
+    "usphone": "ˋkα:ŋkri:t"
+  },
+  {
+    "name": "mill",
+    "trans": [
+      "32.14.29",
+      "n．压榨机，磨坊，磨粉机"
+    ],
+    "ukphone": "mIl",
+    "usphone": "mIl"
+  },
+  {
+    "name": "profitable",
+    "trans": [
+      "32.14.30",
+      "adj．有利可图的；赚钱的；有益的"
+    ],
+    "ukphone": "ˋprα:fItəbl",
+    "usphone": "ˋprα:fItəbl"
+  },
+  {
+    "name": "productive",
+    "trans": [
+      "32.14.31",
+      "adj．能生产的；生产的，生产性的；多产的；富有成效的"
+    ],
+    "ukphone": "prəˋdʌktIv",
+    "usphone": "prəˋdʌktIv"
+  },
+  {
+    "name": "domestic",
+    "trans": [
+      "32.15.1",
+      "adj．家内的（household）"
+    ],
+    "ukphone": "dəˋmestIk",
+    "usphone": "dəˋmestIk"
+  },
+  {
+    "name": "idyllic",
+    "trans": [
+      "32.15.2",
+      "adj．田园诗的（pastoral, rustic）"
+    ],
+    "ukphone": "aIˋdIlIk",
+    "usphone": "aIˋdIlIk"
+  },
+  {
+    "name": "scale",
+    "trans": [
+      "32.15.3",
+      "n．秤"
+    ],
+    "ukphone": "skeIl",
+    "usphone": "skeIl"
+  },
+  {
+    "name": "furniture",
+    "trans": [
+      "32.15.4",
+      "n．家具（furnishing）"
+    ],
+    "ukphone": "ˋfɜ:rnItʃər",
+    "usphone": "ˋfɜ:rnItʃər"
+  },
+  {
+    "name": "rubbish",
+    "trans": [
+      "32.15.5",
+      "n．垃圾（refuse, trash, waste）"
+    ],
+    "ukphone": "ˋrʌbIʃ",
+    "usphone": "ˋrʌbIʃ"
+  },
+  {
+    "name": "trash",
+    "trans": [
+      "32.15.6",
+      "n．垃圾（rubbish, garbage, refuse, waste）"
+    ],
+    "ukphone": "træʃ",
+    "usphone": "træʃ"
+  },
+  {
+    "name": "hurdle",
+    "trans": [
+      "32.15.7",
+      "n．篱笆"
+    ],
+    "ukphone": "ˋhɜ:rdl",
+    "usphone": "ˋhɜ:rdl"
+  },
+  {
+    "name": "sustenance",
+    "trans": [
+      "32.15.8",
+      "n．生计"
+    ],
+    "ukphone": "ˋsʌstənəns",
+    "usphone": "ˋsʌstənəns"
+  },
+  {
+    "name": "nostalgia",
+    "trans": [
+      "32.15.9",
+      "n．思乡，怀旧",
+      "【记】 nost（家）+alg（痛）+ia（病）→思乡"
+    ],
+    "ukphone": "nəˋstældʒə",
+    "usphone": "nəˋstældʒə"
+  },
+  {
+    "name": "singe",
+    "trans": [
+      "32.15.10",
+      "n./v．微烧；烫焦（burn, scorch）"
+    ],
+    "ukphone": "sIndʒ",
+    "usphone": "sIndʒ"
+  },
+  {
+    "name": "baggage",
+    "trans": [
+      "32.15.11",
+      "n．行李（luggage, packing）",
+      "【记】 参考luggage（行李）"
+    ],
+    "ukphone": "ˋbægIdʒ",
+    "usphone": "ˋbægIdʒ"
+  },
+  {
+    "name": "outing",
+    "trans": [
+      "32.15.12",
+      "n．郊游；远足（trip, excursion）"
+    ],
+    "ukphone": "ˋaʊtIŋ",
+    "usphone": "ˋaʊtIŋ"
+  },
+  {
+    "name": "regimen",
+    "trans": [
+      "32.15.13",
+      "n．养生法",
+      "【记】 regi（统治）+men（人）→统治人身的法则→养生之道"
+    ],
+    "ukphone": "ˋredʒImən",
+    "usphone": "ˋredʒImən"
+  },
+  {
+    "name": "slag",
+    "trans": [
+      "32.15.14",
+      "n．渣滓（refuse, waste）"
+    ],
+    "ukphone": "slæg",
+    "usphone": "slæg"
+  },
+  {
+    "name": "sojourn",
+    "trans": [
+      "32.15.15",
+      "vi．逗留；寄居（stay）"
+    ],
+    "ukphone": "ˋsoʊdʒɜ:rn",
+    "usphone": "ˋsoʊdʒɜ:rn"
+  },
+  {
+    "name": "dwell",
+    "trans": [
+      "32.15.16",
+      "vi．居住（reside, inhabit, live）"
+    ],
+    "ukphone": "dwel",
+    "usphone": "dwel"
+  },
+  {
+    "name": "babysit",
+    "trans": [
+      "32.15.17",
+      "vi．看管（婴孩）（take charge of）"
+    ],
+    "ukphone": "ˋbeIbisIt",
+    "usphone": "ˋbeIbisIt"
+  },
+  {
+    "name": "tease",
+    "trans": [
+      "32.15.18",
+      "vt．逗乐，戏弄（taunt, jeer）"
+    ],
+    "ukphone": "ti:z",
+    "usphone": "ti:z"
+  },
+  {
+    "name": "inhabit",
+    "trans": [
+      "32.15.19",
+      "vt．居住于，栖息于（reside, dwell, occupy, live in）",
+      "【记】 in（里面）+habit（住）→住里面→居住"
+    ],
+    "ukphone": "InˋhæbIt",
+    "usphone": "InˋhæbIt"
+  },
+  {
+    "name": "scorch",
+    "trans": [
+      "32.15.20",
+      "vt．烤焦（burn）"
+    ],
+    "ukphone": "skɔ:rtʃ",
+    "usphone": "skɔ:rtʃ"
+  },
+  {
+    "name": "nurture",
+    "trans": [
+      "32.15.21",
+      "vt．养育（feed, nourish）"
+    ],
+    "ukphone": "ˋnɜ:rtʃər",
+    "usphone": "ˋnɜ:rtʃər"
+  },
+  {
+    "name": "reside",
+    "trans": [
+      "32.15.22",
+      "vi．居住（dwell, live）"
+    ],
+    "ukphone": "rIˋzaId",
+    "usphone": "rIˋzaId"
+  },
+  {
+    "name": "resident",
+    "trans": [
+      "32.15.23",
+      "adj．居住的，常驻的（inhabiting）"
+    ],
+    "ukphone": "ˋrezIdənt",
+    "usphone": "ˋrezIdənt"
+  },
+  {
+    "name": "deserted",
+    "trans": [
+      "32.16.1",
+      "adj．荒废的"
+    ],
+    "ukphone": "dIˋzɜ:rtId",
+    "usphone": "dIˋzɜ:rtId"
+  },
+  {
+    "name": "desolate",
+    "trans": [
+      "32.16.2",
+      "adj．荒凉的（deserted, bleak, barren）",
+      "【记】 de（加强）+sol（单独）+ate"
+    ],
+    "ukphone": "ˋdesələt",
+    "usphone": "ˋdesələt"
+  },
+  {
+    "name": "bleak",
+    "trans": [
+      "32.16.3",
+      "adj．荒凉的（desolate, gloomy）"
+    ],
+    "ukphone": "bli:k",
+    "usphone": "bli:k"
+  },
+  {
+    "name": "sterile",
+    "trans": [
+      "32.16.4",
+      "adj．贫瘠的；不育的（barren, arid, infertile）"
+    ],
+    "ukphone": "ˋsterəl",
+    "usphone": "ˋsterəl"
+  },
+  {
+    "name": "barren",
+    "trans": [
+      "32.16.5",
+      "adj．贫瘠的；不孕的（infertile, arid）n．荒地",
+      "【记】 bar=bare（空的）+ren"
+    ],
+    "ukphone": "ˋbærən",
+    "usphone": "ˋbærən"
+  },
+  {
+    "name": "agrarian",
+    "trans": [
+      "32.16.6",
+      "adj．有关土地的，耕地的"
+    ],
+    "ukphone": "əˋgreriən",
+    "usphone": "əˋgreriən"
+  },
+  {
+    "name": "clay",
+    "trans": [
+      "32.16.7",
+      "n．粘土，泥土"
+    ],
+    "ukphone": "kleI",
+    "usphone": "kleI"
+  },
+  {
+    "name": "clod",
+    "trans": [
+      "32.16.8",
+      "n．土块"
+    ],
+    "ukphone": "klα:d",
+    "usphone": "klα:d"
+  },
+  {
+    "name": "stodgy",
+    "trans": [
+      "32.17.1",
+      "adj．躯体笨重的"
+    ],
+    "ukphone": "ˋstα:dʒi",
+    "usphone": "ˋstα:dʒi"
+  },
+  {
+    "name": "stout",
+    "trans": [
+      "32.17.2",
+      "adj．矮胖的"
+    ],
+    "ukphone": "staʊt",
+    "usphone": "staʊt"
+  },
+  {
+    "name": "obese",
+    "trans": [
+      "32.17.3",
+      "adj．肥胖的，肥大的（overweight）"
+    ],
+    "ukphone": "oʊˋbi:s",
+    "usphone": "oʊˋbi:s"
+  },
+  {
+    "name": "corpulent",
+    "trans": [
+      "32.17.4",
+      "adj．肥胖的",
+      "【记】 corp（身体）+ulent→体胖的"
+    ],
+    "ukphone": "ˋkɔ:rpjələnt",
+    "usphone": "ˋkɔ:rpjələnt"
+  },
+  {
+    "name": "shabby",
+    "trans": [
+      "32.17.5",
+      "adj．褴褛的，破旧的"
+    ],
+    "ukphone": "ˋʃæbi",
+    "usphone": "ˋʃæbi"
+  },
+  {
+    "name": "ragged",
+    "trans": [
+      "32.17.6",
+      "adj．褴褛的，破烂的（tattered, scruffy）",
+      "【记】 rag（破布）+ged→破烂的"
+    ],
+    "ukphone": "ˋrægId",
+    "usphone": "ˋrægId"
+  },
+  {
+    "name": "bald",
+    "trans": [
+      "32.17.7",
+      "adj．秃头的，光秃的（hairless）",
+      "【记】 参考 bold（大胆的）"
+    ],
+    "ukphone": "bɔ:ld",
+    "usphone": "bɔ:ld"
+  },
+  {
+    "name": "aspect",
+    "trans": [
+      "32.17.8",
+      "n．样子，外表",
+      "【记】 a+spect（看）→看上去的样子→外观"
+    ],
+    "ukphone": "ˋæspekt",
+    "usphone": "ˋæspekt"
+  },
+  {
+    "name": "costume",
+    "trans": [
+      "32.17.9",
+      "n．服装（attire, dress）",
+      "【记】 比较custom（习俗）"
+    ],
+    "ukphone": "ˋkα:stju:m",
+    "usphone": "ˋkα:stju:m"
+  },
+  {
+    "name": "attire",
+    "trans": [
+      "32.17.10",
+      "n．服装（clothing, dress）"
+    ],
+    "ukphone": "əˋtaIər",
+    "usphone": "əˋtaIər"
+  },
+  {
+    "name": "outfit",
+    "trans": [
+      "32.17.11",
+      "n．服装（costume, suit）",
+      "【记】 来自 fit out（装备）"
+    ],
+    "ukphone": "ˋaʊtfIt",
+    "usphone": "ˋaʊtfIt"
+  },
+  {
+    "name": "garb",
+    "trans": [
+      "32.17.12",
+      "n．服装，装束（uniform, outfit）"
+    ],
+    "ukphone": "gα:rb",
+    "usphone": "gα:rb"
+  },
+  {
+    "name": "strap",
+    "trans": [
+      "32.17.13",
+      "n．皮带（fastening, band）"
+    ],
+    "ukphone": "stræp",
+    "usphone": "stræp"
+  },
+  {
+    "name": "guise",
+    "trans": [
+      "32.17.14",
+      "n．外观；装束（appearance）"
+    ],
+    "ukphone": "gaIz",
+    "usphone": "gaIz"
+  },
+  {
+    "name": "clothing",
+    "trans": [
+      "32.17.15",
+      "n．衣服（apparel, attire）"
+    ],
+    "ukphone": "ˋkloʊðIŋ",
+    "usphone": "ˋkloʊðIŋ"
+  },
+  {
+    "name": "array",
+    "trans": [
+      "32.17.16",
+      "vt．装扮"
+    ],
+    "ukphone": "əˋreI",
+    "usphone": "əˋreI"
+  },
+  {
+    "name": "cosmetics",
+    "trans": [
+      "32.17.17",
+      "n．化妆品"
+    ],
+    "ukphone": "kα:zˋmetIks",
+    "usphone": "kα:zˋmetIks"
+  },
+  {
+    "name": "suit",
+    "trans": [
+      "32.17.18",
+      "n．套装"
+    ],
+    "ukphone": "sju:t",
+    "usphone": "sju:t"
+  },
+  {
+    "name": "sole",
+    "trans": [
+      "32.17.19",
+      "n．鞋底（bottom）"
+    ],
+    "ukphone": "soʊl",
+    "usphone": "soʊl"
+  },
+  {
+    "name": "drowsy",
+    "trans": [
+      "32.18.1",
+      "adj．昏昏欲睡的（sleepy）"
+    ],
+    "ukphone": "ˋdraʊzi",
+    "usphone": "ˋdraʊzi"
+  },
+  {
+    "name": "nap",
+    "trans": [
+      "32.18.2",
+      "n./v．小睡，打盹（doze）"
+    ],
+    "ukphone": "næp",
+    "usphone": "næp"
+  },
+  {
+    "name": "recreation",
+    "trans": [
+      "32.18.3",
+      "n．消遣（pastime, amusement）"
+    ],
+    "ukphone": "ˌri:kriˋeIʃn",
+    "usphone": "ˌri:kriˋeIʃn"
+  },
+  {
+    "name": "lull",
+    "trans": [
+      "32.18.4",
+      "n．歇息"
+    ],
+    "ukphone": "lʌl",
+    "usphone": "lʌl"
+  },
+  {
+    "name": "beguile",
+    "trans": [
+      "32.18.5",
+      "vi．消遣",
+      "【记】 be+guile（欺诈）"
+    ],
+    "ukphone": "bIˋgaIl",
+    "usphone": "bIˋgaIl"
+  },
+  {
+    "name": "doze",
+    "trans": [
+      "32.18.6",
+      "vi．瞌睡（与off连用）（nap, drowse）"
+    ],
+    "ukphone": "doʊz",
+    "usphone": "doʊz"
+  },
+  {
+    "name": "bask",
+    "trans": [
+      "32.18.7",
+      "vt．取暖；曝日"
+    ],
+    "ukphone": "bæsk",
+    "usphone": "bæsk"
+  },
+  {
+    "name": "fateful",
+    "trans": [
+      "32.19.1",
+      "adj．预言性的"
+    ],
+    "ukphone": "ˋfeItfl",
+    "usphone": "ˋfeItfl"
+  },
+  {
+    "name": "imminent",
+    "trans": [
+      "32.19.2",
+      "adj．即将来临的（impending, approaching）",
+      "【记】 im（进）+min（伸）+ent→伸进来→来临的"
+    ],
+    "ukphone": "ˋImInənt",
+    "usphone": "ˋImInənt"
+  },
+  {
+    "name": "estimable",
+    "trans": [
+      "32.19.3",
+      "adj．可估计的"
+    ],
+    "ukphone": "ˋestIməbl",
+    "usphone": "ˋestIməbl"
+  },
+  {
+    "name": "apt",
+    "trans": [
+      "32.19.4",
+      "adj．有…倾向的（prone, likely）"
+    ],
+    "ukphone": "æpt",
+    "usphone": "æpt"
+  },
+  {
+    "name": "promising",
+    "trans": [
+      "32.19.5",
+      "adj．有前途的，有希望的（prospective）"
+    ],
+    "ukphone": "ˋprα:mIsIŋ",
+    "usphone": "ˋprα:mIsIŋ"
+  },
+  {
+    "name": "provident",
+    "trans": [
+      "32.19.6",
+      "adj．有远见的（forward-looking）",
+      "【记】 pro（前）+vid=vis（看见）+ent→有远见的"
+    ],
+    "ukphone": "ˋprα:vIdənt",
+    "usphone": "ˋprα:vIdənt"
+  },
+  {
+    "name": "prospect",
+    "trans": [
+      "32.19.7",
+      "n．前景，期望（outlook, likelihood, possibility）",
+      "【记】 pro（向前）+spect（看）→向前看"
+    ],
+    "ukphone": "ˋprα:spekt",
+    "usphone": "ˋprα:spekt"
+  },
+  {
+    "name": "prospective",
+    "trans": [
+      "32.19.8",
+      "adj．预期的（forward-looking, forthcoming）"
+    ],
+    "ukphone": "prəˋspektIv",
+    "usphone": "prəˋspektIv"
+  },
+  {
+    "name": "perspective",
+    "trans": [
+      "32.19.9",
+      "n．远景（view, outlook）",
+      "【记】 per（全部）+spect（看）+ive→远景"
+    ],
+    "ukphone": "pərˋspektIv",
+    "usphone": "pərˋspektIv"
+  },
+  {
+    "name": "auspice",
+    "trans": [
+      "32.19.10",
+      "n．前兆",
+      "【记】 au+spic（看）+e→提前看到的→前兆"
+    ],
+    "ukphone": "ˋɔ:spIs",
+    "usphone": "ˋɔ:spIs"
+  },
+  {
+    "name": "tendency",
+    "trans": [
+      "32.19.11",
+      "n．趋势（inclination, trend）"
+    ],
+    "ukphone": "ˋtendənsi",
+    "usphone": "ˋtendənsi"
+  },
+  {
+    "name": "precursor",
+    "trans": [
+      "32.19.12",
+      "n．先兆；先驱（sign; forerunner, pioneer, ancestor）",
+      "【记】 pre（提前）+curs（跑）+or→先兆"
+    ],
+    "ukphone": "pri:ˋkɜ:rsər",
+    "usphone": "pri:ˋkɜ:rsər"
+  },
+  {
+    "name": "prediction",
+    "trans": [
+      "32.19.13",
+      "n．预言，预报（forecast, prophecy）"
+    ],
+    "ukphone": "prIˋdIkʃn",
+    "usphone": "prIˋdIkʃn"
+  },
+  {
+    "name": "surmise",
+    "trans": [
+      "32.19.14",
+      "vt．臆测（guess, speculate）",
+      "【记】 sur（下面）+mise（说）→在下面说出的话→猜测"
+    ],
+    "ukphone": "sərˋmaIz",
+    "usphone": "sərˋmaIz"
+  },
+  {
+    "name": "foretell",
+    "trans": [
+      "32.19.15",
+      "vt．预言（predict）",
+      "【记】 fore+tell（告诉）"
+    ],
+    "ukphone": "fɔ:rˋtel",
+    "usphone": "fɔ:rˋtel"
+  },
+  {
+    "name": "foresee",
+    "trans": [
+      "32.19.16",
+      "vt．预知（foreshadow, predict）",
+      "【记】 fore（前）+see（看）→预先看到"
+    ],
+    "ukphone": "fɔ:rˋsi:",
+    "usphone": "fɔ:rˋsi:"
+  },
+  {
+    "name": "foresight",
+    "trans": [
+      "32.19.17",
+      "n．预见，远见",
+      "【记】 sight（视力）"
+    ],
+    "ukphone": "ˋfɔ:rsaIt",
+    "usphone": "ˋfɔ:rsaIt"
+  },
+  {
+    "name": "current",
+    "trans": [
+      "32.19.18",
+      "n．趋势（trend）"
+    ],
+    "ukphone": "ˋkɜ:rənt",
+    "usphone": "ˋkɜ:rənt"
+  },
+  {
+    "name": "forecast",
+    "trans": [
+      "32.19.19",
+      "n．先见，预见；预测，预报"
+    ],
+    "ukphone": "ˋfɔ:rkæst",
+    "usphone": "ˋfɔ:rkæst"
+  },
+  {
+    "name": "disaster",
+    "trans": [
+      "32.20.1",
+      "n．灾难（catastrophe, calamity）"
+    ],
+    "ukphone": "dIˋzæstər",
+    "usphone": "dIˋzæstər"
+  },
+  {
+    "name": "helpless",
+    "trans": [
+      "32.20.2",
+      "adj．无助的（powerless）"
+    ],
+    "ukphone": "ˋhelpləs",
+    "usphone": "ˋhelpləs"
+  },
+  {
+    "name": "disastrous",
+    "trans": [
+      "32.20.3",
+      "adj．灾难性的；悲惨的（catastrophic）"
+    ],
+    "ukphone": "dIˋzæstrəs",
+    "usphone": "dIˋzæstrəs"
+  },
+  {
+    "name": "unfortunately",
+    "trans": [
+      "32.20.4",
+      "adv．不幸地",
+      "【记】 un（不）+fortunately（幸运地）"
+    ],
+    "ukphone": "ʌnˋfɔ:rtʃənətli",
+    "usphone": "ʌnˋfɔ:rtʃənətli"
+  },
+  {
+    "name": "calamity",
+    "trans": [
+      "32.20.5",
+      "n．不幸之事，灾难（catastrophe, mishap）"
+    ],
+    "ukphone": "kəˋlæməti",
+    "usphone": "kəˋlæməti"
+  },
+  {
+    "name": "holocaust",
+    "trans": [
+      "32.20.6",
+      "n．大屠杀（slaughter）",
+      "【记】 holo（全部）+caust（烧）→全部烧死→大屠杀"
+    ],
+    "ukphone": "ˋhα:ləkɔ:st",
+    "usphone": "ˋhα:ləkɔ:st"
+  },
+  {
+    "name": "carnage",
+    "trans": [
+      "32.20.7",
+      "n．大屠杀，残杀（massacre, slaughter）",
+      "【记】 carn（肉）+age"
+    ],
+    "ukphone": "ˋkα:rnIdʒ",
+    "usphone": "ˋkα:rnIdʒ"
+  },
+  {
+    "name": "cataclysm",
+    "trans": [
+      "32.20.8",
+      "n．洪水，大灾难",
+      "【记】 cata（下面）+clysm（洗）→洗掉→洪水"
+    ],
+    "ukphone": "ˋkætəklIzəm",
+    "usphone": "ˋkætəklIzəm"
+  },
+  {
+    "name": "avalanche",
+    "trans": [
+      "32.20.9",
+      "n．雪崩"
+    ],
+    "ukphone": "ˋævəlæntʃ",
+    "usphone": "ˋævəlæntʃ"
+  },
+  {
+    "name": "catastrophe",
+    "trans": [
+      "32.20.10",
+      "n．异常的灾祸（disaster）"
+    ],
+    "ukphone": "kəˋtæstrəfi",
+    "usphone": "kəˋtæstrəfi"
+  },
+  {
+    "name": "plague",
+    "trans": [
+      "32.20.11",
+      "n．疫病，灾祸（disease）v．折磨，使苦恼"
+    ],
+    "ukphone": "pleIg",
+    "usphone": "pleIg"
+  },
+  {
+    "name": "casualty",
+    "trans": [
+      "32.20.12",
+      "n．意外伤亡，事故"
+    ],
+    "ukphone": "ˋkæʒuəlti",
+    "usphone": "ˋkæʒuəlti"
+  },
+  {
+    "name": "mishap",
+    "trans": [
+      "32.20.13",
+      "n．灾祸，不幸（mischance, accident）",
+      "【记】 mis（坏）+hap（运气）→不幸"
+    ],
+    "ukphone": "ˋmIshæp",
+    "usphone": "ˋmIshæp"
+  },
+  {
+    "name": "adversity",
+    "trans": [
+      "32.20.14",
+      "n．不幸，逆境（misfortune）",
+      "【记】 ad+vers（转）+ity→转错方向→不幸"
+    ],
+    "ukphone": "ədˋvɜ:rsəti",
+    "usphone": "ədˋvɜ:rsəti"
+  },
+  {
+    "name": "afflict",
+    "trans": [
+      "32.20.15",
+      "vt．使痛苦，折磨（torture）",
+      "【记】 af（一再）+flict（打击）→一再打击→折磨"
+    ],
+    "ukphone": "əˋflIkt",
+    "usphone": "əˋflIkt"
+  },
+  {
+    "name": "defunct",
+    "trans": [
+      "32.21.1",
+      "adj．死的（dead, demised）",
+      "【记】 de（分离）+funct（功能）"
+    ],
+    "ukphone": "dIˋfʌŋkt",
+    "usphone": "dIˋfʌŋkt"
+  },
+  {
+    "name": "lethal",
+    "trans": [
+      "32.21.2",
+      "adj．致命的（fatal, deadly）",
+      "【记】 leth（死）+al"
+    ],
+    "ukphone": "ˋli:θl",
+    "usphone": "ˋli:θl"
+  },
+  {
+    "name": "deadly",
+    "trans": [
+      "32.21.3",
+      "adj．致命的（fatal, lethal）"
+    ],
+    "ukphone": "ˋdedli",
+    "usphone": "ˋdedli"
+  },
+  {
+    "name": "demise",
+    "trans": [
+      "32.21.4",
+      "n．死亡（death, end）"
+    ],
+    "ukphone": "dIˋmaIz",
+    "usphone": "dIˋmaIz"
+  },
+  {
+    "name": "choke",
+    "trans": [
+      "32.21.5",
+      "n．窒息 v.（使）窒息（suffocate, block）"
+    ],
+    "ukphone": "tʃoʊk",
+    "usphone": "tʃoʊk"
+  },
+  {
+    "name": "smother",
+    "trans": [
+      "32.21.6",
+      "v.（使）窒息，闷死（stifle, suffocate）"
+    ],
+    "ukphone": "ˋsmʌðər",
+    "usphone": "ˋsmʌðər"
+  },
+  {
+    "name": "expire",
+    "trans": [
+      "32.21.7",
+      "vi．断气（perish）",
+      "【记】 ex(出，离开）+pire（呼吸）→离开呼吸→断气"
+    ],
+    "ukphone": "IkˋspaIər",
+    "usphone": "IkˋspaIər"
+  },
+  {
+    "name": "mortal",
+    "trans": [
+      "32.21.8",
+      "adj．终有一死的 n．凡人",
+      "【记】 mort（死）+al"
+    ],
+    "ukphone": "ˋmɔ:rtl",
+    "usphone": "ˋmɔ:rtl"
+  },
+  {
+    "name": "sedate",
+    "trans": [
+      "33.1.1",
+      "adj．安静的（calm, composed）",
+      "【记】 sed=sid（坐）+ate→安静地坐着"
+    ],
+    "ukphone": "sIˋdeIt",
+    "usphone": "sIˋdeIt"
+  },
+  {
+    "name": "tranquil",
+    "trans": [
+      "33.1.2",
+      "adj．安静的（serene, quiet, peaceful）"
+    ],
+    "ukphone": "ˋtræŋkwIl",
+    "usphone": "ˋtræŋkwIl"
+  },
+  {
+    "name": "placid",
+    "trans": [
+      "33.1.3",
+      "adj．安静的（tranquil, serene）"
+    ],
+    "ukphone": "ˋplæsId",
+    "usphone": "ˋplæsId"
+  },
+  {
+    "name": "static",
+    "trans": [
+      "33.1.4",
+      "adj．静的，静态的（changeless, stagnant）"
+    ],
+    "ukphone": "ˋstætIk",
+    "usphone": "ˋstætIk"
+  },
+  {
+    "name": "serene",
+    "trans": [
+      "33.1.5",
+      "adj．平静的；沉静的（calm, tranquil）",
+      "【记】 seren（安静）+e"
+    ],
+    "ukphone": "səˋri:n",
+    "usphone": "səˋri:n"
+  },
+  {
+    "name": "serenity",
+    "trans": [
+      "33.1.6",
+      "n．安静，从容（calmness, tranquility）"
+    ],
+    "ukphone": "səˋrenəti",
+    "usphone": "səˋrenəti"
+  },
+  {
+    "name": "still",
+    "trans": [
+      "33.1.7",
+      "adj．静止的（motionless, stationary, fixed）"
+    ],
+    "ukphone": "stIl",
+    "usphone": "stIl"
+  },
+  {
+    "name": "lull",
+    "trans": [
+      "33.1.8",
+      "vt．使平静（calm down, soothe）"
+    ],
+    "ukphone": "lʌl",
+    "usphone": "lʌl"
+  },
+  {
+    "name": "disgraced",
+    "trans": [
+      "33.2.1",
+      "a．不光彩的，丢脸的（humiliating）",
+      "【记】 dis+graced（体面的）→不体面的"
+    ],
+    "ukphone": "dIsˋgreIst",
+    "usphone": "dIsˋgreIst"
+  },
+  {
+    "name": "dingy",
+    "trans": [
+      "33.2.2",
+      "adj．肮脏的（dirty, shabby）"
+    ],
+    "ukphone": "ˋdIndʒi",
+    "usphone": "ˋdIndʒi"
+  },
+  {
+    "name": "messy",
+    "trans": [
+      "33.2.3",
+      "adj．肮脏的，凌乱的（untidy, dirty）",
+      "【记】 mess（凌乱）+y"
+    ],
+    "ukphone": "ˋmesi",
+    "usphone": "ˋmesi"
+  },
+  {
+    "name": "slovenly",
+    "trans": [
+      "33.2.4",
+      "adj．不洁的（untidy）"
+    ],
+    "ukphone": "ˋslʌvnli",
+    "usphone": "ˋslʌvnli"
+  },
+  {
+    "name": "frowzy",
+    "trans": [
+      "33.2.5",
+      "adj．不整洁的；臭的（filthy）"
+    ],
+    "ukphone": "ˋfraʊzi",
+    "usphone": "ˋfraʊzi"
+  },
+  {
+    "name": "obscene",
+    "trans": [
+      "33.2.6",
+      "adj．猥亵的（indecent, filthy）",
+      "【记】 ob（不）+scene（场景）→不堪入目的"
+    ],
+    "ukphone": "əbˋsi:n",
+    "usphone": "əbˋsi:n"
+  },
+  {
+    "name": "indecent",
+    "trans": [
+      "33.2.7",
+      "adj．淫猥的（improper, unacceptable）",
+      "【记】 in（不）+decent（正派的）"
+    ],
+    "ukphone": "Inˋdi:snt",
+    "usphone": "Inˋdi:snt"
+  },
+  {
+    "name": "impure",
+    "trans": [
+      "33.2.8",
+      "adj．脏的，不纯洁的（adulterated, unrefined）",
+      "【记】 im（不）+pure（纯洁的）"
+    ],
+    "ukphone": "Imˋpjʊr",
+    "usphone": "Imˋpjʊr"
+  },
+  {
+    "name": "blemish",
+    "trans": [
+      "33.2.9",
+      "n./vt．玷污（defect, flaw）",
+      "【记】 blem（弄伤）+ish"
+    ],
+    "ukphone": "ˋblemIʃ",
+    "usphone": "ˋblemIʃ"
+  },
+  {
+    "name": "smear",
+    "trans": [
+      "33.2.10",
+      "vt．弄脏（smudge, stain）"
+    ],
+    "ukphone": "smIr",
+    "usphone": "smIr"
+  },
+  {
+    "name": "defile",
+    "trans": [
+      "33.2.11",
+      "vt．弄污（contaminate）",
+      "【记】 de+file=vile（卑鄙）"
+    ],
+    "ukphone": "dIˋfaIl",
+    "usphone": "dIˋfaIl"
+  },
+  {
+    "name": "spot",
+    "trans": [
+      "33.2.12",
+      "vt．玷污 n．污点（stain）"
+    ],
+    "ukphone": "spα:t",
+    "usphone": "spα:t"
+  },
+  {
+    "name": "incompetent",
+    "trans": [
+      "33.3.1",
+      "adj．不称职的",
+      "【记】 in（不）+competent（能干的）"
+    ],
+    "ukphone": "Inˋkα:mpItənt",
+    "usphone": "Inˋkα:mpItənt"
+  },
+  {
+    "name": "unbecoming",
+    "trans": [
+      "33.3.2",
+      "adj．不配的，不适当的"
+    ],
+    "ukphone": "ˌʌnbIˋkʌmIŋ",
+    "usphone": "ˌʌnbIˋkʌmIŋ"
+  },
+  {
+    "name": "inept",
+    "trans": [
+      "33.3.3",
+      "adj．不适宜的（incompetent, inefficient）",
+      "【记】 in（不）+ept（熟练的）"
+    ],
+    "ukphone": "Iˋnept",
+    "usphone": "Iˋnept"
+  },
+  {
+    "name": "unseemly",
+    "trans": [
+      "33.3.4",
+      "adj．不适宜的（unsuited, incongruous）"
+    ],
+    "ukphone": "ʌnˋsi:mli",
+    "usphone": "ʌnˋsi:mli"
+  },
+  {
+    "name": "ineligible",
+    "trans": [
+      "33.3.5",
+      "adj．无资格的；不适当的（disqualified, unsuitable）",
+      "【记】 in（无）+eligible（有资格的）"
+    ],
+    "ukphone": "InˋelIdʒəbl",
+    "usphone": "InˋelIdʒəbl"
+  },
+  {
+    "name": "impropriety",
+    "trans": [
+      "33.3.6",
+      "n．不适当",
+      "【记】 im（不）+propriety（得体）"
+    ],
+    "ukphone": "ˌImprəˋpraIəti",
+    "usphone": "ˌImprəˋpraIəti"
+  },
+  {
+    "name": "immature",
+    "trans": [
+      "33.3.7",
+      "adj．不成熟的；粗糙的"
+    ],
+    "ukphone": "ˌIməˋtʃʊr",
+    "usphone": "ˌIməˋtʃʊr"
+  },
+  {
+    "name": "fervent",
+    "trans": [
+      "33.4.1",
+      "adj．白热的；强烈的（ardent）",
+      "【记】 ferv（热）+ent"
+    ],
+    "ukphone": "ˋfɜ:rvənt",
+    "usphone": "ˋfɜ:rvənt"
+  },
+  {
+    "name": "rough",
+    "trans": [
+      "33.4.2",
+      "adj．大致的（approximate）"
+    ],
+    "ukphone": "rʌf",
+    "usphone": "rʌf"
+  },
+  {
+    "name": "roughly",
+    "trans": [
+      "33.4.3",
+      "adv．概略地，粗糙地（approximately, nearly, more or less）"
+    ],
+    "ukphone": "ˋrʌfli",
+    "usphone": "ˋrʌfli"
+  },
+  {
+    "name": "intense",
+    "trans": [
+      "33.4.4",
+      "adj．强烈的（severe）"
+    ],
+    "ukphone": "Inˋtens",
+    "usphone": "Inˋtens"
+  },
+  {
+    "name": "intensive",
+    "trans": [
+      "33.4.5",
+      "adj．密集的，加强的（concentrated）"
+    ],
+    "ukphone": "InˋtensIv",
+    "usphone": "InˋtensIv"
+  },
+  {
+    "name": "intensely",
+    "trans": [
+      "33.4.6",
+      "adv．激烈地，热情地（extremely）"
+    ],
+    "ukphone": "Inˋtensli",
+    "usphone": "Inˋtensli"
+  },
+  {
+    "name": "exorbitant",
+    "trans": [
+      "33.4.7",
+      "adj．过分的，过度的（excessive, unreasonable）"
+    ],
+    "ukphone": "Igˋzɔ:rbItənt",
+    "usphone": "Igˋzɔ:rbItənt"
+  },
+  {
+    "name": "probable",
+    "trans": [
+      "33.4.8",
+      "adj．很可能的，大概（likely）"
+    ],
+    "ukphone": "ˋprα:bəbl",
+    "usphone": "ˋprα:bəbl"
+  },
+  {
+    "name": "violent",
+    "trans": [
+      "33.4.9",
+      "adj．激烈的（vehement, radical, sudden）"
+    ],
+    "ukphone": "ˋvaIələnt",
+    "usphone": "ˋvaIələnt"
+  },
+  {
+    "name": "drastic",
+    "trans": [
+      "33.4.10",
+      "adj．激烈的（violent）"
+    ],
+    "ukphone": "ˋdrα:stIk",
+    "usphone": "ˋdrα:stIk"
+  },
+  {
+    "name": "dead",
+    "trans": [
+      "33.4.11",
+      "adv．完全地（completely）"
+    ],
+    "ukphone": "ded",
+    "usphone": "ded"
+  },
+  {
+    "name": "deadly",
+    "trans": [
+      "33.4.12",
+      "adj．极度的（extremey）"
+    ],
+    "ukphone": "ˋdedli",
+    "usphone": "ˋdedli"
+  },
+  {
+    "name": "sharp",
+    "trans": [
+      "33.4.13",
+      "adj．急剧的（sudden）"
+    ],
+    "ukphone": "ʃα:rp",
+    "usphone": "ʃα:rp"
+  },
+  {
+    "name": "categorical",
+    "trans": [
+      "33.4.14",
+      "adj．绝对的，无条件的（definite, positive, absolute, unconditional）"
+    ],
+    "ukphone": "ˌkætəˋgɔ:rIkl",
+    "usphone": "ˌkætəˋgɔ:rIkl"
+  },
+  {
+    "name": "impetuous",
+    "trans": [
+      "33.4.15",
+      "adj．猛烈的"
+    ],
+    "ukphone": "Imˋpetʃuəs",
+    "usphone": "Imˋpetʃuəs"
+  },
+  {
+    "name": "vehement",
+    "trans": [
+      "33.4.16",
+      "adj．猛烈的，激烈的（passionate, ardent）"
+    ],
+    "ukphone": "ˋvi:əmənt",
+    "usphone": "ˋvi:əmənt"
+  },
+  {
+    "name": "vehemence",
+    "trans": [
+      "33.4.17",
+      "n．热切，激烈（passion, ferocity）"
+    ],
+    "ukphone": "ˋvi:əməns",
+    "usphone": "ˋvi:əməns"
+  },
+  {
+    "name": "burning",
+    "trans": [
+      "33.4.18",
+      "adj．强烈的"
+    ],
+    "ukphone": "ˋbɜ:rnIŋ",
+    "usphone": "ˋbɜ:rnIŋ"
+  },
+  {
+    "name": "complete",
+    "trans": [
+      "33.4.19",
+      "adj．完全的 vt．完成"
+    ],
+    "ukphone": "kəmˋpli:t",
+    "usphone": "kəmˋpli:t"
+  },
+  {
+    "name": "completely",
+    "trans": [
+      "33.4.20",
+      "adv．十分，完全地（entirely, wholly）"
+    ],
+    "ukphone": "kəmˋpli:tli",
+    "usphone": "kəmˋpli:tli"
+  },
+  {
+    "name": "inordinate",
+    "trans": [
+      "33.4.21",
+      "adj．无节制的，过度的（excessive, immoderate）",
+      "【记】 in（不）+ordin（正常）+ate→过度的"
+    ],
+    "ukphone": "Inˋɔ:rdInət",
+    "usphone": "Inˋɔ:rdInət"
+  },
+  {
+    "name": "considerable",
+    "trans": [
+      "33.4.22",
+      "adj．相当的（a great deal, large, much, substantial）"
+    ],
+    "ukphone": "kənˋsIdərəbl",
+    "usphone": "kənˋsIdərəbl"
+  },
+  {
+    "name": "substantial",
+    "trans": [
+      "33.4.23",
+      "adj．相当的（plentiful, considerable）"
+    ],
+    "ukphone": "səbˋstænʃl",
+    "usphone": "səbˋstænʃl"
+  },
+  {
+    "name": "grossly",
+    "trans": [
+      "33.4.24",
+      "adv．非常（greatly）"
+    ],
+    "ukphone": "ˋgroʊsli",
+    "usphone": "ˋgroʊsli"
+  },
+  {
+    "name": "extremely",
+    "trans": [
+      "33.4.25",
+      "adv．极端地，非常地（exceptionally, intensely）"
+    ],
+    "ukphone": "Ikˋstri:mli",
+    "usphone": "Ikˋstri:mli"
+  },
+  {
+    "name": "nearly",
+    "trans": [
+      "33.4.26",
+      "adv．几乎（almost）"
+    ],
+    "ukphone": "ˋnIrli",
+    "usphone": "ˋnIrli"
+  },
+  {
+    "name": "virtually",
+    "trans": [
+      "33.4.27",
+      "adv．几乎（almost, practically, actually）"
+    ],
+    "ukphone": "ˋvɜ:rtʃuəli",
+    "usphone": "ˋvɜ:rtʃuəli"
+  },
+  {
+    "name": "hardly",
+    "trans": [
+      "33.4.28",
+      "adv．几乎不（scarcely, barely）"
+    ],
+    "ukphone": "ˋhα:rdli",
+    "usphone": "ˋhα:rdli"
+  },
+  {
+    "name": "barely",
+    "trans": [
+      "33.4.29",
+      "adv．仅仅（merely）"
+    ],
+    "ukphone": "ˋberli",
+    "usphone": "ˋberli"
+  },
+  {
+    "name": "profoundly",
+    "trans": [
+      "33.4.30",
+      "adv．深刻地，深度地（deeply, greatly）",
+      "【记】 profound（深刻的）+ly"
+    ],
+    "ukphone": "prəˋfaʊndli",
+    "usphone": "prəˋfaʊndli"
+  },
+  {
+    "name": "clean",
+    "trans": [
+      "33.4.31",
+      "adv．完全地（totally, completely）"
+    ],
+    "ukphone": "kli:n",
+    "usphone": "kli:n"
+  },
+  {
+    "name": "entirely",
+    "trans": [
+      "33.4.32",
+      "adv．完全地，全然地（totally, solely）"
+    ],
+    "ukphone": "InˋtaIərli",
+    "usphone": "InˋtaIərli"
+  },
+  {
+    "name": "utterly",
+    "trans": [
+      "33.4.33",
+      "adv．完全地，彻底地（completely, absolutely）"
+    ],
+    "ukphone": "ˋʌtərli",
+    "usphone": "ˋʌtərli"
+  },
+  {
+    "name": "somewhat",
+    "trans": [
+      "33.4.34",
+      "adv．有点（rather, to some degree）"
+    ],
+    "ukphone": "ˋsʌmwʌt",
+    "usphone": "ˋsʌmwʌt"
+  },
+  {
+    "name": "fairly",
+    "trans": [
+      "33.4.35",
+      "adv．相当地（relatively, somewhat）"
+    ],
+    "ukphone": "ˋferli",
+    "usphone": "ˋferli"
+  },
+  {
+    "name": "absolute",
+    "trans": [
+      "33.4.36",
+      "adj．绝对的（sheer）",
+      "【记】 比较solute（化学溶质）"
+    ],
+    "ukphone": "ˋæbsəlu:t",
+    "usphone": "ˋæbsəlu:t"
+  },
+  {
+    "name": "radical",
+    "trans": [
+      "33.4.37",
+      "adj．根本的，基本的；激进的"
+    ],
+    "ukphone": "ˋrædIkl",
+    "usphone": "ˋrædIkl"
+  },
+  {
+    "name": "dramatically",
+    "trans": [
+      "33.4.38",
+      "adv．戏剧性地；引人注目地"
+    ],
+    "ukphone": "drəˋmætIkli",
+    "usphone": "drəˋmætIkli"
+  },
+  {
+    "name": "exceedingly",
+    "trans": [
+      "33.4.39",
+      "adv．非常，极度，极其（highly, extremely）"
+    ],
+    "ukphone": "Ikˋsi:dIŋli",
+    "usphone": "Ikˋsi:dIŋli"
+  },
+  {
+    "name": "thorough",
+    "trans": [
+      "33.4.40",
+      "adj．彻底的；十分的；周密的"
+    ],
+    "ukphone": "ˋθɜ:roʊ",
+    "usphone": "ˋθɜ:roʊ"
+  },
+  {
+    "name": "sheer",
+    "trans": [
+      "33.5.1",
+      "adj．纯粹的；全然的（pure, total）"
+    ],
+    "ukphone": "ʃIr",
+    "usphone": "ʃIr"
+  },
+  {
+    "name": "pure",
+    "trans": [
+      "33.5.2",
+      "adj．纯的，纯洁的（clean, unadulterated）"
+    ],
+    "ukphone": "pjʊr",
+    "usphone": "pjʊr"
+  },
+  {
+    "name": "unblemished",
+    "trans": [
+      "33.5.3",
+      "adj．洁白的，无瑕的（flawless, perfect）"
+    ],
+    "ukphone": "ʌnˋblemIʃt",
+    "usphone": "ʌnˋblemIʃt"
+  },
+  {
+    "name": "innocent",
+    "trans": [
+      "33.5.4",
+      "adj．清白的（guiltless, faultless）",
+      "【记】 in（无）+noc（害）+ent→无害的"
+    ],
+    "ukphone": "ˋInəsnt",
+    "usphone": "ˋInəsnt"
+  },
+  {
+    "name": "impeccable",
+    "trans": [
+      "33.5.5",
+      "adj．无瑕的（faultless, stainless）",
+      "【记】 im（无）+pecc（斑点）+able→无瑕的"
+    ],
+    "ukphone": "Imˋpekəbl",
+    "usphone": "Imˋpekəbl"
+  },
+  {
+    "name": "perfect",
+    "trans": [
+      "33.5.6",
+      "adj．无瑕的，完好无损的（intact, untouched）",
+      "【记】 per（全部）+fect（做）→全部做完→完美的"
+    ],
+    "ukphone": "ˋpɜ:rfIkt",
+    "usphone": "ˋpɜ:rfIkt"
+  },
+  {
+    "name": "virtuous",
+    "trans": [
+      "33.5.7",
+      "adj．贞洁的；品德好的（moral, righteous）"
+    ],
+    "ukphone": "ˋvɜ:rtʃuəs",
+    "usphone": "ˋvɜ:rtʃuəs"
+  },
+  {
+    "name": "chaste",
+    "trans": [
+      "33.5.8",
+      "adj．贞洁的；纯正的（pure, virtuous）"
+    ],
+    "ukphone": "tʃeIst",
+    "usphone": "tʃeIst"
+  },
+  {
+    "name": "colossal",
+    "trans": [
+      "33.6.1",
+      "adj．巨大的（immense, huge）",
+      "【记】 源自希腊神话中名为Colossus的大力神"
+    ],
+    "ukphone": "kəˋlα:sl",
+    "usphone": "kəˋlα:sl"
+  },
+  {
+    "name": "spacious",
+    "trans": [
+      "33.6.2",
+      "adj．广大的，宽敞的（roomy, capacious）",
+      "【记】 spac（地方）+ious→地方大的"
+    ],
+    "ukphone": "ˋspeIʃəs",
+    "usphone": "ˋspeIʃəs"
+  },
+  {
+    "name": "expansive",
+    "trans": [
+      "33.6.3",
+      "adj．广阔的；可扩张的，可膨胀的（extensive, large）"
+    ],
+    "ukphone": "IkˋspænsIv",
+    "usphone": "IkˋspænsIv"
+  },
+  {
+    "name": "prodigious",
+    "trans": [
+      "33.6.4",
+      "adj．巨大的（colossal, enormous）",
+      "【记】 prodig（巨大）+ious"
+    ],
+    "ukphone": "prəˋdIdʒəs",
+    "usphone": "prəˋdIdʒəs"
+  },
+  {
+    "name": "massive",
+    "trans": [
+      "33.6.5",
+      "adj．巨大的（heavy, huge, enormous）"
+    ],
+    "ukphone": "ˋmæsIv",
+    "usphone": "ˋmæsIv"
+  },
+  {
+    "name": "enormous",
+    "trans": [
+      "33.6.6",
+      "adj．巨大的（huge, vast, immense, tremendous）",
+      "【记】 e（出）+norm（正常）+ous→超出了正常状态→巨大的"
+    ],
+    "ukphone": "Iˋnɔ:rməs",
+    "usphone": "Iˋnɔ:rməs"
+  },
+  {
+    "name": "mighty",
+    "trans": [
+      "33.6.7",
+      "adj．巨大的（powerful, strong）",
+      "【记】 might（巨大）+y"
+    ],
+    "ukphone": "ˋmaIti",
+    "usphone": "ˋmaIti"
+  },
+  {
+    "name": "vast",
+    "trans": [
+      "33.6.8",
+      "adj．巨大的，大量的（gigantic, huge, immense, tremendous, broad, enormous）"
+    ],
+    "ukphone": "væst",
+    "usphone": "væst"
+  },
+  {
+    "name": "tremendous",
+    "trans": [
+      "33.6.9",
+      "adj．巨大的，惊人的（immense, enormous, huge, great）"
+    ],
+    "ukphone": "trəˋmendəs",
+    "usphone": "trəˋmendəs"
+  },
+  {
+    "name": "immense",
+    "trans": [
+      "33.6.10",
+      "adj．巨大的；无限的",
+      "【记】 im（不）+mense（测量）→不能测量→无限的"
+    ],
+    "ukphone": "Iˋmens",
+    "usphone": "Iˋmens"
+  },
+  {
+    "name": "titanic",
+    "trans": [
+      "33.6.11",
+      "adj．巨大有力的（huge, immense）",
+      "【记】 美国影片《泰坦尼克号》的英文"
+    ],
+    "ukphone": "taIˋtænIk",
+    "usphone": "taIˋtænIk"
+  },
+  {
+    "name": "commodious",
+    "trans": [
+      "33.6.12",
+      "adj．宽敞的（spacious, capacious, roomy）",
+      "【记】 com（共同）+mod（范围）+ious→大家都有范围→宽敞的"
+    ],
+    "ukphone": "kəˋmoʊdiəs",
+    "usphone": "kəˋmoʊdiəs"
+  },
+  {
+    "name": "broad",
+    "trans": [
+      "33.6.13",
+      "adj．宽的，广泛的（wide, general）"
+    ],
+    "ukphone": "brɔ:d",
+    "usphone": "brɔ:d"
+  },
+  {
+    "name": "loose",
+    "trans": [
+      "33.6.14",
+      "adj．宽松的"
+    ],
+    "ukphone": "lu:s",
+    "usphone": "lu:s"
+  },
+  {
+    "name": "bulky",
+    "trans": [
+      "33.6.15",
+      "adj．庞大的；笨重的（cumbersome）"
+    ],
+    "ukphone": "ˋbʌlki",
+    "usphone": "ˋbʌlki"
+  },
+  {
+    "name": "capacious",
+    "trans": [
+      "33.6.16",
+      "adj．容量大的；宽敞的（spacious）"
+    ],
+    "ukphone": "kəˋpeIʃəs",
+    "usphone": "kəˋpeIʃəs"
+  },
+  {
+    "name": "ample",
+    "trans": [
+      "33.6.17",
+      "adj．丰富的；充足的（plentiful, abundant, sufficient）"
+    ],
+    "ukphone": "ˋæmpl",
+    "usphone": "ˋæmpl"
+  },
+  {
+    "name": "sensational",
+    "trans": [
+      "33.6.18",
+      "adj．轰动的；耸人听闻的；非常好的；使人感动的"
+    ],
+    "ukphone": "senˋseIʃənl",
+    "usphone": "senˋseIʃənl"
+  },
+  {
+    "name": "revolutionary",
+    "trans": [
+      "33.6.19",
+      "adj．革命的；旋转的；大变革的"
+    ],
+    "ukphone": "ˌrevəˋlu:ʃəneri",
+    "usphone": "ˌrevəˋlu:ʃəneri"
+  },
+  {
+    "name": "forth",
+    "trans": [
+      "33.7.1",
+      "adv．向前（ahead）"
+    ],
+    "ukphone": "fɔ:rθ",
+    "usphone": "fɔ:rθ"
+  },
+  {
+    "name": "entry",
+    "trans": [
+      "33.7.2",
+      "n．入口；进入"
+    ],
+    "ukphone": "ˋentri",
+    "usphone": "ˋentri"
+  },
+  {
+    "name": "exit",
+    "trans": [
+      "33.7.3",
+      "n．出口（outlet, way-out）",
+      "【记】 ex（出）+it（走）→走出→出口"
+    ],
+    "ukphone": "ˋeksIt",
+    "usphone": "ˋeksIt"
+  },
+  {
+    "name": "outlet",
+    "trans": [
+      "33.7.4",
+      "n．出路，出口（socker, access）"
+    ],
+    "ukphone": "ˋaʊtlet",
+    "usphone": "ˋaʊtlet"
+  },
+  {
+    "name": "site",
+    "trans": [
+      "33.7.5",
+      "n．地点（location, position）"
+    ],
+    "ukphone": "saIt",
+    "usphone": "saIt"
+  },
+  {
+    "name": "destination",
+    "trans": [
+      "33.7.6",
+      "n．目的地"
+    ],
+    "ukphone": "ˌdestIˋneIʃn",
+    "usphone": "ˌdestIˋneIʃn"
+  },
+  {
+    "name": "veer",
+    "trans": [
+      "33.7.7",
+      "v．改变方向（turn, swerve）"
+    ],
+    "ukphone": "vIr",
+    "usphone": "vIr"
+  },
+  {
+    "name": "spot",
+    "trans": [
+      "33.7.8",
+      "n．地点（location）"
+    ],
+    "ukphone": "spα:t",
+    "usphone": "spα:t"
+  },
+  {
+    "name": "head",
+    "trans": [
+      "33.7.9",
+      "vi．向某处走去（set out for, make for）"
+    ],
+    "ukphone": "hed",
+    "usphone": "hed"
+  },
+  {
+    "name": "divert",
+    "trans": [
+      "33.7.10",
+      "v．使转向；转移；使改道；使分心（shift, distract）"
+    ],
+    "ukphone": "daIˋvɜ:rt",
+    "usphone": "daIˋvɜ:rt"
+  },
+  {
+    "name": "periphery",
+    "trans": [
+      "33.7.11",
+      "n．外围，边缘"
+    ],
+    "ukphone": "pəˋrIfəri",
+    "usphone": "pəˋrIfəri"
+  },
+  {
+    "name": "lateral",
+    "trans": [
+      "33.7.12",
+      "adj．侧面的，横向的"
+    ],
+    "ukphone": "ˋlætərəl",
+    "usphone": "ˋlætərəl"
+  },
+  {
+    "name": "valid",
+    "trans": [
+      "33.8.1",
+      "adj．正当的"
+    ],
+    "ukphone": "ˋvælId",
+    "usphone": "ˋvælId"
+  },
+  {
+    "name": "upright",
+    "trans": [
+      "33.8.2",
+      "adj．正直的",
+      "【记】 up（上）+right（正的）"
+    ],
+    "ukphone": "ˋʌpraIt",
+    "usphone": "ˋʌpraIt"
+  },
+  {
+    "name": "unfair",
+    "trans": [
+      "33.8.3",
+      "adj．不公平的（unjust, partial）",
+      "【记】 un（不）+fair（公正的）"
+    ],
+    "ukphone": "ˌʌnˋfer",
+    "usphone": "ˌʌnˋfer"
+  },
+  {
+    "name": "fairly",
+    "trans": [
+      "33.8.4",
+      "adv．公正地"
+    ],
+    "ukphone": "ˋferli",
+    "usphone": "ˋferli"
+  },
+  {
+    "name": "guileless",
+    "trans": [
+      "33.8.5",
+      "adj．不狡猾的，诚实的（frank, honest）"
+    ],
+    "ukphone": "ˋgaIlləs",
+    "usphone": "ˋgaIlləs"
+  },
+  {
+    "name": "equitable",
+    "trans": [
+      "33.8.6",
+      "adj．公平的，公正的（fair, just）"
+    ],
+    "ukphone": "ˋekwItəbl",
+    "usphone": "ˋekwItəbl"
+  },
+  {
+    "name": "detached",
+    "trans": [
+      "33.8.7",
+      "adj．公正的；分开的，分离的"
+    ],
+    "ukphone": "dIˋtætʃt",
+    "usphone": "dIˋtætʃt"
+  },
+  {
+    "name": "disinterested",
+    "trans": [
+      "33.8.8",
+      "adj．公正的（impartial, unbiased）"
+    ],
+    "ukphone": "dIsˋIntrəstId",
+    "usphone": "dIsˋIntrəstId"
+  },
+  {
+    "name": "unbiased",
+    "trans": [
+      "33.8.9",
+      "adj．公正的（neutral, impartial）"
+    ],
+    "ukphone": "ʌnˋbaIəst",
+    "usphone": "ʌnˋbaIəst"
+  },
+  {
+    "name": "partially",
+    "trans": [
+      "33.8.10",
+      "adv．不公平地"
+    ],
+    "ukphone": "ˋpα:rʃəli",
+    "usphone": "ˋpα:rʃəli"
+  },
+  {
+    "name": "impartial",
+    "trans": [
+      "33.8.11",
+      "adj．公正的，无偏见的（fair, unbiased）"
+    ],
+    "ukphone": "Imˋpα:rʃl",
+    "usphone": "Imˋpα:rʃl"
+  },
+  {
+    "name": "conscience",
+    "trans": [
+      "33.8.12",
+      "n．良心，良知"
+    ],
+    "ukphone": "ˋkα:nʃəns",
+    "usphone": "ˋkα:nʃəns"
+  },
+  {
+    "name": "conscientious",
+    "trans": [
+      "33.8.13",
+      "adj．尽职的；正直的（diligent）"
+    ],
+    "ukphone": "ˌkα:nʃiˋenʃəs",
+    "usphone": "ˌkα:nʃiˋenʃəs"
+  },
+  {
+    "name": "incorruptible",
+    "trans": [
+      "33.8.14",
+      "adj．廉洁的",
+      "【记】 in（不）+corruptible（易收买的）"
+    ],
+    "ukphone": "ˌInkəˋrʌptəbl",
+    "usphone": "ˌInkəˋrʌptəbl"
+  },
+  {
+    "name": "decent",
+    "trans": [
+      "33.8.15",
+      "adj．正派的；体面的（reasonable, proper）"
+    ],
+    "ukphone": "ˋdi:snt",
+    "usphone": "ˋdi:snt"
+  },
+  {
+    "name": "faithful",
+    "trans": [
+      "33.8.16",
+      "adj．忠实的（loyal）",
+      "【记】 faith（忠诚）+ful"
+    ],
+    "ukphone": "ˋfeIθfl",
+    "usphone": "ˋfeIθfl"
+  },
+  {
+    "name": "justly",
+    "trans": [
+      "33.8.17",
+      "adv．公正地"
+    ],
+    "ukphone": "ˋdʒʌstli",
+    "usphone": "ˋdʒʌstli"
+  },
+  {
+    "name": "devotion",
+    "trans": [
+      "33.8.18",
+      "n．献身；忠诚；专心（loyalty, dedication）"
+    ],
+    "ukphone": "dIˋvoʊʃn",
+    "usphone": "dIˋvoʊʃn"
+  },
+  {
+    "name": "integrity",
+    "trans": [
+      "33.8.19",
+      "n．正直（honesty）"
+    ],
+    "ukphone": "Inˋtegrəti",
+    "usphone": "Inˋtegrəti"
+  },
+  {
+    "name": "probity",
+    "trans": [
+      "33.8.20",
+      "n．正直（integrity, honesty）"
+    ],
+    "ukphone": "ˋproʊbəti",
+    "usphone": "ˋproʊbəti"
+  },
+  {
+    "name": "fidelity",
+    "trans": [
+      "33.8.21",
+      "n．忠诚（loyalty, faithfulness）",
+      "【记】 fid（相信）+elity→相信→坚贞"
+    ],
+    "ukphone": "fIˋdeləti",
+    "usphone": "fIˋdeləti"
+  },
+  {
+    "name": "dedicate",
+    "trans": [
+      "33.8.22",
+      "vt．奉献，致力于"
+    ],
+    "ukphone": "ˋdedIkeIt",
+    "usphone": "ˋdedIkeIt"
+  },
+  {
+    "name": "sober",
+    "trans": [
+      "33.9.1",
+      "adj．适度的"
+    ],
+    "ukphone": "ˋsoʊbər",
+    "usphone": "ˋsoʊbər"
+  },
+  {
+    "name": "qualified",
+    "trans": [
+      "33.9.2",
+      "adj．合格的"
+    ],
+    "ukphone": "ˋkwα:lIfaId",
+    "usphone": "ˋkwα:lIfaId"
+  },
+  {
+    "name": "rational",
+    "trans": [
+      "33.9.3",
+      "adj．合理的（reasonable）"
+    ],
+    "ukphone": "ˋræʃənl",
+    "usphone": "ˋræʃənl"
+  },
+  {
+    "name": "becoming",
+    "trans": [
+      "33.9.4",
+      "adj．合适的，相称的（fitting, suitable）"
+    ],
+    "ukphone": "bIˋkʌmIŋ",
+    "usphone": "bIˋkʌmIŋ"
+  },
+  {
+    "name": "reliable",
+    "trans": [
+      "33.9.5",
+      "adj．可靠的，可信赖的（dependable）",
+      "【记】 动词rely（依靠）"
+    ],
+    "ukphone": "rIˋlaIəbl",
+    "usphone": "rIˋlaIəbl"
+  },
+  {
+    "name": "preferable",
+    "trans": [
+      "33.9.6",
+      "adj．可取的（advisable）",
+      "【记】 prefer（喜欢）+able"
+    ],
+    "ukphone": "ˋprefrəbl",
+    "usphone": "ˋprefrəbl"
+  },
+  {
+    "name": "available",
+    "trans": [
+      "33.9.7",
+      "adj．可用的（obtainable, accessible）"
+    ],
+    "ukphone": "əˋveIləbl",
+    "usphone": "əˋveIləbl"
+  },
+  {
+    "name": "competent",
+    "trans": [
+      "33.9.8",
+      "adj．能胜任的（capable, qualified）"
+    ],
+    "ukphone": "ˋkα:mpItənt",
+    "usphone": "ˋkα:mpItənt"
+  },
+  {
+    "name": "fit",
+    "trans": [
+      "33.9.9",
+      "adj．适合的（suitable）"
+    ],
+    "ukphone": "fIt",
+    "usphone": "fIt"
+  },
+  {
+    "name": "fitting",
+    "trans": [
+      "33.9.10",
+      "adj．恰当的，得体的（proper, appropriate）",
+      "【记】 fit（合适）+ting"
+    ],
+    "ukphone": "ˋfItIŋ",
+    "usphone": "ˋfItIŋ"
+  },
+  {
+    "name": "feasible",
+    "trans": [
+      "33.9.11",
+      "adj．切实可行的（practical, possible, viable）",
+      "【记】 feas（做）+ible→能够做的→可行的"
+    ],
+    "ukphone": "ˋfi:zəbl",
+    "usphone": "ˋfi:zəbl"
+  },
+  {
+    "name": "expedient",
+    "trans": [
+      "33.9.12",
+      "adj．权宜的；方便的（suitable, convenient）"
+    ],
+    "ukphone": "Ikˋspi:diənt",
+    "usphone": "Ikˋspi:diənt"
+  },
+  {
+    "name": "pertinent",
+    "trans": [
+      "33.9.13",
+      "adj．适当的；切题的（relevant）"
+    ],
+    "ukphone": "ˋpɜ:rtnənt",
+    "usphone": "ˋpɜ:rtnənt"
+  },
+  {
+    "name": "temperate",
+    "trans": [
+      "33.9.14",
+      "adj．适度的，有节制的（appropriate, reasonable, self- controlled）"
+    ],
+    "ukphone": "ˋtempərət",
+    "usphone": "ˋtempərət"
+  },
+  {
+    "name": "suitable",
+    "trans": [
+      "33.9.15",
+      "adj．适合的"
+    ],
+    "ukphone": "ˋsju:təbl",
+    "usphone": "ˋsju:təbl"
+  },
+  {
+    "name": "plausible",
+    "trans": [
+      "33.9.16",
+      "adj．似合理的（reasonable）"
+    ],
+    "ukphone": "ˋplɔ:zəbl",
+    "usphone": "ˋplɔ:zəbl"
+  },
+  {
+    "name": "methodical",
+    "trans": [
+      "33.9.17",
+      "adj．有条理的（systematic）",
+      "【记】 method（方法）+ical→有方法的→有条理的"
+    ],
+    "ukphone": "məˋθα:dIkl",
+    "usphone": "məˋθα:dIkl"
+  },
+  {
+    "name": "entitled",
+    "trans": [
+      "33.9.18",
+      "adj．有资格的（eligible, qualified）"
+    ],
+    "ukphone": "InˋtaItld",
+    "usphone": "InˋtaItld"
+  },
+  {
+    "name": "correspondence",
+    "trans": [
+      "33.9.19",
+      "n．对应；符合",
+      "【记】 cor+respond（反应）+ence"
+    ],
+    "ukphone": "ˌkɔ:rəˋspα:ndəns",
+    "usphone": "ˌkɔ:rəˋspα:ndəns"
+  },
+  {
+    "name": "propriety",
+    "trans": [
+      "33.9.20",
+      "n．适当（correctness）"
+    ],
+    "ukphone": "prəˋpraIəti",
+    "usphone": "prəˋpraIəti"
+  },
+  {
+    "name": "tally",
+    "trans": [
+      "33.9.21",
+      "vi．符合（accord, agree）"
+    ],
+    "ukphone": "ˋtæli",
+    "usphone": "ˋtæli"
+  },
+  {
+    "name": "coincide",
+    "trans": [
+      "33.9.22",
+      "vi．相符合，相巧合",
+      "【记】 co（共同）+in+cide（落下）→共同落下→巧合"
+    ],
+    "ukphone": "ˌkoʊInˋsaId",
+    "usphone": "ˌkoʊInˋsaId"
+  },
+  {
+    "name": "suit",
+    "trans": [
+      "33.9.23",
+      "vt．合适，适应（accommodate, fit, adapt）"
+    ],
+    "ukphone": "sju:t",
+    "usphone": "sju:t"
+  },
+  {
+    "name": "advisable",
+    "trans": [
+      "33.9.24",
+      "adj．合理的（rational, sound）"
+    ],
+    "ukphone": "ədˋvaIzəbl",
+    "usphone": "ədˋvaIzəbl"
+  },
+  {
+    "name": "adapt",
+    "trans": [
+      "33.9.25",
+      "v.（使）适应（adjust, accommodate）"
+    ],
+    "ukphone": "əˋdæpt",
+    "usphone": "əˋdæpt"
+  },
+  {
+    "name": "adaptable",
+    "trans": [
+      "33.9.26",
+      "adj．能适应的"
+    ],
+    "ukphone": "əˋdæptəbl",
+    "usphone": "əˋdæptəbl"
+  },
+  {
+    "name": "adaptation",
+    "trans": [
+      "33.9.27",
+      "n．适应（accomodation）"
+    ],
+    "ukphone": "ˌædæpˋteIʃn",
+    "usphone": "ˌædæpˋteIʃn"
+  },
+  {
+    "name": "conformity",
+    "trans": [
+      "33.9.28",
+      "n．一致，符合"
+    ],
+    "ukphone": "kənˋfɔ:rməti",
+    "usphone": "kənˋfɔ:rməti"
+  },
+  {
+    "name": "credible",
+    "trans": [
+      "33.9.29",
+      "adj．可信的，可靠的（believable）"
+    ],
+    "ukphone": "ˋkredəbl",
+    "usphone": "ˋkredəbl"
+  },
+  {
+    "name": "dependable",
+    "trans": [
+      "33.9.30",
+      "adj．可靠的，可信赖的，可信任的"
+    ],
+    "ukphone": "dIˋpendəbl",
+    "usphone": "dIˋpendəbl"
+  },
+  {
+    "name": "incisive",
+    "trans": [
+      "33.10.1",
+      "adj．尖锐的"
+    ],
+    "ukphone": "InˋsaIsIv",
+    "usphone": "InˋsaIsIv"
+  },
+  {
+    "name": "caustic",
+    "trans": [
+      "33.10.2",
+      "adj．刻薄的"
+    ],
+    "ukphone": "ˋkɔ:stIk",
+    "usphone": "ˋkɔ:stIk"
+  },
+  {
+    "name": "acid",
+    "trans": [
+      "33.10.3",
+      "adj．尖酸的"
+    ],
+    "ukphone": "ˋæsId",
+    "usphone": "ˋæsId"
+  },
+  {
+    "name": "acrimonious",
+    "trans": [
+      "33.10.4",
+      "adj．尖酸的（bitter, spiteful）"
+    ],
+    "ukphone": "ˌækrIˋmoʊniəs",
+    "usphone": "ˌækrIˋmoʊniəs"
+  },
+  {
+    "name": "acrid",
+    "trans": [
+      "33.10.5",
+      "adj．辛辣的（pungent, bitter, acrimonious, trenchant）"
+    ],
+    "ukphone": "ˋækrId",
+    "usphone": "ˋækrId"
+  },
+  {
+    "name": "acrimony",
+    "trans": [
+      "33.10.6",
+      "n．刻薄",
+      "【记】 acri（尖，酸）+mony→尖刻"
+    ],
+    "ukphone": "ˋækrImoʊni",
+    "usphone": "ˋækrImoʊni"
+  },
+  {
+    "name": "cunning",
+    "trans": [
+      "33.11.1",
+      "adj．可爱的（cute, clever）"
+    ],
+    "ukphone": "ˋkʌnIŋ",
+    "usphone": "ˋkʌnIŋ"
+  },
+  {
+    "name": "elegant",
+    "trans": [
+      "33.11.2",
+      "adj.（举止、服饰）雅致的（refined, exquisite, elaborate）",
+      "【记】 e（出）+leg=lig（选）+ant→选出的→好的"
+    ],
+    "ukphone": "ˋelIgənt",
+    "usphone": "ˋelIgənt"
+  },
+  {
+    "name": "handy",
+    "trans": [
+      "33.11.3",
+      "adj．方便的；灵巧的（convenient; skilful）"
+    ],
+    "ukphone": "ˋhændi",
+    "usphone": "ˋhændi"
+  },
+  {
+    "name": "ingenious",
+    "trans": [
+      "33.11.4",
+      "adj．机灵的（clever, intelligent）；精巧制成的",
+      "【记】 in（内）+geni（产生）+ous→自内心产生→聪明的"
+    ],
+    "ukphone": "Inˋdʒi:niəs",
+    "usphone": "Inˋdʒi:niəs"
+  },
+  {
+    "name": "exquisite",
+    "trans": [
+      "33.11.5",
+      "adj．精美的（delicate, fine, elaborate）",
+      "【记】 ex+quisite（要求）→按要求做出来→精美的"
+    ],
+    "ukphone": "IkˋskwIzIt",
+    "usphone": "IkˋskwIzIt"
+  },
+  {
+    "name": "delicate",
+    "trans": [
+      "33.11.6",
+      "adj．精巧的（dainty, elegant）"
+    ],
+    "ukphone": "ˋdelIkət",
+    "usphone": "ˋdelIkət"
+  },
+  {
+    "name": "refined",
+    "trans": [
+      "33.11.7",
+      "adj．精致的；文雅的（elegant, well-mannered）"
+    ],
+    "ukphone": "rIˋfaInd",
+    "usphone": "rIˋfaInd"
+  },
+  {
+    "name": "dexterous",
+    "trans": [
+      "33.11.8",
+      "adj．灵巧的（adroit, skillful）",
+      "【记】 dexter（右边的）+ous"
+    ],
+    "ukphone": "ˋdekstrəs",
+    "usphone": "ˋdekstrəs"
+  },
+  {
+    "name": "crafty",
+    "trans": [
+      "33.11.9",
+      "adj．灵巧的，巧妙的（cunning, sneaky）"
+    ],
+    "ukphone": "ˋkræfti",
+    "usphone": "ˋkræfti"
+  },
+  {
+    "name": "elaborate",
+    "trans": [
+      "33.11.10",
+      "vt．精心制作（或计划）adj．精心构思的（careful）"
+    ],
+    "ukphone": "Iˋlæbərət",
+    "usphone": "Iˋlæbərət"
+  },
+  {
+    "name": "elaboration",
+    "trans": [
+      "33.11.11",
+      "n．精心制作；精巧；详细阐述（intricacy, refinement）"
+    ],
+    "ukphone": "IˌlæbəˋreIʃn",
+    "usphone": "IˌlæbəˋreIʃn"
+  },
+  {
+    "name": "ingenuity",
+    "trans": [
+      "33.11.12",
+      "n．心灵手巧，独创性；精巧；精巧的装置"
+    ],
+    "ukphone": "ˌIndʒəˋnju:əti",
+    "usphone": "ˌIndʒəˋnju:əti"
+  },
+  {
+    "name": "sophistication",
+    "trans": [
+      "33.11.13",
+      "n．复杂；诡辩；老于世故；有教养"
+    ],
+    "ukphone": "səˌfIstIˋkeIʃn",
+    "usphone": "səˌfIstIˋkeIʃn"
+  },
+  {
+    "name": "sophisticated",
+    "trans": [
+      "33.11.14",
+      "adj．复杂的；精致的；久经世故的；富有经验的"
+    ],
+    "ukphone": "səˋfIstIkeItId",
+    "usphone": "səˋfIstIkeItId"
+  },
+  {
+    "name": "remote",
+    "trans": [
+      "33.12.1",
+      "adj．遥远的，远程的（distant, inaccessible）"
+    ],
+    "ukphone": "rIˋmoʊt",
+    "usphone": "rIˋmoʊt"
+  },
+  {
+    "name": "distant",
+    "trans": [
+      "33.12.2",
+      "adj．远的（remote）"
+    ],
+    "ukphone": "ˋdIstənt",
+    "usphone": "ˋdIstənt"
+  },
+  {
+    "name": "gap",
+    "trans": [
+      "33.12.3",
+      "n．差距（distance）"
+    ],
+    "ukphone": "gæp",
+    "usphone": "gæp"
+  },
+  {
+    "name": "proximity",
+    "trans": [
+      "33.12.4",
+      "n．临近（nearness）",
+      "【记】 proxim（接近）+ity"
+    ],
+    "ukphone": "prα:kˋsIməti",
+    "usphone": "prα:kˋsIməti"
+  },
+  {
+    "name": "distribute",
+    "trans": [
+      "33.12.5",
+      "vt．分布"
+    ],
+    "ukphone": "dIˋstrIbju:t",
+    "usphone": "dIˋstrIbju:t"
+  },
+  {
+    "name": "adjacent",
+    "trans": [
+      "33.12.6",
+      "adj．邻近的（adjoining, neigh-boring）"
+    ],
+    "ukphone": "əˋdʒeIsnt",
+    "usphone": "əˋdʒeIsnt"
+  },
+  {
+    "name": "access",
+    "trans": [
+      "33.12.7",
+      "vt．接近",
+      "【记】 ac+cess（走）→走过去→通道"
+    ],
+    "ukphone": "ˋækses",
+    "usphone": "ˋækses"
+  },
+  {
+    "name": "adjoin",
+    "trans": [
+      "33.12.8",
+      "vt．贴近，毗连，靠近（abut）",
+      "【记】 ad（一再）+join（连）→一再连上→毗连"
+    ],
+    "ukphone": "əˋdʒɔIn",
+    "usphone": "əˋdʒɔIn"
+  },
+  {
+    "name": "adjoining",
+    "trans": [
+      "33.12.9",
+      "adj．接近的，邻接的（adjacent, neighboring）",
+      "【记】 adjoin+ing"
+    ],
+    "ukphone": "əˋdʒɔInIŋ",
+    "usphone": "əˋdʒɔInIŋ"
+  },
+  {
+    "name": "infallible",
+    "trans": [
+      "33.13.1",
+      "adj．必然的；不会错的",
+      "【记】 in（无）+fallible（错误的）"
+    ],
+    "ukphone": "Inˋfæləbl",
+    "usphone": "Inˋfæləbl"
+  },
+  {
+    "name": "inevitable",
+    "trans": [
+      "33.13.2",
+      "adj．不可避免的，必然的（unavoidable, certain）"
+    ],
+    "ukphone": "InˋevItəbl",
+    "usphone": "InˋevItəbl"
+  },
+  {
+    "name": "definite",
+    "trans": [
+      "33.13.3",
+      "adj．明确的，肯定的（specific, straightforward）"
+    ],
+    "ukphone": "ˋdefInət",
+    "usphone": "ˋdefInət"
+  },
+  {
+    "name": "confident",
+    "trans": [
+      "33.13.4",
+      "adj．确信的，自信的",
+      "【记】 con+fid（相信）+ent"
+    ],
+    "ukphone": "ˋkα:nfIdənt",
+    "usphone": "ˋkα:nfIdənt"
+  },
+  {
+    "name": "undoubtedly",
+    "trans": [
+      "33.13.5",
+      "adv．毋庸置疑地，的确（unquestionably, surely）"
+    ],
+    "ukphone": "ʌnˋdaʊtIdli",
+    "usphone": "ʌnˋdaʊtIdli"
+  },
+  {
+    "name": "ascertain",
+    "trans": [
+      "33.13.6",
+      "vt．确定；探知（determine, make sure）",
+      "【记】 as+certain（确信）"
+    ],
+    "ukphone": "ˌæsərˋteIn",
+    "usphone": "ˌæsərˋteIn"
+  },
+  {
+    "name": "null",
+    "trans": [
+      "33.14.1",
+      "adj．空的"
+    ],
+    "ukphone": "nʌl",
+    "usphone": "nʌl"
+  },
+  {
+    "name": "empty",
+    "trans": [
+      "33.14.2",
+      "adj．空的（vacant, void）"
+    ],
+    "ukphone": "ˋempti",
+    "usphone": "ˋempti"
+  },
+  {
+    "name": "vacant",
+    "trans": [
+      "33.14.3",
+      "adj．空的；未被占用的（unoccupied, empty）",
+      "【记】 vac（空）+ant"
+    ],
+    "ukphone": "ˋveIkənt",
+    "usphone": "ˋveIkənt"
+  },
+  {
+    "name": "void",
+    "trans": [
+      "33.14.4",
+      "n．空间（space）adj．空的（invalid, null）"
+    ],
+    "ukphone": "vɔId",
+    "usphone": "vɔId"
+  },
+  {
+    "name": "vacuum",
+    "trans": [
+      "33.14.5",
+      "n．真空（gap, void）"
+    ],
+    "ukphone": "ˋvækjuəm",
+    "usphone": "ˋvækjuəm"
+  },
+  {
+    "name": "evacuate",
+    "trans": [
+      "33.14.6",
+      "vt．使…空，清空（remove）",
+      "【记】 e+vacu（空）+ate→使空"
+    ],
+    "ukphone": "IˋvækjueIt",
+    "usphone": "IˋvækjueIt"
+  },
+  {
+    "name": "bare",
+    "trans": [
+      "33.14.7",
+      "adj．空的"
+    ],
+    "ukphone": "ber",
+    "usphone": "ber"
+  },
+  {
+    "name": "sensible",
+    "trans": [
+      "33.15.1",
+      "adj．明显的，感觉得到的（discernible）",
+      "【记】 sens（感觉）+ible"
+    ],
+    "ukphone": "ˋsensəbl",
+    "usphone": "ˋsensəbl"
+  },
+  {
+    "name": "imposing",
+    "trans": [
+      "33.15.2",
+      "adj．令人难忘的（impressive）"
+    ],
+    "ukphone": "ImˋpoʊzIŋ",
+    "usphone": "ImˋpoʊzIŋ"
+  },
+  {
+    "name": "obvious",
+    "trans": [
+      "33.15.3",
+      "adj．明显的（distinct, evident）"
+    ],
+    "ukphone": "ˋα:bviəs",
+    "usphone": "ˋα:bviəs"
+  },
+  {
+    "name": "pronounced",
+    "trans": [
+      "33.15.4",
+      "adj．明显的（notable, prominent）",
+      "【记】 pronounce（发音）+ed →（人人都能）发的音→著名的"
+    ],
+    "ukphone": "prəˋnaʊnst",
+    "usphone": "prəˋnaʊnst"
+  },
+  {
+    "name": "sharp",
+    "trans": [
+      "33.15.5",
+      "adj．明显的，清晰的（clear）"
+    ],
+    "ukphone": "ʃα:rp",
+    "usphone": "ʃα:rp"
+  },
+  {
+    "name": "outstanding",
+    "trans": [
+      "33.15.6",
+      "adj．显著的（notable, remarkable）",
+      "【记】 来自stand out（醒目，突出）"
+    ],
+    "ukphone": "aʊtˋstændIŋ",
+    "usphone": "aʊtˋstændIŋ"
+  },
+  {
+    "name": "emphatic",
+    "trans": [
+      "33.15.7",
+      "adj．显著的；强调的；有力的（powerful）"
+    ],
+    "ukphone": "ImˋfætIk",
+    "usphone": "ImˋfætIk"
+  },
+  {
+    "name": "remarkable",
+    "trans": [
+      "33.15.8",
+      "adj．值得注意的（striking, considerable）"
+    ],
+    "ukphone": "rIˋmα:rkəbl",
+    "usphone": "rIˋmα:rkəbl"
+  },
+  {
+    "name": "impressively",
+    "trans": [
+      "33.15.9",
+      "adv．令人难忘地"
+    ],
+    "ukphone": "ImˋpresIvli",
+    "usphone": "ImˋpresIvli"
+  },
+  {
+    "name": "markedly",
+    "trans": [
+      "33.15.10",
+      "adv．显著地，明显地（significantly, substantially, noticeably）"
+    ],
+    "ukphone": "ˋmα:rkIdli",
+    "usphone": "ˋmα:rkIdli"
+  },
+  {
+    "name": "especially",
+    "trans": [
+      "33.15.11",
+      "adv．尤其（notably, particularly）"
+    ],
+    "ukphone": "Iˋspeʃəli",
+    "usphone": "Iˋspeʃəli"
+  },
+  {
+    "name": "routine",
+    "trans": [
+      "33.16.1",
+      "adj．常规的（regular, conventional，usual）"
+    ],
+    "ukphone": "ru:ˋti:n",
+    "usphone": "ru:ˋti:n"
+  },
+  {
+    "name": "extensive",
+    "trans": [
+      "33.16.2",
+      "adj．大量的；广泛的（comprehensive; thorough）"
+    ],
+    "ukphone": "IkˋstensIv",
+    "usphone": "IkˋstensIv"
+  },
+  {
+    "name": "mediocre",
+    "trans": [
+      "33.16.3",
+      "adj．平常的，普通的（ordinary, average）",
+      "【记】 medi（中间）+ocre→平庸的"
+    ],
+    "ukphone": "ˌmi:diˋoʊkər",
+    "usphone": "ˌmi:diˋoʊkər"
+  },
+  {
+    "name": "hackneyed",
+    "trans": [
+      "33.16.4",
+      "adj．平凡的",
+      "【记】 参考hack（陈腐的），Internet用语hacker（黑客）"
+    ],
+    "ukphone": "ˋhæknid",
+    "usphone": "ˋhæknid"
+  },
+  {
+    "name": "universal",
+    "trans": [
+      "33.16.5",
+      "adj．普遍的（general, absolute）"
+    ],
+    "ukphone": "ˌju:nIˋvɜ:rsl",
+    "usphone": "ˌju:nIˋvɜ:rsl"
+  },
+  {
+    "name": "catholic",
+    "trans": [
+      "33.16.6",
+      "adj．普遍的，广泛的（universal）"
+    ],
+    "ukphone": "ˋkæθlIk",
+    "usphone": "ˋkæθlIk"
+  },
+  {
+    "name": "general",
+    "trans": [
+      "33.16.7",
+      "adj．普通的（ordinary）"
+    ],
+    "ukphone": "ˋdʒenrəl",
+    "usphone": "ˋdʒenrəl"
+  },
+  {
+    "name": "generally",
+    "trans": [
+      "33.16.8",
+      "adv．广泛地，一般地（widely, usually, broadly）"
+    ],
+    "ukphone": "ˋdʒenrəli",
+    "usphone": "ˋdʒenrəli"
+  },
+  {
+    "name": "exhaustive",
+    "trans": [
+      "33.16.9",
+      "adj．无遗漏的，彻底的，广泛的（comprehensive, thorough）"
+    ],
+    "ukphone": "Igˋzɔ:stIv",
+    "usphone": "Igˋzɔ:stIv"
+  },
+  {
+    "name": "average",
+    "trans": [
+      "33.16.10",
+      "adj．一般的（normal）"
+    ],
+    "ukphone": "ˋævərIdʒ",
+    "usphone": "ˋævərIdʒ"
+  },
+  {
+    "name": "mostly",
+    "trans": [
+      "33.16.11",
+      "adv．多半地；通常",
+      "【记】 most（主要的）+ly"
+    ],
+    "ukphone": "ˋmoʊstli",
+    "usphone": "ˋmoʊstli"
+  },
+  {
+    "name": "usually",
+    "trans": [
+      "33.16.12",
+      "adv．通常，大抵（customarily, commonly）"
+    ],
+    "ukphone": "ˋju:ʒuəli",
+    "usphone": "ˋju:ʒuəli"
+  },
+  {
+    "name": "commonplace",
+    "trans": [
+      "33.16.13",
+      "n．平凡事，平凡话 adj．平凡的（average, ordinary）"
+    ],
+    "ukphone": "ˋkα:mənpleIs",
+    "usphone": "ˋkα:mənpleIs"
+  },
+  {
+    "name": "tender",
+    "trans": [
+      "33.17.1",
+      "adj．嫩的（soft）"
+    ],
+    "ukphone": "ˋtendər",
+    "usphone": "ˋtendər"
+  },
+  {
+    "name": "concrete",
+    "trans": [
+      "33.17.2",
+      "adj．具体的"
+    ],
+    "ukphone": "ˋkα:ŋkri:t",
+    "usphone": "ˋkα:ŋkri:t"
+  },
+  {
+    "name": "portable",
+    "trans": [
+      "33.17.3",
+      "adj．可携带的（movable, transportable）",
+      "【记】 port（拿）+able→可拿的"
+    ],
+    "ukphone": "ˋpɔ:rtəbl",
+    "usphone": "ˋpɔ:rtəbl"
+  },
+  {
+    "name": "sloppy",
+    "trans": [
+      "33.17.4",
+      "adj．泥泞的（muddled, semi-liquid）",
+      "【记】 slop（溅，弄脏）+py"
+    ],
+    "ukphone": "ˋslα:pi",
+    "usphone": "ˋslα:pi"
+  },
+  {
+    "name": "congested",
+    "trans": [
+      "33.17.5",
+      "adj．拥挤的（overcrowded）",
+      "【记】 con（共同）+gest（管道）+ed→共同在一个管道→拥挤的"
+    ],
+    "ukphone": "kənˋdʒestId",
+    "usphone": "kənˋdʒestId"
+  },
+  {
+    "name": "irreversible",
+    "trans": [
+      "33.17.6",
+      "adj．不可逆的；不能取消的；不能翻转的"
+    ],
+    "ukphone": "ˌIrIˋvɜ:rsəbl",
+    "usphone": "ˌIrIˋvɜ:rsəbl"
+  },
+  {
+    "name": "fraught",
+    "trans": [
+      "33.18.1",
+      "adj．充满的（full of）",
+      "【记】 比较freight（装运的货物）"
+    ],
+    "ukphone": "frɔ:t",
+    "usphone": "frɔ:t"
+  },
+  {
+    "name": "sole",
+    "trans": [
+      "33.18.2",
+      "adj．惟一的（only, mere, exclusive）"
+    ],
+    "ukphone": "soʊl",
+    "usphone": "soʊl"
+  },
+  {
+    "name": "solitary",
+    "trans": [
+      "33.18.3",
+      "adj．单一的（lonesome, isolated）",
+      "【记】 solit（单独）+ary"
+    ],
+    "ukphone": "ˋsα:ləteri",
+    "usphone": "ˋsα:ləteri"
+  },
+  {
+    "name": "quantity",
+    "trans": [
+      "33.18.4",
+      "n．量，数量（amount）"
+    ],
+    "ukphone": "ˋkwα:ntəti",
+    "usphone": "ˋkwα:ntəti"
+  },
+  {
+    "name": "quantitative",
+    "trans": [
+      "33.18.5",
+      "adj．定量的",
+      "【记】 quant（数量）+itative→定量的"
+    ],
+    "ukphone": "ˋkwα:ntəteItIv",
+    "usphone": "ˋkwα:ntəteItIv"
+  },
+  {
+    "name": "excess",
+    "trans": [
+      "33.18.6",
+      "n./adj．过度（的）（surplus）",
+      "【记】 ex+cess（走）→走出格→过分"
+    ],
+    "ukphone": "Ikˋses",
+    "usphone": "Ikˋses"
+  },
+  {
+    "name": "excessive",
+    "trans": [
+      "33.18.7",
+      "adj．过多的，极度的（overabundant, inordinate）"
+    ],
+    "ukphone": "IkˋsesIv",
+    "usphone": "IkˋsesIv"
+  },
+  {
+    "name": "redundant",
+    "trans": [
+      "33.18.8",
+      "adj．过多的，冗长的（unnecessary, superfluous）"
+    ],
+    "ukphone": "rIˋdʌndənt",
+    "usphone": "rIˋdʌndənt"
+  },
+  {
+    "name": "sporadic",
+    "trans": [
+      "33.18.9",
+      "adj．零星的（irregular, intermittent）"
+    ],
+    "ukphone": "spəˋrædIk",
+    "usphone": "spəˋrædIk"
+  },
+  {
+    "name": "numerous",
+    "trans": [
+      "33.18.10",
+      "adj．众多的",
+      "【记】 numer（数字）+ous"
+    ],
+    "ukphone": "ˋnju:mərəs",
+    "usphone": "ˋnju:mərəs"
+  },
+  {
+    "name": "innumerable",
+    "trans": [
+      "33.18.11",
+      "adj．无数的（countless, numerous）",
+      "【记】 in（不）+numer（数）+able→数不过来→无数的"
+    ],
+    "ukphone": "Iˋnju:mərəbl",
+    "usphone": "Iˋnju:mərəbl"
+  },
+  {
+    "name": "countless",
+    "trans": [
+      "33.18.12",
+      "adj．无数的（innumerable, many）",
+      "【记】 count（数）+less"
+    ],
+    "ukphone": "ˋkaʊntləs",
+    "usphone": "ˋkaʊntləs"
+  },
+  {
+    "name": "sufficient",
+    "trans": [
+      "33.18.13",
+      "adj．足够的，充分的（enough, adequate）",
+      "【记】 其动词形式为suffice"
+    ],
+    "ukphone": "səˋfIʃnt",
+    "usphone": "səˋfIʃnt"
+  },
+  {
+    "name": "skimpy",
+    "trans": [
+      "33.18.14",
+      "adj．太少的（scant, inadequate）"
+    ],
+    "ukphone": "ˋskImpi",
+    "usphone": "ˋskImpi"
+  },
+  {
+    "name": "sparsely",
+    "trans": [
+      "33.18.15",
+      "adv．稀少地，稀疏地（thinly, scarcely）"
+    ],
+    "ukphone": "ˋspα:rsli",
+    "usphone": "ˋspα:rsli"
+  },
+  {
+    "name": "bulk",
+    "trans": [
+      "33.18.16",
+      "n．大批（mass, volume, most majority）"
+    ],
+    "ukphone": "bʌlk",
+    "usphone": "bʌlk"
+  },
+  {
+    "name": "majority",
+    "trans": [
+      "33.18.17",
+      "n．多数，大多数"
+    ],
+    "ukphone": "məˋdʒɔ:rəti",
+    "usphone": "məˋdʒɔ:rəti"
+  },
+  {
+    "name": "block",
+    "trans": [
+      "33.18.18",
+      "n．一块（木或石等）"
+    ],
+    "ukphone": "blα:k",
+    "usphone": "blα:k"
+  },
+  {
+    "name": "multitude",
+    "trans": [
+      "33.18.19",
+      "n．众多（host, mass）",
+      "【记】 multi（多）+tude"
+    ],
+    "ukphone": "ˋmʌltItju:d",
+    "usphone": "ˋmʌltItju:d"
+  },
+  {
+    "name": "sum",
+    "trans": [
+      "33.18.20",
+      "n．总数"
+    ],
+    "ukphone": "sʌm",
+    "usphone": "sʌm"
+  },
+  {
+    "name": "teem",
+    "trans": [
+      "33.18.21",
+      "vi．充满（abound, be full of）"
+    ],
+    "ukphone": "ti:m",
+    "usphone": "ti:m"
+  },
+  {
+    "name": "pervade",
+    "trans": [
+      "33.18.22",
+      "vt．遍布；弥漫（permeate）",
+      "【记】 per（全部，遍）+vade（走）→遍布"
+    ],
+    "ukphone": "pərˋveId",
+    "usphone": "pərˋveId"
+  },
+  {
+    "name": "suffuse",
+    "trans": [
+      "33.18.23",
+      "vt．充满（fill）",
+      "【记】 suf（到处）+fuse（流）→到处流→充满"
+    ],
+    "ukphone": "səˋfju:z",
+    "usphone": "səˋfju:z"
+  },
+  {
+    "name": "abundant",
+    "trans": [
+      "33.18.24",
+      "adj．充裕的（sufficient）",
+      "【记】 a+bun（小圆面包）+d+ant（蚂蚁）→蚂蚁有充裕的小圆面包"
+    ],
+    "ukphone": "əˋbʌndənt",
+    "usphone": "əˋbʌndənt"
+  },
+  {
+    "name": "further",
+    "trans": [
+      "33.18.25",
+      "adj．更多的（additional）"
+    ],
+    "ukphone": "ˋfɜ:rðər",
+    "usphone": "ˋfɜ:rðər"
+  },
+  {
+    "name": "adequate",
+    "trans": [
+      "33.18.26",
+      "adj．足够的（sufficient）"
+    ],
+    "ukphone": "ˋædIkwət",
+    "usphone": "ˋædIkwət"
+  },
+  {
+    "name": "spare",
+    "trans": [
+      "33.18.27",
+      "adj．多余的，剩下的"
+    ],
+    "ukphone": "sper",
+    "usphone": "sper"
+  },
+  {
+    "name": "times",
+    "trans": [
+      "33.18.28",
+      "n．时期，次"
+    ],
+    "ukphone": "taImz",
+    "usphone": "taImz"
+  },
+  {
+    "name": "total",
+    "trans": [
+      "33.18.29",
+      "n．总数，合计"
+    ],
+    "ukphone": "ˋtoʊtl",
+    "usphone": "ˋtoʊtl"
+  },
+  {
+    "name": "volume",
+    "trans": [
+      "33.18.30",
+      "n．量，大量"
+    ],
+    "ukphone": "ˋvα:lju:m",
+    "usphone": "ˋvα:lju:m"
+  },
+  {
+    "name": "duplicate",
+    "trans": [
+      "33.18.31",
+      "n．副本，复制品 v．复制；影印，拷贝；复写；重复（copy, reproduce）adj．双重的；二倍的；完全相同的"
+    ],
+    "ukphone": "ˋdu:plIkeIt",
+    "usphone": "ˋdu:plIkeIt"
+  },
+  {
+    "name": "plentiful",
+    "trans": [
+      "33.18.32",
+      "adj．丰富的；许多的；丰饶的；众多的"
+    ],
+    "ukphone": "ˋplentIfl",
+    "usphone": "ˋplentIfl"
+  },
+  {
+    "name": "original",
+    "trans": [
+      "33.19.1",
+      "adj．独创的",
+      "【记】 origin（起源）+al"
+    ],
+    "ukphone": "əˋrIdʒənl",
+    "usphone": "əˋrIdʒənl"
+  },
+  {
+    "name": "unique",
+    "trans": [
+      "33.19.2",
+      "adj．独一无二的（unrivaled, matchless）"
+    ],
+    "ukphone": "juˋni:k",
+    "usphone": "juˋni:k"
+  },
+  {
+    "name": "extraordinary",
+    "trans": [
+      "33.19.3",
+      "adj．非凡的，特别的（remarkable, outstanding）"
+    ],
+    "ukphone": "Ikˋstrɔ:rdəneri",
+    "usphone": "Ikˋstrɔ:rdəneri"
+  },
+  {
+    "name": "erratic",
+    "trans": [
+      "33.19.4",
+      "adj．古怪的（odd, eccentric）"
+    ],
+    "ukphone": "IˋrætIk",
+    "usphone": "IˋrætIk"
+  },
+  {
+    "name": "eccentric",
+    "trans": [
+      "33.19.5",
+      "adj．古怪的（odd, erratic, bizarre）",
+      "【记】 ec+centr（中心）+ic→非中心→异常的"
+    ],
+    "ukphone": "IkˋsentrIk",
+    "usphone": "IkˋsentrIk"
+  },
+  {
+    "name": "bizarre",
+    "trans": [
+      "33.19.6",
+      "adj．古怪的（odd, erratic, eccentric）"
+    ],
+    "ukphone": "bIˋzα:r",
+    "usphone": "bIˋzα:r"
+  },
+  {
+    "name": "queer",
+    "trans": [
+      "33.19.7",
+      "adj．奇怪的，古怪的（strange, fishy）",
+      "【记】 比较queen（皇后）"
+    ],
+    "ukphone": "kwIr",
+    "usphone": "kwIr"
+  },
+  {
+    "name": "quaint",
+    "trans": [
+      "33.19.8",
+      "adj．奇异的，不凡的（queer, odd）"
+    ],
+    "ukphone": "kweInt",
+    "usphone": "kweInt"
+  },
+  {
+    "name": "given",
+    "trans": [
+      "33.19.9",
+      "adj．特定的（specified）"
+    ],
+    "ukphone": "ˋgIvn",
+    "usphone": "ˋgIvn"
+  },
+  {
+    "name": "particularly",
+    "trans": [
+      "33.19.10",
+      "adv．独特地，显著地（especially）"
+    ],
+    "ukphone": "pərˋtIkjələrli",
+    "usphone": "pərˋtIkjələrli"
+  },
+  {
+    "name": "abnormal",
+    "trans": [
+      "33.19.11",
+      "adj．异常的（exceptional）",
+      "【记】 ab（离开）+normal（正常的）→异常的"
+    ],
+    "ukphone": "æbˋnɔ:rml",
+    "usphone": "æbˋnɔ:rml"
+  },
+  {
+    "name": "odd",
+    "trans": [
+      "33.19.12",
+      "adj．古怪的"
+    ],
+    "ukphone": "α:d",
+    "usphone": "α:d"
+  },
+  {
+    "name": "weird",
+    "trans": [
+      "33.19.13",
+      "adj．怪异的，超自然的"
+    ],
+    "ukphone": "wIrd",
+    "usphone": "wIrd"
+  },
+  {
+    "name": "sensitive",
+    "trans": [
+      "33.19.14",
+      "adj．敏感的"
+    ],
+    "ukphone": "ˋsensətIv",
+    "usphone": "ˋsensətIv"
+  },
+  {
+    "name": "idiosyncrasy",
+    "trans": [
+      "33.19.15",
+      "n．个人特性"
+    ],
+    "ukphone": "ˌIdiəˋsIŋkrəsi",
+    "usphone": "ˌIdiəˋsIŋkrəsi"
+  },
+  {
+    "name": "trait",
+    "trans": [
+      "33.19.16",
+      "n．特点，特性（characteristic, attribute）"
+    ],
+    "ukphone": "treIt",
+    "usphone": "treIt"
+  },
+  {
+    "name": "character",
+    "trans": [
+      "33.19.17",
+      "n．性格"
+    ],
+    "ukphone": "ˋkærəktər",
+    "usphone": "ˋkærəktər"
+  },
+  {
+    "name": "characteristic",
+    "trans": [
+      "33.19.18",
+      "n．特性，特征 adj．特有的，典型的（distinctive, distinguishing）"
+    ],
+    "ukphone": "ˌkærəktəˋrIstIk",
+    "usphone": "ˌkærəktəˋrIstIk"
+  },
+  {
+    "name": "bear",
+    "trans": [
+      "33.19.19",
+      "vt．具有，带有（carry）"
+    ],
+    "ukphone": "ber",
+    "usphone": "ber"
+  },
+  {
+    "name": "distinctive",
+    "trans": [
+      "33.19.20",
+      "adj．有特色的，与众不同的"
+    ],
+    "ukphone": "dIˋstIŋktIv",
+    "usphone": "dIˋstIŋktIv"
+  },
+  {
+    "name": "peculiar",
+    "trans": [
+      "33.19.21",
+      "adj．特殊的；独特的；奇怪的；罕见的"
+    ],
+    "ukphone": "pIˋkju:liər",
+    "usphone": "pIˋkju:liər"
+  },
+  {
+    "name": "destructive",
+    "trans": [
+      "33.20.1",
+      "adj．破坏（性）的，危害的",
+      "【记】 de（坏）+struct（结构）+ive→破坏结构"
+    ],
+    "ukphone": "dIˋstrʌktIv",
+    "usphone": "dIˋstrʌktIv"
+  },
+  {
+    "name": "critical",
+    "trans": [
+      "33.20.2",
+      "adj．危急的；临界的"
+    ],
+    "ukphone": "ˋkrItIkl",
+    "usphone": "ˋkrItIkl"
+  },
+  {
+    "name": "perilous",
+    "trans": [
+      "33.20.3",
+      "adj．危险的（dangerous, hazardous）"
+    ],
+    "ukphone": "ˋperələs",
+    "usphone": "ˋperələs"
+  },
+  {
+    "name": "hazard",
+    "trans": [
+      "33.20.4",
+      "n．危险（risk, danger）；公害"
+    ],
+    "ukphone": "ˋhæzərd",
+    "usphone": "ˋhæzərd"
+  },
+  {
+    "name": "hazardous",
+    "trans": [
+      "33.20.5",
+      "adj．危险的（dangerous, perilous）"
+    ],
+    "ukphone": "ˋhæzərdəs",
+    "usphone": "ˋhæzərdəs"
+  },
+  {
+    "name": "dangerous",
+    "trans": [
+      "33.20.6",
+      "adj．危险的（hazardous, risky）"
+    ],
+    "ukphone": "ˋdeIndʒərəs",
+    "usphone": "ˋdeIndʒərəs"
+  },
+  {
+    "name": "endanger",
+    "trans": [
+      "33.20.7",
+      "vt．危害（harm）",
+      "【记】 en+danger（危险）"
+    ],
+    "ukphone": "InˋdeIndʒər",
+    "usphone": "InˋdeIndʒər"
+  },
+  {
+    "name": "harmful",
+    "trans": [
+      "33.20.8",
+      "adj．有害的（dangerous, detrimental）"
+    ],
+    "ukphone": "ˋhα:rmfl",
+    "usphone": "ˋhα:rmfl"
+  },
+  {
+    "name": "deleterious",
+    "trans": [
+      "33.20.9",
+      "adj．有害的（harmful, detrimental）"
+    ],
+    "ukphone": "ˌdeləˋtIriəs",
+    "usphone": "ˌdeləˋtIriəs"
+  },
+  {
+    "name": "detriment",
+    "trans": [
+      "33.20.10",
+      "n．损害",
+      "【记】 de+trim（修剪）+ent→剪坏→损害"
+    ],
+    "ukphone": "ˋdetrImənt",
+    "usphone": "ˋdetrImənt"
+  },
+  {
+    "name": "detrimental",
+    "trans": [
+      "33.20.11",
+      "adj．有害的，有损的"
+    ],
+    "ukphone": "ˌdetrIˋmentl",
+    "usphone": "ˌdetrIˋmentl"
+  },
+  {
+    "name": "peril",
+    "trans": [
+      "33.20.12",
+      "n．危机；危险的事物"
+    ],
+    "ukphone": "ˋperəl",
+    "usphone": "ˋperəl"
+  },
+  {
+    "name": "jeopardy",
+    "trans": [
+      "33.20.13",
+      "n．危险（danger, risk）"
+    ],
+    "ukphone": "ˋdʒepərdi",
+    "usphone": "ˋdʒepərdi"
+  },
+  {
+    "name": "injure",
+    "trans": [
+      "33.20.14",
+      "vt．伤害，损害，损伤（hurt, wound）"
+    ],
+    "ukphone": "ˋIndʒər",
+    "usphone": "ˋIndʒər"
+  },
+  {
+    "name": "maim",
+    "trans": [
+      "33.20.15",
+      "vt．使残废（disable, mutilate）；损伤",
+      "【记】 比较main（主要的）"
+    ],
+    "ukphone": "meIm",
+    "usphone": "meIm"
+  },
+  {
+    "name": "impair",
+    "trans": [
+      "33.20.16",
+      "vt．损害（harm, damage）",
+      "【记】 im（进入）+pair（坏）→使…坏→损害"
+    ],
+    "ukphone": "Imˋper",
+    "usphone": "Imˋper"
+  },
+  {
+    "name": "threaten",
+    "trans": [
+      "33.20.17",
+      "v．威胁（menace, terrify）"
+    ],
+    "ukphone": "ˋθretn",
+    "usphone": "ˋθretn"
+  },
+  {
+    "name": "balmy",
+    "trans": [
+      "33.21.1",
+      "adj．芳香的",
+      "【记】 balm（香气）+y"
+    ],
+    "ukphone": "ˋbα:mi",
+    "usphone": "ˋbα:mi"
+  },
+  {
+    "name": "delicious",
+    "trans": [
+      "33.21.2",
+      "adj．美味的，怡人的"
+    ],
+    "ukphone": "dIˋlIʃəs",
+    "usphone": "dIˋlIʃəs"
+  },
+  {
+    "name": "palatable",
+    "trans": [
+      "33.21.3",
+      "adj．味美的（savory, flavorous）",
+      "【记】 palate（上颚）+able"
+    ],
+    "ukphone": "ˋpælətəbl",
+    "usphone": "ˋpælətəbl"
+  },
+  {
+    "name": "fragrant",
+    "trans": [
+      "33.21.4",
+      "adj．香的，芬芳的（aromatic）"
+    ],
+    "ukphone": "ˋfreIgrənt",
+    "usphone": "ˋfreIgrənt"
+  },
+  {
+    "name": "pungent",
+    "trans": [
+      "33.21.5",
+      "adj．辛辣的（acrid, penetrating）",
+      "【记】 pung（刺）+ent→刺激的"
+    ],
+    "ukphone": "ˋpʌndʒənt",
+    "usphone": "ˋpʌndʒənt"
+  },
+  {
+    "name": "odor",
+    "trans": [
+      "33.21.6",
+      "n．气味，臭气；名誉，声誉（smell, scent; fame）"
+    ],
+    "ukphone": "ˋoʊdər",
+    "usphone": "ˋoʊdər"
+  },
+  {
+    "name": "taste",
+    "trans": [
+      "33.21.7",
+      "n．味道；品味（flavor, savor; appreciation）"
+    ],
+    "ukphone": "teIst",
+    "usphone": "teIst"
+  },
+  {
+    "name": "aura",
+    "trans": [
+      "33.21.8",
+      "n．气味"
+    ],
+    "ukphone": "ˋɔ:rə",
+    "usphone": "ˋɔ:rə"
+  },
+  {
+    "name": "flavor",
+    "trans": [
+      "33.21.9",
+      "n．味，风味"
+    ],
+    "ukphone": "ˋfleIvər",
+    "usphone": "ˋfleIvər"
+  },
+  {
+    "name": "aroma",
+    "trans": [
+      "33.21.10",
+      "n．香气，芬芳，芳香（fragrance, scent, perfume）"
+    ],
+    "ukphone": "əˋroʊmə",
+    "usphone": "əˋroʊmə"
+  },
+  {
+    "name": "smell",
+    "trans": [
+      "33.21.11",
+      "v．发出气味"
+    ],
+    "ukphone": "smel",
+    "usphone": "smel"
+  },
+  {
+    "name": "stink",
+    "trans": [
+      "33.21.12",
+      "vi．发出臭味（smell bad）"
+    ],
+    "ukphone": "stIŋk",
+    "usphone": "stIŋk"
+  },
+  {
+    "name": "savor",
+    "trans": [
+      "33.21.13",
+      "vt．尝味（taste, relish）"
+    ],
+    "ukphone": "ˋseIvər",
+    "usphone": "ˋseIvər"
+  },
+  {
+    "name": "acid",
+    "trans": [
+      "33.21.14",
+      "adj．酸的（sour, tart）n．酸"
+    ],
+    "ukphone": "ˋæsId",
+    "usphone": "ˋæsId"
+  },
+  {
+    "name": "hectic",
+    "trans": [
+      "33.22.1",
+      "adj．发热的（feverish）；紧张忙碌的",
+      "【记】 hect（许多）+ic→许多事要做→紧张兴奋的"
+    ],
+    "ukphone": "ˋhektIk",
+    "usphone": "ˋhektIk"
+  },
+  {
+    "name": "impervious",
+    "trans": [
+      "33.22.2",
+      "adj．不能渗透的（impenetrable, impermeable）",
+      "【记】 im（不）+pervious（渗透的）"
+    ],
+    "ukphone": "Imˋpɜ:rviəs",
+    "usphone": "Imˋpɜ:rviəs"
+  },
+  {
+    "name": "ponderous",
+    "trans": [
+      "33.22.3",
+      "adj．沉重的，笨重的（heavy）"
+    ],
+    "ukphone": "ˋpα:ndərəs",
+    "usphone": "ˋpα:ndərəs"
+  },
+  {
+    "name": "crisp",
+    "trans": [
+      "33.22.4",
+      "adj．脆的；卷曲的（crunchy, brittle）"
+    ],
+    "ukphone": "krIsp",
+    "usphone": "krIsp"
+  },
+  {
+    "name": "lofty",
+    "trans": [
+      "33.22.5",
+      "adj．高耸的（high, towering）",
+      "【记】 loft（阁楼，顶楼）+y"
+    ],
+    "ukphone": "ˋlɔ:fti",
+    "usphone": "ˋlɔ:fti"
+  },
+  {
+    "name": "slippery",
+    "trans": [
+      "33.22.6",
+      "adj．滑的，使人摔跤的（slick, smooth）"
+    ],
+    "ukphone": "ˋslIpəri",
+    "usphone": "ˋslIpəri"
+  },
+  {
+    "name": "dense",
+    "trans": [
+      "33.22.7",
+      "adj．密集的（thick, close）"
+    ],
+    "ukphone": "dens",
+    "usphone": "dens"
+  },
+  {
+    "name": "crooked",
+    "trans": [
+      "33.22.8",
+      "adj．扭曲的（bent, twisted）",
+      "【记】 crook（弯曲）+ed→拐弯抹角的"
+    ],
+    "ukphone": "ˋkrʊkId",
+    "usphone": "ˋkrʊkId"
+  },
+  {
+    "name": "shallow",
+    "trans": [
+      "33.22.9",
+      "adj．浅的（superficial）"
+    ],
+    "ukphone": "ˋʃæloʊ",
+    "usphone": "ˋʃæloʊ"
+  },
+  {
+    "name": "ethereal",
+    "trans": [
+      "33.22.10",
+      "adj．轻的，天上的（light, delicate）"
+    ],
+    "ukphone": "iˋθIriəl",
+    "usphone": "iˋθIriəl"
+  },
+  {
+    "name": "lithe",
+    "trans": [
+      "33.22.11",
+      "adj．柔软的；易弯的（flexible, supple）"
+    ],
+    "ukphone": "laIð",
+    "usphone": "laIð"
+  },
+  {
+    "name": "sloppy",
+    "trans": [
+      "33.22.12",
+      "adj．稀薄的",
+      "【记】 slop（溅，弄脏）+py"
+    ],
+    "ukphone": "ˋslα:pi",
+    "usphone": "ˋslα:pi"
+  },
+  {
+    "name": "slim",
+    "trans": [
+      "33.22.13",
+      "adj．细长的，苗条的（slender, thin）"
+    ],
+    "ukphone": "slIm",
+    "usphone": "slIm"
+  },
+  {
+    "name": "tenuous",
+    "trans": [
+      "33.22.14",
+      "adj．细的；稀薄的（thin, weak）",
+      "【记】 ten（细，薄）+uous"
+    ],
+    "ukphone": "ˋtenjuəs",
+    "usphone": "ˋtenjuəs"
+  },
+  {
+    "name": "compact",
+    "trans": [
+      "33.22.15",
+      "adj．压缩的；密集的（packed）",
+      "【记】 com+pact（打包，压紧）"
+    ],
+    "ukphone": "ˋkα:mpækt",
+    "usphone": "ˋkα:mpækt"
+  },
+  {
+    "name": "supple",
+    "trans": [
+      "33.22.16",
+      "adj．柔软的，易曲的（flexible, lithe）"
+    ],
+    "ukphone": "ˋsʌpl",
+    "usphone": "ˋsʌpl"
+  },
+  {
+    "name": "malleable",
+    "trans": [
+      "33.22.17",
+      "adj．有延展性的（pliable）；可锻的",
+      "【记】 malle（锤子）+able→可锻的"
+    ],
+    "ukphone": "ˋmæliəbl",
+    "usphone": "ˋmæliəbl"
+  },
+  {
+    "name": "depression",
+    "trans": [
+      "33.22.18",
+      "n．凹陷"
+    ],
+    "ukphone": "dIˋpreʃn",
+    "usphone": "dIˋpreʃn"
+  },
+  {
+    "name": "conductive",
+    "trans": [
+      "33.22.19",
+      "adj．传导性的，传导的，有传导力的"
+    ],
+    "ukphone": "kənˋdʌktIv",
+    "usphone": "kənˋdʌktIv"
+  },
+  {
+    "name": "resilient",
+    "trans": [
+      "33.22.20",
+      "adj．弹回的；迅速恢复精力的；有弹力的（springy, bouncy）"
+    ],
+    "ukphone": "rIˋzIliənt",
+    "usphone": "rIˋzIliənt"
+  },
+  {
+    "name": "faint",
+    "trans": [
+      "33.23.1",
+      "adj．微弱的（feeble, unsteady）"
+    ],
+    "ukphone": "feInt",
+    "usphone": "feInt"
+  },
+  {
+    "name": "ignoble",
+    "trans": [
+      "33.23.2",
+      "adj．卑微的（despicable, dishonorable）",
+      "【记】 ig（不）+noble（高贵）"
+    ],
+    "ukphone": "Igˋnoʊbl",
+    "usphone": "Igˋnoʊbl"
+  },
+  {
+    "name": "minuscule",
+    "trans": [
+      "33.23.3",
+      "adj．极小的（tiny）"
+    ],
+    "ukphone": "ˋmInəskju:l",
+    "usphone": "ˋmInəskju:l"
+  },
+  {
+    "name": "negligible",
+    "trans": [
+      "33.23.4",
+      "adj．可以忽略的，不予重视的（insignificant, minimal）"
+    ],
+    "ukphone": "ˋneglIdʒəbl",
+    "usphone": "ˋneglIdʒəbl"
+  },
+  {
+    "name": "slight",
+    "trans": [
+      "33.23.5",
+      "adj．轻微的，微小的（tiny, microscopic）"
+    ],
+    "ukphone": "slaIt",
+    "usphone": "slaIt"
+  },
+  {
+    "name": "trivial",
+    "trans": [
+      "33.23.6",
+      "adj．微不足道的（unimportant, trifling）"
+    ],
+    "ukphone": "ˋtrIviəl",
+    "usphone": "ˋtrIviəl"
+  },
+  {
+    "name": "feeble",
+    "trans": [
+      "33.23.7",
+      "adj．微弱的（weak, infirm）"
+    ],
+    "ukphone": "ˋfi:bl",
+    "usphone": "ˋfi:bl"
+  },
+  {
+    "name": "trifling",
+    "trans": [
+      "33.23.8",
+      "adj．微小的（insignificant, trivial）"
+    ],
+    "ukphone": "ˋtraIflIŋ",
+    "usphone": "ˋtraIflIŋ"
+  },
+  {
+    "name": "minute",
+    "trans": [
+      "33.23.9",
+      "adj．微小的（tiny, minuscule）",
+      "【记】 min（小）+ute"
+    ],
+    "ukphone": "maIˋnju:t",
+    "usphone": "maIˋnju:t"
+  },
+  {
+    "name": "insular",
+    "trans": [
+      "33.23.10",
+      "adj．狭隘的（isolated; narrow-minded）",
+      "【记】 insul（岛）+ar"
+    ],
+    "ukphone": "ˋInsələr",
+    "usphone": "ˋInsələr"
+  },
+  {
+    "name": "diminutive",
+    "trans": [
+      "33.23.11",
+      "adj．小的（small, tiny）"
+    ],
+    "ukphone": "dIˋmInjətIv",
+    "usphone": "dIˋmInjətIv"
+  },
+  {
+    "name": "tiny",
+    "trans": [
+      "33.23.12",
+      "adj．小的，极小的（microscopic, minute, little, minuscule）"
+    ],
+    "ukphone": "ˋtaIni",
+    "usphone": "ˋtaIni"
+  },
+  {
+    "name": "fine",
+    "trans": [
+      "33.23.13",
+      "adj．细微的（thin, small）"
+    ],
+    "ukphone": "faIn",
+    "usphone": "faIn"
+  },
+  {
+    "name": "mythical",
+    "trans": [
+      "33.24.1",
+      "adj．神话的，虚构的（legendary, fictitious）"
+    ],
+    "ukphone": "ˋmIθIkl",
+    "usphone": "ˋmIθIkl"
+  },
+  {
+    "name": "fictitious",
+    "trans": [
+      "33.24.2",
+      "adj．虚构的（invented, imaginary）",
+      "【记】 fict（做，造）+itious→造出的→虚构的"
+    ],
+    "ukphone": "fIkˋtIʃəs",
+    "usphone": "fIkˋtIʃəs"
+  },
+  {
+    "name": "imaginary",
+    "trans": [
+      "33.24.3",
+      "adj．虚构的"
+    ],
+    "ukphone": "IˋmædʒIneri",
+    "usphone": "IˋmædʒIneri"
+  },
+  {
+    "name": "imaginative",
+    "trans": [
+      "33.24.4",
+      "adj．富于想像的"
+    ],
+    "ukphone": "IˋmædʒInətIv",
+    "usphone": "IˋmædʒInətIv"
+  },
+  {
+    "name": "illusion",
+    "trans": [
+      "33.24.5",
+      "n．幻觉（hallucination）"
+    ],
+    "ukphone": "Iˋlu:ʒn",
+    "usphone": "Iˋlu:ʒn"
+  },
+  {
+    "name": "fantasy",
+    "trans": [
+      "33.24.6",
+      "n．幻想，空想；怪念头（dream; fancy）"
+    ],
+    "ukphone": "ˋfæntəsi",
+    "usphone": "ˋfæntəsi"
+  },
+  {
+    "name": "superstition",
+    "trans": [
+      "33.24.7",
+      "n．迷信"
+    ],
+    "ukphone": "ˌsju:pərˋstIʃn",
+    "usphone": "ˌsju:pərˋstIʃn"
+  },
+  {
+    "name": "panacea",
+    "trans": [
+      "33.24.8",
+      "n．万灵药（cure-all）",
+      "【记】 pan（全部）+acea（治疗）"
+    ],
+    "ukphone": "ˌpænəˋsi:ə",
+    "usphone": "ˌpænəˋsi:ə"
+  },
+  {
+    "name": "figment",
+    "trans": [
+      "33.24.9",
+      "n．虚构之事",
+      "【记】 fig（做）+ment→做出的东西→虚构"
+    ],
+    "ukphone": "ˋfIgmənt",
+    "usphone": "ˋfIgmənt"
+  },
+  {
+    "name": "conceive",
+    "trans": [
+      "33.24.10",
+      "v．想像（devise, visualize）"
+    ],
+    "ukphone": "kənˋsi:v",
+    "usphone": "kənˋsi:v"
+  },
+  {
+    "name": "occult",
+    "trans": [
+      "33.24.11",
+      "adj．神秘的，不可思议的（supernatural）"
+    ],
+    "ukphone": "əˋkʌlt",
+    "usphone": "əˋkʌlt"
+  },
+  {
+    "name": "gratuitous",
+    "trans": [
+      "33.25.1",
+      "adj．不需要的（unwanted）"
+    ],
+    "ukphone": "grəˋtju:Itəs",
+    "usphone": "grəˋtju:Itəs"
+  },
+  {
+    "name": "indispensable",
+    "trans": [
+      "33.25.2",
+      "adj．不可缺少的，绝对必要的（essential, vital）"
+    ],
+    "ukphone": "ˌIndIˋspensəbl",
+    "usphone": "ˌIndIˋspensəbl"
+  },
+  {
+    "name": "imperative",
+    "trans": [
+      "33.25.3",
+      "adj．急需的（necessary, urgent）",
+      "【记】 imper（命令）+ative"
+    ],
+    "ukphone": "ImˋperətIv",
+    "usphone": "ImˋperətIv"
+  },
+  {
+    "name": "tangible",
+    "trans": [
+      "33.26.1",
+      "adj．可见的，确实的（touchable, substantial）",
+      "【记】 tang（接触）+ible→确实（存在）的"
+    ],
+    "ukphone": "ˋtændʒəbl",
+    "usphone": "ˋtændʒəbl"
+  },
+  {
+    "name": "authentic",
+    "trans": [
+      "33.26.2",
+      "adj．可靠，有根据的，真实的（genuine, real）",
+      "【记】 aut（自己）+hent（得到）+ic→亲自得到→真实的"
+    ],
+    "ukphone": "ɔ:ˋθentIk",
+    "usphone": "ɔ:ˋθentIk"
+  },
+  {
+    "name": "genuine",
+    "trans": [
+      "33.26.3",
+      "adj．真实的，真正的（authentic, real）"
+    ],
+    "ukphone": "ˋdʒenjuIn",
+    "usphone": "ˋdʒenjuIn"
+  },
+  {
+    "name": "truly",
+    "trans": [
+      "33.26.4",
+      "adv．真实地，不假（genuinely, actually）"
+    ],
+    "ukphone": "ˋtru:li",
+    "usphone": "ˋtru:li"
+  },
+  {
+    "name": "actual",
+    "trans": [
+      "33.26.5",
+      "adj．实际的，现行的，真实的（practical, real）"
+    ],
+    "ukphone": "ˋæktʃuəl",
+    "usphone": "ˋæktʃuəl"
+  },
+  {
+    "name": "authenticity",
+    "trans": [
+      "33.26.6",
+      "n．可信赖性；诚实；确实（genuineness）"
+    ],
+    "ukphone": "ˌɔ:θenˋtIsəti",
+    "usphone": "ˌɔ:θenˋtIsəti"
+  },
+  {
+    "name": "superb",
+    "trans": [
+      "33.27.1",
+      "adj．超级的"
+    ],
+    "ukphone": "sju:ˋpɜ:rb",
+    "usphone": "sju:ˋpɜ:rb"
+  },
+  {
+    "name": "pivot",
+    "trans": [
+      "33.27.2",
+      "n．转折点，关键"
+    ],
+    "ukphone": "ˋpIvət",
+    "usphone": "ˋpIvət"
+  },
+  {
+    "name": "pivotal",
+    "trans": [
+      "33.27.3",
+      "adj．关键的；枢纽的"
+    ],
+    "ukphone": "ˋpIvətl",
+    "usphone": "ˋpIvətl"
+  },
+  {
+    "name": "foremost",
+    "trans": [
+      "33.27.4",
+      "adj．第一流的（prime）",
+      "【记】 fore（前）+most（最）→最先的"
+    ],
+    "ukphone": "ˋfɔ:rmoʊst",
+    "usphone": "ˋfɔ:rmoʊst"
+  },
+  {
+    "name": "elementary",
+    "trans": [
+      "33.27.5",
+      "adj．基本的，初级的"
+    ],
+    "ukphone": "ˌelIˋmentri",
+    "usphone": "ˌelIˋmentri"
+  },
+  {
+    "name": "fundamental",
+    "trans": [
+      "33.27.6",
+      "adj．基础的，基本的（essential, elementary）"
+    ],
+    "ukphone": "ˌfʌndəˋmentl",
+    "usphone": "ˌfʌndəˋmentl"
+  },
+  {
+    "name": "momentous",
+    "trans": [
+      "33.27.7",
+      "adj．极重要的（important, critical）",
+      "【记】 moment（时刻）+ous→刻不容缓的→重要的"
+    ],
+    "ukphone": "moʊˋmentəs",
+    "usphone": "moʊˋmentəs"
+  },
+  {
+    "name": "vital",
+    "trans": [
+      "33.27.8",
+      "adj．极重要的（important, crucial, essential）"
+    ],
+    "ukphone": "ˋvaItl",
+    "usphone": "ˋvaItl"
+  },
+  {
+    "name": "cardinal",
+    "trans": [
+      "33.27.9",
+      "adj．首要的，基本的（essential）",
+      "【记】 cardi（铰链，要点）+nal"
+    ],
+    "ukphone": "ˋkα:rdInl",
+    "usphone": "ˋkα:rdInl"
+  },
+  {
+    "name": "crucial",
+    "trans": [
+      "33.27.10",
+      "adj．严重的；极重要的（decisive, critical）"
+    ],
+    "ukphone": "ˋkru:ʃl",
+    "usphone": "ˋkru:ʃl"
+  },
+  {
+    "name": "significant",
+    "trans": [
+      "33.27.11",
+      "adj．有意义的；重要的（important, telling）"
+    ],
+    "ukphone": "sIgˋnIfIkənt",
+    "usphone": "sIgˋnIfIkənt"
+  },
+  {
+    "name": "dominant",
+    "trans": [
+      "33.27.12",
+      "adj．占优势的，主导的（predominant, prevalent）"
+    ],
+    "ukphone": "ˋdα:mInənt",
+    "usphone": "ˋdα:mInənt"
+  },
+  {
+    "name": "predominate",
+    "trans": [
+      "33.27.13",
+      "vt．占优势，支配（prevail）",
+      "【记】 pre+domin（统治）+ate"
+    ],
+    "ukphone": "prIˋdα:mIneIt",
+    "usphone": "prIˋdα:mIneIt"
+  },
+  {
+    "name": "predominantly",
+    "trans": [
+      "33.27.14",
+      "adv．占主导地位地，显著地（primarily, chiefy, princi-pally）"
+    ],
+    "ukphone": "prIˋdα:mInəntli",
+    "usphone": "prIˋdα:mInəntli"
+  },
+  {
+    "name": "fateful",
+    "trans": [
+      "33.27.15",
+      "adj．重大的"
+    ],
+    "ukphone": "ˋfeItfl",
+    "usphone": "ˋfeItfl"
+  },
+  {
+    "name": "primary",
+    "trans": [
+      "33.27.16",
+      "adj．重要的（crucial, vital）",
+      "【记】 prim（最初的）+ary"
+    ],
+    "ukphone": "praIˋmerəli",
+    "usphone": "praIˋmerəli"
+  },
+  {
+    "name": "primarily",
+    "trans": [
+      "33.27.17",
+      "adv．首先，主要地（chiefly, mainly, principally）"
+    ],
+    "ukphone": "praIˋmerəli",
+    "usphone": "praIˋmerəli"
+  },
+  {
+    "name": "essential",
+    "trans": [
+      "33.27.18",
+      "adj．重要的；基本的；必需的（crucial; fundamental; necessary, vital）"
+    ],
+    "ukphone": "Iˋsenʃl",
+    "usphone": "Iˋsenʃl"
+  },
+  {
+    "name": "key",
+    "trans": [
+      "33.27.19",
+      "adj．主要的，关键的（dominant, primary）"
+    ],
+    "ukphone": "ki:",
+    "usphone": "ki:"
+  },
+  {
+    "name": "optimum",
+    "trans": [
+      "33.27.20",
+      "adj．最优的（best）",
+      "【记】 optim（最好）+um"
+    ],
+    "ukphone": "ˋα:ptIməm",
+    "usphone": "ˋα:ptIməm"
+  },
+  {
+    "name": "leading",
+    "trans": [
+      "33.27.21",
+      "adj．最主要的（principal, chief）"
+    ],
+    "ukphone": "ˋli:dIŋ",
+    "usphone": "ˋli:dIŋ"
+  },
+  {
+    "name": "chiefly",
+    "trans": [
+      "33.27.22",
+      "adv．主要地，多半地（mainly, principally）",
+      "【记】 chief（主要）+ly"
+    ],
+    "ukphone": "ˋtʃi:fli",
+    "usphone": "ˋtʃi:fli"
+  },
+  {
+    "name": "largely",
+    "trans": [
+      "33.27.23",
+      "adv．主要地，很大程度上（mainly, for the most part）"
+    ],
+    "ukphone": "ˋlα:rdʒli",
+    "usphone": "ˋlα:rdʒli"
+  },
+  {
+    "name": "sum",
+    "trans": [
+      "33.27.24",
+      "n．要点"
+    ],
+    "ukphone": "sʌm",
+    "usphone": "sʌm"
+  },
+  {
+    "name": "preference",
+    "trans": [
+      "33.27.25",
+      "n．优先；优先权（inclination, privilege）",
+      "【记】 prefer（喜欢）+ence"
+    ],
+    "ukphone": "ˋprefrəns",
+    "usphone": "ˋprefrəns"
+  },
+  {
+    "name": "forte",
+    "trans": [
+      "33.27.26",
+      "n．长处（strong point）",
+      "【记】 fort（强）+e→强大→长处"
+    ],
+    "ukphone": "fɔ:rt",
+    "usphone": "fɔ:rt"
+  },
+  {
+    "name": "elite",
+    "trans": [
+      "33.27.27",
+      "n．精华，中坚（best）",
+      "【记】 e（出）+lite=lig（选）→选出的（人物）→精英人物"
+    ],
+    "ukphone": "eIˋli:t",
+    "usphone": "eIˋli:t"
+  },
+  {
+    "name": "gist",
+    "trans": [
+      "33.27.28",
+      "n．要旨（theme）"
+    ],
+    "ukphone": "dʒIst",
+    "usphone": "dʒIst"
+  },
+  {
+    "name": "merit",
+    "trans": [
+      "33.27.29",
+      "n．优点（advantage）",
+      "【记】 比较demerit（缺点）"
+    ],
+    "ukphone": "ˋmerIt",
+    "usphone": "ˋmerIt"
+  },
+  {
+    "name": "motif",
+    "trans": [
+      "33.27.30",
+      "n．主题（theme, subject）；主旨"
+    ],
+    "ukphone": "moʊˋti:f",
+    "usphone": "moʊˋti:f"
+  },
+  {
+    "name": "tenor",
+    "trans": [
+      "33.27.31",
+      "n．要旨，要义（nature）"
+    ],
+    "ukphone": "ˋtenər",
+    "usphone": "ˋtenər"
+  },
+  {
+    "name": "principal",
+    "trans": [
+      "33.27.32",
+      "adj．重要的（main, chief, central）"
+    ],
+    "ukphone": "ˋprInsəpl",
+    "usphone": "ˋprInsəpl"
+  },
+  {
+    "name": "major",
+    "trans": [
+      "33.27.33",
+      "adj．主要的"
+    ],
+    "ukphone": "ˋmeIdʒər",
+    "usphone": "ˋmeIdʒər"
+  },
+  {
+    "name": "sole",
+    "trans": [
+      "33.27.34",
+      "adj．惟一的"
+    ],
+    "ukphone": "soʊl",
+    "usphone": "soʊl"
+  },
+  {
+    "name": "critical",
+    "trans": [
+      "33.27.35",
+      "adj．批评的；危险的；决定性的；临界的（decisive, crucial）"
+    ],
+    "ukphone": "ˋkrItIkl",
+    "usphone": "ˋkrItIkl"
+  },
+  {
+    "name": "monumental",
+    "trans": [
+      "33.27.36",
+      "adj．纪念碑的；不朽的；作为纪念的（extraordinary, memorable, remarkable）"
+    ],
+    "ukphone": "ˌmα:njuˋmentl",
+    "usphone": "ˌmα:njuˋmentl"
+  },
+  {
+    "name": "inventive",
+    "trans": [
+      "33.27.37",
+      "adj．发明的；有发明才能的；别出心裁的"
+    ],
+    "ukphone": "InˋventIv",
+    "usphone": "InˋventIv"
+  },
+  {
+    "name": "glorious",
+    "trans": [
+      "33.28.1",
+      "adj．壮丽的"
+    ],
+    "ukphone": "ˋglɔ:riəs",
+    "usphone": "ˋglɔ:riəs"
+  },
+  {
+    "name": "splendid",
+    "trans": [
+      "33.28.2",
+      "adj．灿烂的，辉煌的（magnificent）",
+      "【记】 splend（明亮）+id→灿烂的"
+    ],
+    "ukphone": "ˋsplendId",
+    "usphone": "ˋsplendId"
+  },
+  {
+    "name": "splendor",
+    "trans": [
+      "33.28.3",
+      "n．光彩，壮丽（grandeur, magnificence）"
+    ],
+    "ukphone": "ˋsplendər",
+    "usphone": "ˋsplendər"
+  },
+  {
+    "name": "grand",
+    "trans": [
+      "33.28.4",
+      "adj．盛大的，壮丽的（splendid, magnificent）"
+    ],
+    "ukphone": "grænd",
+    "usphone": "grænd"
+  },
+  {
+    "name": "gorgeous",
+    "trans": [
+      "33.28.5",
+      "adj．绚丽的（beautiful, admirable, very colorful）",
+      "【记】 参考gorge（峡谷）"
+    ],
+    "ukphone": "ˋgɔ:rdʒəs",
+    "usphone": "ˋgɔ:rdʒəs"
+  },
+  {
+    "name": "radiant",
+    "trans": [
+      "33.28.6",
+      "adj．绚丽的；容光焕发的（joyous, beaming）",
+      "【记】 radi（光，线）+ant→绚丽的"
+    ],
+    "ukphone": "ˋreIdiənt",
+    "usphone": "ˋreIdiənt"
+  },
+  {
+    "name": "spectacular",
+    "trans": [
+      "33.28.7",
+      "adj．引人入胜的，壮观的（breathtaking, impressive, striking）"
+    ],
+    "ukphone": "spekˋtækjələr",
+    "usphone": "spekˋtækjələr"
+  },
+  {
+    "name": "solemn",
+    "trans": [
+      "33.28.8",
+      "adj．庄严的；隆重的（grave, somber）"
+    ],
+    "ukphone": "ˋsα:ləm",
+    "usphone": "ˋsα:ləm"
+  },
+  {
+    "name": "superb",
+    "trans": [
+      "33.28.9",
+      "adj．壮丽的（excellent, first-rate）"
+    ],
+    "ukphone": "sju:ˋpɜ:rb",
+    "usphone": "sju:ˋpɜ:rb"
+  },
+  {
+    "name": "magnificent",
+    "trans": [
+      "33.28.10",
+      "n．壮丽的，华丽的（gallant, splendid）",
+      "【记】 magni（大）+ficent→壮丽的"
+    ],
+    "ukphone": "mægˋnIfIsnt",
+    "usphone": "mægˋnIfIsnt"
+  },
+  {
+    "name": "injurious",
+    "trans": [
+      "34.1.1",
+      "adj．侮辱，诽谤的；有害的（harmful, deleterious）",
+      "【记】 injury+ous"
+    ],
+    "ukphone": "Inˋdʒʊrəriəs",
+    "usphone": "Inˋdʒʊrəriəs"
+  },
+  {
+    "name": "asperse",
+    "trans": [
+      "34.1.2",
+      "vt．诽谤（slander）",
+      "【记】 a+sperse（散开）→散布坏东西→诽谤"
+    ],
+    "ukphone": "əsˋpɜ:rs",
+    "usphone": "əsˋpɜ:rs"
+  },
+  {
+    "name": "aspersion",
+    "trans": [
+      "34.1.3",
+      "n．诽谤"
+    ],
+    "ukphone": "əsˋpɜ:rʒn",
+    "usphone": "əsˋpɜ:rʒn"
+  },
+  {
+    "name": "indignity",
+    "trans": [
+      "34.1.4",
+      "n．侮辱"
+    ],
+    "ukphone": "InˋdIgnəti",
+    "usphone": "InˋdIgnəti"
+  },
+  {
+    "name": "malign",
+    "trans": [
+      "34.1.5",
+      "vt．诋毁，诽谤（defame, slander）"
+    ],
+    "ukphone": "məˋlaIn",
+    "usphone": "məˋlaIn"
+  },
+  {
+    "name": "defame",
+    "trans": [
+      "34.1.6",
+      "vt．诽谤，损毁名誉（slander, malign）",
+      "【记】 de+fame（名声）"
+    ],
+    "ukphone": "dIˋfeIm",
+    "usphone": "dIˋfeIm"
+  },
+  {
+    "name": "disparage",
+    "trans": [
+      "34.1.7",
+      "vt．轻视；毁谤（denigrate, depreciate）",
+      "【记】 dis+par（平等）+age→不平等→贬低"
+    ],
+    "ukphone": "dIˋspærIdʒ",
+    "usphone": "dIˋspærIdʒ"
+  },
+  {
+    "name": "humiliate",
+    "trans": [
+      "34.1.8",
+      "vt．屈辱；贬抑（shame, humble, insult）",
+      "【记】 hum（地）+iliate→使人想找地缝→羞辱别人"
+    ],
+    "ukphone": "hju:ˋmIlieIt",
+    "usphone": "hju:ˋmIlieIt"
+  },
+  {
+    "name": "slander",
+    "trans": [
+      "34.1.9",
+      "n./vt．造谣，诽谤（defame, malign）"
+    ],
+    "ukphone": "ˋslændər",
+    "usphone": "ˋslændər"
+  },
+  {
+    "name": "insult",
+    "trans": [
+      "34.1.10",
+      "n./vt．侮辱，凌辱"
+    ],
+    "ukphone": "Inˋsʌlt",
+    "usphone": "Inˋsʌlt"
+  },
+  {
+    "name": "satirical",
+    "trans": [
+      "34.2.1",
+      "adj．讽刺的（acid, sardonic）"
+    ],
+    "ukphone": "səˋtIrIkl",
+    "usphone": "səˋtIrIkl"
+  },
+  {
+    "name": "sardonic",
+    "trans": [
+      "34.2.2",
+      "adj．讽刺的，嘲笑的（sarcastic, derisive）"
+    ],
+    "ukphone": "sα:rˋdα:nIk",
+    "usphone": "sα:rˋdα:nIk"
+  },
+  {
+    "name": "sarcastic",
+    "trans": [
+      "34.2.3",
+      "adj．讽刺的，挖苦的"
+    ],
+    "ukphone": "sα:rˋkæstIk",
+    "usphone": "sα:rˋkæstIk"
+  },
+  {
+    "name": "sarcasm",
+    "trans": [
+      "34.2.4",
+      "n．讽刺，挖苦（irony, scorn）"
+    ],
+    "ukphone": "ˋsα:rkæzəm",
+    "usphone": "ˋsα:rkæzəm"
+  },
+  {
+    "name": "cynical",
+    "trans": [
+      "34.2.5",
+      "adj．讥讽的，冷嘲热讽的（contemptuous, sarcastic）"
+    ],
+    "ukphone": "ˋsInIkl",
+    "usphone": "ˋsInIkl"
+  },
+  {
+    "name": "mock",
+    "trans": [
+      "34.2.6",
+      "n．嘲弄 vt．嘲弄，挖苦（mimic, ridicule）"
+    ],
+    "ukphone": "mα:k",
+    "usphone": "mα:k"
+  },
+  {
+    "name": "taunt",
+    "trans": [
+      "34.2.7",
+      "n./vt．嘲笑（tease, insult）",
+      "【记】 比较daunt（恐吓）"
+    ],
+    "ukphone": "tɔ:nt",
+    "usphone": "tɔ:nt"
+  },
+  {
+    "name": "jeer",
+    "trans": [
+      "34.2.8",
+      "vi．揶揄，嘲笑（deride, gibe）"
+    ],
+    "ukphone": "dʒIr",
+    "usphone": "dʒIr"
+  },
+  {
+    "name": "flout",
+    "trans": [
+      "34.2.9",
+      "vt．嘲弄（scoff, despise）"
+    ],
+    "ukphone": "flaʊt",
+    "usphone": "flaʊt"
+  },
+  {
+    "name": "sneer",
+    "trans": [
+      "34.2.10",
+      "vt．嘲笑（scoff, scorn）"
+    ],
+    "ukphone": "snIr",
+    "usphone": "snIr"
+  },
+  {
+    "name": "deride",
+    "trans": [
+      "34.2.11",
+      "vt．嘲笑，愚弄（ridicule, mock, gibe）",
+      "【记】 de（坏）+ride（笑）"
+    ],
+    "ukphone": "dIˋraId",
+    "usphone": "dIˋraId"
+  },
+  {
+    "name": "gibe",
+    "trans": [
+      "34.2.12",
+      "n./vt．讥笑（deride, ridicule, mock, make fun of）"
+    ],
+    "ukphone": "dʒaIb",
+    "usphone": "dʒaIb"
+  },
+  {
+    "name": "clamor",
+    "trans": [
+      "34.3.1",
+      "n．叫嚣（uproar, hubbub）",
+      "【记】 clam（喊）+or"
+    ],
+    "ukphone": "ˋklæmər",
+    "usphone": "ˋklæmər"
+  },
+  {
+    "name": "exclaim",
+    "trans": [
+      "34.3.2",
+      "v．呼喊，惊叫（shout, ejaculate）"
+    ],
+    "ukphone": "IkˋskleIm",
+    "usphone": "IkˋskleIm"
+  },
+  {
+    "name": "exhale",
+    "trans": [
+      "34.3.3",
+      "vt．呼出（breathe out, respire）；发出；散发",
+      "【记】 ex+hale（气）→呼出气"
+    ],
+    "ukphone": "eksˋheIl",
+    "usphone": "eksˋheIl"
+  },
+  {
+    "name": "howl",
+    "trans": [
+      "34.3.4",
+      "vt．咆哮（wail, bawl）"
+    ],
+    "ukphone": "haʊl",
+    "usphone": "haʊl"
+  },
+  {
+    "name": "acclaim",
+    "trans": [
+      "34.3.5",
+      "v．喝彩，欢呼；称赞（applaud, approve, praise）",
+      "【记】 ac+claim（喊）"
+    ],
+    "ukphone": "əˋkleIm",
+    "usphone": "əˋkleIm"
+  },
+  {
+    "name": "counsel",
+    "trans": [
+      "34.4.1",
+      "v．劝告（advise）n．商议，忠告"
+    ],
+    "ukphone": "ˋkaʊnsl",
+    "usphone": "ˋkaʊnsl"
+  },
+  {
+    "name": "propose",
+    "trans": [
+      "34.4.2",
+      "v．提出，提议（advance, suggest）"
+    ],
+    "ukphone": "prəˋpoʊz",
+    "usphone": "prəˋpoʊz"
+  },
+  {
+    "name": "proposal",
+    "trans": [
+      "34.4.3",
+      "n．提案；建议（advice）"
+    ],
+    "ukphone": "prəˋpoʊzl",
+    "usphone": "prəˋpoʊzl"
+  },
+  {
+    "name": "offer",
+    "trans": [
+      "34.4.4",
+      "n．提议（proposal）vt．提出，提议（suggest, propose）",
+      "【记】 of（一再）+fer（带来）→一再带来→提供"
+    ],
+    "ukphone": "ˋɔ:fər",
+    "usphone": "ˋɔ:fər"
+  },
+  {
+    "name": "recommend",
+    "trans": [
+      "34.4.5",
+      "vt．劝告；推荐（suggest）"
+    ],
+    "ukphone": "ˌrekəˋmend",
+    "usphone": "ˌrekəˋmend"
+  },
+  {
+    "name": "remind",
+    "trans": [
+      "34.4.6",
+      "vt．提醒（awake）",
+      "【记】 re（再次）+mind=ment（思考）→提醒（自己）"
+    ],
+    "ukphone": "rIˋmaInd",
+    "usphone": "rIˋmaInd"
+  },
+  {
+    "name": "suggest",
+    "trans": [
+      "34.4.7",
+      "vt．提议；暗示（hint, insinuate）"
+    ],
+    "ukphone": "səˋdʒest",
+    "usphone": "səˋdʒest"
+  },
+  {
+    "name": "mention",
+    "trans": [
+      "34.4.8",
+      "vt．主张；提及",
+      "【记】 ment（思考）+ion→思考想到→提到"
+    ],
+    "ukphone": "ˋmenʃn",
+    "usphone": "ˋmenʃn"
+  },
+  {
+    "name": "advice",
+    "trans": [
+      "34.4.9",
+      "n．建议，忠告（suggestion）"
+    ],
+    "ukphone": "ədˋvaIs",
+    "usphone": "ədˋvaIs"
+  },
+  {
+    "name": "advise",
+    "trans": [
+      "34.4.10",
+      "vt．告知；劝告（suggest）"
+    ],
+    "ukphone": "ədˋvaIz",
+    "usphone": "ədˋvaIz"
+  },
+  {
+    "name": "advance",
+    "trans": [
+      "34.4.11",
+      "vt．提出"
+    ],
+    "ukphone": "ədˋvæns",
+    "usphone": "ədˋvæns"
+  },
+  {
+    "name": "submit",
+    "trans": [
+      "34.4.12",
+      "vt．提交（propose）"
+    ],
+    "ukphone": "səbˋmIt",
+    "usphone": "səbˋmIt"
+  },
+  {
+    "name": "reciprocal",
+    "trans": [
+      "34.5.1",
+      "adj．相互的；交往的（mutual, exchanged）"
+    ],
+    "ukphone": "rIˋsIprəkl",
+    "usphone": "rIˋsIprəkl"
+  },
+  {
+    "name": "correspondence",
+    "trans": [
+      "34.5.2",
+      "n．通信",
+      "【记】 cor+respond（反应）+ence"
+    ],
+    "ukphone": "ˌkɔ:rəˋspα:ndəns",
+    "usphone": "ˌkɔ:rəˋspα:ndəns"
+  },
+  {
+    "name": "liaison",
+    "trans": [
+      "34.5.3",
+      "n．联络（contact, connection）"
+    ],
+    "ukphone": "liˋeIzα:n",
+    "usphone": "liˋeIzα:n"
+  },
+  {
+    "name": "propagate",
+    "trans": [
+      "34.5.4",
+      "vt．宣传"
+    ],
+    "ukphone": "ˋprα:pəgeIt",
+    "usphone": "ˋprα:pəgeIt"
+  },
+  {
+    "name": "communicate",
+    "trans": [
+      "34.5.5",
+      "vt．传达 vi．通信；交流",
+      "【记】 commune（交谈）+ic+ate→大家交谈→交流"
+    ],
+    "ukphone": "kəˋmju:nIkeIt",
+    "usphone": "kəˋmju:nIkeIt"
+  },
+  {
+    "name": "impart",
+    "trans": [
+      "34.5.6",
+      "vt．给予；传递；告诉（disseminate, inform）",
+      "【记】 im（进入）+part（部分）→成为（信息的）一部分→传递"
+    ],
+    "ukphone": "Imˋpα:rt",
+    "usphone": "Imˋpα:rt"
+  },
+  {
+    "name": "remit",
+    "trans": [
+      "34.5.7",
+      "vt．汇寄",
+      "【记】 re（再）+mit（送）→再送出去→汇款"
+    ],
+    "ukphone": "rI:ˋmIt",
+    "usphone": "rI:ˋmIt"
+  },
+  {
+    "name": "consort",
+    "trans": [
+      "34.5.8",
+      "vt．结交（associate, connect）"
+    ],
+    "ukphone": "kənˋsɔ:rt",
+    "usphone": "kənˋsɔ:rt"
+  },
+  {
+    "name": "disseminate",
+    "trans": [
+      "34.5.9",
+      "vt．散布，传播（disperse, distribute, spread, impart）",
+      "【记】 dis+semin（种子）+ate→散布（种子）"
+    ],
+    "ukphone": "dIˋsemIneIt",
+    "usphone": "dIˋsemIneIt"
+  },
+  {
+    "name": "tip",
+    "trans": [
+      "34.5.10",
+      "vt．接触（contact）"
+    ],
+    "ukphone": "tIp",
+    "usphone": "tIp"
+  },
+  {
+    "name": "bombastic",
+    "trans": [
+      "34.6.1",
+      "adj．夸大的（boastful）",
+      "【记】 比较bomb（炸弹）"
+    ],
+    "ukphone": "bα:mˋbæstIk",
+    "usphone": "bα:mˋbæstIk"
+  },
+  {
+    "name": "pretentious",
+    "trans": [
+      "34.6.2",
+      "adj．装腔作势的（showy, ostentatious），自命不凡的"
+    ],
+    "ukphone": "prIˋtenʃəs",
+    "usphone": "prIˋtenʃəs"
+  },
+  {
+    "name": "boast",
+    "trans": [
+      "34.6.3",
+      "vi．自夸 vt．吹嘘（brag, self-praise）"
+    ],
+    "ukphone": "boʊst",
+    "usphone": "boʊst"
+  },
+  {
+    "name": "boastful",
+    "trans": [
+      "34.6.4",
+      "adj．自夸的（bragging, conceited）"
+    ],
+    "ukphone": "ˋboʊstfl",
+    "usphone": "ˋboʊstfl"
+  },
+  {
+    "name": "vanity",
+    "trans": [
+      "34.6.5",
+      "n．虚荣心（self-conceit, pride）",
+      "【记】 van（空）+ity→虚荣心"
+    ],
+    "ukphone": "ˋvænəti",
+    "usphone": "ˋvænəti"
+  },
+  {
+    "name": "conceit",
+    "trans": [
+      "34.6.6",
+      "n．自负，自高自大（vanity, arrogance）"
+    ],
+    "ukphone": "kənˋsi:t",
+    "usphone": "kənˋsi:t"
+  },
+  {
+    "name": "exaggerate",
+    "trans": [
+      "34.6.7",
+      "v．夸大，夸张（overstate, overemphasize）"
+    ],
+    "ukphone": "IgˋzædʒəreIt",
+    "usphone": "IgˋzædʒəreIt"
+  },
+  {
+    "name": "brag",
+    "trans": [
+      "34.6.8",
+      "vt．夸张（boast, talk big）"
+    ],
+    "ukphone": "bræg",
+    "usphone": "bræg"
+  },
+  {
+    "name": "imperative",
+    "trans": [
+      "34.7.1",
+      "adj．命令的",
+      "【记】 imper（命令）+ative"
+    ],
+    "ukphone": "ImˋperətIv",
+    "usphone": "ImˋperətIv"
+  },
+  {
+    "name": "bidding",
+    "trans": [
+      "34.7.2",
+      "n．命令，要求"
+    ],
+    "ukphone": "ˋbIdIŋ",
+    "usphone": "ˋbIdIŋ"
+  },
+  {
+    "name": "prescription",
+    "trans": [
+      "34.7.3",
+      "n．指示（instruction, direction）"
+    ],
+    "ukphone": "prIˋskrIpʃn",
+    "usphone": "prIˋskrIpʃn"
+  },
+  {
+    "name": "rally",
+    "trans": [
+      "34.7.4",
+      "n./v．召集（gathering, assemblage）",
+      "【记】 比较ally（联盟）"
+    ],
+    "ukphone": "ˋræli",
+    "usphone": "ˋræli"
+  },
+  {
+    "name": "disband",
+    "trans": [
+      "34.7.5",
+      "v．解散（dismiss, split up）",
+      "【记】 dis+band（队）"
+    ],
+    "ukphone": "dIsˋbænd",
+    "usphone": "dIsˋbænd"
+  },
+  {
+    "name": "distribute",
+    "trans": [
+      "34.7.6",
+      "vt．分发，分送（allocate, allot）"
+    ],
+    "ukphone": "dIˋstrIbju:t",
+    "usphone": "dIˋstrIbju:t"
+  },
+  {
+    "name": "assign",
+    "trans": [
+      "34.7.7",
+      "vt．分配，指派（allot, distribute）"
+    ],
+    "ukphone": "əˋsaIn",
+    "usphone": "əˋsaIn"
+  },
+  {
+    "name": "instruct",
+    "trans": [
+      "34.7.8",
+      "vt．命令（direct, inculcate）；指示"
+    ],
+    "ukphone": "Inˋstrʌkt",
+    "usphone": "Inˋstrʌkt"
+  },
+  {
+    "name": "dispatch",
+    "trans": [
+      "34.7.9",
+      "vt．派遣（send）；分配（allocate, allot）"
+    ],
+    "ukphone": "dIˋspætʃ",
+    "usphone": "dIˋspætʃ"
+  },
+  {
+    "name": "nominate",
+    "trans": [
+      "34.7.10",
+      "vt．任命（appoint, name）",
+      "【记】 nomin（名称）+ate→任命"
+    ],
+    "ukphone": "ˋnα:mIneIt",
+    "usphone": "ˋnα:mIneIt"
+  },
+  {
+    "name": "evacuate",
+    "trans": [
+      "34.7.11",
+      "vt．疏散",
+      "【记】 e+vacu（空）+ate→使空→疏散"
+    ],
+    "ukphone": "IˋvækjueIt",
+    "usphone": "IˋvækjueIt"
+  },
+  {
+    "name": "summon",
+    "trans": [
+      "34.7.12",
+      "vt．召唤（call）",
+      "【记】 sum（下面）+mon→从下面把人命令上来→召唤"
+    ],
+    "ukphone": "ˋsʌmən",
+    "usphone": "ˋsʌmən"
+  },
+  {
+    "name": "destine",
+    "trans": [
+      "34.7.13",
+      "vt．指定（designate）"
+    ],
+    "ukphone": "ˋdestIn",
+    "usphone": "ˋdestIn"
+  },
+  {
+    "name": "designate",
+    "trans": [
+      "34.7.14",
+      "vt．指定；指派（assign, nominate, specify）"
+    ],
+    "ukphone": "ˋdezIgneIt",
+    "usphone": "ˋdezIgneIt"
+  },
+  {
+    "name": "monitor",
+    "trans": [
+      "34.7.15",
+      "v．监控（inspect, control）",
+      "【记】 另一个词义是“班长”"
+    ],
+    "ukphone": "ˋmα:nItər",
+    "usphone": "ˋmα:nItər"
+  },
+  {
+    "name": "accredit",
+    "trans": [
+      "34.7.16",
+      "v．委任；任命"
+    ],
+    "ukphone": "əˋkredIt",
+    "usphone": "əˋkredIt"
+  },
+  {
+    "name": "culpable",
+    "trans": [
+      "34.8.1",
+      "adj．该受谴责的（guilty, blameworthy）",
+      "【记】 culp（罪行）+able"
+    ],
+    "ukphone": "ˋkʌlpəbl",
+    "usphone": "ˋkʌlpəbl"
+  },
+  {
+    "name": "critical",
+    "trans": [
+      "34.8.2",
+      "adj．评论的，批评的"
+    ],
+    "ukphone": "ˋkrItIkl",
+    "usphone": "ˋkrItIkl"
+  },
+  {
+    "name": "censure",
+    "trans": [
+      "34.8.3",
+      "The warden censured the guard for letting the prisoner escape."
+    ],
+    "ukphone": "ˋsenʃər",
+    "usphone": "ˋsenʃər"
+  },
+  {
+    "name": "reproach",
+    "trans": [
+      "34.8.4",
+      "v．责备",
+      "【记】 比较approach（接近）"
+    ],
+    "ukphone": "rIˋproʊtʃ",
+    "usphone": "rIˋproʊtʃ"
+  },
+  {
+    "name": "chide",
+    "trans": [
+      "34.8.5",
+      "vt．斥责（blame, rebuke）"
+    ],
+    "ukphone": "tʃaId",
+    "usphone": "tʃaId"
+  },
+  {
+    "name": "decry",
+    "trans": [
+      "34.8.6",
+      "vt．非难，谴责（condemn, denounce）",
+      "【记】 de+cry（喊）"
+    ],
+    "ukphone": "dIˋkraI",
+    "usphone": "dIˋkraI"
+  },
+  {
+    "name": "deprecate",
+    "trans": [
+      "34.8.7",
+      "vt．抗议，抨击（fustigate, attack）"
+    ],
+    "ukphone": "ˋdeprəkeIt",
+    "usphone": "ˋdeprəkeIt"
+  },
+  {
+    "name": "castigate",
+    "trans": [
+      "34.8.8",
+      "vt．谴责（condemn, denounce）"
+    ],
+    "ukphone": "ˋkæstIgeIt",
+    "usphone": "ˋkæstIgeIt"
+  },
+  {
+    "name": "denounce",
+    "trans": [
+      "34.8.9",
+      "vt．谴责，声讨（censure, condemn）",
+      "【记】 de（坏）+nounce（讲话）→讲坏话→抨击"
+    ],
+    "ukphone": "dIˋnaʊns",
+    "usphone": "dIˋnaʊns"
+  },
+  {
+    "name": "condemn",
+    "trans": [
+      "34.8.10",
+      "vt．谴责",
+      "【记】 联想damn（咒骂）"
+    ],
+    "ukphone": "kənˋdem",
+    "usphone": "kənˋdem"
+  },
+  {
+    "name": "berate",
+    "trans": [
+      "34.8.11",
+      "vt．痛骂（scold, reproach）",
+      "【记】 be+rate（骂）"
+    ],
+    "ukphone": "bIˋreIt",
+    "usphone": "bIˋreIt"
+  },
+  {
+    "name": "rap",
+    "trans": [
+      "34.8.12",
+      "vt．责难"
+    ],
+    "ukphone": "ræp",
+    "usphone": "ræp"
+  },
+  {
+    "name": "rebuke",
+    "trans": [
+      "34.8.13",
+      "vt./n．斥责（censure, reprove）",
+      "【记】 re（反）+buke（打）→反打→斥责"
+    ],
+    "ukphone": "rIˋbju:k",
+    "usphone": "rIˋbju:k"
+  },
+  {
+    "name": "blame",
+    "trans": [
+      "34.8.14",
+      "vt./n．谴责"
+    ],
+    "ukphone": "bleIm",
+    "usphone": "bleIm"
+  },
+  {
+    "name": "repudiate",
+    "trans": [
+      "34.8.15",
+      "vt．批判（reject, renounce）"
+    ],
+    "ukphone": "rIˋpju:dieIt",
+    "usphone": "rIˋpju:dieIt"
+  },
+  {
+    "name": "hoarse",
+    "trans": [
+      "34.9.1",
+      "adj.（声音）嘶哑的（husky, rough）"
+    ],
+    "ukphone": "hɔ:rs",
+    "usphone": "hɔ:rs"
+  },
+  {
+    "name": "colloquial",
+    "trans": [
+      "34.9.2",
+      "adj．会话的，口语的（oral）",
+      "【记】 col（共同）+loqu（说）+ial"
+    ],
+    "ukphone": "kəˋloʊkwiəl",
+    "usphone": "kəˋloʊkwiəl"
+  },
+  {
+    "name": "dumb",
+    "trans": [
+      "34.9.3",
+      "adj．哑的，无言的"
+    ],
+    "ukphone": "dʌm",
+    "usphone": "dʌm"
+  },
+  {
+    "name": "hubbub",
+    "trans": [
+      "34.9.4",
+      "n．嘈杂（uproar）"
+    ],
+    "ukphone": "ˋhʌbʌb",
+    "usphone": "ˋhʌbʌb"
+  },
+  {
+    "name": "dialogue",
+    "trans": [
+      "34.9.5",
+      "n．对话（conversation）",
+      "【记】 dia（对着）+logue（说）→对着说"
+    ],
+    "ukphone": "ˋdaIəlα:g",
+    "usphone": "ˋdaIəlα:g"
+  },
+  {
+    "name": "nonsense",
+    "trans": [
+      "34.9.6",
+      "n．胡说，废话"
+    ],
+    "ukphone": "ˋnα:nsens",
+    "usphone": "ˋnα:nsens"
+  },
+  {
+    "name": "excuse",
+    "trans": [
+      "34.9.7",
+      "n．借口（reason）"
+    ],
+    "ukphone": "Ikˋskju:s",
+    "usphone": "Ikˋskju:s"
+  },
+  {
+    "name": "compliment",
+    "trans": [
+      "34.9.8",
+      "n．问候"
+    ],
+    "ukphone": "ˋkα:mplImənt",
+    "usphone": "ˋkα:mplImənt"
+  },
+  {
+    "name": "gossip",
+    "trans": [
+      "34.9.9",
+      "n．闲话"
+    ],
+    "ukphone": "ˋgα:sIp",
+    "usphone": "ˋgα:sIp"
+  },
+  {
+    "name": "oration",
+    "trans": [
+      "34.9.10",
+      "n．演说（speech, address）"
+    ],
+    "ukphone": "ɔ:ˋreIʃn",
+    "usphone": "ɔ:ˋreIʃn"
+  },
+  {
+    "name": "hearsay",
+    "trans": [
+      "34.9.11",
+      "n．谣传，风闻（rumor, gossip）",
+      "【记】 hear（听）+say（说）→道听途说"
+    ],
+    "ukphone": "ˋhIrseI",
+    "usphone": "ˋhIrseI"
+  },
+  {
+    "name": "interrupt",
+    "trans": [
+      "34.9.12",
+      "v．打断，插嘴（intermit, halt）"
+    ],
+    "ukphone": "ˌIntəˋrʌpt",
+    "usphone": "ˌIntəˋrʌpt"
+  },
+  {
+    "name": "rumble",
+    "trans": [
+      "34.9.13",
+      "v．低沉地说"
+    ],
+    "ukphone": "ˋrʌmbl",
+    "usphone": "ˋrʌmbl"
+  },
+  {
+    "name": "gabble",
+    "trans": [
+      "34.9.14",
+      "v．急促而不清楚地说出",
+      "【记】 比较gobble（贪婪地大吃）"
+    ],
+    "ukphone": "ˋgæbl",
+    "usphone": "ˋgæbl"
+  },
+  {
+    "name": "solicit",
+    "trans": [
+      "34.9.15",
+      "v．恳求（request, demand）"
+    ],
+    "ukphone": "səˋlIsIt",
+    "usphone": "səˋlIsIt"
+  },
+  {
+    "name": "declaim",
+    "trans": [
+      "34.9.16",
+      "v．朗诵；演讲",
+      "【记】 de+claim（宣称）"
+    ],
+    "ukphone": "dIˋkleIm",
+    "usphone": "dIˋkleIm"
+  },
+  {
+    "name": "confide",
+    "trans": [
+      "34.9.17",
+      "v．倾诉（confess, disclose）",
+      "【记】 con（全部）+fide（相信）→吐露（真情）"
+    ],
+    "ukphone": "kənˋfaId",
+    "usphone": "kənˋfaId"
+  },
+  {
+    "name": "refer",
+    "trans": [
+      "34.9.18",
+      "v．言及，提到（mention）",
+      "【记】 re（再次）+fer（带来）→再次带来→提到"
+    ],
+    "ukphone": "rIˋfɜ:r",
+    "usphone": "rIˋfɜ:r"
+  },
+  {
+    "name": "chat",
+    "trans": [
+      "34.9.19",
+      "v./n．闲谈"
+    ],
+    "ukphone": "tʃæt",
+    "usphone": "tʃæt"
+  },
+  {
+    "name": "grumble",
+    "trans": [
+      "34.9.20",
+      "vi．喃喃诉苦（complain, grunt）"
+    ],
+    "ukphone": "ˋgrʌmbl",
+    "usphone": "ˋgrʌmbl"
+  },
+  {
+    "name": "equivocate",
+    "trans": [
+      "34.9.21",
+      "vi．说模棱两可的话，支吾"
+    ],
+    "ukphone": "IˋkwIvəkeIt",
+    "usphone": "IˋkwIvəkeIt"
+  },
+  {
+    "name": "coax",
+    "trans": [
+      "34.9.22",
+      "vt．哄"
+    ],
+    "ukphone": "koʊks",
+    "usphone": "koʊks"
+  },
+  {
+    "name": "outwit",
+    "trans": [
+      "34.9.23",
+      "vt．哄骗",
+      "【记】 out（出）+wit（机智）→用计谋去→哄骗"
+    ],
+    "ukphone": "ˌaʊtˋwIt",
+    "usphone": "ˌaʊtˋwIt"
+  },
+  {
+    "name": "effuse",
+    "trans": [
+      "34.9.24",
+      "vt．流出；散布",
+      "【记】 ef（出）+fuse（流）"
+    ],
+    "ukphone": "Iˋfju:s",
+    "usphone": "Iˋfju:s"
+  },
+  {
+    "name": "accost",
+    "trans": [
+      "34.9.25",
+      "vt．向人搭话（address, speak to）"
+    ],
+    "ukphone": "əˋkɔ:st",
+    "usphone": "əˋkɔ:st"
+  },
+  {
+    "name": "account",
+    "trans": [
+      "34.10.1",
+      "n．描述"
+    ],
+    "ukphone": "əˋkaʊnt",
+    "usphone": "əˋkaʊnt"
+  },
+  {
+    "name": "exposition",
+    "trans": [
+      "34.10.2",
+      "n．展览（exhibition）；说明，阐明（description）"
+    ],
+    "ukphone": "ˌekspəˋzIʃn",
+    "usphone": "ˌekspəˋzIʃn"
+  },
+  {
+    "name": "enunciate",
+    "trans": [
+      "34.10.3",
+      "v．阐明；清晰发音（articulate）",
+      "【记】 e（出）+nunci（清楚）+ate→讲出来→清楚表达"
+    ],
+    "ukphone": "IˋnʌnsieIt",
+    "usphone": "IˋnʌnsieIt"
+  },
+  {
+    "name": "narrate",
+    "trans": [
+      "34.10.4",
+      "v．叙述（describe, recount）"
+    ],
+    "ukphone": "nəˋreIt",
+    "usphone": "nəˋreIt"
+  },
+  {
+    "name": "insinuate",
+    "trans": [
+      "34.10.5",
+      "vt．暗示（allude, hint, imply）",
+      "【记】 in（进入）+sinu（弯曲）+ate→绕着弯进入→迂回进入"
+    ],
+    "ukphone": "InˋsInjueIt",
+    "usphone": "InˋsInjueIt"
+  },
+  {
+    "name": "cover",
+    "trans": [
+      "34.10.6",
+      "vt．报道"
+    ],
+    "ukphone": "ˋkʌvər",
+    "usphone": "ˋkʌvər"
+  },
+  {
+    "name": "convey",
+    "trans": [
+      "34.10.7",
+      "vt．表达（communicate）"
+    ],
+    "ukphone": "kənˋveI",
+    "usphone": "kənˋveI"
+  },
+  {
+    "name": "illuminate",
+    "trans": [
+      "34.10.8",
+      "vt．说明（clarify）"
+    ],
+    "ukphone": "Iˋlu:mIneIt",
+    "usphone": "Iˋlu:mIneIt"
+  },
+  {
+    "name": "render",
+    "trans": [
+      "34.10.9",
+      "vt．表达（deliver, perform, express）"
+    ],
+    "ukphone": "ˋrendər",
+    "usphone": "ˋrendər"
+  },
+  {
+    "name": "elucidate",
+    "trans": [
+      "34.10.10",
+      "vt．阐明，说明（clarify, explain）",
+      "【记】 e（出）+lucid（清楚）+ate→弄清楚→阐明"
+    ],
+    "ukphone": "iˋlu:sIdeIt",
+    "usphone": "iˋlu:sIdeIt"
+  },
+  {
+    "name": "clarify",
+    "trans": [
+      "34.10.11",
+      "vt．澄清，阐明",
+      "【记】 clar（清楚）+ify"
+    ],
+    "ukphone": "ˋklærəfaI",
+    "usphone": "ˋklærəfaI"
+  },
+  {
+    "name": "expound",
+    "trans": [
+      "34.10.12",
+      "vt．解释（explain, interpret）"
+    ],
+    "ukphone": "Ikˋspaʊnd",
+    "usphone": "Ikˋspaʊnd"
+  },
+  {
+    "name": "construe",
+    "trans": [
+      "34.10.13",
+      "vt．解释；翻译（expound; translate, interpret）"
+    ],
+    "ukphone": "kənˋstru:",
+    "usphone": "kənˋstru:"
+  },
+  {
+    "name": "delineate",
+    "trans": [
+      "34.10.14",
+      "vt．刻画；记述（depict, portray）",
+      "【记】 de（加强）+line（线）+ate→用力画线→描画"
+    ],
+    "ukphone": "dIˋlInieIt",
+    "usphone": "dIˋlInieIt"
+  },
+  {
+    "name": "exemplify",
+    "trans": [
+      "34.10.15",
+      "vt．例证，例示（illustrate）"
+    ],
+    "ukphone": "IgˋzemplIfaI",
+    "usphone": "IgˋzemplIfaI"
+  },
+  {
+    "name": "depict",
+    "trans": [
+      "34.10.16",
+      "vt．描写，叙述（delineate, describe, portray）"
+    ],
+    "ukphone": "dIˋpIkt",
+    "usphone": "dIˋpIkt"
+  },
+  {
+    "name": "emphasize",
+    "trans": [
+      "34.10.17",
+      "vt．强调，着重（underscore, underline, highlight, stress, accentuate）"
+    ],
+    "ukphone": "ˋemfəsaIz",
+    "usphone": "ˋemfəsaIz"
+  },
+  {
+    "name": "illustrate",
+    "trans": [
+      "34.10.18",
+      "vt．说明（exemplify, explain）",
+      "【记】 il（不断）+lustr（光明）+ate→不断给光明→说明"
+    ],
+    "ukphone": "ˋIləstreIt",
+    "usphone": "ˋIləstreIt"
+  },
+  {
+    "name": "highlight",
+    "trans": [
+      "34.10.19",
+      "vt．突出显示，强调（climax, underline, underscore, stress）"
+    ],
+    "ukphone": "ˋhaIlaIt",
+    "usphone": "ˋhaIlaIt"
+  },
+  {
+    "name": "specify",
+    "trans": [
+      "34.10.20",
+      "vt．详述（define）"
+    ],
+    "ukphone": "ˋspesIfaI",
+    "usphone": "ˋspesIfaI"
+  },
+  {
+    "name": "elaborate",
+    "trans": [
+      "34.10.21",
+      "vt．详细阐述（explain, embellish）"
+    ],
+    "ukphone": "IˋlæbəreIt",
+    "usphone": "IˋlæbəreIt"
+  },
+  {
+    "name": "divulge",
+    "trans": [
+      "34.10.22",
+      "vt．宣布（reveal）"
+    ],
+    "ukphone": "daIˋvʌldʒ",
+    "usphone": "daIˋvʌldʒ"
+  },
+  {
+    "name": "proclaim",
+    "trans": [
+      "34.10.23",
+      "vt．宣布，声明（announce, declare）",
+      "【记】 pro（前）+claim（喊）→宣布"
+    ],
+    "ukphone": "prəˋkleIm",
+    "usphone": "prəˋkleIm"
+  },
+  {
+    "name": "cite",
+    "trans": [
+      "34.10.24",
+      "vt．引用；举例（mention, quote, refer to）"
+    ],
+    "ukphone": "saIt",
+    "usphone": "saIt"
+  },
+  {
+    "name": "reiterate",
+    "trans": [
+      "34.10.25",
+      "vt．重述（restate）",
+      "【记】 re（反复）+iterate（重申）"
+    ],
+    "ukphone": "riˋItəreIt",
+    "usphone": "riˋItəreIt"
+  },
+  {
+    "name": "accentuate",
+    "trans": [
+      "34.10.26",
+      "vt．重读；强调（emphasize, underline, highlight）",
+      "【记】 ac+cent=cant（唱，说）+uate→不断说→强调"
+    ],
+    "ukphone": "əkˋsentʃueIt",
+    "usphone": "əkˋsentʃueIt"
+  },
+  {
+    "name": "uniform",
+    "trans": [
+      "34.11.1",
+      "adj．统一的，一致的（alike, consistent）"
+    ],
+    "ukphone": "ˋju:nIfɔ:rm",
+    "usphone": "ˋju:nIfɔ:rm"
+  },
+  {
+    "name": "unanimity",
+    "trans": [
+      "34.11.2",
+      "n．全体一致（harmony, accord）"
+    ],
+    "ukphone": "ˌju:nəˋnIməti",
+    "usphone": "ˌju:nəˋnIməti"
+  },
+  {
+    "name": "unanimous",
+    "trans": [
+      "34.11.3",
+      "adj．意见一致的（uniform）"
+    ],
+    "ukphone": "juˋnænIməs",
+    "usphone": "juˋnænIməs"
+  },
+  {
+    "name": "reconcile",
+    "trans": [
+      "34.11.4",
+      "vt．和解（conform, harmonize）"
+    ],
+    "ukphone": "ˋrekənsaIl",
+    "usphone": "ˋrekənsaIl"
+  },
+  {
+    "name": "reconciliation",
+    "trans": [
+      "34.11.5",
+      "n．和解（compromise, pacification）"
+    ],
+    "ukphone": "ˌrekənsIliˋeIʃn",
+    "usphone": "ˌrekənsIliˋeIʃn"
+  },
+  {
+    "name": "convention",
+    "trans": [
+      "34.11.6",
+      "n．协定；会议（conference）"
+    ],
+    "ukphone": "kənˋvenʃən",
+    "usphone": "kənˋvenʃən"
+  },
+  {
+    "name": "pact",
+    "trans": [
+      "34.11.7",
+      "n．协定（treaty, agreement）"
+    ],
+    "ukphone": "pækt",
+    "usphone": "pækt"
+  },
+  {
+    "name": "consult",
+    "trans": [
+      "34.11.8",
+      "v．商量；请教（ask for）"
+    ],
+    "ukphone": "kənˋsʌlt",
+    "usphone": "kənˋsʌlt"
+  },
+  {
+    "name": "negotiate",
+    "trans": [
+      "34.11.9",
+      "v．谈判，交涉（discuss）；议定"
+    ],
+    "ukphone": "nIˋgoʊʃieIt",
+    "usphone": "nIˋgoʊʃieIt"
+  },
+  {
+    "name": "confer",
+    "trans": [
+      "34.11.10",
+      "v．协商（discuss）",
+      "【记】 con（共同）+fer→共同带来观点→协商"
+    ],
+    "ukphone": "kənˋfɜ:r",
+    "usphone": "kənˋfɜ:r"
+  },
+  {
+    "name": "eloquent",
+    "trans": [
+      "34.12.1",
+      "adj．雄辩的，有口才的（persuasive, fluent）"
+    ],
+    "ukphone": "ˋeləkwənt",
+    "usphone": "ˋeləkwənt"
+  },
+  {
+    "name": "eloquence",
+    "trans": [
+      "34.12.2",
+      "n．雄辩",
+      "【记】 e（出）+loqu（说）+ence→总能说出→雄辩"
+    ],
+    "ukphone": "ˋeləkwəns",
+    "usphone": "ˋeləkwəns"
+  },
+  {
+    "name": "debate",
+    "trans": [
+      "34.12.3",
+      "n./v．争论，辩论（discussion, argument）"
+    ],
+    "ukphone": "dIˋbeIt",
+    "usphone": "dIˋbeIt"
+  },
+  {
+    "name": "debatable",
+    "trans": [
+      "34.12.4",
+      "adj．争论中的，未决定的（controversial, unsettled）",
+      "【记】 来自debate（争论）"
+    ],
+    "ukphone": "dIˋbeItəbl",
+    "usphone": "dIˋbeItəbl"
+  },
+  {
+    "name": "squabble",
+    "trans": [
+      "34.12.5",
+      "n．口角，争论（quarrel, argument）"
+    ],
+    "ukphone": "ˋskwα:bl",
+    "usphone": "ˋskwα:bl"
+  },
+  {
+    "name": "dispute",
+    "trans": [
+      "34.12.6",
+      "n./v．争论，辩论（disagreement, argument, question）"
+    ],
+    "ukphone": "dIˋspju:t",
+    "usphone": "dIˋspju:t"
+  },
+  {
+    "name": "retort",
+    "trans": [
+      "34.12.7",
+      "v．反驳（refute, reply）",
+      "【记】 re（反）+tort（歪曲）→反驳"
+    ],
+    "ukphone": "rIˋtɔ:rt",
+    "usphone": "rIˋtɔ:rt"
+  },
+  {
+    "name": "brawl",
+    "trans": [
+      "34.12.8",
+      "n./vi．争吵（bicker, quarrel）"
+    ],
+    "ukphone": "brɔ:l",
+    "usphone": "brɔ:l"
+  },
+  {
+    "name": "bicker",
+    "trans": [
+      "34.12.9",
+      "vi．争吵（brawl, quarrel）"
+    ],
+    "ukphone": "ˋbIkər",
+    "usphone": "ˋbIkər"
+  },
+  {
+    "name": "haggle",
+    "trans": [
+      "34.12.10",
+      "vi．争论（argue, bargain）"
+    ],
+    "ukphone": "ˋhægl",
+    "usphone": "ˋhægl"
+  },
+  {
+    "name": "refute",
+    "trans": [
+      "34.12.11",
+      "vt．驳斥，反驳，驳倒（disprove, rebut）",
+      "【记】 re（反）+fute=fuse（流）→反流→反驳"
+    ],
+    "ukphone": "rIˋfju:t",
+    "usphone": "rIˋfju:t"
+  },
+  {
+    "name": "disprove",
+    "trans": [
+      "34.12.12",
+      "vt．反驳，证明…有误",
+      "【记】 dis+prove（证明）"
+    ],
+    "ukphone": "ˌdIsˋpru:v",
+    "usphone": "ˌdIsˋpru:v"
+  },
+  {
+    "name": "controvert",
+    "trans": [
+      "34.12.13",
+      "vt．反驳；辩论（deny, contradict）",
+      "【记】 contro（反）+vert（转）"
+    ],
+    "ukphone": "ˋkα:ntrəvɜ:rt",
+    "usphone": "ˋkα:ntrəvɜ:rt"
+  },
+  {
+    "name": "controversy",
+    "trans": [
+      "34.12.14",
+      "n．争论"
+    ],
+    "ukphone": "ˋkα:ntrəvɜ:rsI",
+    "usphone": "ˋkα:ntrəvɜ:rsI"
+  },
+  {
+    "name": "controversial",
+    "trans": [
+      "34.12.15",
+      "adj．引起争论的"
+    ],
+    "ukphone": "ˌkα:ntrəˋvɜ:rʃl",
+    "usphone": "ˌkα:ntrəˋvɜ:rʃl"
+  },
+  {
+    "name": "contradict",
+    "trans": [
+      "34.12.16",
+      "vt．反驳；抵触（counteract, oppose）",
+      "【记】 contra（相反）+dic（言）→相反之言"
+    ],
+    "ukphone": "ˌkα:ntrəˋdIkt",
+    "usphone": "ˌkα:ntrəˋdIkt"
+  },
+  {
+    "name": "contradictory",
+    "trans": [
+      "34.12.17",
+      "adj．矛盾的，反驳的（opposing）"
+    ],
+    "ukphone": "ˌkα:ntrəˋdIktəri",
+    "usphone": "ˌkα:ntrəˋdIktəri"
+  },
+  {
+    "name": "contravene",
+    "trans": [
+      "34.12.18",
+      "vt．反对；违反（contradict, oppose）",
+      "【记】 contra（相反）+vene（走）→违背"
+    ],
+    "ukphone": "ˌkα:ntrəˋvi:n",
+    "usphone": "ˌkα:ntrəˋvi:n"
+  },
+  {
+    "name": "contention",
+    "trans": [
+      "34.12.19",
+      "n．争论；所持的论点，争辩（debate, argument）"
+    ],
+    "ukphone": "kənˋtenʃn",
+    "usphone": "kənˋtenʃn"
+  },
+  {
+    "name": "cabbage",
+    "trans": [
+      "35.1.1",
+      "n．甘蓝，卷心菜"
+    ],
+    "ukphone": "ˋkæbIdʒ",
+    "usphone": "ˋkæbIdʒ"
+  },
+  {
+    "name": "carrot",
+    "trans": [
+      "35.1.2",
+      "n．胡萝卜"
+    ],
+    "ukphone": "ˋkærət",
+    "usphone": "ˋkærət"
+  },
+  {
+    "name": "celery",
+    "trans": [
+      "35.1.3",
+      "n．旱芹，芹菜"
+    ],
+    "ukphone": "ˋseləri",
+    "usphone": "ˋseləri"
+  },
+  {
+    "name": "cereal",
+    "trans": [
+      "35.1.4",
+      "n．谷类食品，谷类"
+    ],
+    "ukphone": "ˋsIriəl",
+    "usphone": "ˋsIriəl"
+  },
+  {
+    "name": "corn",
+    "trans": [
+      "35.1.5",
+      "n．<美>玉米，<英>谷物，五谷"
+    ],
+    "ukphone": "kɔ:rn",
+    "usphone": "kɔ:rn"
+  },
+  {
+    "name": "cucumber",
+    "trans": [
+      "35.1.6",
+      "n．黄瓜"
+    ],
+    "ukphone": "ˋkju:kʌmbər",
+    "usphone": "ˋkju:kʌmbər"
+  },
+  {
+    "name": "grain",
+    "trans": [
+      "35.1.7",
+      "n．谷物，谷类，谷粒，细粒，颗粒，粮食"
+    ],
+    "ukphone": "greIn",
+    "usphone": "greIn"
+  },
+  {
+    "name": "leek",
+    "trans": [
+      "35.1.8",
+      "n．韭葱"
+    ],
+    "ukphone": "li:k",
+    "usphone": "li:k"
+  },
+  {
+    "name": "lettuce",
+    "trans": [
+      "35.1.9",
+      "n．莴苣，生菜"
+    ],
+    "ukphone": "ˋletIs",
+    "usphone": "ˋletIs"
+  },
+  {
+    "name": "millet",
+    "trans": [
+      "35.1.10",
+      "n．稷，粟"
+    ],
+    "ukphone": "ˋmIlIt",
+    "usphone": "ˋmIlIt"
+  },
+  {
+    "name": "mustard",
+    "trans": [
+      "35.1.11",
+      "n．芥菜，芥末"
+    ],
+    "ukphone": "ˋmʌstərd",
+    "usphone": "ˋmʌstərd"
+  },
+  {
+    "name": "oats",
+    "trans": [
+      "35.1.12",
+      "n．燕麦，燕麦片"
+    ],
+    "ukphone": "oʊts",
+    "usphone": "oʊts"
+  },
+  {
+    "name": "onion",
+    "trans": [
+      "35.1.13",
+      "n．洋葱"
+    ],
+    "ukphone": "ˋʌnjən",
+    "usphone": "ˋʌnjən"
+  },
+  {
+    "name": "pea",
+    "trans": [
+      "35.1.14",
+      "n．豌豆"
+    ],
+    "ukphone": "pi:",
+    "usphone": "pi:"
+  },
+  {
+    "name": "peanut",
+    "trans": [
+      "35.1.15",
+      "n．花生"
+    ],
+    "ukphone": "ˋpi:nʌt",
+    "usphone": "ˋpi:nʌt"
+  },
+  {
+    "name": "pepper",
+    "trans": [
+      "35.1.16",
+      "n．胡椒粉"
+    ],
+    "ukphone": "ˋpepər",
+    "usphone": "ˋpepər"
+  },
+  {
+    "name": "potato",
+    "trans": [
+      "35.1.17",
+      "n．马铃薯"
+    ],
+    "ukphone": "pəˋteItoʊ",
+    "usphone": "pəˋteItoʊ"
+  },
+  {
+    "name": "pumpkin",
+    "trans": [
+      "35.1.18",
+      "n．南瓜"
+    ],
+    "ukphone": "ˋpʌmpkIn",
+    "usphone": "ˋpʌmpkIn"
+  },
+  {
+    "name": "radish",
+    "trans": [
+      "35.1.19",
+      "n．萝卜"
+    ],
+    "ukphone": "ˋrædIʃ",
+    "usphone": "ˋrædIʃ"
+  },
+  {
+    "name": "rice",
+    "trans": [
+      "35.1.20",
+      "n．稻，米"
+    ],
+    "ukphone": "raIs",
+    "usphone": "raIs"
+  },
+  {
+    "name": "rye",
+    "trans": [
+      "35.1.21",
+      "n．裸麦，黑麦"
+    ],
+    "ukphone": "raI",
+    "usphone": "raI"
+  },
+  {
+    "name": "sesame",
+    "trans": [
+      "35.1.22",
+      "n．芝麻"
+    ],
+    "ukphone": "ˋsesəmi",
+    "usphone": "ˋsesəmi"
+  },
+  {
+    "name": "soybean",
+    "trans": [
+      "35.1.23",
+      "n．大豆"
+    ],
+    "ukphone": "ˋsɔIbi:n",
+    "usphone": "ˋsɔIbi:n"
+  },
+  {
+    "name": "spinach",
+    "trans": [
+      "35.1.24",
+      "n．菠菜"
+    ],
+    "ukphone": "ˋspInItʃ",
+    "usphone": "ˋspInItʃ"
+  },
+  {
+    "name": "tomato",
+    "trans": [
+      "35.1.25",
+      "n．番茄，西红柿"
+    ],
+    "ukphone": "təˋmeItoʊ",
+    "usphone": "təˋmeItoʊ"
+  },
+  {
+    "name": "wheat",
+    "trans": [
+      "35.1.26",
+      "n．小麦；小麦色"
+    ],
+    "ukphone": "wi:t",
+    "usphone": "wi:t"
+  },
+  {
+    "name": "edible",
+    "trans": [
+      "35.1.27",
+      "adj．可食的（eatable, comestible）",
+      "【记】 ed（吃）+ible"
+    ],
+    "ukphone": "ˋedəbl",
+    "usphone": "ˋedəbl"
+  },
+  {
+    "name": "bland",
+    "trans": [
+      "35.1.28",
+      "adj.（食物等）无刺激性的（mild, gentle）"
+    ],
+    "ukphone": "blænd",
+    "usphone": "blænd"
+  },
+  {
+    "name": "seasoning",
+    "trans": [
+      "35.1.29",
+      "n．调味品，佐料（flavoring, spice）"
+    ],
+    "ukphone": "ˋsi:zənIŋ",
+    "usphone": "ˋsi:zənIŋ"
+  },
+  {
+    "name": "condiment",
+    "trans": [
+      "35.1.30",
+      "n．调味品"
+    ],
+    "ukphone": "ˋkα:ndImənt",
+    "usphone": "ˋkα:ndImənt"
+  },
+  {
+    "name": "butter",
+    "trans": [
+      "35.1.31",
+      "n．奶油"
+    ],
+    "ukphone": "ˋbʌtər",
+    "usphone": "ˋbʌtər"
+  },
+  {
+    "name": "chop",
+    "trans": [
+      "35.1.32",
+      "n．排骨"
+    ],
+    "ukphone": "tʃα:p",
+    "usphone": "tʃα:p"
+  },
+  {
+    "name": "cuisine",
+    "trans": [
+      "35.1.33",
+      "n．烹调"
+    ],
+    "ukphone": "kwIˋzi:n",
+    "usphone": "kwIˋzi:n"
+  },
+  {
+    "name": "dessert",
+    "trans": [
+      "35.1.34",
+      "n．甜点"
+    ],
+    "ukphone": "dIˋzɜ:rt",
+    "usphone": "dIˋzɜ:rt"
+  },
+  {
+    "name": "beverage",
+    "trans": [
+      "35.1.35",
+      "n．饮料",
+      "【记】 bever（喝）+age"
+    ],
+    "ukphone": "ˋbevərIdʒ",
+    "usphone": "ˋbevərIdʒ"
+  },
+  {
+    "name": "diet",
+    "trans": [
+      "35.1.36",
+      "n．饮食，食物 v．节食"
+    ],
+    "ukphone": "ˋdaIət",
+    "usphone": "ˋdaIət"
+  },
+  {
+    "name": "nutriment",
+    "trans": [
+      "35.1.37",
+      "n．营养品"
+    ],
+    "ukphone": "ˋnjutrəmənt",
+    "usphone": "ˋnjutrəmənt"
+  },
+  {
+    "name": "nibble",
+    "trans": [
+      "35.1.38",
+      "vt．细咬；细食（bite; eat）",
+      "【记】 nib（小）+ble"
+    ],
+    "ukphone": "ˋnIbl",
+    "usphone": "ˋnIbl"
+  },
+  {
+    "name": "imbibe",
+    "trans": [
+      "35.1.39",
+      "vt．饮（absorb, assimilate）",
+      "【记】 im（进入）+bibe（喝）"
+    ],
+    "ukphone": "ImˋbaIb",
+    "usphone": "ImˋbaIb"
+  },
+  {
+    "name": "scoop",
+    "trans": [
+      "35.1.40",
+      "n．勺子 v．舀"
+    ],
+    "ukphone": "sku:p",
+    "usphone": "sku:p"
+  },
+  {
+    "name": "barley",
+    "trans": [
+      "35.1.41",
+      "n．大麦"
+    ],
+    "ukphone": "ˋbα:rli",
+    "usphone": "ˋbα:rli"
+  },
+  {
+    "name": "beet",
+    "trans": [
+      "35.1.42",
+      "n．甜菜，甜菜根"
+    ],
+    "ukphone": "bi:t",
+    "usphone": "bi:t"
+  },
+  {
+    "name": "broccoli",
+    "trans": [
+      "35.1.43",
+      "n．椰菜"
+    ],
+    "ukphone": "ˋbrα:kəli",
+    "usphone": "ˋbrα:kəli"
+  },
+  {
+    "name": "indigenous",
+    "trans": [
+      "35.2.1",
+      "adj．固有的（aboriginal, native）；本土的",
+      "【记】 indi（内部）+gen（产生）+ous→内部产生→土产的"
+    ],
+    "ukphone": "InˋdIdʒənəs",
+    "usphone": "InˋdIdʒənəs"
+  },
+  {
+    "name": "intrinsic",
+    "trans": [
+      "35.2.2",
+      "adj．本质的（substantive）；本身的"
+    ],
+    "ukphone": "InˋtrInzIk",
+    "usphone": "InˋtrInzIk"
+  },
+  {
+    "name": "radical",
+    "trans": [
+      "35.2.3",
+      "adj．根本的"
+    ],
+    "ukphone": "ˋrædIkl",
+    "usphone": "ˋrædIkl"
+  },
+  {
+    "name": "radically",
+    "trans": [
+      "35.2.4",
+      "adv．根本上（basically）"
+    ],
+    "ukphone": "ˋrædIkli",
+    "usphone": "ˋrædIkli"
+  },
+  {
+    "name": "rudimentary",
+    "trans": [
+      "35.2.5",
+      "adj．根本的，低级的（undeveloped, elementary, primitive, unsophisticated）",
+      "【记】 rudi（无知的）+ment+ary→无知的→最初的"
+    ],
+    "ukphone": "ˌru:dIˋmentri",
+    "usphone": "ˌru:dIˋmentri"
+  },
+  {
+    "name": "inherent",
+    "trans": [
+      "35.2.6",
+      "adj．固有的（innate, intrinsic）",
+      "【记】 in（里面）+her（连）+ent→天生（与身体内）连着→天赋的"
+    ],
+    "ukphone": "InˋhIrənt",
+    "usphone": "InˋhIrənt"
+  },
+  {
+    "name": "inherently",
+    "trans": [
+      "35.2.7",
+      "adv．天性地，固有地（intrinsically, fundamentally, basically）"
+    ],
+    "ukphone": "InˋhIrəntli",
+    "usphone": "InˋhIrəntli"
+  },
+  {
+    "name": "objective",
+    "trans": [
+      "35.2.8",
+      "adj．客观的",
+      "【记】 object（客观）+ive"
+    ],
+    "ukphone": "əbˋdʒektIv",
+    "usphone": "əbˋdʒektIv"
+  },
+  {
+    "name": "internal",
+    "trans": [
+      "35.2.9",
+      "adj．内在的（inside, interior）",
+      "【记】 比较external（外在的）"
+    ],
+    "ukphone": "Inˋtɜ:rnl",
+    "usphone": "Inˋtɜ:rnl"
+  },
+  {
+    "name": "incisive",
+    "trans": [
+      "35.2.10",
+      "adj．深刻的（profound）"
+    ],
+    "ukphone": "InˋsaIsIv",
+    "usphone": "InˋsaIsIv"
+  },
+  {
+    "name": "substantive",
+    "trans": [
+      "35.2.11",
+      "adj．实质性的（actual）"
+    ],
+    "ukphone": "səbˋstæntIv",
+    "usphone": "səbˋstæntIv"
+  },
+  {
+    "name": "innate",
+    "trans": [
+      "35.2.12",
+      "adj．天生的（inborn, inherent）",
+      "【记】 in（进）+nate（生）→与出生一起来→天生的"
+    ],
+    "ukphone": "IˋneIt",
+    "usphone": "IˋneIt"
+  },
+  {
+    "name": "inborn",
+    "trans": [
+      "35.2.13",
+      "adj．天生的（innate）",
+      "【记】 in（内）+born（出生）→与生俱来的"
+    ],
+    "ukphone": "ˌInˋbɔ:rn",
+    "usphone": "ˌInˋbɔ:rn"
+  },
+  {
+    "name": "instinctive",
+    "trans": [
+      "35.2.14",
+      "adj．天生的，本能的（impulsive, spontaneous）",
+      "【记】 instinct（本能）+ive"
+    ],
+    "ukphone": "InˋstIŋktIv",
+    "usphone": "InˋstIŋktIv"
+  },
+  {
+    "name": "crude",
+    "trans": [
+      "35.2.15",
+      "adj．未提炼的；生的（raw, unpolished, unprocessed）"
+    ],
+    "ukphone": "kru:d",
+    "usphone": "kru:d"
+  },
+  {
+    "name": "spontaneous",
+    "trans": [
+      "35.2.16",
+      "adj．自发的；本能的（impulsive, involuntary）",
+      "【记】 spont（自然）+aneous→自然的→自发的"
+    ],
+    "ukphone": "spα:nˋteIniəs",
+    "usphone": "spα:nˋteIniəs"
+  },
+  {
+    "name": "interior",
+    "trans": [
+      "35.2.17",
+      "n．内部（inside, inner）",
+      "【记】 比较exterior（外部）"
+    ],
+    "ukphone": "InˋtIriər",
+    "usphone": "InˋtIriər"
+  },
+  {
+    "name": "attribute",
+    "trans": [
+      "35.2.18",
+      "n．性质（characteristic, quality, trait）"
+    ],
+    "ukphone": "æˋtrIbju:t",
+    "usphone": "æˋtrIbju:t"
+  },
+  {
+    "name": "abstruse",
+    "trans": [
+      "35.2.19",
+      "adj．深奥的（complicated, profound）",
+      "【记】 abs+trus（走）+e→走不进去的→难懂的"
+    ],
+    "ukphone": "əbˋstru:s",
+    "usphone": "əbˋstru:s"
+  },
+  {
+    "name": "analogous",
+    "trans": [
+      "35.2.20",
+      "adj．类似的；可比拟的；相似的（similar）"
+    ],
+    "ukphone": "əˋnæləgəs",
+    "usphone": "əˋnæləgəs"
+  },
+  {
+    "name": "intrinsically",
+    "trans": [
+      "35.2.21",
+      "adv．从本质上（fundamentally）"
+    ],
+    "ukphone": "InˋtrInzIkli",
+    "usphone": "InˋtrInzIkli"
+  },
+  {
+    "name": "phenomenon",
+    "trans": [
+      "35.2.22",
+      "n．现象；奇迹"
+    ],
+    "ukphone": "fəˋnα:mInən",
+    "usphone": "fəˋnα:mInən"
+  },
+  {
+    "name": "comparative",
+    "trans": [
+      "35.3.1",
+      "adj．比较的"
+    ],
+    "ukphone": "kəmˋpærətIv",
+    "usphone": "kəmˋpærətIv"
+  },
+  {
+    "name": "comparable",
+    "trans": [
+      "35.3.2",
+      "adj．可比的；类似的（similar）"
+    ],
+    "ukphone": "ˋkα:mpərəbl",
+    "usphone": "ˋkα:mpərəbl"
+  },
+  {
+    "name": "similar",
+    "trans": [
+      "35.3.3",
+      "adj．相似的，类似的（comparable）"
+    ],
+    "ukphone": "ˋsImələr",
+    "usphone": "ˋsImələr"
+  },
+  {
+    "name": "dissimilar",
+    "trans": [
+      "35.3.4",
+      "adj．不相似的，不同的（different）",
+      "【记】 dis+similar（相似的）"
+    ],
+    "ukphone": "dIˋsImIlər",
+    "usphone": "dIˋsImIlər"
+  },
+  {
+    "name": "subordinate",
+    "trans": [
+      "35.3.5",
+      "adj．次要的，附属的（inferior, secondary）",
+      "【记】 sub（下面）+ordin（顺序）+ate→下面的顺序→附属的"
+    ],
+    "ukphone": "səˋbɔ:rdInət",
+    "usphone": "səˋbɔ:rdInət"
+  },
+  {
+    "name": "monotonous",
+    "trans": [
+      "35.3.6",
+      "adj．单调的（boring, dull）",
+      "【记】 mono（单个）+ton（声音）+ous"
+    ],
+    "ukphone": "məˋnα:tənəs",
+    "usphone": "məˋnα:tənəs"
+  },
+  {
+    "name": "typical",
+    "trans": [
+      "35.3.7",
+      "adj．典型的，代表性的（ordinary）"
+    ],
+    "ukphone": "ˋtIpIkl",
+    "usphone": "ˋtIpIkl"
+  },
+  {
+    "name": "invert",
+    "trans": [
+      "35.3.8",
+      "vt．倒转（overturn, reverse）"
+    ],
+    "ukphone": "Inˋvɜ:rt",
+    "usphone": "Inˋvɜ:rt"
+  },
+  {
+    "name": "inverse",
+    "trans": [
+      "35.3.9",
+      "adj．反的（contrary, opposite）",
+      "【记】 in（反）+verse（转）→反转的→相反的"
+    ],
+    "ukphone": "ˌInˋvɜ:rs",
+    "usphone": "ˌInˋvɜ:rs"
+  },
+  {
+    "name": "preferable",
+    "trans": [
+      "35.3.10",
+      "adj．更好的",
+      "【记】 prefer（喜欢）+able"
+    ],
+    "ukphone": "ˋprefrəbl",
+    "usphone": "ˋprefrəbl"
+  },
+  {
+    "name": "approximate",
+    "trans": [
+      "35.3.11",
+      "adj．近似的（proximate）",
+      "【记】 ap+proxim（接近）+ate→ 接近的，近似的"
+    ],
+    "ukphone": "əˋprα:ksImət",
+    "usphone": "əˋprα:ksImət"
+  },
+  {
+    "name": "coordinate",
+    "trans": [
+      "35.3.12",
+      "adj．同等的，并列的（equal, juxtaposed）"
+    ],
+    "ukphone": "koʊˋɔ:rdineIt",
+    "usphone": "koʊˋɔ:rdineIt"
+  },
+  {
+    "name": "homogeneous",
+    "trans": [
+      "35.3.13",
+      "adj．同类的；相似的（uniform, same）",
+      "【记】 homo（同）+gen（产生）+ous→产生相同的"
+    ],
+    "ukphone": "ˌhoʊməˋdʒi:niəs",
+    "usphone": "ˌhoʊməˋdʒi:niəs"
+  },
+  {
+    "name": "identical",
+    "trans": [
+      "35.3.14",
+      "adj．同一的（tantamount, same）",
+      "【记】 iden（相同）+tical"
+    ],
+    "ukphone": "aIˋdentIkl",
+    "usphone": "aIˋdentIkl"
+  },
+  {
+    "name": "peerless",
+    "trans": [
+      "35.3.15",
+      "adj．无与伦比的（matchless, unparalleled）",
+      "【记】 peer（同等）+less→无相提并论者→无与伦比的"
+    ],
+    "ukphone": "ˋpIrləs",
+    "usphone": "ˋpIrləs"
+  },
+  {
+    "name": "equal",
+    "trans": [
+      "35.3.16",
+      "adj．相等的，同样的（equivalent）",
+      "【记】 equ（平）+al"
+    ],
+    "ukphone": "ˋi:kwəl",
+    "usphone": "ˋi:kwəl"
+  },
+  {
+    "name": "equate",
+    "trans": [
+      "35.3.17",
+      "vt．使相等，视为同等"
+    ],
+    "ukphone": "iˋkweIt",
+    "usphone": "iˋkweIt"
+  },
+  {
+    "name": "equivalent",
+    "trans": [
+      "35.3.18",
+      "adj．相等的 n．等同品（counterpart, match）"
+    ],
+    "ukphone": "IˋkwIvələnt",
+    "usphone": "IˋkwIvələnt"
+  },
+  {
+    "name": "intermediate",
+    "trans": [
+      "35.3.19",
+      "adj．中级的"
+    ],
+    "ukphone": "ˌIntərˋmi:diət",
+    "usphone": "ˌIntərˋmi:diət"
+  },
+  {
+    "name": "neutral",
+    "trans": [
+      "35.3.20",
+      "adj．中性的；中立的（nonaligned）",
+      "【记】 neutr（中）+al"
+    ],
+    "ukphone": "ˋnju:trəl",
+    "usphone": "ˋnju:trəl"
+  },
+  {
+    "name": "backward",
+    "trans": [
+      "35.3.21",
+      "adj./adv．退步的；相反的",
+      "【记】 back（背，后）+ward（方向）"
+    ],
+    "ukphone": "ˋbækwərd",
+    "usphone": "ˋbækwərd"
+  },
+  {
+    "name": "relatively",
+    "trans": [
+      "35.3.22",
+      "adv．相关地，相对地（comparatively）"
+    ],
+    "ukphone": "ˋrelətIvli",
+    "usphone": "ˋrelətIvli"
+  },
+  {
+    "name": "shade",
+    "trans": [
+      "35.3.23",
+      "n．差别（difference）"
+    ],
+    "ukphone": "ʃeId",
+    "usphone": "ʃeId"
+  },
+  {
+    "name": "reproduction",
+    "trans": [
+      "35.3.24",
+      "n．复制品（copy）",
+      "【记】 re（重新）+production（生产）→复制"
+    ],
+    "ukphone": "ˌri:prəˋdʌkʃn",
+    "usphone": "ˌri:prəˋdʌkʃn"
+  },
+  {
+    "name": "inferior",
+    "trans": [
+      "35.3.25",
+      "n．次品 adj．自卑的，劣等的",
+      "【记】 infer（低）+ior；比较superior（高级的）"
+    ],
+    "ukphone": "InˋfIriər",
+    "usphone": "InˋfIriər"
+  },
+  {
+    "name": "sample",
+    "trans": [
+      "35.3.26",
+      "n．范例，样品（specimen）"
+    ],
+    "ukphone": "ˋsæmpl",
+    "usphone": "ˋsæmpl"
+  },
+  {
+    "name": "medium",
+    "trans": [
+      "35.3.27",
+      "n．媒介；中间 adj．中等的",
+      "【记】 medi（中间）+um→中间物，媒介"
+    ],
+    "ukphone": "ˋmi:diəm",
+    "usphone": "ˋmi:diəm"
+  },
+  {
+    "name": "counterpart",
+    "trans": [
+      "35.3.28",
+      "n．相对物；极相似之物（equivalent, correspondent）"
+    ],
+    "ukphone": "ˋkaʊntərpα:rt",
+    "usphone": "ˋkaʊntərpα:rt"
+  },
+  {
+    "name": "midst",
+    "trans": [
+      "35.3.29",
+      "n．中间 prep．在…之间（during, undergoing）"
+    ],
+    "ukphone": "mIdst",
+    "usphone": "mIdst"
+  },
+  {
+    "name": "contrast",
+    "trans": [
+      "35.3.30",
+      "n．对比（着重于相异处）"
+    ],
+    "ukphone": "ˋkα:ntræst",
+    "usphone": "ˋkα:ntræst"
+  },
+  {
+    "name": "compare",
+    "trans": [
+      "35.3.31",
+      "vt．比较（着重于相似处）；比喻"
+    ],
+    "ukphone": "kəmˋper",
+    "usphone": "kəmˋper"
+  },
+  {
+    "name": "copy",
+    "trans": [
+      "35.3.32",
+      "vt．复制，模仿（imitate）"
+    ],
+    "ukphone": "ˋkα:pi",
+    "usphone": "ˋkα:pi"
+  },
+  {
+    "name": "imitate",
+    "trans": [
+      "35.3.33",
+      "vt．模仿（copy, mimic）"
+    ],
+    "ukphone": "ˋImIteIt",
+    "usphone": "ˋImIteIt"
+  },
+  {
+    "name": "resemble",
+    "trans": [
+      "35.3.34",
+      "vt．像，类似"
+    ],
+    "ukphone": "rIˋzembl",
+    "usphone": "rIˋzembl"
+  },
+  {
+    "name": "affinity",
+    "trans": [
+      "35.3.35",
+      "n．类似处（similarity）",
+      "【记】 af（一再）+fin（范围）+ity→一再能进入别人的范围→亲密"
+    ],
+    "ukphone": "əˋfInəti",
+    "usphone": "əˋfInəti"
+  },
+  {
+    "name": "distinguish",
+    "trans": [
+      "35.3.36",
+      "v．区别；辨认出；识别；把……区别分类（detect）"
+    ],
+    "ukphone": "dIˋstIŋgwIʃ",
+    "usphone": "dIˋstIŋgwIʃ"
+  },
+  {
+    "name": "likewise",
+    "trans": [
+      "35.3.37",
+      "adv．同样地，也（similarly, also）"
+    ],
+    "ukphone": "ˋlaIkwaIz",
+    "usphone": "ˋlaIkwaIz"
+  },
+  {
+    "name": "heterogeneous",
+    "trans": [
+      "35.3.38",
+      "adj．异种的，异质的；非均匀的（varied）",
+      "【记】 hetero-（异，杂）+geneous"
+    ],
+    "ukphone": "ˌhetərəˋdʒi:niəs",
+    "usphone": "ˌhetərəˋdʒi:niəs"
+  },
+  {
+    "name": "merely",
+    "trans": [
+      "35.3.39",
+      "adv．只是，不过，仅仅（barely, purely, only）"
+    ],
+    "ukphone": "ˋmIrli",
+    "usphone": "ˋmIrli"
+  },
+  {
+    "name": "exception",
+    "trans": [
+      "35.4.1",
+      "n．例外",
+      "【记】 ex+cept（拿）+ion→拿出去→例外"
+    ],
+    "ukphone": "Ikˋsepʃn",
+    "usphone": "Ikˋsepʃn"
+  },
+  {
+    "name": "exceptional",
+    "trans": [
+      "35.4.2",
+      "adj．例外的"
+    ],
+    "ukphone": "Ikˋsepʃənl",
+    "usphone": "Ikˋsepʃənl"
+  },
+  {
+    "name": "relieved",
+    "trans": [
+      "35.4.3",
+      "adj．免除的（exempted）",
+      "【记】 名词relief（宽慰）"
+    ],
+    "ukphone": "rIˋli:vd",
+    "usphone": "rIˋli:vd"
+  },
+  {
+    "name": "extra",
+    "trans": [
+      "35.4.4",
+      "adj．额外的（additional, surplus）"
+    ],
+    "ukphone": "ˋekstrə",
+    "usphone": "ˋekstrə"
+  },
+  {
+    "name": "extraneous",
+    "trans": [
+      "35.4.5",
+      "adj．无关的（irrelevant, unrelated）; 外来的",
+      "【记】 extra（外）+neous"
+    ],
+    "ukphone": "IkˋstreIniəs",
+    "usphone": "IkˋstreIniəs"
+  },
+  {
+    "name": "irrelevant",
+    "trans": [
+      "35.4.6",
+      "adj．离题的；无关的（impertinent, extraneous）",
+      "【记】 ir（无）+relevant（有关的）"
+    ],
+    "ukphone": "iˋreləvənt",
+    "usphone": "iˋreləvənt"
+  },
+  {
+    "name": "exclude",
+    "trans": [
+      "35.4.7",
+      "vt．把…排除在外（rule out）",
+      "【记】 ex+clude（关闭）→关出去→排除在外"
+    ],
+    "ukphone": "Ikˋsklu:d",
+    "usphone": "Ikˋsklu:d"
+  },
+  {
+    "name": "exclusive",
+    "trans": [
+      "35.4.8",
+      "adj．排外的；独占的（prohibitive; restrictive）"
+    ],
+    "ukphone": "Ikˋsklu:sIv",
+    "usphone": "Ikˋsklu:sIv"
+  },
+  {
+    "name": "exclusion",
+    "trans": [
+      "35.4.9",
+      "n．除外（omission）"
+    ],
+    "ukphone": "Ikˋsklu:ʒn",
+    "usphone": "Ikˋsklu:ʒn"
+  },
+  {
+    "name": "unconventional",
+    "trans": [
+      "35.4.10",
+      "adj．破例的"
+    ],
+    "ukphone": "ˌʌnkənˋvenʃənl",
+    "usphone": "ˌʌnkənˋvenʃənl"
+  },
+  {
+    "name": "external",
+    "trans": [
+      "35.4.11",
+      "adj．外部的（exterior）"
+    ],
+    "ukphone": "Ikˋstɜ:rnl",
+    "usphone": "Ikˋstɜ:rnl"
+  },
+  {
+    "name": "impertinent",
+    "trans": [
+      "35.4.12",
+      "adj．无关的（unrelated）"
+    ],
+    "ukphone": "Imˋpɜ:rtnənt",
+    "usphone": "Imˋpɜ:rtnənt"
+  },
+  {
+    "name": "besides",
+    "trans": [
+      "35.4.13",
+      "adv．除了（还有）"
+    ],
+    "ukphone": "bIˋsaIdz",
+    "usphone": "bIˋsaIdz"
+  },
+  {
+    "name": "scope",
+    "trans": [
+      "35.4.14",
+      "n．范围；余地（range, extent）"
+    ],
+    "ukphone": "skoʊp",
+    "usphone": "skoʊp"
+  },
+  {
+    "name": "span",
+    "trans": [
+      "35.4.15",
+      "n．跨度 vt．跨越（cover, reach across）"
+    ],
+    "ukphone": "spæn",
+    "usphone": "spæn"
+  },
+  {
+    "name": "content",
+    "trans": [
+      "35.4.16",
+      "n．内容（matter）"
+    ],
+    "ukphone": "ˋkα:ntent",
+    "usphone": "ˋkα:ntent"
+  },
+  {
+    "name": "save",
+    "trans": [
+      "35.4.17",
+      "prep．除了（except）"
+    ],
+    "ukphone": "seIv",
+    "usphone": "seIv"
+  },
+  {
+    "name": "deviate",
+    "trans": [
+      "35.4.18",
+      "v．出轨；离题（deflect, diverge）",
+      "【记】 de+via（路）+te→离正路→出轨"
+    ],
+    "ukphone": "ˋdi:vieIt",
+    "usphone": "ˋdi:vieIt"
+  },
+  {
+    "name": "digress",
+    "trans": [
+      "35.4.19",
+      "vi．离开本题（deviate, turn away）",
+      "【记】 di（偏离）+gress（走）→走偏离→离题"
+    ],
+    "ukphone": "daIˋgres",
+    "usphone": "daIˋgres"
+  },
+  {
+    "name": "embrace",
+    "trans": [
+      "35.4.20",
+      "vt．包含，拥抱（hug, cuddle）"
+    ],
+    "ukphone": "ImˋbreIs",
+    "usphone": "ImˋbreIs"
+  },
+  {
+    "name": "cover",
+    "trans": [
+      "35.4.21",
+      "vt．包括"
+    ],
+    "ukphone": "ˋkʌvər",
+    "usphone": "ˋkʌvər"
+  },
+  {
+    "name": "comprise",
+    "trans": [
+      "35.4.22",
+      "vt．包括（constitute, contain, consist of, be made up of）"
+    ],
+    "ukphone": "kəmˋpraIz",
+    "usphone": "kəmˋpraIz"
+  },
+  {
+    "name": "bias",
+    "trans": [
+      "35.4.23",
+      "vt．使…偏离"
+    ],
+    "ukphone": "ˋbaIəs",
+    "usphone": "ˋbaIəs"
+  },
+  {
+    "name": "deflect",
+    "trans": [
+      "35.4.24",
+      "vt．使偏离（divert, deviate）",
+      "【记】 de（偏离）+flect（做）→偏斜"
+    ],
+    "ukphone": "dIˋflekt",
+    "usphone": "dIˋflekt"
+  },
+  {
+    "name": "embody",
+    "trans": [
+      "35.4.25",
+      "vt．体现；包含（include, incorporate）",
+      "【记】 em+body（身体，主体）"
+    ],
+    "ukphone": "Imˋbα:di",
+    "usphone": "Imˋbα:di"
+  },
+  {
+    "name": "accommodate",
+    "trans": [
+      "35.4.26",
+      "vt．容纳（contain, load）"
+    ],
+    "ukphone": "əˋkα:mədeIt",
+    "usphone": "əˋkα:mədeIt"
+  },
+  {
+    "name": "preclude",
+    "trans": [
+      "35.4.27",
+      "vt．排除；防止（prevent, prohibit）",
+      "【记】 pre（提前）+clude（关闭）→防止"
+    ],
+    "ukphone": "prIˋklu:d",
+    "usphone": "prIˋklu:d"
+  },
+  {
+    "name": "forthright",
+    "trans": [
+      "35.5.1",
+      "adv．直接地（frank, direct）"
+    ],
+    "ukphone": "ˋfɔ:rθraIt",
+    "usphone": "ˋfɔ:rθraIt"
+  },
+  {
+    "name": "shortcut",
+    "trans": [
+      "35.5.2",
+      "n．捷径（direct route）"
+    ],
+    "ukphone": "ˋʃɔ:rtkʌt",
+    "usphone": "ˋʃɔ:rtkʌt"
+  },
+  {
+    "name": "tip",
+    "trans": [
+      "35.5.3",
+      "n．窍门（cleverness）"
+    ],
+    "ukphone": "tIp",
+    "usphone": "tIp"
+  },
+  {
+    "name": "means",
+    "trans": [
+      "35.5.4",
+      "n．手段，方法（way）"
+    ],
+    "ukphone": "mi:nz",
+    "usphone": "mi:nz"
+  },
+  {
+    "name": "via",
+    "trans": [
+      "35.5.5",
+      "prep．经过，经由（by way of）"
+    ],
+    "ukphone": "ˋvaIə",
+    "usphone": "ˋvaIə"
+  },
+  {
+    "name": "direct",
+    "trans": [
+      "35.5.6",
+      "adj．直接的（straightforward）"
+    ],
+    "ukphone": "dəˋrekt",
+    "usphone": "dəˋrekt"
+  },
+  {
+    "name": "access",
+    "trans": [
+      "35.5.7",
+      "n．通路，入门（outlet）",
+      "【记】 ac+cess（走）→走过去→通道"
+    ],
+    "ukphone": "ˋækses",
+    "usphone": "ˋækses"
+  },
+  {
+    "name": "faint",
+    "trans": [
+      "35.6.1",
+      "adj．模糊的"
+    ],
+    "ukphone": "feInt",
+    "usphone": "feInt"
+  },
+  {
+    "name": "gloom",
+    "trans": [
+      "35.6.2",
+      "n．黑暗"
+    ],
+    "ukphone": "glu:m",
+    "usphone": "glu:m"
+  },
+  {
+    "name": "gloomy",
+    "trans": [
+      "35.6.3",
+      "adj．暗的（dark, dim）"
+    ],
+    "ukphone": "ˋglu:mi",
+    "usphone": "ˋglu:mi"
+  },
+  {
+    "name": "luminous",
+    "trans": [
+      "35.6.4",
+      "adj．发光的；光亮的（glowing; bright）",
+      "【记】 lumin（光）+ous"
+    ],
+    "ukphone": "ˋlu:mInəs",
+    "usphone": "ˋlu:mInəs"
+  },
+  {
+    "name": "illuminate",
+    "trans": [
+      "35.6.5",
+      "vt．照明，照亮",
+      "【记】 il（一再）+lumin（光明）+ate→给予光明→照亮"
+    ],
+    "ukphone": "Iˋlu:mIneIt",
+    "usphone": "Iˋlu:mIneIt"
+  },
+  {
+    "name": "dingy",
+    "trans": [
+      "35.6.6",
+      "adj．昏暗的"
+    ],
+    "ukphone": "ˋdIndʒi",
+    "usphone": "ˋdIndʒi"
+  },
+  {
+    "name": "dim",
+    "trans": [
+      "35.6.7",
+      "adj．昏暗的；朦胧的（faint, vague）"
+    ],
+    "ukphone": "dIm",
+    "usphone": "dIm"
+  },
+  {
+    "name": "obscure",
+    "trans": [
+      "35.6.8",
+      "adj．模糊的（unclear）",
+      "【记】 ob（离开）+scure（跑）→跑开→模糊的"
+    ],
+    "ukphone": "əbˋskjʊr",
+    "usphone": "əbˋskjʊr"
+  },
+  {
+    "name": "vague",
+    "trans": [
+      "35.6.9",
+      "adj．模糊的，含糊的（imprecise, elementary, obscure, ambiguous）"
+    ],
+    "ukphone": "veIg",
+    "usphone": "veIg"
+  },
+  {
+    "name": "dusky",
+    "trans": [
+      "35.6.10",
+      "adj．微暗的，肤色黑的（dim, dark）"
+    ],
+    "ukphone": "ˋdʌski",
+    "usphone": "ˋdʌski"
+  },
+  {
+    "name": "extinct",
+    "trans": [
+      "35.6.11",
+      "adj．熄灭的；灭绝的",
+      "【记】 ex+tinct（促使）→促使出去→灭绝"
+    ],
+    "ukphone": "IkˋstIŋkt",
+    "usphone": "IkˋstIŋkt"
+  },
+  {
+    "name": "glaring",
+    "trans": [
+      "35.6.12",
+      "adj．耀眼的（dazzling）",
+      "【记】 参考glare（瞪）"
+    ],
+    "ukphone": "ˋglerIŋ",
+    "usphone": "ˋglerIŋ"
+  },
+  {
+    "name": "dazzling",
+    "trans": [
+      "35.6.13",
+      "adj．耀眼的"
+    ],
+    "ukphone": "ˋdæzlIŋ",
+    "usphone": "ˋdæzlIŋ"
+  },
+  {
+    "name": "dismal",
+    "trans": [
+      "35.6.14",
+      "adj．阴暗的"
+    ],
+    "ukphone": "ˋdIzməl",
+    "usphone": "ˋdIzməl"
+  },
+  {
+    "name": "glossy",
+    "trans": [
+      "35.6.15",
+      "adj．有光泽的（smooth, lustrous）"
+    ],
+    "ukphone": "ˋglα:si",
+    "usphone": "ˋglα:si"
+  },
+  {
+    "name": "luster",
+    "trans": [
+      "35.6.16",
+      "n．光彩，光泽（brightness, distinction, radiance）",
+      "【记】 lust（光亮）+er"
+    ],
+    "ukphone": "ˋlʌstər",
+    "usphone": "ˋlʌstər"
+  },
+  {
+    "name": "glaze",
+    "trans": [
+      "35.6.17",
+      "v.（使）光滑"
+    ],
+    "ukphone": "gleIz",
+    "usphone": "gleIz"
+  },
+  {
+    "name": "flare",
+    "trans": [
+      "35.6.18",
+      "v．闪耀（glare, shine）",
+      "【记】 比较flame（火焰）"
+    ],
+    "ukphone": "fler",
+    "usphone": "fler"
+  },
+  {
+    "name": "burnish",
+    "trans": [
+      "35.6.19",
+      "vt．磨光，使光滑（polish）"
+    ],
+    "ukphone": "ˋbɜ:rnIʃ",
+    "usphone": "ˋbɜ:rnIʃ"
+  },
+  {
+    "name": "flicker",
+    "trans": [
+      "35.6.20",
+      "vt．闪烁（flutter, waver）"
+    ],
+    "ukphone": "ˋflIkər",
+    "usphone": "ˋflIkər"
+  },
+  {
+    "name": "brighten",
+    "trans": [
+      "35.6.21",
+      "vt．使发光",
+      "【记】 bright（光亮）+en"
+    ],
+    "ukphone": "ˋbraItn",
+    "usphone": "ˋbraItn"
+  },
+  {
+    "name": "gleam",
+    "trans": [
+      "35.6.22",
+      "vt．使闪光；闪烁（glimmer; flash）"
+    ],
+    "ukphone": "gli:m",
+    "usphone": "gli:m"
+  },
+  {
+    "name": "extinguish",
+    "trans": [
+      "35.6.23",
+      "vt．熄灭"
+    ],
+    "ukphone": "IkˋstIŋgwIʃ",
+    "usphone": "IkˋstIŋgwIʃ"
+  },
+  {
+    "name": "ablaze",
+    "trans": [
+      "35.6.24",
+      "adj．闪耀的（gleaming, glowing）",
+      "【记】 a（加强）+blaze（火焰）→闪耀的"
+    ],
+    "ukphone": "əˋbleIz",
+    "usphone": "əˋbleIz"
+  },
+  {
+    "name": "twinkle",
+    "trans": [
+      "35.6.25",
+      "v．闪烁，闪耀，（使）闪光"
+    ],
+    "ukphone": "ˋtwIŋkl",
+    "usphone": "ˋtwIŋkl"
+  },
+  {
+    "name": "tentative",
+    "trans": [
+      "35.7.1",
+      "adj．试验性的（trial）",
+      "【记】 tent=test（测试）+ative"
+    ],
+    "ukphone": "ˋtentətIv",
+    "usphone": "ˋtentətIv"
+  },
+  {
+    "name": "mechanical",
+    "trans": [
+      "35.7.2",
+      "adj．机械的"
+    ],
+    "ukphone": "məˋkænIkl",
+    "usphone": "məˋkænIkl"
+  },
+  {
+    "name": "exact",
+    "trans": [
+      "35.7.3",
+      "adj．精确的，严格的（accurate, precise）"
+    ],
+    "ukphone": "Igˋzækt",
+    "usphone": "Igˋzækt"
+  },
+  {
+    "name": "theoretical",
+    "trans": [
+      "35.7.4",
+      "adj．理论的（academic）"
+    ],
+    "ukphone": "ˌθi:əˋretIkl",
+    "usphone": "ˌθi:əˋretIkl"
+  },
+  {
+    "name": "precise",
+    "trans": [
+      "35.7.5",
+      "adj．周密的，精确的（accurate, exact）"
+    ],
+    "ukphone": "prIˋsaIs",
+    "usphone": "prIˋsaIs"
+  },
+  {
+    "name": "trial",
+    "trans": [
+      "35.7.6",
+      "adj．实验性的"
+    ],
+    "ukphone": "ˋtraIəl",
+    "usphone": "ˋtraIəl"
+  },
+  {
+    "name": "specimen",
+    "trans": [
+      "35.7.7",
+      "n．标本，样品（sample, instance）"
+    ],
+    "ukphone": "ˋspesImən",
+    "usphone": "ˋspesImən"
+  },
+  {
+    "name": "symbol",
+    "trans": [
+      "35.7.8",
+      "n．符号（emblem, token）"
+    ],
+    "ukphone": "ˋsImbl",
+    "usphone": "ˋsImbl"
+  },
+  {
+    "name": "symbolic",
+    "trans": [
+      "35.7.9",
+      "adj．象征的，符号的"
+    ],
+    "ukphone": "sImˋbα:lIk",
+    "usphone": "sImˋbα:lIk"
+  },
+  {
+    "name": "precision",
+    "trans": [
+      "35.7.10",
+      "n．精确，精密度（accuracy, exactness）"
+    ],
+    "ukphone": "prIˋsIʒn",
+    "usphone": "prIˋsIʒn"
+  },
+  {
+    "name": "doctrine",
+    "trans": [
+      "35.7.11",
+      "n．学说（theory）"
+    ],
+    "ukphone": "ˋdα:ktrIn",
+    "usphone": "ˋdα:ktrIn"
+  },
+  {
+    "name": "threshold",
+    "trans": [
+      "35.7.12",
+      "n．阈值；门槛（doorsill）"
+    ],
+    "ukphone": "ˋθreʃhoʊld",
+    "usphone": "ˋθreʃhoʊld"
+  },
+  {
+    "name": "expertise",
+    "trans": [
+      "35.7.13",
+      "n．专门知识（know-how, special skill）",
+      "【记】 expert（专家）+ise→专家的知识"
+    ],
+    "ukphone": "ˌekspɜ:rˋti:z",
+    "usphone": "ˌekspɜ:rˋti:z"
+  },
+  {
+    "name": "institute",
+    "trans": [
+      "35.7.14",
+      "n.（研究）所"
+    ],
+    "ukphone": "ˋInstItju:t",
+    "usphone": "ˋInstItju:t"
+  },
+  {
+    "name": "invent",
+    "trans": [
+      "35.7.15",
+      "v．发明（create, originate）"
+    ],
+    "ukphone": "Inˋvent",
+    "usphone": "Inˋvent"
+  },
+  {
+    "name": "dissect",
+    "trans": [
+      "35.7.16",
+      "vt．详细研究（analyze）"
+    ],
+    "ukphone": "daIˋsekt",
+    "usphone": "daIˋsekt"
+  },
+  {
+    "name": "contrive",
+    "trans": [
+      "35.7.17",
+      "vt．发明（invent）"
+    ],
+    "ukphone": "kənˋtraIv",
+    "usphone": "kənˋtraIv"
+  },
+  {
+    "name": "launch",
+    "trans": [
+      "35.7.18",
+      "vt．发射，投射（send off）；推出"
+    ],
+    "ukphone": "lɔ:ntʃ",
+    "usphone": "lɔ:ntʃ"
+  },
+  {
+    "name": "devise",
+    "trans": [
+      "35.7.19",
+      "vt．计划；发明（create, invent）"
+    ],
+    "ukphone": "dIˋvaIz",
+    "usphone": "dIˋvaIz"
+  },
+  {
+    "name": "gauge",
+    "trans": [
+      "35.7.20",
+      "vt．精确计量（calculate, measure）"
+    ],
+    "ukphone": "geIdʒ",
+    "usphone": "geIdʒ"
+  },
+  {
+    "name": "accurate",
+    "trans": [
+      "35.7.21",
+      "adj．准确的，正确的（exact, correct）"
+    ],
+    "ukphone": "ˋækjərət",
+    "usphone": "ˋækjərət"
+  },
+  {
+    "name": "scale",
+    "trans": [
+      "35.7.22",
+      "n．规模；尺度；天平"
+    ],
+    "ukphone": "skeIl",
+    "usphone": "skeIl"
+  },
+  {
+    "name": "logical",
+    "trans": [
+      "35.8.1",
+      "adj．合逻辑的（reasonable）"
+    ],
+    "ukphone": "ˋlα:dʒIkl",
+    "usphone": "ˋlα:dʒIkl"
+  },
+  {
+    "name": "therefore",
+    "trans": [
+      "35.8.2",
+      "adv．因此（thus, consequently, in result）"
+    ],
+    "ukphone": "ˋðerfɔ:r",
+    "usphone": "ˋðerfɔ:r"
+  },
+  {
+    "name": "hence",
+    "trans": [
+      "35.8.3",
+      "adv．因此，从此（as a result）"
+    ],
+    "ukphone": "hens",
+    "usphone": "hens"
+  },
+  {
+    "name": "framework",
+    "trans": [
+      "35.8.4",
+      "n．构架，框架（structure, skeleton）"
+    ],
+    "ukphone": "ˋfreImwɜ:rk",
+    "usphone": "ˋfreImwɜ:rk"
+  },
+  {
+    "name": "hypothesis",
+    "trans": [
+      "35.8.5",
+      "n．假设（assumption）",
+      "【记】 hypo（下，次）+thesis（论点）→次论点→非正式论点→假设"
+    ],
+    "ukphone": "haIˋpα:θəsIs",
+    "usphone": "haIˋpα:θəsIs"
+  },
+  {
+    "name": "assumption",
+    "trans": [
+      "35.8.6",
+      "n．假设（supposition; hypothesis）"
+    ],
+    "ukphone": "əˋsʌmpʃn",
+    "usphone": "əˋsʌmpʃn"
+  },
+  {
+    "name": "presume",
+    "trans": [
+      "35.8.7",
+      "vt．假定，假设（suppose, imagine, assume）"
+    ],
+    "ukphone": "prIˋzu:m",
+    "usphone": "prIˋzu:m"
+  },
+  {
+    "name": "presumption",
+    "trans": [
+      "35.8.8",
+      "n．推定；猜想（assumption, presupposition）"
+    ],
+    "ukphone": "prIˋzʌmpʃn",
+    "usphone": "prIˋzʌmpʃn"
+  },
+  {
+    "name": "clue",
+    "trans": [
+      "35.8.9",
+      "n．线索（information）"
+    ],
+    "ukphone": "klu:",
+    "usphone": "klu:"
+  },
+  {
+    "name": "generalize",
+    "trans": [
+      "35.8.10",
+      "v．归纳，概括（summarize, outline）"
+    ],
+    "ukphone": "ˋdʒenərəlaIz",
+    "usphone": "ˋdʒenərəlaIz"
+  },
+  {
+    "name": "incur",
+    "trans": [
+      "35.8.11",
+      "vt．承担；遭遇；招致（arouse, provoke）",
+      "【记】 in（进入）+cur（跑）→跑进来→招致"
+    ],
+    "ukphone": "Inˋkɜ:r",
+    "usphone": "Inˋkɜ:r"
+  },
+  {
+    "name": "suppose",
+    "trans": [
+      "35.8.12",
+      "vt．假想，推测（think, speculate, imagine）"
+    ],
+    "ukphone": "səˋpoʊz",
+    "usphone": "səˋpoʊz"
+  },
+  {
+    "name": "premise",
+    "trans": [
+      "35.8.13",
+      "vt．提出前提 n．前提（assumption, hypothesis）"
+    ],
+    "ukphone": "ˋpremIs",
+    "usphone": "ˋpremIs"
+  },
+  {
+    "name": "infer",
+    "trans": [
+      "35.8.14",
+      "vt．推知（deduce, imply）",
+      "【记】 in（进入）+fer→带进（意义）→推断"
+    ],
+    "ukphone": "Inˋfɜ:r",
+    "usphone": "Inˋfɜ:r"
+  },
+  {
+    "name": "demonstrate",
+    "trans": [
+      "35.8.15",
+      "vt．演示；论证"
+    ],
+    "ukphone": "ˋdemənstreIt",
+    "usphone": "ˋdemənstreIt"
+  },
+  {
+    "name": "furthermore",
+    "trans": [
+      "35.8.16",
+      "adv．此外；而且（besides, addition）"
+    ],
+    "ukphone": "ˌfɜ:rðərˋmɔ:r",
+    "usphone": "ˌfɜ:rðərˋmɔ:r"
+  },
+  {
+    "name": "paradoxically",
+    "trans": [
+      "35.8.17",
+      "adv．似非而是地；反常地；悖理地"
+    ],
+    "ukphone": "ˌpærəˋdα:ksIkli",
+    "usphone": "ˌpærəˋdα:ksIkli"
+  },
+  {
+    "name": "postulate",
+    "trans": [
+      "35.8.18",
+      "v．要求；假定（hypothesize）"
+    ],
+    "ukphone": "ˋpα:stʃələt］/［ˋpα:stʃəleIt",
+    "usphone": "ˋpα:stʃələt］/［ˋpα:stʃəleIt"
+  },
+  {
+    "name": "metaphor",
+    "trans": [
+      "35.8.19",
+      "n．暗喻，隐喻"
+    ],
+    "ukphone": "ˋmetəfər",
+    "usphone": "ˋmetəfər"
+  },
+  {
+    "name": "due",
+    "trans": [
+      "35.9.1",
+      "adj．到期的；预定的，约定的"
+    ],
+    "ukphone": "dju:",
+    "usphone": "dju:"
+  },
+  {
+    "name": "cursory",
+    "trans": [
+      "35.9.2",
+      "adj．仓促的（hurried）",
+      "【记】 curs（跑）+ory"
+    ],
+    "ukphone": "ˋkɜ:rsəri",
+    "usphone": "ˋkɜ:rsəri"
+  },
+  {
+    "name": "perennial",
+    "trans": [
+      "35.9.3",
+      "adj．长久的，永远的（permanent, long-lasting, year-round）",
+      "【记】 per（全部）+enn（年）+ial"
+    ],
+    "ukphone": "pəˋreniəl",
+    "usphone": "pəˋreniəl"
+  },
+  {
+    "name": "chronic",
+    "trans": [
+      "35.9.4",
+      "adj．长期的；慢性的（recurring, periodic）",
+      "【记】 chron（时间）+ic→长时间的"
+    ],
+    "ukphone": "ˋkrα:nIk",
+    "usphone": "ˋkrα:nIk"
+  },
+  {
+    "name": "lasting",
+    "trans": [
+      "35.9.5",
+      "adj．持久的（enduring, long-term, continuing）",
+      "【记】 last（持久）+ing"
+    ],
+    "ukphone": "ˋlæstIŋ",
+    "usphone": "ˋlæstIŋ"
+  },
+  {
+    "name": "everlasting",
+    "trans": [
+      "35.9.6",
+      "adj．永恒的，持久的"
+    ],
+    "ukphone": "ˌevərˋlæstIŋ",
+    "usphone": "ˌevərˋlæstIŋ"
+  },
+  {
+    "name": "hasty",
+    "trans": [
+      "35.9.7",
+      "adj．匆忙的（rushed）"
+    ],
+    "ukphone": "ˋheIsti",
+    "usphone": "ˋheIsti"
+  },
+  {
+    "name": "transitory",
+    "trans": [
+      "35.9.8",
+      "adj．短暂的（temporary, momentary）",
+      "【记】 trans（交换）+it（走）+ory→交换走，你走他来→短暂的"
+    ],
+    "ukphone": "ˋtrænsətɔ:ri",
+    "usphone": "ˋtrænsətɔ:ri"
+  },
+  {
+    "name": "transient",
+    "trans": [
+      "35.9.9",
+      "adj．短暂的；过路的（temporary, short-term）"
+    ],
+    "ukphone": "ˋtrænʃnt",
+    "usphone": "ˋtrænʃnt"
+  },
+  {
+    "name": "obsolete",
+    "trans": [
+      "35.9.10",
+      "adj．过时的；废弃的（disused, outmoded）",
+      "【记】 ob（不）+solete（使用）→过时的"
+    ],
+    "ukphone": "ˌα:bsəˋli:t",
+    "usphone": "ˌα:bsəˋli:t"
+  },
+  {
+    "name": "extemporaneous",
+    "trans": [
+      "35.9.11",
+      "adj．即席的（impromptu, improvised）",
+      "【记】 ex+tempor（时间）+aneous→在安排时间之外→即席的"
+    ],
+    "ukphone": "IkˌstempəˋreIniəs",
+    "usphone": "IkˌstempəˋreIniəs"
+  },
+  {
+    "name": "urgent",
+    "trans": [
+      "35.9.12",
+      "adj．紧急的，迫切的（imperative）"
+    ],
+    "ukphone": "ˋɜ:rdʒənt",
+    "usphone": "ˋɜ:rdʒənt"
+  },
+  {
+    "name": "pressing",
+    "trans": [
+      "35.9.13",
+      "adj．紧迫的（urgent）"
+    ],
+    "ukphone": "ˋpresIŋ",
+    "usphone": "ˋpresIŋ"
+  },
+  {
+    "name": "immediate",
+    "trans": [
+      "35.9.14",
+      "adj．立即的（instant）",
+      "【记】 im（无）+medi（中间）+ate→无中间休息→立刻的"
+    ],
+    "ukphone": "Iˋmi:diət",
+    "usphone": "Iˋmi:diət"
+  },
+  {
+    "name": "forthright",
+    "trans": [
+      "35.9.15",
+      "adj．立即的"
+    ],
+    "ukphone": "ˋfɔ:rθraIt",
+    "usphone": "ˋfɔ:rθraIt"
+  },
+  {
+    "name": "offhand",
+    "trans": [
+      "35.9.16",
+      "adj．临时的"
+    ],
+    "ukphone": "ˌɔ:fˋhænd",
+    "usphone": "ˌɔ:fˋhænd"
+  },
+  {
+    "name": "temporal",
+    "trans": [
+      "35.9.17",
+      "adj．一时的；暂时的（transient, momentary）",
+      "【记】 tempor（时间）+al"
+    ],
+    "ukphone": "ˋtempərəl",
+    "usphone": "ˋtempərəl"
+  },
+  {
+    "name": "temporary",
+    "trans": [
+      "35.9.18",
+      "adj．临时的（momentary, make-do）"
+    ],
+    "ukphone": "ˋtempəreri",
+    "usphone": "ˋtempəreri"
+  },
+  {
+    "name": "contemporary",
+    "trans": [
+      "35.9.19",
+      "adj．当代的，同时代的"
+    ],
+    "ukphone": "kənˋtempəreri",
+    "usphone": "kənˋtempəreri"
+  },
+  {
+    "name": "impromptu",
+    "trans": [
+      "35.9.20",
+      "adj．临时的；即兴的（extempore, improvised）",
+      "【记】 im（不）+promptu（时间）→不在时间表内→临时的"
+    ],
+    "ukphone": "Imˋprα:mptju:",
+    "usphone": "Imˋprα:mptju:"
+  },
+  {
+    "name": "occasional",
+    "trans": [
+      "35.9.21",
+      "adj．临时的；偶然的"
+    ],
+    "ukphone": "əˋkeIʒənl",
+    "usphone": "əˋkeIʒənl"
+  },
+  {
+    "name": "punctual",
+    "trans": [
+      "35.9.22",
+      "adj．守时的",
+      "【记】 punct（点）+ual→卡着点的→守时的"
+    ],
+    "ukphone": "ˋpʌŋktʃuəl",
+    "usphone": "ˋpʌŋktʃuəl"
+  },
+  {
+    "name": "instantaneous",
+    "trans": [
+      "35.9.23",
+      "adj．瞬间的，即刻的（ephemeral）",
+      "【记】 instant（马上）+aneous→瞬间"
+    ],
+    "ukphone": "ˌInstənˋteIniəs",
+    "usphone": "ˌInstənˋteIniəs"
+  },
+  {
+    "name": "subsequent",
+    "trans": [
+      "35.9.24",
+      "adj．随后的，后来的（following, later）",
+      "【记】 sub（下面）+sequent（随着的）"
+    ],
+    "ukphone": "ˋsʌbsIkwənt",
+    "usphone": "ˋsʌbsIkwənt"
+  },
+  {
+    "name": "current",
+    "trans": [
+      "35.9.25",
+      "adj．现今的（present）"
+    ],
+    "ukphone": "ˋkɜ:rənt",
+    "usphone": "ˋkɜ:rənt"
+  },
+  {
+    "name": "concurrent",
+    "trans": [
+      "35.9.26",
+      "adj．同时发生的（simultaneous）",
+      "【记】 con+current（发生）→同时发生"
+    ],
+    "ukphone": "kənˋkɜ:rənt",
+    "usphone": "kənˋkɜ:rənt"
+  },
+  {
+    "name": "extant",
+    "trans": [
+      "35.9.27",
+      "adj．现存的（existing）"
+    ],
+    "ukphone": "ekˋstænt",
+    "usphone": "ekˋstænt"
+  },
+  {
+    "name": "nocturnal",
+    "trans": [
+      "35.9.28",
+      "adj．夜间的（nighttime, nightly）",
+      "【记】 noct（夜）+urnal；比较diurnal（白天的）"
+    ],
+    "ukphone": "nα:kˋtɜ:rnl",
+    "usphone": "nα:kˋtɜ:rnl"
+  },
+  {
+    "name": "former",
+    "trans": [
+      "35.9.29",
+      "adj．以前的（ago, previous）"
+    ],
+    "ukphone": "ˋfɔ:rmər",
+    "usphone": "ˋfɔ:rmər"
+  },
+  {
+    "name": "formerly",
+    "trans": [
+      "35.9.30",
+      "adv．从前，原来（previously）"
+    ],
+    "ukphone": "ˋfɔ:rmərli",
+    "usphone": "ˋfɔ:rmərli"
+  },
+  {
+    "name": "previous",
+    "trans": [
+      "35.9.31",
+      "adj．以前的（preceding, foregoing）",
+      "【记】 pre（预先）+vious"
+    ],
+    "ukphone": "ˋpri:viəs",
+    "usphone": "ˋpri:viəs"
+  },
+  {
+    "name": "previously",
+    "trans": [
+      "35.9.32",
+      "adv．先前，以前（earlier, formerly）"
+    ],
+    "ukphone": "ˋpri:viəsli",
+    "usphone": "ˋpri:viəsli"
+  },
+  {
+    "name": "eternal",
+    "trans": [
+      "35.9.33",
+      "adj．永恒的（everlasting, perpetual）"
+    ],
+    "ukphone": "Iˋtɜ:rnl",
+    "usphone": "Iˋtɜ:rnl"
+  },
+  {
+    "name": "permanent",
+    "trans": [
+      "35.9.34",
+      "adj．永久的（constant, continuous）"
+    ],
+    "ukphone": "ˋpɜ:rmənənt",
+    "usphone": "ˋpɜ:rmənənt"
+  },
+  {
+    "name": "abiding",
+    "trans": [
+      "35.9.35",
+      "adj．永久的，永恒的（enduring, lasting）"
+    ],
+    "ukphone": "əˋbaIdIŋ",
+    "usphone": "əˋbaIdIŋ"
+  },
+  {
+    "name": "dated",
+    "trans": [
+      "35.9.36",
+      "adj．有年头的，陈旧的",
+      "【记】 date（时间，日子）+d"
+    ],
+    "ukphone": "ˋdeItId",
+    "usphone": "ˋdeItId"
+  },
+  {
+    "name": "overdue",
+    "trans": [
+      "35.9.37",
+      "adj．逾期的（tardy, late）",
+      "【记】 over（过）+due（到期）→逾期"
+    ],
+    "ukphone": "ˌoʊvərˋdju:",
+    "usphone": "ˌoʊvərˋdju:"
+  },
+  {
+    "name": "beforehand",
+    "trans": [
+      "35.9.38",
+      "adv．事先地（in advance）"
+    ],
+    "ukphone": "bIˋfɔ:rhænd",
+    "usphone": "bIˋfɔ:rhænd"
+  },
+  {
+    "name": "simultaneously",
+    "trans": [
+      "35.9.39",
+      "adv．同时地（at the same time, concurrently）"
+    ],
+    "ukphone": "ˌsaImlˋteIniəsli",
+    "usphone": "ˌsaImlˋteIniəsli"
+  },
+  {
+    "name": "recently",
+    "trans": [
+      "35.9.40",
+      "adv．最近地（lately, currently）"
+    ],
+    "ukphone": "ˋri:sntli",
+    "usphone": "ˋri:sntli"
+  },
+  {
+    "name": "lately",
+    "trans": [
+      "35.9.41",
+      "adv．最近"
+    ],
+    "ukphone": "ˋleItli",
+    "usphone": "ˋleItli"
+  },
+  {
+    "name": "duration",
+    "trans": [
+      "35.9.42",
+      "n．持续时间，期间（length）"
+    ],
+    "ukphone": "duˋreIʃn",
+    "usphone": "duˋreIʃn"
+  },
+  {
+    "name": "epoch",
+    "trans": [
+      "35.9.43",
+      "n．纪元；时代（age, era）"
+    ],
+    "ukphone": "ˋepək",
+    "usphone": "ˋepək"
+  },
+  {
+    "name": "interlude",
+    "trans": [
+      "35.9.44",
+      "n．间隔；插曲（interval; episode）",
+      "【记】 inter（在…中间）+lude（玩）→在中间玩→中间休息"
+    ],
+    "ukphone": "ˋIntərlu:d",
+    "usphone": "ˋIntərlu:d"
+  },
+  {
+    "name": "era",
+    "trans": [
+      "35.9.45",
+      "n．时代，时期（period, age）"
+    ],
+    "ukphone": "ˋIrə",
+    "usphone": "ˋIrə"
+  },
+  {
+    "name": "schedule",
+    "trans": [
+      "35.9.46",
+      "n．时间表；计划表（calendar, timetable）"
+    ],
+    "ukphone": "ˋskedʒu:l",
+    "usphone": "ˋskedʒu:l"
+  },
+  {
+    "name": "juncture",
+    "trans": [
+      "35.9.47",
+      "n．时刻"
+    ],
+    "ukphone": "ˋdʒʌŋktʃər",
+    "usphone": "ˋdʒʌŋktʃər"
+  },
+  {
+    "name": "session",
+    "trans": [
+      "35.9.48",
+      "n．一段时间；一次"
+    ],
+    "ukphone": "ˋseʃn",
+    "usphone": "ˋseʃn"
+  },
+  {
+    "name": "elapse",
+    "trans": [
+      "35.9.49",
+      "vi.（时间）消逝（go by, pass）",
+      "【记】 e（出）+lapse（滑）→滑出去→时光流去"
+    ],
+    "ukphone": "Iˋlæps",
+    "usphone": "Iˋlæps"
+  },
+  {
+    "name": "concur",
+    "trans": [
+      "35.9.50",
+      "vi．同意，一致"
+    ],
+    "ukphone": "kənˋkɜ:r",
+    "usphone": "kənˋkɜ:r"
+  },
+  {
+    "name": "improvise",
+    "trans": [
+      "35.9.51",
+      "vt．即席而作（extemporize）",
+      "【记】 im（不）+pro（前）+vise（看）→没有预先看过→即席而作"
+    ],
+    "ukphone": "ˋImprəvaIz",
+    "usphone": "ˋImprəvaIz"
+  },
+  {
+    "name": "synchronize",
+    "trans": [
+      "35.9.52",
+      "vt．同时发生（concur）",
+      "【记】 syn（共同）+chron（时间）+ize→同时"
+    ],
+    "ukphone": "ˋsIŋkrənaIz",
+    "usphone": "ˋsIŋkrənaIz"
+  },
+  {
+    "name": "abruptly",
+    "trans": [
+      "35.9.53",
+      "adv．突然地，唐突地（suddenly）"
+    ],
+    "ukphone": "əˋbrʌptli",
+    "usphone": "əˋbrʌptli"
+  },
+  {
+    "name": "vperiodically",
+    "trans": [
+      "35.9.54",
+      "adv．周期性地；偶尔；定期地（regularly）"
+    ],
+    "ukphone": "ˌpIriˋα:dIkli",
+    "usphone": "ˌpIriˋα:dIkli"
+  },
+  {
+    "name": "priority",
+    "trans": [
+      "35.9.55",
+      "n．先，优先，前（antecedence, precedence）"
+    ],
+    "ukphone": "praIˋɔ:rəti",
+    "usphone": "praIˋɔ:rəti"
+  },
+  {
+    "name": "pristine",
+    "trans": [
+      "35.9.56",
+      "adj．原来的，原始的，古时的（primitive）"
+    ],
+    "ukphone": "ˋprIsti:n",
+    "usphone": "ˋprIsti:n"
+  },
+  {
+    "name": "sequentially",
+    "trans": [
+      "35.9.57",
+      "adv．相继地；结果地；连续地"
+    ],
+    "ukphone": "sIˋkwenʃəli",
+    "usphone": "sIˋkwenʃəli"
+  },
+  {
+    "name": "periodically",
+    "trans": [
+      "35.9.58",
+      "adv．定期地；周期性地；偶尔；间歇"
+    ],
+    "ukphone": "ˌpIriˋα:dIkli",
+    "usphone": "ˌpIriˋα:dIkli"
+  },
+  {
+    "name": "itinerant",
+    "trans": [
+      "35.10.1",
+      "adj．巡回的（travelling）；流动的",
+      "【记】 itiner（走）+ant→走来走去的→巡回的"
+    ],
+    "ukphone": "aIˋtInərənt",
+    "usphone": "aIˋtInərənt"
+  },
+  {
+    "name": "flow",
+    "trans": [
+      "35.10.2",
+      "n．流程，流动（circulation）v．流动（travel）"
+    ],
+    "ukphone": "floʊ",
+    "usphone": "floʊ"
+  },
+  {
+    "name": "influx",
+    "trans": [
+      "35.10.3",
+      "n．流入；灌输",
+      "【记】 in（进入）+flux（流入）→涌入"
+    ],
+    "ukphone": "ˋInflʌks",
+    "usphone": "ˋInflʌks"
+  },
+  {
+    "name": "spray",
+    "trans": [
+      "35.10.4",
+      "n./v．喷雾（sprinkle, shower）"
+    ],
+    "ukphone": "spreI",
+    "usphone": "spreI"
+  },
+  {
+    "name": "drift",
+    "trans": [
+      "35.10.5",
+      "n./v．漂流（move aimlessly）"
+    ],
+    "ukphone": "drIft",
+    "usphone": "drIft"
+  },
+  {
+    "name": "fluctuate",
+    "trans": [
+      "35.10.6",
+      "v．波动（waver, alternate, move up and down）",
+      "【记】 fluct=flu（流动）+uate"
+    ],
+    "ukphone": "ˋflʌktʃueIt",
+    "usphone": "ˋflʌktʃueIt"
+  },
+  {
+    "name": "splash",
+    "trans": [
+      "35.10.7",
+      "v．溅，泼（sprinkle）"
+    ],
+    "ukphone": "splæʃ",
+    "usphone": "splæʃ"
+  },
+  {
+    "name": "dip",
+    "trans": [
+      "35.10.8",
+      "v．浸，蘸，沾（immerse in）"
+    ],
+    "ukphone": "dIp",
+    "usphone": "dIp"
+  },
+  {
+    "name": "spurt",
+    "trans": [
+      "35.10.9",
+      "v．喷出，涌出（burst, squirt）"
+    ],
+    "ukphone": "spɜ:rt",
+    "usphone": "spɜ:rt"
+  },
+  {
+    "name": "spout",
+    "trans": [
+      "35.10.10",
+      "v．喷出，涌出（gush, spurt）"
+    ],
+    "ukphone": "spaʊt",
+    "usphone": "spaʊt"
+  },
+  {
+    "name": "meander",
+    "trans": [
+      "35.10.11",
+      "v．蜿蜒而流（wind, zigzag）"
+    ],
+    "ukphone": "miˋændər",
+    "usphone": "miˋændər"
+  },
+  {
+    "name": "gush",
+    "trans": [
+      "35.10.12",
+      "vi．涌出（effuse）"
+    ],
+    "ukphone": "gʌʃ",
+    "usphone": "gʌʃ"
+  },
+  {
+    "name": "immerse",
+    "trans": [
+      "35.10.13",
+      "vt．沉浸",
+      "【记】 im（进）+merse（沉）→沉进去→沉浸"
+    ],
+    "ukphone": "Iˋmɜ:rs",
+    "usphone": "Iˋmɜ:rs"
+  },
+  {
+    "name": "overflow",
+    "trans": [
+      "35.10.14",
+      "vt．从…中溢出（surplus, excess）",
+      "【记】 over（过）+flow（流）→流出"
+    ],
+    "ukphone": "ˌoʊvərˋfloʊ",
+    "usphone": "ˌoʊvərˋfloʊ"
+  },
+  {
+    "name": "infuse",
+    "trans": [
+      "35.10.15",
+      "vt．灌输（imbue, instill）；浸渍",
+      "【记】 in（进入）+fuse（流）→注入"
+    ],
+    "ukphone": "Inˋfju:z",
+    "usphone": "Inˋfju:z"
+  },
+  {
+    "name": "submerge",
+    "trans": [
+      "35.10.16",
+      "vt．浸没，淹没 vi．潜水",
+      "【记】 sub（下面）+merge（沉）→沉到下面→淹没"
+    ],
+    "ukphone": "səbˋmɜ:rdʒ",
+    "usphone": "səbˋmɜ:rdʒ"
+  },
+  {
+    "name": "imbue",
+    "trans": [
+      "35.10.17",
+      "vt．浸染；灌输（permeate）"
+    ],
+    "ukphone": "Imˋbju:",
+    "usphone": "Imˋbju:"
+  },
+  {
+    "name": "saturate",
+    "trans": [
+      "35.10.18",
+      "vt．浸透（soak, imbue）"
+    ],
+    "ukphone": "ˋsætʃəreIt",
+    "usphone": "ˋsætʃəreIt"
+  },
+  {
+    "name": "exude",
+    "trans": [
+      "35.10.19",
+      "vt．渗出；流出（discharge）",
+      "【记】 ex+（s）ude（出汗）→渗出"
+    ],
+    "ukphone": "Igˋzu:d",
+    "usphone": "Igˋzu:d"
+  },
+  {
+    "name": "permeate",
+    "trans": [
+      "35.10.20",
+      "vt．渗透，弥漫（penetrate, pervade）",
+      "【记】 per（全部）+mea（通过）+te→渗透"
+    ],
+    "ukphone": "ˋpɜ:rmieIt",
+    "usphone": "ˋpɜ:rmieIt"
+  },
+  {
+    "name": "dampen",
+    "trans": [
+      "35.10.21",
+      "I don't want to dampen your enthusiasm, but take it easy!"
+    ],
+    "ukphone": "ˋdæmpən",
+    "usphone": "ˋdæmpən"
+  },
+  {
+    "name": "moisten",
+    "trans": [
+      "35.10.22",
+      "vt．使湿润"
+    ],
+    "ukphone": "ˋmɔIsn",
+    "usphone": "ˋmɔIsn"
+  },
+  {
+    "name": "article",
+    "trans": [
+      "35.11.1",
+      "n．物品"
+    ],
+    "ukphone": "ˋα:rtIkl",
+    "usphone": "ˋα:rtIkl"
+  },
+  {
+    "name": "craft",
+    "trans": [
+      "35.11.2",
+      "n．船（单复数相同）（vessel）",
+      "【记】 craftsman（手艺人）"
+    ],
+    "ukphone": "kræft",
+    "usphone": "kræft"
+  },
+  {
+    "name": "vessel",
+    "trans": [
+      "35.11.3",
+      "n．器皿；导管；船（ship）"
+    ],
+    "ukphone": "ˋvesl",
+    "usphone": "ˋvesl"
+  },
+  {
+    "name": "girdle",
+    "trans": [
+      "35.11.4",
+      "n．带状物；带，腰带（waistband）",
+      "【记】 gird（束腰）+le"
+    ],
+    "ukphone": "ˋgɜ:rdl",
+    "usphone": "ˋgɜ:rdl"
+  },
+  {
+    "name": "canvas",
+    "trans": [
+      "35.11.5",
+      "n．帆布"
+    ],
+    "ukphone": "ˋkænvəs",
+    "usphone": "ˋkænvəs"
+  },
+  {
+    "name": "stick",
+    "trans": [
+      "35.11.6",
+      "n．棍，棒"
+    ],
+    "ukphone": "stIk",
+    "usphone": "stIk"
+  },
+  {
+    "name": "souvenir",
+    "trans": [
+      "35.11.7",
+      "n．纪念品（reminder）"
+    ],
+    "ukphone": "ˌsu:vəˋnIr",
+    "usphone": "ˌsu:vəˋnIr"
+  },
+  {
+    "name": "board",
+    "trans": [
+      "35.11.8",
+      "n．木板"
+    ],
+    "ukphone": "bɔ:rd",
+    "usphone": "bɔ:rd"
+  },
+  {
+    "name": "screen",
+    "trans": [
+      "35.11.9",
+      "n．屏幕"
+    ],
+    "ukphone": "skri:n",
+    "usphone": "skri:n"
+  },
+  {
+    "name": "container",
+    "trans": [
+      "35.11.10",
+      "n．容器（receptacle, vessel）"
+    ],
+    "ukphone": "kənˋteInər",
+    "usphone": "kənˋteInər"
+  },
+  {
+    "name": "entity",
+    "trans": [
+      "35.11.11",
+      "n．实体"
+    ],
+    "ukphone": "ˋentəti",
+    "usphone": "ˋentəti"
+  },
+  {
+    "name": "spur",
+    "trans": [
+      "35.11.12",
+      "n．踢马刺"
+    ],
+    "ukphone": "spɜ:r",
+    "usphone": "spɜ:r"
+  },
+  {
+    "name": "leash",
+    "trans": [
+      "35.11.13",
+      "n．牵狗的皮带；控制"
+    ],
+    "ukphone": "li:ʃ",
+    "usphone": "li:ʃ"
+  },
+  {
+    "name": "strip",
+    "trans": [
+      "35.11.14",
+      "n．条，带"
+    ],
+    "ukphone": "strIp",
+    "usphone": "strIp"
+  },
+  {
+    "name": "band",
+    "trans": [
+      "35.11.15",
+      "n．条；带（stripe）"
+    ],
+    "ukphone": "bænd",
+    "usphone": "bænd"
+  },
+  {
+    "name": "hinge",
+    "trans": [
+      "35.11.16",
+      "n．铰链（joint, pivot）"
+    ],
+    "ukphone": "hIndʒ",
+    "usphone": "hIndʒ"
+  },
+  {
+    "name": "ledge",
+    "trans": [
+      "35.11.17",
+      "n．突出物；壁架",
+      "【记】 联想“l”加edge（边）"
+    ],
+    "ukphone": "ledʒ",
+    "usphone": "ledʒ"
+  },
+  {
+    "name": "bulk",
+    "trans": [
+      "35.11.18",
+      "n．物体"
+    ],
+    "ukphone": "bʌlk",
+    "usphone": "bʌlk"
+  },
+  {
+    "name": "varnish",
+    "trans": [
+      "35.11.19",
+      "n．油漆（gloss, polish）"
+    ],
+    "ukphone": "ˋvα:rnIʃ",
+    "usphone": "ˋvα:rnIʃ"
+  },
+  {
+    "name": "tug",
+    "trans": [
+      "35.11.20",
+      "n．拖船"
+    ],
+    "ukphone": "tʌg",
+    "usphone": "tʌg"
+  },
+  {
+    "name": "null",
+    "trans": [
+      "35.12.1",
+      "adj．无效的（invalid, void）"
+    ],
+    "ukphone": "nʌl",
+    "usphone": "nʌl"
+  },
+  {
+    "name": "valid",
+    "trans": [
+      "35.12.2",
+      "adj．有效的（soundly based, acceptable）"
+    ],
+    "ukphone": "ˋvælId",
+    "usphone": "ˋvælId"
+  },
+  {
+    "name": "invalid",
+    "trans": [
+      "35.12.3",
+      "adj．无效的（void）",
+      "【记】 in（不）+valid（有效的）"
+    ],
+    "ukphone": "InˋvælId",
+    "usphone": "InˋvælId"
+  },
+  {
+    "name": "effect",
+    "trans": [
+      "35.12.4",
+      "n．效果；印象（result; impression）",
+      "【记】 ef（出）+fect（做）→做出来→生效，效果"
+    ],
+    "ukphone": "Iˋfekt",
+    "usphone": "Iˋfekt"
+  },
+  {
+    "name": "effective",
+    "trans": [
+      "35.12.5",
+      "adj．有效的；有影响的（valid, resultful）",
+      "【记】 effect（效果）+ive"
+    ],
+    "ukphone": "IˋfektIv",
+    "usphone": "IˋfektIv"
+  },
+  {
+    "name": "efficient",
+    "trans": [
+      "35.12.6",
+      "adj．有效率的（effective, competent）",
+      "【记】 ef（出）+fic（做）+ient→能做出事来→有效率的"
+    ],
+    "ukphone": "IˋfIʃnt",
+    "usphone": "IˋfIʃnt"
+  },
+  {
+    "name": "outcome",
+    "trans": [
+      "35.12.7",
+      "n．后果；成果（result, consequence）",
+      "【记】 来自come out（结果是）"
+    ],
+    "ukphone": "ˋaʊtkʌm",
+    "usphone": "ˋaʊtkʌm"
+  },
+  {
+    "name": "impotence",
+    "trans": [
+      "35.12.8",
+      "n．无效",
+      "【记】 im（无）+potence（能力）→无能"
+    ],
+    "ukphone": "ˋImpətəns",
+    "usphone": "ˋImpətəns"
+  },
+  {
+    "name": "trigger",
+    "trans": [
+      "35.12.9",
+      "n．起动装置；触发器；扳柄；计算机启动某程序的信号（计算机用语）v．引发，触发，引起（cause, kindle）"
+    ],
+    "ukphone": "ˋtrIgər",
+    "usphone": "ˋtrIgər"
+  },
+  {
+    "name": "continuous",
+    "trans": [
+      "35.12.10",
+      "adj．连续的，持续的；连绵不断的"
+    ],
+    "ukphone": "kənˋtInjuəs",
+    "usphone": "kənˋtInjuəs"
+  },
+  {
+    "name": "viable",
+    "trans": [
+      "35.12.11",
+      "adj．可行的；能养活的；能生育的"
+    ],
+    "ukphone": "ˋvaIəbl",
+    "usphone": "ˋvaIəbl"
+  },
+  {
+    "name": "gratuitous",
+    "trans": [
+      "35.13.1",
+      "adj．无理由的，不必要的"
+    ],
+    "ukphone": "grəˋtju:Itəs",
+    "usphone": "grəˋtju:Itəs"
+  },
+  {
+    "name": "source",
+    "trans": [
+      "35.13.2",
+      "n．来源，源头（beginning, origin）"
+    ],
+    "ukphone": "sɔ:rs",
+    "usphone": "sɔ:rs"
+  },
+  {
+    "name": "account",
+    "trans": [
+      "35.13.3",
+      "n．原因"
+    ],
+    "ukphone": "əˋkaʊnt",
+    "usphone": "əˋkaʊnt"
+  },
+  {
+    "name": "reason",
+    "trans": [
+      "35.13.4",
+      "n．原因 v．推论（deduce）"
+    ],
+    "ukphone": "ˋri:zn",
+    "usphone": "ˋri:zn"
+  },
+  {
+    "name": "sake",
+    "trans": [
+      "35.13.5",
+      "n．缘故，原因（reason）"
+    ],
+    "ukphone": "seIk",
+    "usphone": "seIk"
+  },
+  {
+    "name": "cause",
+    "trans": [
+      "35.13.6",
+      "vt．导致 n．原因（reason）"
+    ],
+    "ukphone": "kɔ:z",
+    "usphone": "kɔ:z"
+  },
+  {
+    "name": "impute",
+    "trans": [
+      "35.13.7",
+      "vt．归咎于（ascribe, attribute）",
+      "【记】 比较put（放，归于）"
+    ],
+    "ukphone": "Imˋpju:t",
+    "usphone": "Imˋpju:t"
+  },
+  {
+    "name": "attribute",
+    "trans": [
+      "35.13.8",
+      "vt．归因于（accredit, ascribe）"
+    ],
+    "ukphone": "əˋtrIbju:t",
+    "usphone": "əˋtrIbju:t"
+  },
+  {
+    "name": "superficial",
+    "trans": [
+      "35.14.1",
+      "adj．表面的，肤浅的（seeming, apparent）",
+      "【记】 super（上面）+fic（做）+ial→表面的"
+    ],
+    "ukphone": "ˌsu:pərˋfIʃl",
+    "usphone": "ˌsu:pərˋfIʃl"
+  },
+  {
+    "name": "partial",
+    "trans": [
+      "35.14.2",
+      "adj．部分的（fractional, part）",
+      "【记】 part（部分）+ial"
+    ],
+    "ukphone": "ˋpα:rʃl",
+    "usphone": "ˋpα:rʃl"
+  },
+  {
+    "name": "partially",
+    "trans": [
+      "35.14.3",
+      "adv．部分地"
+    ],
+    "ukphone": "ˋpα:rʃəli",
+    "usphone": "ˋpα:rʃəli"
+  },
+  {
+    "name": "overall",
+    "trans": [
+      "35.14.4",
+      "adj．全部的，全面的（general）"
+    ],
+    "ukphone": "ˌoʊvərˋɔ:l",
+    "usphone": "ˌoʊvərˋɔ:l"
+  },
+  {
+    "name": "integral",
+    "trans": [
+      "35.14.5",
+      "adj．组成的；完整的（complete, full）",
+      "【记】 integr（完整）+al"
+    ],
+    "ukphone": "ˋIntIgrəl",
+    "usphone": "ˋIntIgrəl"
+  },
+  {
+    "name": "integrate",
+    "trans": [
+      "35.14.6",
+      "vt．使结合，使并入（combine, join）"
+    ],
+    "ukphone": "ˋIntIgreIt",
+    "usphone": "ˋIntIgreIt"
+  },
+  {
+    "name": "integrity",
+    "trans": [
+      "35.14.7",
+      "n．完整性（congruity）"
+    ],
+    "ukphone": "Inˋtegrəti",
+    "usphone": "Inˋtegrəti"
+  },
+  {
+    "name": "seemingly",
+    "trans": [
+      "35.14.8",
+      "adv．表面上，似乎（apparently）"
+    ],
+    "ukphone": "ˋsi:mIŋli",
+    "usphone": "ˋsi:mIŋli"
+  },
+  {
+    "name": "portion",
+    "trans": [
+      "35.14.9",
+      "n．一部分（part, fraction）"
+    ],
+    "ukphone": "ˋpɔ:rʃn",
+    "usphone": "ˋpɔ:rʃn"
+  },
+  {
+    "name": "proportion",
+    "trans": [
+      "35.14.10",
+      "n．比例；部分（percentage, ration）",
+      "【记】 比较portion（部分）"
+    ],
+    "ukphone": "prəˋpɔ:rʃn",
+    "usphone": "prəˋpɔ:rʃn"
+  },
+  {
+    "name": "segment",
+    "trans": [
+      "35.14.11",
+      "n．部分；片段（part, section, portion, sector）"
+    ],
+    "ukphone": "ˋsegmənt",
+    "usphone": "ˋsegmənt"
+  },
+  {
+    "name": "facet",
+    "trans": [
+      "35.14.12",
+      "n．方面（aspect）"
+    ],
+    "ukphone": "ˋfæsIt",
+    "usphone": "ˋfæsIt"
+  },
+  {
+    "name": "aspect",
+    "trans": [
+      "35.14.13",
+      "n．方面（facet）",
+      "【记】 a+spect（看）→看上去的样子→外观"
+    ],
+    "ukphone": "ˋæspekt",
+    "usphone": "ˋæspekt"
+  },
+  {
+    "name": "juncture",
+    "trans": [
+      "35.14.14",
+      "n．结合点（junction, joining）"
+    ],
+    "ukphone": "ˋdʒʌŋktʃər",
+    "usphone": "ˋdʒʌŋktʃər"
+  },
+  {
+    "name": "junction",
+    "trans": [
+      "35.14.15",
+      "n．连接，汇合处",
+      "【记】 junct（连接）+ion"
+    ],
+    "ukphone": "ˋdʒʌŋkʃn",
+    "usphone": "ˋdʒʌŋkʃn"
+  },
+  {
+    "name": "fraction",
+    "trans": [
+      "35.14.16",
+      "n．片断（part, bit）",
+      "【记】 fract（碎裂）+ion"
+    ],
+    "ukphone": "ˋfrækʃn",
+    "usphone": "ˋfrækʃn"
+  },
+  {
+    "name": "respect",
+    "trans": [
+      "35.14.17",
+      "n．着眼点，方面（aspect）"
+    ],
+    "ukphone": "rIˋspekt",
+    "usphone": "rIˋspekt"
+  },
+  {
+    "name": "component",
+    "trans": [
+      "35.14.18",
+      "n．组成部分（constituent, ingredient）"
+    ],
+    "ukphone": "kəmˋpoʊnənt",
+    "usphone": "kəmˋpoʊnənt"
+  },
+  {
+    "name": "system",
+    "trans": [
+      "35.14.19",
+      "n．系统，体系"
+    ],
+    "ukphone": "ˋsIstəm",
+    "usphone": "ˋsIstəm"
+  },
+  {
+    "name": "fringe",
+    "trans": [
+      "35.14.20",
+      "n．边缘；流苏；端 v．加饰边于（border, brim）"
+    ],
+    "ukphone": "frIndʒ",
+    "usphone": "frIndʒ"
+  }
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -1628,6 +1628,17 @@ const internationalExam: DictionaryResource[] = [
     language: 'en',
     languageCategory: 'en',
   },
+  {
+    id: 'Categorized_TOEFL_Vocabulary_by_Zhanghongyan',
+    name: 'Categorized Vocab.',
+    description: '词以类记 TOEFL 2021 by ZhangHongYan (原书释义和助记; 单词序号)',
+    category: '国际考试',
+    tags: ['TOEFL'],
+    url: '/dicts/Categorized_TOEFL_Vocabulary_by_Zhanghongyan.json',
+    length: 4123,
+    language: 'en',
+    languageCategory: 'en',
+  },
 ]
 
 // 青少儿英语


### PR DESCRIPTION
为什么添加一个与现有词典类似的 TOEFL 词典？

- 本词典仅引用原书释义和助记，删除了繁杂的其他释义；
- 为单词添加了序号，方便与原书对照使用；
- 标记了书的版本。