### PR TITLE
fix: text contrast issue when system prefers dark mode

### DIFF
--- a/src/pages/Typing/components/DictChapterButton/index.tsx
+++ b/src/pages/Typing/components/DictChapterButton/index.tsx
@@ -22,7 +22,7 @@ export const DictChapterButton = () => {
     <>
       <Tooltip content="词典切换">
         <NavLink
-          className="block rounded-lg px-3 py-1 text-lg transition-colors duration-300 ease-in-out hover:bg-indigo-400 hover:text-white focus:outline-none dark:text-white dark:text-opacity-60 dark:hover:text-opacity-100"
+          className="block rounded-lg px-3 py-1 text-lg text-black transition-colors duration-300 ease-in-out hover:bg-indigo-400 hover:text-white focus:outline-none dark:text-white dark:text-opacity-60 dark:hover:text-opacity-100"
           to="/gallery"
         >
           {currentDictInfo.name} {isReviewMode && '错题复习'}
@@ -33,7 +33,7 @@ export const DictChapterButton = () => {
           <Listbox value={currentChapter} onChange={setCurrentChapter}>
             <Listbox.Button
               onKeyDown={handleKeyDown}
-              className="rounded-lg px-3 py-1 text-lg transition-colors duration-300 ease-in-out hover:bg-indigo-400 hover:text-white focus:outline-none dark:text-white dark:text-opacity-60 dark:hover:text-opacity-100"
+              className="rounded-lg px-3 py-1 text-lg text-black transition-colors duration-300 ease-in-out hover:bg-indigo-400 hover:text-white focus:outline-none dark:text-white dark:text-opacity-60 dark:hover:text-opacity-100"
             >
               第 {currentChapter + 1} 章
             </Listbox.Button>

--- a/src/pages/Typing/components/PronunciationSwitcher/index.tsx
+++ b/src/pages/Typing/components/PronunciationSwitcher/index.tsx
@@ -109,7 +109,7 @@ const PronunciationSwitcher = () => {
       {({ open }) => (
         <>
           <Popover.Button
-            className={`flex h-8 min-w-max cursor-pointer items-center justify-center rounded-md px-1 transition-colors duration-300 ease-in-out hover:bg-indigo-400 hover:text-white focus:outline-none dark:text-white dark:text-opacity-60 dark:hover:text-opacity-100  ${
+            className={`flex h-8 min-w-max cursor-pointer items-center justify-center rounded-md px-1 text-black transition-colors duration-300 ease-in-out hover:bg-indigo-400 hover:text-white focus:outline-none dark:text-white dark:text-opacity-60 dark:hover:text-opacity-100  ${
               open ? 'bg-indigo-400 text-white' : 'bg-transparent'
             }`}
             onFocus={(e) => {

--- a/src/pages/Typing/components/Speed/InfoBox.tsx
+++ b/src/pages/Typing/components/Speed/InfoBox.tsx
@@ -6,7 +6,7 @@ const InfoBox: React.FC<InfoBoxProps> = ({ info, description }) => {
       <span className="w-4/5 border-b pb-2 text-center text-xl font-bold text-gray-600 transition-colors duration-300 dark:text-gray-400">
         {info}
       </span>
-      <span className="pt-2 text-xs transition-colors duration-300 dark:text-gray-300">{description}</span>
+      <span className="pt-2 text-xs text-gray-600 transition-colors duration-300 dark:text-gray-300">{description}</span>
     </div>
   )
 }

--- a/src/pages/Typing/components/WordPanel/components/Translation/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Translation/index.tsx
@@ -27,7 +27,7 @@ export default function Translation({ trans, showTrans = true, onMouseEnter, onM
   return (
     <div className={`flex items-center justify-center  pb-4 pt-5`} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
       <span
-        className={`max-w-4xl text-center font-sans transition-colors duration-300 dark:text-white dark:text-opacity-80 ${
+        className={`max-w-4xl text-center font-sans text-black transition-colors duration-300 dark:text-white dark:text-opacity-80 ${
           isShowTransRead && 'pl-8'
         } ${isTextSelectable && 'select-text'}`}
         style={{ fontSize: fontSizeConfig.translateFont.toString() + 'px' }}


### PR DESCRIPTION
Fixes #1051

修复了 [issuw](https://github.com/RealKai42/qwerty-learner/issues/1051) 提到的问题

在对应的元素中设定了text的颜色作为默认颜色，使其在浅色模式下不会被系统更改为深色模式下的颜色，
并且确保修复部分的文本颜色与原本在系统为浅色且网页为浅色的情况下的颜色一致


修复后效果截图：
系统：深色，网页：浅色
<img width="3636" height="2106" alt="b425155487866ad5fcd3dcaa748c629f" src="https://github.com/user-attachments/assets/6a082064-7c27-40f1-a6f7-845be5b3a2fa" />
