### PR TITLE
feat: add Japanese Hiragana and Katakana dictionaries

### DIFF
--- a/public/dicts/JapaneseHiragana.json
+++ b/public/dicts/JapaneseHiragana.json
@@ -1,0 +1,1402 @@
+[
+    {
+        "name": "aiueo",
+        "trans": [],
+        "notation": "あいうえお"
+    },
+    {
+        "name": "aeoui",
+        "trans": [],
+        "notation": "あえおうい"
+    },
+    {
+        "name": "uieoa",
+        "trans": [],
+        "notation": "ういえおあ"
+    },
+    {
+        "name": "oaiue",
+        "trans": [],
+        "notation": "おあいうえ"
+    },
+    {
+        "name": "euoai",
+        "trans": [],
+        "notation": "えうおあい"
+    },
+    {
+        "name": "ieaou",
+        "trans": [],
+        "notation": "いえあおう"
+    },
+    {
+        "name": "oueai",
+        "trans": [],
+        "notation": "おうえあい"
+    },
+    {
+        "name": "auieo",
+        "trans": [],
+        "notation": "あういえお"
+    },
+    {
+        "name": "eaoiu",
+        "trans": [],
+        "notation": "えあおいう"
+    },
+    {
+        "name": "iouea",
+        "trans": [],
+        "notation": "いおうえあ"
+    },
+    {
+        "name": "ueoia",
+        "trans": [],
+        "notation": "うえおいあ"
+    },
+    {
+        "name": "aoieu",
+        "trans": [],
+        "notation": "あおいえう"
+    },
+    {
+        "name": "eiuoa",
+        "trans": [],
+        "notation": "えいうおあ"
+    },
+    {
+        "name": "ouaei",
+        "trans": [],
+        "notation": "おうあえい"
+    },
+    {
+        "name": "iaueo",
+        "trans": [],
+        "notation": "いあうえお"
+    },
+    {
+        "name": "uoeia",
+        "trans": [],
+        "notation": "うおえいあ"
+    },
+    {
+        "name": "eioua",
+        "trans": [],
+        "notation": "えいおうあ"
+    },
+    {
+        "name": "aueio",
+        "trans": [],
+        "notation": "あうえいお"
+    },
+    {
+        "name": "oiaue",
+        "trans": [],
+        "notation": "おいあうえ"
+    },
+    {
+        "name": "ueoai",
+        "trans": [],
+        "notation": "うえおあい"
+    },
+    {
+        "name": "kakikukeko",
+        "trans": [],
+        "notation": "かきくけこ"
+    },
+    {
+        "name": "kekokakiku",
+        "trans": [],
+        "notation": "けこかきく"
+    },
+    {
+        "name": "kikukekako",
+        "trans": [],
+        "notation": "きくけかこ"
+    },
+    {
+        "name": "kokakikuke",
+        "trans": [],
+        "notation": "こかきくけ"
+    },
+    {
+        "name": "kukekokaki",
+        "trans": [],
+        "notation": "くけこかき"
+    },
+    {
+        "name": "kekakukoki",
+        "trans": [],
+        "notation": "けかくこき"
+    },
+    {
+        "name": "kikokakuke",
+        "trans": [],
+        "notation": "きこかくけ"
+    },
+    {
+        "name": "kokukekika",
+        "trans": [],
+        "notation": "こくけきか"
+    },
+    {
+        "name": "kukikekoka",
+        "trans": [],
+        "notation": "くきけこか"
+    },
+    {
+        "name": "kakekokiku",
+        "trans": [],
+        "notation": "かけこきく"
+    },
+    {
+        "name": "kikakekuko",
+        "trans": [],
+        "notation": "きかけくこ"
+    },
+    {
+        "name": "kokikakuke",
+        "trans": [],
+        "notation": "こきかくけ"
+    },
+    {
+        "name": "kekukakiko",
+        "trans": [],
+        "notation": "けくかきこ"
+    },
+    {
+        "name": "kukokekika",
+        "trans": [],
+        "notation": "くこけきか"
+    },
+    {
+        "name": "kakukekoki",
+        "trans": [],
+        "notation": "かくけこき"
+    },
+    {
+        "name": "kikekakuko",
+        "trans": [],
+        "notation": "きけかくこ"
+    },
+    {
+        "name": "kokekikuka",
+        "trans": [],
+        "notation": "こけきくか"
+    },
+    {
+        "name": "kekikokuka",
+        "trans": [],
+        "notation": "けきこくか"
+    },
+    {
+        "name": "kukakikeko",
+        "trans": [],
+        "notation": "くかきけこ"
+    },
+    {
+        "name": "kakokukeki",
+        "trans": [],
+        "notation": "かこくけき"
+    },
+    {
+        "name": "sashisuseso",
+        "trans": [],
+        "notation": "さしすせそ"
+    },
+    {
+        "name": "sesosashisu",
+        "trans": [],
+        "notation": "せそさしす"
+    },
+    {
+        "name": "shisusesaso",
+        "trans": [],
+        "notation": "しすせさそ"
+    },
+    {
+        "name": "sosashisuse",
+        "trans": [],
+        "notation": "そさしすせ"
+    },
+    {
+        "name": "susesosashi",
+        "trans": [],
+        "notation": "すせそさし"
+    },
+    {
+        "name": "sesasusoshi",
+        "trans": [],
+        "notation": "せさすそし"
+    },
+    {
+        "name": "shisosasuse",
+        "trans": [],
+        "notation": "しそさすせ"
+    },
+    {
+        "name": "sosuseshisa",
+        "trans": [],
+        "notation": "そすせしさ"
+    },
+    {
+        "name": "sushisesosa",
+        "trans": [],
+        "notation": "すしせそさ"
+    },
+    {
+        "name": "sasesoshisu",
+        "trans": [],
+        "notation": "させそしす"
+    },
+    {
+        "name": "shisasesuso",
+        "trans": [],
+        "notation": "しさせすそ"
+    },
+    {
+        "name": "soshisasuse",
+        "trans": [],
+        "notation": "そしさすせ"
+    },
+    {
+        "name": "sesusashiso",
+        "trans": [],
+        "notation": "せすさしそ"
+    },
+    {
+        "name": "susoseshisa",
+        "trans": [],
+        "notation": "すそせしさ"
+    },
+    {
+        "name": "sasusesoshi",
+        "trans": [],
+        "notation": "さすせそし"
+    },
+    {
+        "name": "shisesasuso",
+        "trans": [],
+        "notation": "しせさすそ"
+    },
+    {
+        "name": "soseshisusa",
+        "trans": [],
+        "notation": "そせしすさ"
+    },
+    {
+        "name": "seshisosusa",
+        "trans": [],
+        "notation": "せしそすさ"
+    },
+    {
+        "name": "susashiseso",
+        "trans": [],
+        "notation": "すさしせそ"
+    },
+    {
+        "name": "sasosushise",
+        "trans": [],
+        "notation": "さそすしせ"
+    },
+    {
+        "name": "tachitsuteto",
+        "trans": [],
+        "notation": "たちつてと"
+    },
+    {
+        "name": "tetotachitsu",
+        "trans": [],
+        "notation": "てとたちつ"
+    },
+    {
+        "name": "chitsutetato",
+        "trans": [],
+        "notation": "ちつてたと"
+    },
+    {
+        "name": "totachitsute",
+        "trans": [],
+        "notation": "とたちつて"
+    },
+    {
+        "name": "tsutetotachi",
+        "trans": [],
+        "notation": "つてとたち"
+    },
+    {
+        "name": "tetatsutochi",
+        "trans": [],
+        "notation": "てたつとち"
+    },
+    {
+        "name": "chitotatsute",
+        "trans": [],
+        "notation": "ちとたつて"
+    },
+    {
+        "name": "totsutechita",
+        "trans": [],
+        "notation": "とつてちた"
+    },
+    {
+        "name": "tsuchitetota",
+        "trans": [],
+        "notation": "つちてとた"
+    },
+    {
+        "name": "tatetochitsu",
+        "trans": [],
+        "notation": "たてとちつ"
+    },
+    {
+        "name": "chitatsuteto",
+        "trans": [],
+        "notation": "ちたつてと"
+    },
+    {
+        "name": "tochitatsute",
+        "trans": [],
+        "notation": "とちたつて"
+    },
+    {
+        "name": "tetsutachito",
+        "trans": [],
+        "notation": "てつたちと"
+    },
+    {
+        "name": "tsutotechita",
+        "trans": [],
+        "notation": "つとてちた"
+    },
+    {
+        "name": "tatsutetochi",
+        "trans": [],
+        "notation": "たつてとち"
+    },
+    {
+        "name": "chitetsutato",
+        "trans": [],
+        "notation": "ちてつたと"
+    },
+    {
+        "name": "totetsuchita",
+        "trans": [],
+        "notation": "とてつちた"
+    },
+    {
+        "name": "techitotsuta",
+        "trans": [],
+        "notation": "てちとつた"
+    },
+    {
+        "name": "tsutachiteto",
+        "trans": [],
+        "notation": "つたちてと"
+    },
+    {
+        "name": "tatotsuchite",
+        "trans": [],
+        "notation": "たとつちて"
+    },
+    {
+        "name": "naninuneno",
+        "trans": [],
+        "notation": "なにぬねの"
+    },
+    {
+        "name": "nenonaninu",
+        "trans": [],
+        "notation": "ねのなにぬ"
+    },
+    {
+        "name": "ninunenano",
+        "trans": [],
+        "notation": "にぬねなの"
+    },
+    {
+        "name": "nonaninune",
+        "trans": [],
+        "notation": "のなにぬね"
+    },
+    {
+        "name": "nunenonani",
+        "trans": [],
+        "notation": "ぬねのなに"
+    },
+    {
+        "name": "nenanunoni",
+        "trans": [],
+        "notation": "ねなぬのに"
+    },
+    {
+        "name": "ninonanune",
+        "trans": [],
+        "notation": "にのなぬね"
+    },
+    {
+        "name": "nonunenina",
+        "trans": [],
+        "notation": "のぬねにな"
+    },
+    {
+        "name": "nuninenona",
+        "trans": [],
+        "notation": "ぬにねのな"
+    },
+    {
+        "name": "nanenoninu",
+        "trans": [],
+        "notation": "なねのにぬ"
+    },
+    {
+        "name": "ninanuneno",
+        "trans": [],
+        "notation": "になぬねの"
+    },
+    {
+        "name": "noninanune",
+        "trans": [],
+        "notation": "のになぬね"
+    },
+    {
+        "name": "nenunanino",
+        "trans": [],
+        "notation": "ねぬなにの"
+    },
+    {
+        "name": "nunonenina",
+        "trans": [],
+        "notation": "ぬのねにな"
+    },
+    {
+        "name": "nanunenoni",
+        "trans": [],
+        "notation": "なぬねのに"
+    },
+    {
+        "name": "ninenanuno",
+        "trans": [],
+        "notation": "にねなぬの"
+    },
+    {
+        "name": "noneninanu",
+        "trans": [],
+        "notation": "のねになぬ"
+    },
+    {
+        "name": "neninunona",
+        "trans": [],
+        "notation": "ねにぬのな"
+    },
+    {
+        "name": "nunanineno",
+        "trans": [],
+        "notation": "ぬなにねの"
+    },
+    {
+        "name": "nanonunine",
+        "trans": [],
+        "notation": "なのぬにね"
+    },
+    {
+        "name": "hahifuheho",
+        "trans": [],
+        "notation": "はひふへほ"
+    },
+    {
+        "name": "hehohahifu",
+        "trans": [],
+        "notation": "へほはひふ"
+    },
+    {
+        "name": "hifuhehaho",
+        "trans": [],
+        "notation": "ひふへはほ"
+    },
+    {
+        "name": "hohahifuhe",
+        "trans": [],
+        "notation": "ほはひふへ"
+    },
+    {
+        "name": "fuhehohahi",
+        "trans": [],
+        "notation": "ふへほはひ"
+    },
+    {
+        "name": "hehafuhohi",
+        "trans": [],
+        "notation": "へはふほひ"
+    },
+    {
+        "name": "hihohafuhe",
+        "trans": [],
+        "notation": "ひほはふへ"
+    },
+    {
+        "name": "hofuhehiha",
+        "trans": [],
+        "notation": "ほふへひは"
+    },
+    {
+        "name": "fuhihehoha",
+        "trans": [],
+        "notation": "ふひへほは"
+    },
+    {
+        "name": "hahehohifu",
+        "trans": [],
+        "notation": "はへほひふ"
+    },
+    {
+        "name": "hihafuheho",
+        "trans": [],
+        "notation": "ひはふへほ"
+    },
+    {
+        "name": "hohihafuhe",
+        "trans": [],
+        "notation": "ほひはふへ"
+    },
+    {
+        "name": "hefuhahiho",
+        "trans": [],
+        "notation": "へふはひほ"
+    },
+    {
+        "name": "fuhohehiha",
+        "trans": [],
+        "notation": "ふほへひは"
+    },
+    {
+        "name": "hafuhehohi",
+        "trans": [],
+        "notation": "はふへほひ"
+    },
+    {
+        "name": "hihehafuho",
+        "trans": [],
+        "notation": "ひへはふほ"
+    },
+    {
+        "name": "hohefuhiha",
+        "trans": [],
+        "notation": "ほへふひは"
+    },
+    {
+        "name": "hehihofuha",
+        "trans": [],
+        "notation": "へひほふは"
+    },
+    {
+        "name": "fuhahiheho",
+        "trans": [],
+        "notation": "ふはひへほ"
+    },
+    {
+        "name": "hahofuhihe",
+        "trans": [],
+        "notation": "はほふひへ"
+    },
+    {
+        "name": "mamimumemo",
+        "trans": [],
+        "notation": "まみむめも"
+    },
+    {
+        "name": "memomamimu",
+        "trans": [],
+        "notation": "めもまみむ"
+    },
+    {
+        "name": "mimumemamo",
+        "trans": [],
+        "notation": "みむめまも"
+    },
+    {
+        "name": "momamimume",
+        "trans": [],
+        "notation": "もまみむめ"
+    },
+    {
+        "name": "mumemomami",
+        "trans": [],
+        "notation": "むめもまみ"
+    },
+    {
+        "name": "memamumomi",
+        "trans": [],
+        "notation": "めまむもみ"
+    },
+    {
+        "name": "mimomamume",
+        "trans": [],
+        "notation": "みもまむめ"
+    },
+    {
+        "name": "momumemima",
+        "trans": [],
+        "notation": "もむめみま"
+    },
+    {
+        "name": "mumimemoma",
+        "trans": [],
+        "notation": "むみめもま"
+    },
+    {
+        "name": "mamemomimu",
+        "trans": [],
+        "notation": "まめもみむ"
+    },
+    {
+        "name": "mimamumome",
+        "trans": [],
+        "notation": "みまむもめ"
+    },
+    {
+        "name": "momimamume",
+        "trans": [],
+        "notation": "もみまむめ"
+    },
+    {
+        "name": "memumamimo",
+        "trans": [],
+        "notation": "めむまみも"
+    },
+    {
+        "name": "mumomemima",
+        "trans": [],
+        "notation": "むもめみま"
+    },
+    {
+        "name": "mamumemomi",
+        "trans": [],
+        "notation": "まむめもみ"
+    },
+    {
+        "name": "mimemamumo",
+        "trans": [],
+        "notation": "みめまむも"
+    },
+    {
+        "name": "momemimuma",
+        "trans": [],
+        "notation": "もめみむま"
+    },
+    {
+        "name": "memimomuma",
+        "trans": [],
+        "notation": "めみもむま"
+    },
+    {
+        "name": "mumamimemo",
+        "trans": [],
+        "notation": "むまみめも"
+    },
+    {
+        "name": "mamomumime",
+        "trans": [],
+        "notation": "まもむみめ"
+    },
+    {
+        "name": "yayuyowawon",
+        "trans": [],
+        "notation": "やゆよわをん"
+    },
+    {
+        "name": "yuwonyayowa",
+        "trans": [],
+        "notation": "ゆをんやよわ"
+    },
+    {
+        "name": "yoyawayuwon",
+        "trans": [],
+        "notation": "よやわゆをん"
+    },
+    {
+        "name": "wonyayuyowa",
+        "trans": [],
+        "notation": "をんやゆよわ"
+    },
+    {
+        "name": "woyuyayowan",
+        "trans": [],
+        "notation": "をゆやよわん"
+    },
+    {
+        "name": "wayunyowoya",
+        "trans": [],
+        "notation": "わゆんよをや"
+    },
+    {
+        "name": "nyayuwoyowa",
+        "trans": [],
+        "notation": "んやゆをよわ"
+    },
+    {
+        "name": "yowonyuwaya",
+        "trans": [],
+        "notation": "よをんゆわや"
+    },
+    {
+        "name": "wonyawayuyo",
+        "trans": [],
+        "notation": "をんやわゆよ"
+    },
+    {
+        "name": "yawoyoyuwan",
+        "trans": [],
+        "notation": "やをよゆわん"
+    },
+    {
+        "name": "yuyowanyawo",
+        "trans": [],
+        "notation": "ゆよわんやを"
+    },
+    {
+        "name": "woyayuyowan",
+        "trans": [],
+        "notation": "をやゆよわん"
+    },
+    {
+        "name": "nyuyayowawo",
+        "trans": [],
+        "notation": "んゆやよわを"
+    },
+    {
+        "name": "yuwanyoyawo",
+        "trans": [],
+        "notation": "ゆわんよやを"
+    },
+    {
+        "name": "wayoyuwonya",
+        "trans": [],
+        "notation": "わよゆをんや"
+    },
+    {
+        "name": "nyayuwawoyo",
+        "trans": [],
+        "notation": "んやゆわをよ"
+    },
+    {
+        "name": "yowayayuwon",
+        "trans": [],
+        "notation": "よわやゆをん"
+    },
+    {
+        "name": "wonyawayuyo",
+        "trans": [],
+        "notation": "をんやわゆよ"
+    },
+    {
+        "name": "yuwoyanwayo",
+        "trans": [],
+        "notation": "ゆをやんわよ"
+    },
+    {
+        "name": "wayoyuyawon",
+        "trans": [],
+        "notation": "わよゆやをん"
+    },
+    {
+        "name": "rarirurero",
+        "trans": [],
+        "notation": "らりるれろ"
+    },
+    {
+        "name": "rerorariru",
+        "trans": [],
+        "notation": "れろらりる"
+    },
+    {
+        "name": "rirureraro",
+        "trans": [],
+        "notation": "りるれらろ"
+    },
+    {
+        "name": "rorarirure",
+        "trans": [],
+        "notation": "ろらりるれ"
+    },
+    {
+        "name": "rurerorari",
+        "trans": [],
+        "notation": "るれろらり"
+    },
+    {
+        "name": "rerarurori",
+        "trans": [],
+        "notation": "れらるろり"
+    },
+    {
+        "name": "rirorarure",
+        "trans": [],
+        "notation": "りろらるれ"
+    },
+    {
+        "name": "rorurerira",
+        "trans": [],
+        "notation": "ろるれりら"
+    },
+    {
+        "name": "rurirerora",
+        "trans": [],
+        "notation": "るりれろら"
+    },
+    {
+        "name": "rareroriru",
+        "trans": [],
+        "notation": "られろりる"
+    },
+    {
+        "name": "rirarurero",
+        "trans": [],
+        "notation": "りらるれろ"
+    },
+    {
+        "name": "rorirarure",
+        "trans": [],
+        "notation": "ろりらるれ"
+    },
+    {
+        "name": "rerurariro",
+        "trans": [],
+        "notation": "れるらりろ"
+    },
+    {
+        "name": "rurorerira",
+        "trans": [],
+        "notation": "るろれりら"
+    },
+    {
+        "name": "rarurerori",
+        "trans": [],
+        "notation": "らるれろり"
+    },
+    {
+        "name": "rireraruro",
+        "trans": [],
+        "notation": "りれらるろ"
+    },
+    {
+        "name": "rorerirura",
+        "trans": [],
+        "notation": "ろれりるら"
+    },
+    {
+        "name": "rerirorura",
+        "trans": [],
+        "notation": "れりろるら"
+    },
+    {
+        "name": "rurarirero",
+        "trans": [],
+        "notation": "るらりれろ"
+    },
+    {
+        "name": "rarorurire",
+        "trans": [],
+        "notation": "らろるりれ"
+    },
+    {
+        "name": "gagigugego",
+        "trans": [],
+        "notation": "がぎぐげご"
+    },
+    {
+        "name": "gegogagigu",
+        "trans": [],
+        "notation": "げごがぎぐ"
+    },
+    {
+        "name": "gigugegago",
+        "trans": [],
+        "notation": "ぎぐげがご"
+    },
+    {
+        "name": "gogagiguge",
+        "trans": [],
+        "notation": "ごがぎぐげ"
+    },
+    {
+        "name": "gugegogagi",
+        "trans": [],
+        "notation": "ぐげごがぎ"
+    },
+    {
+        "name": "gegagugogi",
+        "trans": [],
+        "notation": "げがぐごぎ"
+    },
+    {
+        "name": "gigogaguge",
+        "trans": [],
+        "notation": "ぎごがぐげ"
+    },
+    {
+        "name": "gogugegiga",
+        "trans": [],
+        "notation": "ごぐげぎが"
+    },
+    {
+        "name": "gugigegoga",
+        "trans": [],
+        "notation": "ぐぎげごが"
+    },
+    {
+        "name": "gagegogigu",
+        "trans": [],
+        "notation": "がげごぎぐ"
+    },
+    {
+        "name": "gigagegugo",
+        "trans": [],
+        "notation": "ぎがげぐご"
+    },
+    {
+        "name": "gogigaguge",
+        "trans": [],
+        "notation": "ごぎがぐげ"
+    },
+    {
+        "name": "gegugagigo",
+        "trans": [],
+        "notation": "げぐがぎご"
+    },
+    {
+        "name": "gugogegiga",
+        "trans": [],
+        "notation": "ぐごげぎが"
+    },
+    {
+        "name": "gagugegogi",
+        "trans": [],
+        "notation": "がぐげごぎ"
+    },
+    {
+        "name": "gigegagugo",
+        "trans": [],
+        "notation": "ぎげがぐご"
+    },
+    {
+        "name": "gogegigagu",
+        "trans": [],
+        "notation": "ごげぎがぐ"
+    },
+    {
+        "name": "gegigoguga",
+        "trans": [],
+        "notation": "げぎごぐが"
+    },
+    {
+        "name": "gugagigego",
+        "trans": [],
+        "notation": "ぐがぎげご"
+    },
+    {
+        "name": "gagogugige",
+        "trans": [],
+        "notation": "がごぐぎげ"
+    },
+    {
+        "name": "zajizuzezo",
+        "trans": [],
+        "notation": "ざじずぜぞ"
+    },
+    {
+        "name": "zezozajizu",
+        "trans": [],
+        "notation": "ぜぞざじず"
+    },
+    {
+        "name": "jizuzezazo",
+        "trans": [],
+        "notation": "じずぜざぞ"
+    },
+    {
+        "name": "zozajizuze",
+        "trans": [],
+        "notation": "ぞざじずぜ"
+    },
+    {
+        "name": "zuzezozaji",
+        "trans": [],
+        "notation": "ずぜぞざじ"
+    },
+    {
+        "name": "zezazuzoji",
+        "trans": [],
+        "notation": "ぜざずぞじ"
+    },
+    {
+        "name": "jizozazuze",
+        "trans": [],
+        "notation": "じぞざずぜ"
+    },
+    {
+        "name": "zozuzejiza",
+        "trans": [],
+        "notation": "ぞずぜじざ"
+    },
+    {
+        "name": "zujizezoza",
+        "trans": [],
+        "notation": "ずじぜぞざ"
+    },
+    {
+        "name": "zazezojizu",
+        "trans": [],
+        "notation": "ざぜぞじず"
+    },
+    {
+        "name": "jizazuzezo",
+        "trans": [],
+        "notation": "じざずぜぞ"
+    },
+    {
+        "name": "zojizazuze",
+        "trans": [],
+        "notation": "ぞじざずぜ"
+    },
+    {
+        "name": "zezujizazo",
+        "trans": [],
+        "notation": "ぜずじざぞ"
+    },
+    {
+        "name": "zuzozejiza",
+        "trans": [],
+        "notation": "ずぞぜじざ"
+    },
+    {
+        "name": "zazuzezoji",
+        "trans": [],
+        "notation": "ざずぜぞじ"
+    },
+    {
+        "name": "jizezazuzo",
+        "trans": [],
+        "notation": "じぜざずぞ"
+    },
+    {
+        "name": "zozejizuza",
+        "trans": [],
+        "notation": "ぞぜじずざ"
+    },
+    {
+        "name": "zejizuzoza",
+        "trans": [],
+        "notation": "ぜじずぞざ"
+    },
+    {
+        "name": "zuzajizezo",
+        "trans": [],
+        "notation": "ずざじぜぞ"
+    },
+    {
+        "name": "zazozujize",
+        "trans": [],
+        "notation": "ざぞずじぜ"
+    },
+    {
+        "name": "dajizudedo",
+        "trans": [],
+        "notation": "だぢづでど"
+    },
+    {
+        "name": "dedodajizu",
+        "trans": [],
+        "notation": "でどだぢづ"
+    },
+    {
+        "name": "jizudedado",
+        "trans": [],
+        "notation": "ぢづでだど"
+    },
+    {
+        "name": "dodajizude",
+        "trans": [],
+        "notation": "どだぢづで"
+    },
+    {
+        "name": "zudedodaji",
+        "trans": [],
+        "notation": "づでどだぢ"
+    },
+    {
+        "name": "dedazudoji",
+        "trans": [],
+        "notation": "でだづどぢ"
+    },
+    {
+        "name": "jidodazude",
+        "trans": [],
+        "notation": "ぢどだづで"
+    },
+    {
+        "name": "dozudejida",
+        "trans": [],
+        "notation": "どづでぢだ"
+    },
+    {
+        "name": "zujidedoda",
+        "trans": [],
+        "notation": "づぢでどだ"
+    },
+    {
+        "name": "dadedojizu",
+        "trans": [],
+        "notation": "だでどぢづ"
+    },
+    {
+        "name": "jidazudedo",
+        "trans": [],
+        "notation": "ぢだづでど"
+    },
+    {
+        "name": "dojidazude",
+        "trans": [],
+        "notation": "どぢだづで"
+    },
+    {
+        "name": "dezudajido",
+        "trans": [],
+        "notation": "でづだぢど"
+    },
+    {
+        "name": "zudodejida",
+        "trans": [],
+        "notation": "づどでぢだ"
+    },
+    {
+        "name": "dazudedoji",
+        "trans": [],
+        "notation": "だづでどぢ"
+    },
+    {
+        "name": "jidedazudo",
+        "trans": [],
+        "notation": "ぢでだづど"
+    },
+    {
+        "name": "dodejizuda",
+        "trans": [],
+        "notation": "どでぢづだ"
+    },
+    {
+        "name": "dejizudoda",
+        "trans": [],
+        "notation": "でぢづどだ"
+    },
+    {
+        "name": "zudajidedo",
+        "trans": [],
+        "notation": "づだぢでど"
+    },
+    {
+        "name": "dadozujide",
+        "trans": [],
+        "notation": "だどづぢで"
+    },
+    {
+        "name": "babibubebo",
+        "trans": [],
+        "notation": "ばびぶべぼ"
+    },
+    {
+        "name": "bebobabibu",
+        "trans": [],
+        "notation": "べぼばびぶ"
+    },
+    {
+        "name": "bibubebabo",
+        "trans": [],
+        "notation": "びぶべばぼ"
+    },
+    {
+        "name": "bobabibube",
+        "trans": [],
+        "notation": "ぼばびぶべ"
+    },
+    {
+        "name": "bubebobabi",
+        "trans": [],
+        "notation": "ぶべぼばび"
+    },
+    {
+        "name": "bebabubobi",
+        "trans": [],
+        "notation": "べばぶぼび"
+    },
+    {
+        "name": "bibobabube",
+        "trans": [],
+        "notation": "びぼばぶべ"
+    },
+    {
+        "name": "bobubebiba",
+        "trans": [],
+        "notation": "ぼぶべびば"
+    },
+    {
+        "name": "bubibeboba",
+        "trans": [],
+        "notation": "ぶびべぼば"
+    },
+    {
+        "name": "babebobibu",
+        "trans": [],
+        "notation": "ばべぼびぶ"
+    },
+    {
+        "name": "bibabubebo",
+        "trans": [],
+        "notation": "びばぶべぼ"
+    },
+    {
+        "name": "bobibabube",
+        "trans": [],
+        "notation": "ぼびばぶべ"
+    },
+    {
+        "name": "bebubabibo",
+        "trans": [],
+        "notation": "べぶばびぼ"
+    },
+    {
+        "name": "bubobebiba",
+        "trans": [],
+        "notation": "ぶぼべびば"
+    },
+    {
+        "name": "babubebobi",
+        "trans": [],
+        "notation": "ばぶべぼび"
+    },
+    {
+        "name": "bibebabubo",
+        "trans": [],
+        "notation": "びべばぶぼ"
+    },
+    {
+        "name": "bobebibuba",
+        "trans": [],
+        "notation": "ぼべびぶば"
+    },
+    {
+        "name": "bebibuboba",
+        "trans": [],
+        "notation": "べびぶぼば"
+    },
+    {
+        "name": "bubabibebo",
+        "trans": [],
+        "notation": "ぶばびべぼ"
+    },
+    {
+        "name": "babobubibe",
+        "trans": [],
+        "notation": "ばぼぶびべ"
+    },
+    {
+        "name": "papipupepo",
+        "trans": [],
+        "notation": "ぱぴぷぺぽ"
+    },
+    {
+        "name": "pepopapipu",
+        "trans": [],
+        "notation": "ぺぽぱぴぷ"
+    },
+    {
+        "name": "pipupepapo",
+        "trans": [],
+        "notation": "ぴぷぺぱぽ"
+    },
+    {
+        "name": "popapipupe",
+        "trans": [],
+        "notation": "ぽぱぴぷぺ"
+    },
+    {
+        "name": "pupepopapi",
+        "trans": [],
+        "notation": "ぷぺぽぱぴ"
+    },
+    {
+        "name": "pepapupopi",
+        "trans": [],
+        "notation": "ぺぱぷぽぴ"
+    },
+    {
+        "name": "pipopapupe",
+        "trans": [],
+        "notation": "ぴぽぱぷぺ"
+    },
+    {
+        "name": "popupepipa",
+        "trans": [],
+        "notation": "ぽぷぺぴぱ"
+    },
+    {
+        "name": "pupipepopa",
+        "trans": [],
+        "notation": "ぷぴぺぽぱ"
+    },
+    {
+        "name": "papepopipu",
+        "trans": [],
+        "notation": "ぱぺぽぴぷ"
+    },
+    {
+        "name": "pipapupepo",
+        "trans": [],
+        "notation": "ぴぱぷぺぽ"
+    },
+    {
+        "name": "popipapupe",
+        "trans": [],
+        "notation": "ぽぴぱぷぺ"
+    },
+    {
+        "name": "pepupapipo",
+        "trans": [],
+        "notation": "ぺぷぱぴぽ"
+    },
+    {
+        "name": "pupopepipa",
+        "trans": [],
+        "notation": "ぷぽぺぴぱ"
+    },
+    {
+        "name": "papupepopi",
+        "trans": [],
+        "notation": "ぱぷぺぽぴ"
+    },
+    {
+        "name": "pipepapupo",
+        "trans": [],
+        "notation": "ぴぺぱぷぽ"
+    },
+    {
+        "name": "popepipupa",
+        "trans": [],
+        "notation": "ぽぺぴぷぱ"
+    },
+    {
+        "name": "pepipupopa",
+        "trans": [],
+        "notation": "ぺぴぷぽぱ"
+    },
+    {
+        "name": "pupapipepo",
+        "trans": [],
+        "notation": "ぷぱぴぺぽ"
+    },
+    {
+        "name": "papopupipe",
+        "trans": [],
+        "notation": "ぱぽぷぴぺ"
+    }
+]

--- a/public/dicts/JapaneseKatakana.json
+++ b/public/dicts/JapaneseKatakana.json
@@ -1,0 +1,1402 @@
+[
+    {
+        "name": "aiueo",
+        "trans": [],
+        "notation": "アイウエオ"
+    },
+    {
+        "name": "aeoui",
+        "trans": [],
+        "notation": "アエオウイ"
+    },
+    {
+        "name": "uieoa",
+        "trans": [],
+        "notation": "ウイエオア"
+    },
+    {
+        "name": "oaiue",
+        "trans": [],
+        "notation": "オアイウエ"
+    },
+    {
+        "name": "euoai",
+        "trans": [],
+        "notation": "エウオアイ"
+    },
+    {
+        "name": "ieaou",
+        "trans": [],
+        "notation": "イエアオウ"
+    },
+    {
+        "name": "oueai",
+        "trans": [],
+        "notation": "オウエアイ"
+    },
+    {
+        "name": "auieo",
+        "trans": [],
+        "notation": "アウイエオ"
+    },
+    {
+        "name": "eaoiu",
+        "trans": [],
+        "notation": "エアオイウ"
+    },
+    {
+        "name": "iouea",
+        "trans": [],
+        "notation": "イオウエア"
+    },
+    {
+        "name": "ueoia",
+        "trans": [],
+        "notation": "ウエオイア"
+    },
+    {
+        "name": "aoieu",
+        "trans": [],
+        "notation": "アオイエウ"
+    },
+    {
+        "name": "eiuoa",
+        "trans": [],
+        "notation": "エイウオア"
+    },
+    {
+        "name": "ouaei",
+        "trans": [],
+        "notation": "オウアエイ"
+    },
+    {
+        "name": "iaueo",
+        "trans": [],
+        "notation": "イアウエオ"
+    },
+    {
+        "name": "uoeia",
+        "trans": [],
+        "notation": "ウオエイア"
+    },
+    {
+        "name": "eioua",
+        "trans": [],
+        "notation": "エイオウア"
+    },
+    {
+        "name": "aueio",
+        "trans": [],
+        "notation": "アウエイオ"
+    },
+    {
+        "name": "oiaue",
+        "trans": [],
+        "notation": "オイアウエ"
+    },
+    {
+        "name": "ueoai",
+        "trans": [],
+        "notation": "ウエオアイ"
+    },
+    {
+        "name": "kakikukeko",
+        "trans": [],
+        "notation": "カキクケコ"
+    },
+    {
+        "name": "kekokakiku",
+        "trans": [],
+        "notation": "ケコカキク"
+    },
+    {
+        "name": "kikukekako",
+        "trans": [],
+        "notation": "キクケカコ"
+    },
+    {
+        "name": "kokakikuke",
+        "trans": [],
+        "notation": "コカキクケ"
+    },
+    {
+        "name": "kukekokaki",
+        "trans": [],
+        "notation": "クケコカキ"
+    },
+    {
+        "name": "kekakukoki",
+        "trans": [],
+        "notation": "ケカクコキ"
+    },
+    {
+        "name": "kikokakuke",
+        "trans": [],
+        "notation": "キコカクケ"
+    },
+    {
+        "name": "kokukekika",
+        "trans": [],
+        "notation": "コクケキカ"
+    },
+    {
+        "name": "kukikekoka",
+        "trans": [],
+        "notation": "クキケコカ"
+    },
+    {
+        "name": "kakekokiku",
+        "trans": [],
+        "notation": "カケコキク"
+    },
+    {
+        "name": "kikakekuko",
+        "trans": [],
+        "notation": "キカケクコ"
+    },
+    {
+        "name": "kokikakuke",
+        "trans": [],
+        "notation": "コキカクケ"
+    },
+    {
+        "name": "kekukakiko",
+        "trans": [],
+        "notation": "ケクカキコ"
+    },
+    {
+        "name": "kukokekika",
+        "trans": [],
+        "notation": "クコケキカ"
+    },
+    {
+        "name": "kakukekoki",
+        "trans": [],
+        "notation": "カクケコキ"
+    },
+    {
+        "name": "kikekakuko",
+        "trans": [],
+        "notation": "キケカクコ"
+    },
+    {
+        "name": "kokekikuka",
+        "trans": [],
+        "notation": "コケキクカ"
+    },
+    {
+        "name": "kekikokuka",
+        "trans": [],
+        "notation": "ケキコクカ"
+    },
+    {
+        "name": "kukakikeko",
+        "trans": [],
+        "notation": "クカキケコ"
+    },
+    {
+        "name": "kakokukeki",
+        "trans": [],
+        "notation": "カコクケキ"
+    },
+    {
+        "name": "sashisuseso",
+        "trans": [],
+        "notation": "サシスセソ"
+    },
+    {
+        "name": "sesosashisu",
+        "trans": [],
+        "notation": "セソサシス"
+    },
+    {
+        "name": "shisusesaso",
+        "trans": [],
+        "notation": "シスセサソ"
+    },
+    {
+        "name": "sosashisuse",
+        "trans": [],
+        "notation": "ソサシスセ"
+    },
+    {
+        "name": "susesosashi",
+        "trans": [],
+        "notation": "スセソサシ"
+    },
+    {
+        "name": "sesasusoshi",
+        "trans": [],
+        "notation": "セサスソシ"
+    },
+    {
+        "name": "shisosasuse",
+        "trans": [],
+        "notation": "シソサスセ"
+    },
+    {
+        "name": "sosuseshisa",
+        "trans": [],
+        "notation": "ソスセシサ"
+    },
+    {
+        "name": "sushisesosa",
+        "trans": [],
+        "notation": "スシセソサ"
+    },
+    {
+        "name": "sasesoshisu",
+        "trans": [],
+        "notation": "サセソシス"
+    },
+    {
+        "name": "shisasesuso",
+        "trans": [],
+        "notation": "シサセスソ"
+    },
+    {
+        "name": "soshisasuse",
+        "trans": [],
+        "notation": "ソシサスセ"
+    },
+    {
+        "name": "sesusashiso",
+        "trans": [],
+        "notation": "セスサシソ"
+    },
+    {
+        "name": "susoseshisa",
+        "trans": [],
+        "notation": "スソセシサ"
+    },
+    {
+        "name": "sasusesoshi",
+        "trans": [],
+        "notation": "サスセソシ"
+    },
+    {
+        "name": "shisesasuso",
+        "trans": [],
+        "notation": "シセサスソ"
+    },
+    {
+        "name": "soseshisusa",
+        "trans": [],
+        "notation": "ソセシスサ"
+    },
+    {
+        "name": "seshisosusa",
+        "trans": [],
+        "notation": "セシソスサ"
+    },
+    {
+        "name": "susashiseso",
+        "trans": [],
+        "notation": "スサシセソ"
+    },
+    {
+        "name": "sasosushise",
+        "trans": [],
+        "notation": "サソスシセ"
+    },
+    {
+        "name": "tachitsuteto",
+        "trans": [],
+        "notation": "タチツテト"
+    },
+    {
+        "name": "tetotachitsu",
+        "trans": [],
+        "notation": "テトタチツ"
+    },
+    {
+        "name": "chitsutetato",
+        "trans": [],
+        "notation": "チツテタト"
+    },
+    {
+        "name": "totachitsute",
+        "trans": [],
+        "notation": "トタチツテ"
+    },
+    {
+        "name": "tsutetotachi",
+        "trans": [],
+        "notation": "ツテトタチ"
+    },
+    {
+        "name": "tetatsutochi",
+        "trans": [],
+        "notation": "テタツトチ"
+    },
+    {
+        "name": "chitotatsute",
+        "trans": [],
+        "notation": "チトタツテ"
+    },
+    {
+        "name": "totsutechita",
+        "trans": [],
+        "notation": "トツテチタ"
+    },
+    {
+        "name": "tsuchitetota",
+        "trans": [],
+        "notation": "ツチテトタ"
+    },
+    {
+        "name": "tatetochitsu",
+        "trans": [],
+        "notation": "タテトチツ"
+    },
+    {
+        "name": "chitatsuteto",
+        "trans": [],
+        "notation": "チタツテト"
+    },
+    {
+        "name": "tochitatsute",
+        "trans": [],
+        "notation": "トチタツテ"
+    },
+    {
+        "name": "tetsutachito",
+        "trans": [],
+        "notation": "テツタチト"
+    },
+    {
+        "name": "tsutotechita",
+        "trans": [],
+        "notation": "ツトテチタ"
+    },
+    {
+        "name": "tatsutetochi",
+        "trans": [],
+        "notation": "タツテトチ"
+    },
+    {
+        "name": "chitetsutato",
+        "trans": [],
+        "notation": "チテツタト"
+    },
+    {
+        "name": "totetsuchita",
+        "trans": [],
+        "notation": "トテツチタ"
+    },
+    {
+        "name": "techitotsuta",
+        "trans": [],
+        "notation": "テチトツタ"
+    },
+    {
+        "name": "tsutachiteto",
+        "trans": [],
+        "notation": "ツタチテト"
+    },
+    {
+        "name": "tatotsuchite",
+        "trans": [],
+        "notation": "タトツチテ"
+    },
+    {
+        "name": "naninuneno",
+        "trans": [],
+        "notation": "ナニヌネノ"
+    },
+    {
+        "name": "nenonaninu",
+        "trans": [],
+        "notation": "ネノナニヌ"
+    },
+    {
+        "name": "ninunenano",
+        "trans": [],
+        "notation": "ニヌネナノ"
+    },
+    {
+        "name": "nonaninune",
+        "trans": [],
+        "notation": "ノナニヌネ"
+    },
+    {
+        "name": "nunenonani",
+        "trans": [],
+        "notation": "ヌネノナニ"
+    },
+    {
+        "name": "nenanunoni",
+        "trans": [],
+        "notation": "ネナヌノニ"
+    },
+    {
+        "name": "ninonanune",
+        "trans": [],
+        "notation": "ニノナヌネ"
+    },
+    {
+        "name": "nonunenina",
+        "trans": [],
+        "notation": "ノヌネニナ"
+    },
+    {
+        "name": "nuninenona",
+        "trans": [],
+        "notation": "ヌニネノナ"
+    },
+    {
+        "name": "nanenoninu",
+        "trans": [],
+        "notation": "ナネノニヌ"
+    },
+    {
+        "name": "ninanuneno",
+        "trans": [],
+        "notation": "ニナヌネノ"
+    },
+    {
+        "name": "noninanune",
+        "trans": [],
+        "notation": "ノニナヌネ"
+    },
+    {
+        "name": "nenunanino",
+        "trans": [],
+        "notation": "ネヌナニノ"
+    },
+    {
+        "name": "nunonenina",
+        "trans": [],
+        "notation": "ヌノネニナ"
+    },
+    {
+        "name": "nanunenoni",
+        "trans": [],
+        "notation": "ナヌネノニ"
+    },
+    {
+        "name": "ninenanuno",
+        "trans": [],
+        "notation": "ニネナヌノ"
+    },
+    {
+        "name": "noneninanu",
+        "trans": [],
+        "notation": "ノネニナヌ"
+    },
+    {
+        "name": "neninunona",
+        "trans": [],
+        "notation": "ネニヌノナ"
+    },
+    {
+        "name": "nunanineno",
+        "trans": [],
+        "notation": "ヌナニネノ"
+    },
+    {
+        "name": "nanonunine",
+        "trans": [],
+        "notation": "ナノヌニネ"
+    },
+    {
+        "name": "hahifuheho",
+        "trans": [],
+        "notation": "ハヒフヘホ"
+    },
+    {
+        "name": "hehohahifu",
+        "trans": [],
+        "notation": "ヘホハヒフ"
+    },
+    {
+        "name": "hifuhehaho",
+        "trans": [],
+        "notation": "ヒフヘハホ"
+    },
+    {
+        "name": "hohahifuhe",
+        "trans": [],
+        "notation": "ホハヒフヘ"
+    },
+    {
+        "name": "fuhehohahi",
+        "trans": [],
+        "notation": "フヘホハヒ"
+    },
+    {
+        "name": "hehafuhohi",
+        "trans": [],
+        "notation": "ヘハフホヒ"
+    },
+    {
+        "name": "hihohafuhe",
+        "trans": [],
+        "notation": "ヒホハフヘ"
+    },
+    {
+        "name": "hofuhehiha",
+        "trans": [],
+        "notation": "ホフヘヒハ"
+    },
+    {
+        "name": "fuhihehoha",
+        "trans": [],
+        "notation": "フヒヘホハ"
+    },
+    {
+        "name": "hahehohifu",
+        "trans": [],
+        "notation": "ハヘホヒフ"
+    },
+    {
+        "name": "hihafuheho",
+        "trans": [],
+        "notation": "ヒハフヘホ"
+    },
+    {
+        "name": "hohihafuhe",
+        "trans": [],
+        "notation": "ホヒハフヘ"
+    },
+    {
+        "name": "hefuhahiho",
+        "trans": [],
+        "notation": "ヘフハヒホ"
+    },
+    {
+        "name": "fuhohehiha",
+        "trans": [],
+        "notation": "フホヘヒハ"
+    },
+    {
+        "name": "hafuhehohi",
+        "trans": [],
+        "notation": "ハフヘホヒ"
+    },
+    {
+        "name": "hihehafuho",
+        "trans": [],
+        "notation": "ヒヘハフホ"
+    },
+    {
+        "name": "hohefuhiha",
+        "trans": [],
+        "notation": "ホヘフヒハ"
+    },
+    {
+        "name": "hehihofuha",
+        "trans": [],
+        "notation": "ヘヒホフハ"
+    },
+    {
+        "name": "fuhahiheho",
+        "trans": [],
+        "notation": "フハヒヘホ"
+    },
+    {
+        "name": "hahofuhihe",
+        "trans": [],
+        "notation": "ハホフヒヘ"
+    },
+    {
+        "name": "mamimumemo",
+        "trans": [],
+        "notation": "マミムメモ"
+    },
+    {
+        "name": "memomamimu",
+        "trans": [],
+        "notation": "メモマミム"
+    },
+    {
+        "name": "mimumemamo",
+        "trans": [],
+        "notation": "ミムメマモ"
+    },
+    {
+        "name": "momamimume",
+        "trans": [],
+        "notation": "モマミムメ"
+    },
+    {
+        "name": "mumemomami",
+        "trans": [],
+        "notation": "ムメモマミ"
+    },
+    {
+        "name": "memamumomi",
+        "trans": [],
+        "notation": "メマムモミ"
+    },
+    {
+        "name": "mimomamume",
+        "trans": [],
+        "notation": "ミモマムメ"
+    },
+    {
+        "name": "momumemima",
+        "trans": [],
+        "notation": "モムメミマ"
+    },
+    {
+        "name": "mumimemoma",
+        "trans": [],
+        "notation": "ムミメモマ"
+    },
+    {
+        "name": "mamemomimu",
+        "trans": [],
+        "notation": "マメモミム"
+    },
+    {
+        "name": "mimamumome",
+        "trans": [],
+        "notation": "ミマムモメ"
+    },
+    {
+        "name": "momimamume",
+        "trans": [],
+        "notation": "モミマムメ"
+    },
+    {
+        "name": "memumamimo",
+        "trans": [],
+        "notation": "メムマミモ"
+    },
+    {
+        "name": "mumomemima",
+        "trans": [],
+        "notation": "ムモメミマ"
+    },
+    {
+        "name": "mamumemomi",
+        "trans": [],
+        "notation": "マムメモミ"
+    },
+    {
+        "name": "mimemamumo",
+        "trans": [],
+        "notation": "ミメマムモ"
+    },
+    {
+        "name": "momemimuma",
+        "trans": [],
+        "notation": "モメミムマ"
+    },
+    {
+        "name": "memimomuma",
+        "trans": [],
+        "notation": "メミモムマ"
+    },
+    {
+        "name": "mumamimemo",
+        "trans": [],
+        "notation": "ムマミメモ"
+    },
+    {
+        "name": "mamomumime",
+        "trans": [],
+        "notation": "マモムミメ"
+    },
+    {
+        "name": "yayuyowawon",
+        "trans": [],
+        "notation": "ヤユヨワヲン"
+    },
+    {
+        "name": "yuwonyayowa",
+        "trans": [],
+        "notation": "ユヲンヤヨワ"
+    },
+    {
+        "name": "yoyawayuwon",
+        "trans": [],
+        "notation": "ヨヤワユヲン"
+    },
+    {
+        "name": "wonyayuyowa",
+        "trans": [],
+        "notation": "ヲンヤユヨワ"
+    },
+    {
+        "name": "woyuyayowan",
+        "trans": [],
+        "notation": "ヲユヤヨワン"
+    },
+    {
+        "name": "wayunyowoya",
+        "trans": [],
+        "notation": "ワユンヨヲヤ"
+    },
+    {
+        "name": "nyayuwoyowa",
+        "trans": [],
+        "notation": "ンヤユヲヨワ"
+    },
+    {
+        "name": "yowonyuwaya",
+        "trans": [],
+        "notation": "ヨヲンユワヤ"
+    },
+    {
+        "name": "wonyawayuyo",
+        "trans": [],
+        "notation": "ヲンヤワユヨ"
+    },
+    {
+        "name": "yawoyoyuwan",
+        "trans": [],
+        "notation": "ヤヲヨユワン"
+    },
+    {
+        "name": "yuyowanyawo",
+        "trans": [],
+        "notation": "ユヨワンヤヲ"
+    },
+    {
+        "name": "woyayuyowan",
+        "trans": [],
+        "notation": "ヲヤユヨワン"
+    },
+    {
+        "name": "nyuyayowawo",
+        "trans": [],
+        "notation": "ンユヤヨワヲ"
+    },
+    {
+        "name": "yuwanyoyawo",
+        "trans": [],
+        "notation": "ユワンヨヤヲ"
+    },
+    {
+        "name": "wayoyuwonya",
+        "trans": [],
+        "notation": "ワヨユヲンヤ"
+    },
+    {
+        "name": "nyayuwawoyo",
+        "trans": [],
+        "notation": "ンヤユワヲヨ"
+    },
+    {
+        "name": "yowayayuwon",
+        "trans": [],
+        "notation": "ヨワヤユヲン"
+    },
+    {
+        "name": "wonyawayuyo",
+        "trans": [],
+        "notation": "ヲンヤワユヨ"
+    },
+    {
+        "name": "yuwoyanwayo",
+        "trans": [],
+        "notation": "ユヲヤンワヨ"
+    },
+    {
+        "name": "wayoyuyawon",
+        "trans": [],
+        "notation": "ワヨユヤヲン"
+    },
+    {
+        "name": "rarirurero",
+        "trans": [],
+        "notation": "ラリルレロ"
+    },
+    {
+        "name": "rerorariru",
+        "trans": [],
+        "notation": "レロラリル"
+    },
+    {
+        "name": "rirureraro",
+        "trans": [],
+        "notation": "リルレラロ"
+    },
+    {
+        "name": "rorarirure",
+        "trans": [],
+        "notation": "ロラリルレ"
+    },
+    {
+        "name": "rurerorari",
+        "trans": [],
+        "notation": "ルレロラリ"
+    },
+    {
+        "name": "rerarurori",
+        "trans": [],
+        "notation": "レラルロリ"
+    },
+    {
+        "name": "rirorarure",
+        "trans": [],
+        "notation": "リロラルレ"
+    },
+    {
+        "name": "rorurerira",
+        "trans": [],
+        "notation": "ロルレリラ"
+    },
+    {
+        "name": "rurirerora",
+        "trans": [],
+        "notation": "ルリレロラ"
+    },
+    {
+        "name": "rareroriru",
+        "trans": [],
+        "notation": "ラレロリル"
+    },
+    {
+        "name": "rirarurero",
+        "trans": [],
+        "notation": "リラルレロ"
+    },
+    {
+        "name": "rorirarure",
+        "trans": [],
+        "notation": "ロリラルレ"
+    },
+    {
+        "name": "rerurariro",
+        "trans": [],
+        "notation": "レルラリロ"
+    },
+    {
+        "name": "rurorerira",
+        "trans": [],
+        "notation": "ルロレリラ"
+    },
+    {
+        "name": "rarurerori",
+        "trans": [],
+        "notation": "ラルレロリ"
+    },
+    {
+        "name": "rireraruro",
+        "trans": [],
+        "notation": "リレラルロ"
+    },
+    {
+        "name": "rorerirura",
+        "trans": [],
+        "notation": "ロレリルラ"
+    },
+    {
+        "name": "rerirorura",
+        "trans": [],
+        "notation": "レリロルラ"
+    },
+    {
+        "name": "rurarirero",
+        "trans": [],
+        "notation": "ルラリレロ"
+    },
+    {
+        "name": "rarorurire",
+        "trans": [],
+        "notation": "ラロルリレ"
+    },
+    {
+        "name": "gagigugego",
+        "trans": [],
+        "notation": "ガギグゲゴ"
+    },
+    {
+        "name": "gegogagigu",
+        "trans": [],
+        "notation": "ゲゴガギグ"
+    },
+    {
+        "name": "gigugegago",
+        "trans": [],
+        "notation": "ギグゲガゴ"
+    },
+    {
+        "name": "gogagiguge",
+        "trans": [],
+        "notation": "ゴガギグゲ"
+    },
+    {
+        "name": "gugegogagi",
+        "trans": [],
+        "notation": "グゲゴガギ"
+    },
+    {
+        "name": "gegagugogi",
+        "trans": [],
+        "notation": "ゲガグゴギ"
+    },
+    {
+        "name": "gigogaguge",
+        "trans": [],
+        "notation": "ギゴガグゲ"
+    },
+    {
+        "name": "gogugegiga",
+        "trans": [],
+        "notation": "ゴグゲギガ"
+    },
+    {
+        "name": "gugigegoga",
+        "trans": [],
+        "notation": "グギゲゴガ"
+    },
+    {
+        "name": "gagegogigu",
+        "trans": [],
+        "notation": "ガゲゴギグ"
+    },
+    {
+        "name": "gigagegugo",
+        "trans": [],
+        "notation": "ギガゲグゴ"
+    },
+    {
+        "name": "gogigaguge",
+        "trans": [],
+        "notation": "ゴギガグゲ"
+    },
+    {
+        "name": "gegugagigo",
+        "trans": [],
+        "notation": "ゲグガギゴ"
+    },
+    {
+        "name": "gugogegiga",
+        "trans": [],
+        "notation": "グゴゲギガ"
+    },
+    {
+        "name": "gagugegogi",
+        "trans": [],
+        "notation": "ガグゲゴギ"
+    },
+    {
+        "name": "gigegagugo",
+        "trans": [],
+        "notation": "ギゲガグゴ"
+    },
+    {
+        "name": "gogegigagu",
+        "trans": [],
+        "notation": "ゴゲギガグ"
+    },
+    {
+        "name": "gegigoguga",
+        "trans": [],
+        "notation": "ゲギゴグガ"
+    },
+    {
+        "name": "gugagigego",
+        "trans": [],
+        "notation": "グガギゲゴ"
+    },
+    {
+        "name": "gagogugige",
+        "trans": [],
+        "notation": "ガゴグギゲ"
+    },
+    {
+        "name": "zajizuzezo",
+        "trans": [],
+        "notation": "ザジズゼゾ"
+    },
+    {
+        "name": "zezozajizu",
+        "trans": [],
+        "notation": "ゼゾザジズ"
+    },
+    {
+        "name": "jizuzezazo",
+        "trans": [],
+        "notation": "ジズゼザゾ"
+    },
+    {
+        "name": "zozajizuze",
+        "trans": [],
+        "notation": "ゾザジズゼ"
+    },
+    {
+        "name": "zuzezozaji",
+        "trans": [],
+        "notation": "ズゼゾザジ"
+    },
+    {
+        "name": "zezazuzoji",
+        "trans": [],
+        "notation": "ゼザズゾジ"
+    },
+    {
+        "name": "jizozazuze",
+        "trans": [],
+        "notation": "ジゾザズゼ"
+    },
+    {
+        "name": "zozuzejiza",
+        "trans": [],
+        "notation": "ゾズゼジザ"
+    },
+    {
+        "name": "zujizezoza",
+        "trans": [],
+        "notation": "ズジゼゾザ"
+    },
+    {
+        "name": "zazezojizu",
+        "trans": [],
+        "notation": "ザゼゾジズ"
+    },
+    {
+        "name": "jizazuzezo",
+        "trans": [],
+        "notation": "ジザズゼゾ"
+    },
+    {
+        "name": "zojizazuze",
+        "trans": [],
+        "notation": "ゾジザズゼ"
+    },
+    {
+        "name": "zezujizazo",
+        "trans": [],
+        "notation": "ゼズジザゾ"
+    },
+    {
+        "name": "zuzozejiza",
+        "trans": [],
+        "notation": "ズゾゼジザ"
+    },
+    {
+        "name": "zazuzezoji",
+        "trans": [],
+        "notation": "ザズゼゾジ"
+    },
+    {
+        "name": "jizezazuzo",
+        "trans": [],
+        "notation": "ジゼザズゾ"
+    },
+    {
+        "name": "zozejizuza",
+        "trans": [],
+        "notation": "ゾゼジズザ"
+    },
+    {
+        "name": "zejizuzoza",
+        "trans": [],
+        "notation": "ゼジズゾザ"
+    },
+    {
+        "name": "zuzajizezo",
+        "trans": [],
+        "notation": "ズザジゼゾ"
+    },
+    {
+        "name": "zazozujize",
+        "trans": [],
+        "notation": "ザゾズジゼ"
+    },
+    {
+        "name": "dajizudedo",
+        "trans": [],
+        "notation": "ダヂヅデド"
+    },
+    {
+        "name": "dedodajizu",
+        "trans": [],
+        "notation": "デドダヂヅ"
+    },
+    {
+        "name": "jizudedado",
+        "trans": [],
+        "notation": "ヂヅデダド"
+    },
+    {
+        "name": "dodajizude",
+        "trans": [],
+        "notation": "ドダヂヅデ"
+    },
+    {
+        "name": "zudedodaji",
+        "trans": [],
+        "notation": "ヅデドダヂ"
+    },
+    {
+        "name": "dedazudoji",
+        "trans": [],
+        "notation": "デダヅドヂ"
+    },
+    {
+        "name": "jidodazude",
+        "trans": [],
+        "notation": "ヂドダヅデ"
+    },
+    {
+        "name": "dozudejida",
+        "trans": [],
+        "notation": "ドヅデヂダ"
+    },
+    {
+        "name": "zujidedoda",
+        "trans": [],
+        "notation": "ヅヂデドダ"
+    },
+    {
+        "name": "dadedojizu",
+        "trans": [],
+        "notation": "ダデドヂヅ"
+    },
+    {
+        "name": "jidazudedo",
+        "trans": [],
+        "notation": "ヂダヅデド"
+    },
+    {
+        "name": "dojidazude",
+        "trans": [],
+        "notation": "ドヂダヅデ"
+    },
+    {
+        "name": "dezudajido",
+        "trans": [],
+        "notation": "デヅダヂド"
+    },
+    {
+        "name": "zudodejida",
+        "trans": [],
+        "notation": "ヅドデヂダ"
+    },
+    {
+        "name": "dazudedoji",
+        "trans": [],
+        "notation": "ダヅデドヂ"
+    },
+    {
+        "name": "jidedazudo",
+        "trans": [],
+        "notation": "ヂデダヅド"
+    },
+    {
+        "name": "dodejizuda",
+        "trans": [],
+        "notation": "ドデヂヅダ"
+    },
+    {
+        "name": "dejizudoda",
+        "trans": [],
+        "notation": "デヂヅドダ"
+    },
+    {
+        "name": "zudajidedo",
+        "trans": [],
+        "notation": "ヅダヂデド"
+    },
+    {
+        "name": "dadozujide",
+        "trans": [],
+        "notation": "ダドヅヂデ"
+    },
+    {
+        "name": "babibubebo",
+        "trans": [],
+        "notation": "バビブベボ"
+    },
+    {
+        "name": "bebobabibu",
+        "trans": [],
+        "notation": "ベボバビブ"
+    },
+    {
+        "name": "bibubebabo",
+        "trans": [],
+        "notation": "ビブベバボ"
+    },
+    {
+        "name": "bobabibube",
+        "trans": [],
+        "notation": "ボバビブベ"
+    },
+    {
+        "name": "bubebobabi",
+        "trans": [],
+        "notation": "ブベボバビ"
+    },
+    {
+        "name": "bebabubobi",
+        "trans": [],
+        "notation": "ベバブボビ"
+    },
+    {
+        "name": "bibobabube",
+        "trans": [],
+        "notation": "ビボバブベ"
+    },
+    {
+        "name": "bobubebiba",
+        "trans": [],
+        "notation": "ボブベビバ"
+    },
+    {
+        "name": "bubibeboba",
+        "trans": [],
+        "notation": "ブビベボバ"
+    },
+    {
+        "name": "babebobibu",
+        "trans": [],
+        "notation": "バベボビブ"
+    },
+    {
+        "name": "bibabubebo",
+        "trans": [],
+        "notation": "ビバブベボ"
+    },
+    {
+        "name": "bobibabube",
+        "trans": [],
+        "notation": "ボビバブベ"
+    },
+    {
+        "name": "bebubabibo",
+        "trans": [],
+        "notation": "ベブバビボ"
+    },
+    {
+        "name": "bubobebiba",
+        "trans": [],
+        "notation": "ブボベビバ"
+    },
+    {
+        "name": "babubebobi",
+        "trans": [],
+        "notation": "バブベボビ"
+    },
+    {
+        "name": "bibebabubo",
+        "trans": [],
+        "notation": "ビベバブボ"
+    },
+    {
+        "name": "bobebibuba",
+        "trans": [],
+        "notation": "ボベビブバ"
+    },
+    {
+        "name": "bebibuboba",
+        "trans": [],
+        "notation": "ベビブボバ"
+    },
+    {
+        "name": "bubabibebo",
+        "trans": [],
+        "notation": "ブバビベボ"
+    },
+    {
+        "name": "babobubibe",
+        "trans": [],
+        "notation": "バボブビベ"
+    },
+    {
+        "name": "papipupepo",
+        "trans": [],
+        "notation": "パピプペポ"
+    },
+    {
+        "name": "pepopapipu",
+        "trans": [],
+        "notation": "ペポパピプ"
+    },
+    {
+        "name": "pipupepapo",
+        "trans": [],
+        "notation": "ピプペパポ"
+    },
+    {
+        "name": "popapipupe",
+        "trans": [],
+        "notation": "ポパピプペ"
+    },
+    {
+        "name": "pupepopapi",
+        "trans": [],
+        "notation": "プペポパピ"
+    },
+    {
+        "name": "pepapupopi",
+        "trans": [],
+        "notation": "ペパプポピ"
+    },
+    {
+        "name": "pipopapupe",
+        "trans": [],
+        "notation": "ピポパプペ"
+    },
+    {
+        "name": "popupepipa",
+        "trans": [],
+        "notation": "ポプペピパ"
+    },
+    {
+        "name": "pupipepopa",
+        "trans": [],
+        "notation": "プピペポパ"
+    },
+    {
+        "name": "papepopipu",
+        "trans": [],
+        "notation": "パペポピプ"
+    },
+    {
+        "name": "pipapupepo",
+        "trans": [],
+        "notation": "ピパプペポ"
+    },
+    {
+        "name": "popipapupe",
+        "trans": [],
+        "notation": "ポピパプペ"
+    },
+    {
+        "name": "pepupapipo",
+        "trans": [],
+        "notation": "ペプパピポ"
+    },
+    {
+        "name": "pupopepipa",
+        "trans": [],
+        "notation": "プポペピパ"
+    },
+    {
+        "name": "papupepopi",
+        "trans": [],
+        "notation": "パプペポピ"
+    },
+    {
+        "name": "pipepapupo",
+        "trans": [],
+        "notation": "ピペパプポ"
+    },
+    {
+        "name": "popepipupa",
+        "trans": [],
+        "notation": "ポペピプパ"
+    },
+    {
+        "name": "pepipupopa",
+        "trans": [],
+        "notation": "ペピプポパ"
+    },
+    {
+        "name": "pupapipepo",
+        "trans": [],
+        "notation": "プパピペポ"
+    },
+    {
+        "name": "papopupipe",
+        "trans": [],
+        "notation": "パポプピペ"
+    }
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -3867,6 +3867,28 @@ const programming: DictionaryResource[] = [
 // 日语词典
 const japaneseExam: DictionaryResource[] = [
   {
+    id: 'japanese-hiragana',
+    name: '平假名',
+    description: '平假名练习',
+    category: '日语学习',
+    tags: ['基础', '五十音', '平假名'],
+    url: '/dicts/JapaneseHiragana.json',
+    length: 280,
+    language: 'romaji',
+    languageCategory: 'ja',
+  },
+  {
+    id: 'japanese-katakana',
+    name: '片假名',
+    description: '片假名练习',
+    category: '日语学习',
+    tags: ['基础', '五十音', '片假名'],
+    url: '/dicts/JapaneseKatakana.json',
+    length: 280,
+    language: 'romaji',
+    languageCategory: 'ja',
+  },
+  {
     id: 'japanese001',
     name: '日语常见词',
     description: '英语翻译',


### PR DESCRIPTION
Add two new dictionaries for practicing Japanese Hiragana and Katakana.

添加平假名，片假名两个日语五十音练习字典。あかさ 等行每行一个练习章节。每个章节随机打乱顺序。