### PR TITLE
fix(Gallery-N): 修复字典组件key重复问题

### DIFF
--- a/src/pages/Gallery-N/CategoryDicts.tsx
+++ b/src/pages/Gallery-N/CategoryDicts.tsx
@@ -27,7 +27,9 @@ export default function DictionaryGroup({ groupedDictsByTag }: { groupedDictsByT
       <DictTagSwitcher tagList={tagList} currentTag={currentTag} onChangeCurrentTag={onChangeCurrentTag} />
       <div className="mt-8 grid gap-x-5 gap-y-10 px-1 pb-4 sm:grid-cols-1 md:grid-cols-2 dic3:grid-cols-3 dic4:grid-cols-4">
         {currentTag && groupedDictsByTag[currentTag] ? (
-          groupedDictsByTag[currentTag].map((dict) => <DictionaryComponent key={dict.id} dictionary={dict} />)
+          groupedDictsByTag[currentTag].map((dict, index) => (
+            <DictionaryComponent key={`${currentTag}-${dict.id}-${index}`} dictionary={dict} />
+          ))
         ) : (
           <div className="col-span-full text-center text-gray-500">当前分类下没有可用的词典</div>
         )}


### PR DESCRIPTION
为字典组件添加更唯一的key值，结合currentTag和index避免潜在的重渲染问题
<img width="1626" height="729" alt="image" src="https://github.com/user-attachments/assets/a9e88393-1412-4bd9-82ba-f0d2c5b1a61b" />
<img width="1524" height="697" alt="image" src="https://github.com/user-attachments/assets/4b5a4861-24cf-4955-ac07-53b627955f83" />
Close #1016