### PR TITLE
feat: 添加 NGSL 2809 核心词汇词典

### DIFF
--- a/public/dicts/NGSL_1.2.json
+++ b/public/dicts/NGSL_1.2.json
@@ -1,0 +1,19665 @@
+[
+  {
+    "name": "abuse",
+    "trans": [
+      "虐待",
+      "to treat someone or something in a way that is cruel, harmful, or wrong"
+    ]
+  },
+  {
+    "name": "accident",
+    "trans": [
+      "事故",
+      "sudden unplanned event causing damage, injury, etc."
+    ]
+  },
+  {
+    "name": "habit",
+    "trans": [
+      "习惯",
+      "the usual way of behaving; something often repeated"
+    ]
+  },
+  {
+    "name": "activity",
+    "trans": [
+      "活动",
+      "an action or task (e.g., sports, washing your clothes)"
+    ]
+  },
+  {
+    "name": "add",
+    "trans": [
+      "添加",
+      "to put two things or numbers together (e.g., 2+2)"
+    ]
+  },
+  {
+    "name": "adjust",
+    "trans": [
+      "调整",
+      "to change so as to fit in with new conditions"
+    ]
+  },
+  {
+    "name": "administration",
+    "trans": [
+      "行政",
+      "the work of running something (e.g., a business)"
+    ]
+  },
+  {
+    "name": "advocate",
+    "trans": [
+      "提倡",
+      "to publicly support a belief, or to request a change"
+    ]
+  },
+  {
+    "name": "analyst",
+    "trans": [
+      "分析师",
+      "someone who is skilled at studying the details of data"
+    ]
+  },
+  {
+    "name": "arrival",
+    "trans": [
+      "到达",
+      "when someone or something gets to a place"
+    ]
+  },
+  {
+    "name": "highlight",
+    "trans": [
+      "强调",
+      "the best or most interesting part of something"
+    ]
+  },
+  {
+    "name": "button",
+    "trans": [
+      "按钮",
+      "small round piece of material used to fasten clothing"
+    ]
+  },
+  {
+    "name": "appearance",
+    "trans": [
+      "外貌",
+      "way that someone or something looks"
+    ]
+  },
+  {
+    "name": "application",
+    "trans": [
+      "应用",
+      "formal request for a job, building permission, etc."
+    ]
+  },
+  {
+    "name": "apply",
+    "trans": [
+      "申请",
+      "to ask formally for (a job, building permission, etc.)"
+    ]
+  },
+  {
+    "name": "as",
+    "trans": [
+      "作为",
+      "a word used to compare two equal things"
+    ]
+  },
+  {
+    "name": "argument",
+    "trans": [
+      "争论",
+      "a discussion in which you disagree with another's opinion"
+    ]
+  },
+  {
+    "name": "arrange",
+    "trans": [
+      "安排",
+      "to put things into a particular order; to plan and organize an event"
+    ]
+  },
+  {
+    "name": "arrangement",
+    "trans": [
+      "安排",
+      "plan or preparation to make something happen; an agreement"
+    ]
+  },
+  {
+    "name": "hunt",
+    "trans": [
+      "打猎",
+      "to search for wild animals to kill for food or sport"
+    ]
+  },
+  {
+    "name": "art",
+    "trans": [
+      "艺术",
+      "a creative skill using the imagination (e.g., painting)"
+    ]
+  },
+  {
+    "name": "characterize",
+    "trans": [
+      "表征",
+      "to describe the qualities of a person, place, thing"
+    ]
+  },
+  {
+    "name": "assessment",
+    "trans": [
+      "评估",
+      "opinion based on judging the qualities of something or someone"
+    ]
+  },
+  {
+    "name": "asset",
+    "trans": [
+      "资产",
+      "a person or thing that has value or use to someone or to a company"
+    ]
+  },
+  {
+    "name": "back",
+    "trans": [
+      "后退",
+      "behind; to the rear; previous"
+    ]
+  },
+  {
+    "name": "associate",
+    "trans": [
+      "联系",
+      "partner in professional work (e.g., in law)"
+    ]
+  },
+  {
+    "name": "atmosphere",
+    "trans": [
+      "气氛",
+      "The mixture of gases surrounding the Earth; the feeling that a place or situation gives you"
+    ]
+  },
+  {
+    "name": "attitude",
+    "trans": [
+      "态度",
+      "way you act, think, and feel about something"
+    ]
+  },
+  {
+    "name": "illustrate",
+    "trans": [
+      "阐明",
+      "to explain with examples, to make it easier to understand"
+    ]
+  },
+  {
+    "name": "audience",
+    "trans": [
+      "观众",
+      "group of people listening, watch a play, movie, etc."
+    ]
+  },
+  {
+    "name": "author",
+    "trans": [
+      "作者",
+      "person who writes books, plays, poems, etc."
+    ]
+  },
+  {
+    "name": "impose",
+    "trans": [
+      "强加",
+      "to make someone to do, believe, or accept something"
+    ]
+  },
+  {
+    "name": "band",
+    "trans": [
+      "乐队",
+      "group of people who work together (e.g., play music)"
+    ]
+  },
+  {
+    "name": "bar",
+    "trans": [
+      "酒吧",
+      "to prevent entry, exit, or an action"
+    ]
+  },
+  {
+    "name": "basically",
+    "trans": [
+      "基本上",
+      "in the most important ways even if not completely true"
+    ]
+  },
+  {
+    "name": "bedroom",
+    "trans": [
+      "卧室",
+      "room for sleeping usually with a bed"
+    ]
+  },
+  {
+    "name": "belief",
+    "trans": [
+      "信仰",
+      "a feeling of being sure that something exists or is true"
+    ]
+  },
+  {
+    "name": "bind",
+    "trans": [
+      "绑定",
+      "to join two or more things together to limit their freedom"
+    ]
+  },
+  {
+    "name": "birth",
+    "trans": [
+      "出生",
+      "when a baby comes out of the body of its mother"
+    ]
+  },
+  {
+    "name": "bomb",
+    "trans": [
+      "炸弹",
+      "a weapon designed to break apart very suddenly and violently"
+    ]
+  },
+  {
+    "name": "bond",
+    "trans": [
+      "纽带",
+      "something that joins or connects people, groups, or parts; a duty or promise to another; glue"
+    ]
+  },
+  {
+    "name": "border",
+    "trans": [
+      "边界",
+      "line separating one country or state from another"
+    ]
+  },
+  {
+    "name": "competitor",
+    "trans": [
+      "竞争者",
+      "someone taking part in a race, business, etc."
+    ]
+  },
+  {
+    "name": "incident",
+    "trans": [
+      "事件",
+      "something that happens, especially if it is bad or unusual"
+    ]
+  },
+  {
+    "name": "intelligence",
+    "trans": [
+      "智力",
+      "ability to learn, think about, and understand things"
+    ]
+  },
+  {
+    "name": "branch",
+    "trans": [
+      "分支",
+      "a part of a tree that grows out from the main part; a part of an organization connected to but separate from the main office"
+    ]
+  },
+  {
+    "name": "brand",
+    "trans": [
+      "品牌",
+      "name given to a product or service"
+    ]
+  },
+  {
+    "name": "build",
+    "trans": [
+      "建造",
+      "to make (e.g., a house, by putting materials together)"
+    ]
+  },
+  {
+    "name": "business",
+    "trans": [
+      "商业",
+      "the making, buying, or selling goods or services for money"
+    ]
+  },
+  {
+    "name": "bridge",
+    "trans": [
+      "桥",
+      "structure built over river or road so people, vehicles, or animals can cross"
+    ]
+  },
+  {
+    "name": "coverage",
+    "trans": [
+      "覆盖范围",
+      "way a newspaper, television program, etc., reports an event or subject"
+    ]
+  },
+  {
+    "name": "crew",
+    "trans": [
+      "全体人员",
+      "an organized group of workers (e.g., on a ship)"
+    ]
+  },
+  {
+    "name": "kick",
+    "trans": [
+      "踢",
+      "to hit someone or something using your foot"
+    ]
+  },
+  {
+    "name": "kiss",
+    "trans": [
+      "吻",
+      "to put your lips against another's to show love"
+    ]
+  },
+  {
+    "name": "dependent",
+    "trans": [
+      "依赖的",
+      "someone who depends on another for (financial) support"
+    ]
+  },
+  {
+    "name": "campaign",
+    "trans": [
+      "活动",
+      "to work in an organized and active way toward a goal"
+    ]
+  },
+  {
+    "name": "latter",
+    "trans": [
+      "后者",
+      "the second or last mentioned thing"
+    ]
+  },
+  {
+    "name": "lock",
+    "trans": [
+      "锁",
+      "to close something with a device so others can't open it"
+    ]
+  },
+  {
+    "name": "cent",
+    "trans": [
+      "分",
+      "100th of the basic unit of money (e.g., there are 100 of these in a dollar)"
+    ]
+  },
+  {
+    "name": "certainly",
+    "trans": [
+      "当然",
+      "definitely true or is sure to happen"
+    ]
+  },
+  {
+    "name": "chain",
+    "trans": [
+      "链",
+      "series of connected  things, events, or people"
+    ]
+  },
+  {
+    "name": "channel",
+    "trans": [
+      "渠道",
+      "1. a narrow, deep body of water used by ships; 2. a system used for sending something from one place or person to another"
+    ]
+  },
+  {
+    "name": "characteristic",
+    "trans": [
+      "特征",
+      "a typical feature or quality that a particular person or thing has"
+    ]
+  },
+  {
+    "name": "milk",
+    "trans": [
+      "牛奶",
+      "the white liquid produced by females to feed their babies"
+    ]
+  },
+  {
+    "name": "color",
+    "trans": [
+      "颜色",
+      "the quality of things you can see (e.g., red, blue)"
+    ]
+  },
+  {
+    "name": "origin",
+    "trans": [
+      "起源",
+      "the point at which something begins or is created"
+    ]
+  },
+  {
+    "name": "church",
+    "trans": [
+      "教会",
+      "building where religious people gather and pray"
+    ]
+  },
+  {
+    "name": "drag",
+    "trans": [
+      "拖",
+      "to pull something that is difficult to move"
+    ]
+  },
+  {
+    "name": "civil",
+    "trans": [
+      "民事",
+      "related to the people of a country; not military/criminal"
+    ]
+  },
+  {
+    "name": "proportion",
+    "trans": [
+      "部分",
+      "an amount that is a part of a whole thing"
+    ]
+  },
+  {
+    "name": "reject",
+    "trans": [
+      "拒绝",
+      "to refuse to believe, accept, or consider"
+    ]
+  },
+  {
+    "name": "clothes",
+    "trans": [
+      "衣服",
+      "things you wear on your body (e.g., shirt, dress, tie)"
+    ]
+  },
+  {
+    "name": "course",
+    "trans": [
+      "课程",
+      "route or direction that a river, etc., moves along"
+    ]
+  },
+  {
+    "name": "colleague",
+    "trans": [
+      "同事",
+      "someone who works with you; coworker"
+    ]
+  },
+  {
+    "name": "formula",
+    "trans": [
+      "公式",
+      "plan, rule, or method for doing or making something"
+    ]
+  },
+  {
+    "name": "combination",
+    "trans": [
+      "组合",
+      "result of mixing things together"
+    ]
+  },
+  {
+    "name": "foundation",
+    "trans": [
+      "基础",
+      "underground base on which a building is constructed"
+    ]
+  },
+  {
+    "name": "lip",
+    "trans": [
+      "唇",
+      "top and bottom part of the outside of a person's mouth"
+    ]
+  },
+  {
+    "name": "comment",
+    "trans": [
+      "评论",
+      "something you say; give an opinion; remark"
+    ]
+  },
+  {
+    "name": "commission",
+    "trans": [
+      "委员会",
+      "a group officially put in charge of finding out about something or controlling something"
+    ]
+  },
+  {
+    "name": "commitment",
+    "trans": [
+      "承诺",
+      "a promise or decision to do something; something that you must do that takes your time"
+    ]
+  },
+  {
+    "name": "relief",
+    "trans": [
+      "宽慰",
+      "the pleasant and relaxed feeling when something unpleasant stops or does not happen"
+    ]
+  },
+  {
+    "name": "complain",
+    "trans": [
+      "抱怨",
+      "to say that you are not happy or satisfied with something or someone"
+    ]
+  },
+  {
+    "name": "component",
+    "trans": [
+      "成分",
+      "one of the parts that make up something"
+    ]
+  },
+  {
+    "name": "concentrate",
+    "trans": [
+      "集中",
+      "to give all your attention to a task; focus"
+    ]
+  },
+  {
+    "name": "condition",
+    "trans": [
+      "状况",
+      "state of living you are in (e.g., good health)"
+    ]
+  },
+  {
+    "name": "margin",
+    "trans": [
+      "利润",
+      "the empty space at the top, bottom, and sides of a written or printed page"
+    ]
+  },
+  {
+    "name": "content",
+    "trans": [
+      "内容",
+      "information in something (e.g., a book or computer program)"
+    ]
+  },
+  {
+    "name": "contract",
+    "trans": [
+      "合同",
+      "legal agreement (e.g., for doing work for money)"
+    ]
+  },
+  {
+    "name": "contribute",
+    "trans": [
+      "贡献",
+      "give something of value to or help someone or something"
+    ]
+  },
+  {
+    "name": "pace",
+    "trans": [
+      "步伐",
+      "the speed at which someone or something moves or happens"
+    ]
+  },
+  {
+    "name": "corner",
+    "trans": [
+      "角落",
+      "place where two lines, sides, corners, etc., meet"
+    ]
+  },
+  {
+    "name": "reputation",
+    "trans": [
+      "名声",
+      "an opinion that people have about someone or something based on the past"
+    ]
+  },
+  {
+    "name": "shoulder",
+    "trans": [
+      "肩膀",
+      "the part of the body where an arm attaches or joins"
+    ]
+  },
+  {
+    "name": "perception",
+    "trans": [
+      "洞察力",
+      "the way in which one sees or understands something"
+    ]
+  },
+  {
+    "name": "similarly",
+    "trans": [
+      "相似地",
+      "in a way that is almost the same as something or someone else"
+    ]
+  },
+  {
+    "name": "crime",
+    "trans": [
+      "犯罪",
+      "act that is against the law; murder, theft, etc."
+    ]
+  },
+  {
+    "name": "supporter",
+    "trans": [
+      "支持者",
+      "someone who shows they are in favor of an idea/plan"
+    ]
+  },
+  {
+    "name": "symbol",
+    "trans": [
+      "象征",
+      "action or object that represents a particular idea or quality"
+    ]
+  },
+  {
+    "name": "cultural",
+    "trans": [
+      "文化",
+      "of a particular society's customs and beliefs"
+    ]
+  },
+  {
+    "name": "sky",
+    "trans": [
+      "天空",
+      "the place where we see clouds above us"
+    ]
+  },
+  {
+    "name": "cream",
+    "trans": [
+      "奶油",
+      "the thick white liquid that comes from milk and is used in cooking"
+    ]
+  },
+  {
+    "name": "evolution",
+    "trans": [
+      "进化",
+      "slow, steady change or development"
+    ]
+  },
+  {
+    "name": "example",
+    "trans": [
+      "例子",
+      "something or someone who represents a group"
+    ]
+  },
+  {
+    "name": "decrease",
+    "trans": [
+      "减少",
+      "to reduce the size, amount, or number of something"
+    ]
+  },
+  {
+    "name": "exhaust",
+    "trans": [
+      "排气",
+      "to use all of something such as energy, resources, or possibilities; to make someone very, very tired"
+    ]
+  },
+  {
+    "name": "soul",
+    "trans": [
+      "灵魂",
+      "the spiritual part of a person"
+    ]
+  },
+  {
+    "name": "delay",
+    "trans": [
+      "延迟",
+      "to cause something to happen later than planned or expected"
+    ]
+  },
+  {
+    "name": "specifically",
+    "trans": [
+      "具体来说",
+      "in a well-defined or clear manner; in particular"
+    ]
+  },
+  {
+    "name": "demonstrate",
+    "trans": [
+      "证明",
+      "to show how something works (e.g., product)"
+    ]
+  },
+  {
+    "name": "extract",
+    "trans": [
+      "提炼",
+      "to take something out of something else"
+    ]
+  },
+  {
+    "name": "talent",
+    "trans": [
+      "天赋",
+      "the natural ability of a person to do something well"
+    ]
+  },
+  {
+    "name": "desire",
+    "trans": [
+      "欲望",
+      "to wish for, hope, or want something"
+    ]
+  },
+  {
+    "name": "destroy",
+    "trans": [
+      "破坏",
+      "to damage something so badly that it no longer exists"
+    ]
+  },
+  {
+    "name": "direction",
+    "trans": [
+      "方向",
+      "describes the way you are going (e.g., north)"
+    ]
+  },
+  {
+    "name": "distinction",
+    "trans": [
+      "区别",
+      "the special quality that makes something different"
+    ]
+  },
+  {
+    "name": "division",
+    "trans": [
+      "分配",
+      "act of separating something into parts; groups formed by different functions or opinions"
+    ]
+  },
+  {
+    "name": "doctor",
+    "trans": [
+      "医生",
+      "a professional who is trained and licensed to treat sick or injured people; a person who has the highest degree given by a university"
+    ]
+  },
+  {
+    "name": "domestic",
+    "trans": [
+      "国内的",
+      "of or relating to a particular country; of or relating to the home and family"
+    ]
+  },
+  {
+    "name": "iron",
+    "trans": [
+      "铁",
+      "the hard metal used to make steel (symbol Fe)"
+    ]
+  },
+  {
+    "name": "economy",
+    "trans": [
+      "经济",
+      "total of all the goods, services, and wages in an area"
+    ]
+  },
+  {
+    "name": "editor",
+    "trans": [
+      "编辑",
+      "a person whose job is to correct and make changes to the contents of a book or magazine"
+    ]
+  },
+  {
+    "name": "elect",
+    "trans": [
+      "选",
+      "choose someone for a position usually by voting"
+    ]
+  },
+  {
+    "name": "knee",
+    "trans": [
+      "膝盖",
+      "the middle part of your leg that bends"
+    ]
+  },
+  {
+    "name": "stem",
+    "trans": [
+      "干",
+      "the long, thin part of a plant that supports leaves and flowers"
+    ]
+  },
+  {
+    "name": "engineer",
+    "trans": [
+      "工程师",
+      "professional who designs and builds machines, roads, and other complicated structures"
+    ]
+  },
+  {
+    "name": "entirely",
+    "trans": [
+      "完全",
+      "fully or completely"
+    ]
+  },
+  {
+    "name": "wage",
+    "trans": [
+      "工资",
+      "money paid to workers for the hours they worked"
+    ]
+  },
+  {
+    "name": "wheel",
+    "trans": [
+      "车轮",
+      "the round thing under a vehicle that turns and makes it move"
+    ]
+  },
+  {
+    "name": "escape",
+    "trans": [
+      "逃脱",
+      "to get away from a place where you are being held"
+    ]
+  },
+  {
+    "name": "winner",
+    "trans": [
+      "优胜者",
+      "the person or animal that is the best in a contest or first in a race"
+    ]
+  },
+  {
+    "name": "estimate",
+    "trans": [
+      "估计",
+      "guess or calculation of cost, size, or value"
+    ]
+  },
+  {
+    "name": "appointment",
+    "trans": [
+      "预约",
+      "the time you arranged to meet someone or do something"
+    ]
+  },
+  {
+    "name": "here",
+    "trans": [
+      "这里",
+      "in, at, or to this position or place"
+    ]
+  },
+  {
+    "name": "examine",
+    "trans": [
+      "检查",
+      "to look at someone or something very carefully in order to learn more"
+    ]
+  },
+  {
+    "name": "breakfast",
+    "trans": [
+      "早餐",
+      "the first meal of the day"
+    ]
+  },
+  {
+    "name": "excite",
+    "trans": [
+      "激发",
+      "to make someone feel happy, interested, or eager"
+    ]
+  },
+  {
+    "name": "however",
+    "trans": [
+      "然而",
+      "used to say something is different from what was said before; but"
+    ]
+  },
+  {
+    "name": "breast",
+    "trans": [
+      "胸部",
+      "one of the two parts on the front of a woman's body that produce milk when she has a baby"
+    ]
+  },
+  {
+    "name": "capture",
+    "trans": [
+      "捕获",
+      "to catch and prevent a person/animal from being free"
+    ]
+  },
+  {
+    "name": "celebrate",
+    "trans": [
+      "庆祝",
+      "to observe an event or occasion (e.g., a birthday)"
+    ]
+  },
+  {
+    "name": "expense",
+    "trans": [
+      "费用",
+      "the amount of money that is needed to pay for something"
+    ]
+  },
+  {
+    "name": "explore",
+    "trans": [
+      "探索",
+      "to learn about something by examining in detail or someplace by traveling to it"
+    ]
+  },
+  {
+    "name": "extend",
+    "trans": [
+      "延长",
+      "to straighten or stretch something out (e.g., your leg)"
+    ]
+  },
+  {
+    "name": "childhood",
+    "trans": [
+      "童年",
+      "the time when you are a child"
+    ]
+  },
+  {
+    "name": "fairly",
+    "trans": [
+      "相当",
+      "in a reasonable way; between a little and very much"
+    ]
+  },
+  {
+    "name": "farmer",
+    "trans": [
+      "农民",
+      "someone who owns or looks after farm, a place for growing crops and keeping animals"
+    ]
+  },
+  {
+    "name": "fear",
+    "trans": [
+      "害怕",
+      "unpleasant feelings caused by being aware of danger"
+    ]
+  },
+  {
+    "name": "feed",
+    "trans": [
+      "喂养",
+      "to give food (e.g., to an animal or a baby)"
+    ]
+  },
+  {
+    "name": "closely",
+    "trans": [
+      "密切",
+      "very near in space or time; just next to"
+    ]
+  },
+  {
+    "name": "file",
+    "trans": [
+      "文件",
+      "to submit documents to an authority (e.g., city hall)"
+    ]
+  },
+  {
+    "name": "angle",
+    "trans": [
+      "角度",
+      "a place where two lines or surfaces meet"
+    ]
+  },
+  {
+    "name": "flower",
+    "trans": [
+      "花",
+      "plant with a pretty head (e.g., a rose)"
+    ]
+  },
+  {
+    "name": "attribute",
+    "trans": [
+      "属性",
+      "a quality or characteristic that someone or something has (e.g., size or color)"
+    ]
+  },
+  {
+    "name": "command",
+    "trans": [
+      "命令",
+      "to give an order; have control over others"
+    ]
+  },
+  {
+    "name": "consistent",
+    "trans": [
+      "持续的",
+      "always acting or happening in the same way"
+    ]
+  },
+  {
+    "name": "core",
+    "trans": [
+      "核",
+      "the central part of a fruit that contains the seeds; the central part of something"
+    ]
+  },
+  {
+    "name": "frame",
+    "trans": [
+      "框架",
+      "(n) 1. the basic structure of something that gives it its shape, to which other parts are added; 2. one picture in a series that make a video; (v) 1. to put a picture in a supporting structure; 2. to produce false evidence so an innocent person appears guilty of a crime"
+    ]
+  },
+  {
+    "name": "bowl",
+    "trans": [
+      "碗",
+      "a round container used for holding things like rice or soup"
+    ]
+  },
+  {
+    "name": "crop",
+    "trans": [
+      "庄稼",
+      "plants grown on a farm for food (e.g., corn or rice)"
+    ]
+  },
+  {
+    "name": "gain",
+    "trans": [
+      "获得",
+      "to get something wanted, needed, or valued"
+    ]
+  },
+  {
+    "name": "debt",
+    "trans": [
+      "债务",
+      "the sum of money owed to somebody that is not yet paid"
+    ]
+  },
+  {
+    "name": "generally",
+    "trans": [
+      "一般来说",
+      "usually; as a rule; by, to, or for most people"
+    ]
+  },
+  {
+    "name": "last",
+    "trans": [
+      "最后的",
+      "the one before"
+    ]
+  },
+  {
+    "name": "exhibition",
+    "trans": [
+      "展览",
+      "an event at which an object or group of objects is shown to the public"
+    ]
+  },
+  {
+    "name": "graduate",
+    "trans": [
+      "毕业",
+      "(v) to receive a degree from a college or university; (n) a person who has received a degree"
+    ]
+  },
+  {
+    "name": "leave",
+    "trans": [
+      "离开",
+      "to go away from; depart"
+    ]
+  },
+  {
+    "name": "liability",
+    "trans": [
+      "责任",
+      "something that is owed to someone else (e.g., a debt)"
+    ]
+  },
+  {
+    "name": "gun",
+    "trans": [
+      "枪",
+      "a weapon that shoots small metal objects down a metal tube"
+    ]
+  },
+  {
+    "name": "life",
+    "trans": [
+      "生活",
+      "all the living things (e.g., animals, plants, humans)"
+    ]
+  },
+  {
+    "name": "hall",
+    "trans": [
+      "大厅",
+      "a usually long, narrow room in a building  that leads to other rooms"
+    ]
+  },
+  {
+    "name": "hang",
+    "trans": [
+      "悬挂",
+      "to attach a picture, photograph, etc., onto a wall"
+    ]
+  },
+  {
+    "name": "line",
+    "trans": [
+      "线",
+      "mark that is long, straight, and very thin"
+    ]
+  },
+  {
+    "name": "cake",
+    "trans": [
+      "蛋糕",
+      "a sweet baked food made from flour, eggs, fat, and sugar"
+    ]
+  },
+  {
+    "name": "hire",
+    "trans": [
+      "聘请",
+      "to employ a person to do a particular job"
+    ]
+  },
+  {
+    "name": "historical",
+    "trans": [
+      "历史的",
+      "of or related to events or people in the past"
+    ]
+  },
+  {
+    "name": "host",
+    "trans": [
+      "主持人",
+      "person who entertains guests"
+    ]
+  },
+  {
+    "name": "hotel",
+    "trans": [
+      "酒店",
+      "place where people can stay when traveling"
+    ]
+  },
+  {
+    "name": "fellow",
+    "trans": [
+      "同胞",
+      "someone in the same group or situation; a boy or man"
+    ]
+  },
+  {
+    "name": "many",
+    "trans": [
+      "许多",
+      "used to refer to a large number of things"
+    ]
+  },
+  {
+    "name": "currency",
+    "trans": [
+      "货币",
+      "a money system that a country uses"
+    ]
+  },
+  {
+    "name": "hurt",
+    "trans": [
+      "伤害",
+      "to cause pain, damage, or injury"
+    ]
+  },
+  {
+    "name": "ice",
+    "trans": [
+      "冰",
+      "frozen water"
+    ]
+  },
+  {
+    "name": "gene",
+    "trans": [
+      "基因",
+      "part of a cell that controls the development and appearance of a living thing"
+    ]
+  },
+  {
+    "name": "identity",
+    "trans": [
+      "身份",
+      "who someone is; the collection of qualities that makes a person"
+    ]
+  },
+  {
+    "name": "curve",
+    "trans": [
+      "曲线",
+      "a smooth rounded line that is not straight"
+    ]
+  },
+  {
+    "name": "image",
+    "trans": [
+      "图像",
+      "picture, sculpture, or painting of something"
+    ]
+  },
+  {
+    "name": "imagine",
+    "trans": [
+      "想象",
+      "to think creatively about; form a mental picture of"
+    ]
+  },
+  {
+    "name": "modify",
+    "trans": [
+      "调整",
+      "to make small changes to something"
+    ]
+  },
+  {
+    "name": "month",
+    "trans": [
+      "月",
+      "one of 12 time periods that make a year, each from 28 to 31 days long"
+    ]
+  },
+  {
+    "name": "income",
+    "trans": [
+      "收入",
+      "earned money from work, investments, or business"
+    ]
+  },
+  {
+    "name": "indicate",
+    "trans": [
+      "表明",
+      "to show something, direct attention to, or point out"
+    ]
+  },
+  {
+    "name": "industrial",
+    "trans": [
+      "工业的",
+      "concerning the people and businesses that make certain products"
+    ]
+  },
+  {
+    "name": "guard",
+    "trans": [
+      "警卫",
+      "to keep watch over something to protect it e.g., a bank"
+    ]
+  },
+  {
+    "name": "insist",
+    "trans": [
+      "坚持",
+      "to state your opinion strongly and firmly; to demand that something must happen"
+    ]
+  },
+  {
+    "name": "instrument",
+    "trans": [
+      "乐器",
+      "a piece of equipment used for a particular purpose such as making music or measuring something"
+    ]
+  },
+  {
+    "name": "depression",
+    "trans": [
+      "沮丧",
+      "a feeling of great sadness"
+    ]
+  },
+  {
+    "name": "off",
+    "trans": [
+      "离开",
+      "away from; not on"
+    ]
+  },
+  {
+    "name": "investor",
+    "trans": [
+      "投资者",
+      "a person who gives money to help a business grow for a profit"
+    ]
+  },
+  {
+    "name": "on",
+    "trans": [
+      "在",
+      "located on the surface of something (e.g., a table or wall)"
+    ]
+  },
+  {
+    "name": "entrance",
+    "trans": [
+      "入口",
+      "a way into a place"
+    ]
+  },
+  {
+    "name": "order",
+    "trans": [
+      "命令",
+      "to ask for something you want to buy (e.g., a meal)"
+    ]
+  },
+  {
+    "name": "accommodation",
+    "trans": [
+      "住宿",
+      "a place to stay, often a hotel"
+    ]
+  },
+  {
+    "name": "flood",
+    "trans": [
+      "洪水",
+      "a large amount of water covering land that is usually dry"
+    ]
+  },
+  {
+    "name": "assistant",
+    "trans": [
+      "助手",
+      "a person who helps another, usually as a job"
+    ]
+  },
+  {
+    "name": "party",
+    "trans": [
+      "派对",
+      "social event often with food, drinks, and dancing"
+    ]
+  },
+  {
+    "name": "label",
+    "trans": [
+      "标签",
+      "a piece of paper or cloth that is attached to something and gives information about it"
+    ]
+  },
+  {
+    "name": "lady",
+    "trans": [
+      "女士",
+      "another way of saying 'woman'"
+    ]
+  },
+  {
+    "name": "boss",
+    "trans": [
+      "老板",
+      "a person who manages you, or is in charge of you at work"
+    ]
+  },
+  {
+    "name": "past",
+    "trans": [
+      "过去的",
+      "the time that existed before now (e.g., long ago)"
+    ]
+  },
+  {
+    "name": "forecast",
+    "trans": [
+      "预报",
+      "a prediction of some future thing (e.g., the weather)"
+    ]
+  },
+  {
+    "name": "jacket",
+    "trans": [
+      "夹克",
+      "a light, thin coat"
+    ]
+  },
+  {
+    "name": "lawyer",
+    "trans": [
+      "律师",
+      "a professional who is paid to help people with the law"
+    ]
+  },
+  {
+    "name": "plan",
+    "trans": [
+      "计划",
+      "to decide a set of actions to do something"
+    ]
+  },
+  {
+    "name": "lesson",
+    "trans": [
+      "课",
+      "a time or event where teaching and learning occur; class"
+    ]
+  },
+  {
+    "name": "bottle",
+    "trans": [
+      "瓶子",
+      "a container with a narrow neck used to hold liquids like water or wine"
+    ]
+  },
+  {
+    "name": "license",
+    "trans": [
+      "执照",
+      "official document which allows a person to do or have something"
+    ]
+  },
+  {
+    "name": "chemical",
+    "trans": [
+      "化学",
+      "a basic substance produced by mixing elements"
+    ]
+  },
+  {
+    "name": "delight",
+    "trans": [
+      "喜",
+      "a strong feeling of great pleasure and happiness"
+    ]
+  },
+  {
+    "name": "engine",
+    "trans": [
+      "引擎",
+      "a machine that changes energy into motion"
+    ]
+  },
+  {
+    "name": "loan",
+    "trans": [
+      "贷款",
+      "something (usually money) that is given to someone for a period of time with a promise that it will be returned"
+    ]
+  },
+  {
+    "name": "locate",
+    "trans": [
+      "定位",
+      "to find a certain place, position, or location of something"
+    ]
+  },
+  {
+    "name": "expectation",
+    "trans": [
+      "期待",
+      "a belief or hope that something is going to happen"
+    ]
+  },
+  {
+    "name": "gentleman",
+    "trans": [
+      "绅士",
+      "a man who has good manners and is considerate"
+    ]
+  },
+  {
+    "name": "journalist",
+    "trans": [
+      "记者",
+      "a person who writes news reports for newspapers, magazines, television, or radio"
+    ]
+  },
+  {
+    "name": "lake",
+    "trans": [
+      "湖",
+      "a large area of water surrounded by land"
+    ]
+  },
+  {
+    "name": "room",
+    "trans": [
+      "房间",
+      "a part of building enclosed by walls (e.g., kitchen)"
+    ]
+  },
+  {
+    "name": "mass",
+    "trans": [
+      "大量的",
+      "a large amount of something, often of no particular shape"
+    ]
+  },
+  {
+    "name": "master",
+    "trans": [
+      "掌握",
+      "1. someone who has control over others; 2. someone who is very skilled at doing something"
+    ]
+  },
+  {
+    "name": "meal",
+    "trans": [
+      "一顿饭",
+      "food for eating at a particular time (e.g., dinner)"
+    ]
+  },
+  {
+    "name": "landscape",
+    "trans": [
+      "景观",
+      "a large area of countryside or land that has a particular quality or appearance"
+    ]
+  },
+  {
+    "name": "set",
+    "trans": [
+      "放",
+      "complete group of something (e.g., a chess set)"
+    ]
+  },
+  {
+    "name": "miss",
+    "trans": [
+      "错过",
+      "to be too late to ride on something (e.g., train or bus)"
+    ]
+  },
+  {
+    "name": "mistake",
+    "trans": [
+      "错误",
+      "something done wrong, calculated wrong.; error"
+    ]
+  },
+  {
+    "name": "model",
+    "trans": [
+      "模型",
+      "a copy that represents an object or standard"
+    ]
+  },
+  {
+    "name": "mirror",
+    "trans": [
+      "镜子",
+      "a thing with a glass surface used to look at yourself"
+    ]
+  },
+  {
+    "name": "mouse",
+    "trans": [
+      "老鼠",
+      "a small animal that has fur and a long tail"
+    ]
+  },
+  {
+    "name": "moral",
+    "trans": [
+      "道德",
+      "relating to people's belief about right or wrong behavior"
+    ]
+  },
+  {
+    "name": "morning",
+    "trans": [
+      "早晨",
+      "early part of the day before 12 noon"
+    ]
+  },
+  {
+    "name": "participant",
+    "trans": [
+      "参与者",
+      "a person who is actively involved and included in something"
+    ]
+  },
+  {
+    "name": "passenger",
+    "trans": [
+      "乘客",
+      "A person who is traveling in a vehicle"
+    ]
+  },
+  {
+    "name": "narrow",
+    "trans": [
+      "狭窄的",
+      "long but not wide; a small distance from one side to the other compared to length"
+    ]
+  },
+  {
+    "name": "negative",
+    "trans": [
+      "消极的",
+      "being harmful, unwanted, or unhelpful"
+    ]
+  },
+  {
+    "name": "neither",
+    "trans": [
+      "两者都不",
+      "not one or the other; not either; none of two things"
+    ]
+  },
+  {
+    "name": "net",
+    "trans": [
+      "网",
+      "material made of string tied together and used to catch fish or other small animals"
+    ]
+  },
+  {
+    "name": "nevertheless",
+    "trans": [
+      "尽管如此",
+      "despite what has just been done or said; nonetheless"
+    ]
+  },
+  {
+    "name": "musician",
+    "trans": [
+      "音乐家",
+      "a person who writes, sings, or plays music, as a job"
+    ]
+  },
+  {
+    "name": "noise",
+    "trans": [
+      "噪音",
+      "a loud or unpleasant sound"
+    ]
+  },
+  {
+    "name": "none",
+    "trans": [
+      "没有任何",
+      "not one of a group; not at all or in no way"
+    ]
+  },
+  {
+    "name": "opponent",
+    "trans": [
+      "对手",
+      "a person that you are competing against in a game or contest"
+    ]
+  },
+  {
+    "name": "occasion",
+    "trans": [
+      "场合",
+      "particular time when something important or special happens"
+    ]
+  },
+  {
+    "name": "odd",
+    "trans": [
+      "奇怪的",
+      "being strange or different from what is usual or expected"
+    ]
+  },
+  {
+    "name": "plate",
+    "trans": [
+      "盘子",
+      "a flat dish used for eating or serving food"
+    ]
+  },
+  {
+    "name": "snap",
+    "trans": [
+      "折断",
+      "to break something long and thin"
+    ]
+  },
+  {
+    "name": "onto",
+    "trans": [
+      "到",
+      "movement towards a position that is on something"
+    ]
+  },
+  {
+    "name": "plot",
+    "trans": [
+      "阴谋",
+      "a plan to do something, often in secret and bad"
+    ]
+  },
+  {
+    "name": "oppose",
+    "trans": [
+      "反对",
+      "to be against someone in a contest, game, or fight; to disagree"
+    ]
+  },
+  {
+    "name": "producer",
+    "trans": [
+      "制片人",
+      "a company making or growing a certain product"
+    ]
+  },
+  {
+    "name": "organize",
+    "trans": [
+      "组织",
+      "to arrange and plan things (e.g., a party)"
+    ]
+  },
+  {
+    "name": "phenomenon",
+    "trans": [
+      "现象",
+      "a fact that can be observed and studied"
+    ]
+  },
+  {
+    "name": "original",
+    "trans": [
+      "原来的",
+      "being first made, thought, or performed; fresh"
+    ]
+  },
+  {
+    "name": "stay",
+    "trans": [
+      "停留",
+      "to spend time visiting a place or someone's home"
+    ]
+  },
+  {
+    "name": "package",
+    "trans": [
+      "包裹",
+      "box or container in which items are placed for mailing"
+    ]
+  },
+  {
+    "name": "pair",
+    "trans": [
+      "一对",
+      "two of the same thing (e.g., socks)"
+    ]
+  },
+  {
+    "name": "shadow",
+    "trans": [
+      "阴影",
+      "a dark shape that appears when something stops the light"
+    ]
+  },
+  {
+    "name": "subject",
+    "trans": [
+      "主题",
+      "the person, or thing that is being talked, or written about"
+    ]
+  },
+  {
+    "name": "singer",
+    "trans": [
+      "歌手",
+      "a person who sings, often as a profession"
+    ]
+  },
+  {
+    "name": "such",
+    "trans": [
+      "这样的",
+      "so like, or similar"
+    ]
+  },
+  {
+    "name": "statistic",
+    "trans": [
+      "统计",
+      "a number that represents a piece of information"
+    ]
+  },
+  {
+    "name": "substance",
+    "trans": [
+      "物质",
+      "a particular type of material"
+    ]
+  },
+  {
+    "name": "summary",
+    "trans": [
+      "概括",
+      "a brief statement that gives the most important information"
+    ]
+  },
+  {
+    "name": "permit",
+    "trans": [
+      "允许",
+      "to allow someone to do something or for something to happen"
+    ]
+  },
+  {
+    "name": "protein",
+    "trans": [
+      "蛋白质",
+      "a substance found in some foods, such as meat, that is needed by the body to stay healthy"
+    ]
+  },
+  {
+    "name": "teenager",
+    "trans": [
+      "青少年",
+      "a person between the ages of 13 and 19"
+    ]
+  },
+  {
+    "name": "photograph",
+    "trans": [
+      "照片",
+      "a picture made with a camera that shows how things look in real life"
+    ]
+  },
+  {
+    "name": "throat",
+    "trans": [
+      "喉",
+      "passage inside the neck used to swallow and breathe"
+    ]
+  },
+  {
+    "name": "tourism",
+    "trans": [
+      "旅游",
+      "traveling to new places (e.g., abroad, for vacations)"
+    ]
+  },
+  {
+    "name": "plenty",
+    "trans": [
+      "足够",
+      "a large  amount of something; a lot; not too little"
+    ]
+  },
+  {
+    "name": "tower",
+    "trans": [
+      "塔",
+      "a tall, narrow building"
+    ]
+  },
+  {
+    "name": "transition",
+    "trans": [
+      "过渡",
+      "a gradual change from one condition to another"
+    ]
+  },
+  {
+    "name": "population",
+    "trans": [
+      "人口",
+      "number of people who live in a country, area, etc."
+    ]
+  },
+  {
+    "name": "trap",
+    "trans": [
+      "陷阱",
+      "a device used for catching animals"
+    ]
+  },
+  {
+    "name": "practical",
+    "trans": [
+      "实际的",
+      "relating to what is sensible, real, or useful rather than with ideas or theories"
+    ]
+  },
+  {
+    "name": "presence",
+    "trans": [
+      "在场",
+      "fact that someone or something is in a particular place"
+    ]
+  },
+  {
+    "name": "president",
+    "trans": [
+      "总统",
+      "person in charge of a country, company, or organization"
+    ]
+  },
+  {
+    "name": "principal",
+    "trans": [
+      "主要的",
+      "1. most important; main; 2.  the person in charge of a (US) public school"
+    ]
+  },
+  {
+    "name": "principle",
+    "trans": [
+      "原则",
+      "strong belief that influences a person's actions; basic law or belief"
+    ]
+  },
+  {
+    "name": "print",
+    "trans": [
+      "打印",
+      "to make many copies of a page, magazine, or book"
+    ]
+  },
+  {
+    "name": "prison",
+    "trans": [
+      "监狱",
+      "a place where people who have committed serious crimes are held"
+    ]
+  },
+  {
+    "name": "turn",
+    "trans": [
+      "转动",
+      "to change the direction of something (e.g., a car)"
+    ]
+  },
+  {
+    "name": "professional",
+    "trans": [
+      "专业的",
+      "about a job such as a doctor, lawyer, accountant, etc."
+    ]
+  },
+  {
+    "name": "property",
+    "trans": [
+      "财产",
+      "things, buildings, or pieces of land owned by someone"
+    ]
+  },
+  {
+    "name": "vegetable",
+    "trans": [
+      "蔬菜",
+      "a plant that is raised and eaten as food"
+    ]
+  },
+  {
+    "name": "row",
+    "trans": [
+      "排",
+      "a straight line of people or things; one after another"
+    ]
+  },
+  {
+    "name": "provision",
+    "trans": [
+      "条款",
+      "1. supplies that are needed or wanted; something that is supplied; 2. part of a law or an agreement"
+    ]
+  },
+  {
+    "name": "sheet",
+    "trans": [
+      "床单",
+      "a large piece of fabric or material that is used to cover something, often a bed"
+    ]
+  },
+  {
+    "name": "race",
+    "trans": [
+      "种族",
+      "contest between people, animals, or vehicles, to determine which is the fastest"
+    ]
+  },
+  {
+    "name": "rank",
+    "trans": [
+      "秩",
+      "to place someone or something in higher or lower position relative to others"
+    ]
+  },
+  {
+    "name": "ready",
+    "trans": [
+      "准备好",
+      "prepared to do something"
+    ]
+  },
+  {
+    "name": "recommendation",
+    "trans": [
+      "推荐",
+      "suggestion about someone or something being a good choice"
+    ]
+  },
+  {
+    "name": "water",
+    "trans": [
+      "水",
+      "clear liquid that forms the seas, rivers, and rain"
+    ]
+  },
+  {
+    "name": "reflect",
+    "trans": [
+      "反映",
+      "to bounce back off a surface (e.g., light)"
+    ]
+  },
+  {
+    "name": "region",
+    "trans": [
+      "地区",
+      "part of a country, of the world, area, etc."
+    ]
+  },
+  {
+    "name": "shirt",
+    "trans": [
+      "衬衫",
+      "a light piece of clothing with sleeves for the upper body"
+    ]
+  },
+  {
+    "name": "relation",
+    "trans": [
+      "关系",
+      "manner in which people, groups, or countries behave toward one another"
+    ]
+  },
+  {
+    "name": "relax",
+    "trans": [
+      "放松",
+      "to stop feeling nervous or worried; to rest and do something enjoyable"
+    ]
+  },
+  {
+    "name": "release",
+    "trans": [
+      "发布",
+      "to allow to leave jail, cage, prison, etc."
+    ]
+  },
+  {
+    "name": "relevant",
+    "trans": [
+      "相关的",
+      "direct related to a subject in a considerable way"
+    ]
+  },
+  {
+    "name": "which",
+    "trans": [
+      "哪个",
+      "question word to ask about a person's choice"
+    ]
+  },
+  {
+    "name": "rely",
+    "trans": [
+      "依靠",
+      "able to depend on"
+    ]
+  },
+  {
+    "name": "voter",
+    "trans": [
+      "选民",
+      "a person who can vote in an election"
+    ]
+  },
+  {
+    "name": "represent",
+    "trans": [
+      "代表",
+      "to stand in the place or to act the part of"
+    ]
+  },
+  {
+    "name": "witness",
+    "trans": [
+      "证人",
+      "a person who sees something happen"
+    ]
+  },
+  {
+    "name": "would",
+    "trans": [
+      "会",
+      "modal verb used to indicate possibility, request, etc."
+    ]
+  },
+  {
+    "name": "ring",
+    "trans": [
+      "戒指",
+      "to produce a sound from a bell, alarm, or telephone; a piece of jewelry worn on a finger"
+    ]
+  },
+  {
+    "name": "write",
+    "trans": [
+      "写",
+      "to make letters and words on paper or a screen"
+    ]
+  },
+  {
+    "name": "joint",
+    "trans": [
+      "联合的",
+      "1. (n.) place where two things meet; 2. (adj.) done together"
+    ]
+  },
+  {
+    "name": "reserve",
+    "trans": [
+      "预订",
+      "1. (v) to arrange to use a room or table at a particular time; 2. (n) a store of something"
+    ]
+  },
+  {
+    "name": "pupil",
+    "trans": [
+      "瞳孔",
+      "1. a child or young person who is being taught; a student; 2. the black round part in the center of the eye that lets in light"
+    ]
+  },
+  {
+    "name": "sample",
+    "trans": [
+      "样本",
+      "to try something to see if you like it (e.g., food)"
+    ]
+  },
+  {
+    "name": "scientist",
+    "trans": [
+      "科学家",
+      "a person who is trained to gain knowledge by making predictions, testing them, and developing theories"
+    ]
+  },
+  {
+    "name": "seat",
+    "trans": [
+      "座位",
+      "something on which a person can sit"
+    ]
+  },
+  {
+    "name": "secret",
+    "trans": [
+      "秘密",
+      "something that you don't want others to know; private"
+    ]
+  },
+  {
+    "name": "secretary",
+    "trans": [
+      "秘书",
+      "an employee who does general office work for another person in the office"
+    ]
+  },
+  {
+    "name": "security",
+    "trans": [
+      "安全",
+      "things done to protect people, buildings, a country, etc., from harm"
+    ]
+  },
+  {
+    "name": "seriously",
+    "trans": [
+      "严重地",
+      "in a serious way; in a way that shows something is important"
+    ]
+  },
+  {
+    "name": "session",
+    "trans": [
+      "会议",
+      "period of time for doing a particular activity"
+    ]
+  },
+  {
+    "name": "pitch",
+    "trans": [
+      "沥青",
+      "1. the level of a sound; 2. a throw of a ball; 3. a speech to sell something; 4. black substance that is sticky when hot and hard when dry"
+    ]
+  },
+  {
+    "name": "second",
+    "trans": [
+      "第二",
+      "2nd; the one following first"
+    ]
+  },
+  {
+    "name": "hour",
+    "trans": [
+      "小时",
+      "60 minutes; one of 24 equal units of time in a day"
+    ]
+  },
+  {
+    "name": "fault",
+    "trans": [
+      "过错",
+      "a bad quality or part of someone or something; responsibility for a mistake or bad situation"
+    ]
+  },
+  {
+    "name": "shoe",
+    "trans": [
+      "鞋",
+      "outer covering worn on the foot to protect it usually sold in pairs"
+    ]
+  },
+  {
+    "name": "shot",
+    "trans": [
+      "射击",
+      "the act of firing a gun, or kicking or throwing a ball at a goal"
+    ]
+  },
+  {
+    "name": "god",
+    "trans": [
+      "上帝",
+      "a being with special powers that cannot be explained by nature"
+    ]
+  },
+  {
+    "name": "sight",
+    "trans": [
+      "视线",
+      "the ability to see"
+    ]
+  },
+  {
+    "name": "sign",
+    "trans": [
+      "符号",
+      "something such as a mark or event that shows that something exists, is true, is happening or will happen"
+    ]
+  },
+  {
+    "name": "signal",
+    "trans": [
+      "信号",
+      "An action, change, or process that gives information about something"
+    ]
+  },
+  {
+    "name": "muscle",
+    "trans": [
+      "肌肉",
+      "a body tissue that can become longer or shorter and moves the body"
+    ]
+  },
+  {
+    "name": "enterprise",
+    "trans": [
+      "企业",
+      "a business or organization"
+    ]
+  },
+  {
+    "name": "site",
+    "trans": [
+      "地点",
+      "present, former, or future location of something, such as a building"
+    ]
+  },
+  {
+    "name": "skin",
+    "trans": [
+      "皮肤",
+      "outer layer of an animal's or human's body"
+    ]
+  },
+  {
+    "name": "company",
+    "trans": [
+      "公司",
+      "a business that sells things or provides services"
+    ]
+  },
+  {
+    "name": "slowly",
+    "trans": [
+      "慢慢地",
+      "done in a way that takes a long time"
+    ]
+  },
+  {
+    "name": "smile",
+    "trans": [
+      "微笑",
+      "to show happiness by pulling up the corners of your mouth"
+    ]
+  },
+  {
+    "name": "symptom",
+    "trans": [
+      "症状",
+      "a change in someone or something that shows they have an illness or problem"
+    ]
+  },
+  {
+    "name": "revolution",
+    "trans": [
+      "革命",
+      "a change in the way a country is governed, usually by violence or war; a complete change"
+    ]
+  },
+  {
+    "name": "amendment",
+    "trans": [
+      "修正案",
+      "a change, addition, or improvement to something"
+    ]
+  },
+  {
+    "name": "carbon",
+    "trans": [
+      "碳",
+      "a chemical element (C) found in all living things"
+    ]
+  },
+  {
+    "name": "square",
+    "trans": [
+      "正方形",
+      "shape with four sides of equal length sides and four right (90°) angles"
+    ]
+  },
+  {
+    "name": "cousin",
+    "trans": [
+      "表哥",
+      "a child of your uncle or aunt"
+    ]
+  },
+  {
+    "name": "insight",
+    "trans": [
+      "洞察力",
+      "a clear idea about how something works"
+    ]
+  },
+  {
+    "name": "orange",
+    "trans": [
+      "橙子",
+      "a color that is a mixture of red and yellow"
+    ]
+  },
+  {
+    "name": "tournament",
+    "trans": [
+      "比赛",
+      "a competition made up of a series of games between many competitors"
+    ]
+  },
+  {
+    "name": "bin",
+    "trans": [
+      "垃圾桶",
+      "a container for storing things"
+    ]
+  },
+  {
+    "name": "stock",
+    "trans": [
+      "库存",
+      "piece of a business bought in the form of shares"
+    ]
+  },
+  {
+    "name": "strongly",
+    "trans": [
+      "强烈地",
+      "in a strong manner; in a very serious way"
+    ]
+  },
+  {
+    "name": "structure",
+    "trans": [
+      "结构",
+      "way something is built, arranged, or organized"
+    ]
+  },
+  {
+    "name": "studio",
+    "trans": [
+      "工作室",
+      "the building or room where art is made, such as paintings, movies, or music"
+    ]
+  },
+  {
+    "name": "style",
+    "trans": [
+      "风格",
+      "the particular way something is done or made"
+    ]
+  },
+  {
+    "name": "emotion",
+    "trans": [
+      "情感",
+      "a feeling such as sadness, anger, or love"
+    ]
+  },
+  {
+    "name": "mother",
+    "trans": [
+      "母亲",
+      "a female who has a child or children"
+    ]
+  },
+  {
+    "name": "succeed",
+    "trans": [
+      "成功",
+      "to finally achieve something that you were trying to achieve"
+    ]
+  },
+  {
+    "name": "slice",
+    "trans": [
+      "片",
+      "a flat piece of food that has been cut from a bigger piece"
+    ]
+  },
+  {
+    "name": "disk",
+    "trans": [
+      "磁盘",
+      "a flat round object"
+    ]
+  },
+  {
+    "name": "resolution",
+    "trans": [
+      "解决",
+      "a formal agreement or statement decided by a group of people"
+    ]
+  },
+  {
+    "name": "suspect",
+    "trans": [
+      "怀疑",
+      "to think that someone may have committed a crime or done something wrong"
+    ]
+  },
+  {
+    "name": "switch",
+    "trans": [
+      "转变",
+      "to change from one thing to another; a thing you move to change from one thing to another"
+    ]
+  },
+  {
+    "name": "negotiation",
+    "trans": [
+      "谈判",
+      "a formal discussion to reach an agreement"
+    ]
+  },
+  {
+    "name": "welfare",
+    "trans": [
+      "福利",
+      "a government program to help poor people"
+    ]
+  },
+  {
+    "name": "taste",
+    "trans": [
+      "品尝",
+      "the particular quality of food or drink that can be sensed by a person's mouth"
+    ]
+  },
+  {
+    "name": "tear",
+    "trans": [
+      "撕",
+      "1. (v) to damage something by pulling it apart; 2. (n) drop of salty water from the eye"
+    ]
+  },
+  {
+    "name": "technology",
+    "trans": [
+      "技术",
+      "use or knowledge of science in industry, engineering, etc."
+    ]
+  },
+  {
+    "name": "family",
+    "trans": [
+      "家庭",
+      "a group of people who are related through blood"
+    ]
+  },
+  {
+    "name": "television",
+    "trans": [
+      "电视",
+      "device that broadcasts programs, movies, or show"
+    ]
+  },
+  {
+    "name": "temperature",
+    "trans": [
+      "温度",
+      "a measure of how hot or cold something is (e.g., the weather)"
+    ]
+  },
+  {
+    "name": "theory",
+    "trans": [
+      "理论",
+      "idea or set of ideas that try to explain facts or events"
+    ]
+  },
+  {
+    "name": "species",
+    "trans": [
+      "物种",
+      "a group of related animals or plant"
+    ]
+  },
+  {
+    "name": "dozen",
+    "trans": [
+      "打",
+      "a group of twelve people or things"
+    ]
+  },
+  {
+    "name": "tie",
+    "trans": [
+      "领带",
+      "to join together two ends of string or rope; to join two or more things together with string or rope"
+    ]
+  },
+  {
+    "name": "phrase",
+    "trans": [
+      "短语",
+      "a group of words that forms a unit and expresses a single meaning"
+    ]
+  },
+  {
+    "name": "tool",
+    "trans": [
+      "工具",
+      "device used to make things (e.g., a hammer or driver)"
+    ]
+  },
+  {
+    "name": "touch",
+    "trans": [
+      "触碰",
+      "to feel an object with your fingers, etc."
+    ]
+  },
+  {
+    "name": "gesture",
+    "trans": [
+      "手势",
+      "a hand or body movement that expresses a particular idea or feeling"
+    ]
+  },
+  {
+    "name": "city",
+    "trans": [
+      "城市",
+      "a heavily populated area with many buildings and roads"
+    ]
+  },
+  {
+    "name": "tradition",
+    "trans": [
+      "传统",
+      "way of thinking, and behaving that was used for a long time"
+    ]
+  },
+  {
+    "name": "bell",
+    "trans": [
+      "钟",
+      "a hollow metal object shaped like a cup that rings when it is hit"
+    ]
+  },
+  {
+    "name": "disorder",
+    "trans": [
+      "紊乱",
+      "a lack of organization"
+    ]
+  },
+  {
+    "name": "troop",
+    "trans": [
+      "部队",
+      "group of soldiers; an organized group"
+    ]
+  },
+  {
+    "name": "true",
+    "trans": [
+      "真的",
+      "agreeing with the facts; not false; real or actual"
+    ]
+  },
+  {
+    "name": "chicken",
+    "trans": [
+      "鸡",
+      "a large bird that is raised on farms for its eggs and meat"
+    ]
+  },
+  {
+    "name": "union",
+    "trans": [
+      "联盟",
+      "organization of people or groups who have a similar interest or particular goal"
+    ]
+  },
+  {
+    "name": "user",
+    "trans": [
+      "用户",
+      "person that uses a service or thing (e.g., a website)"
+    ]
+  },
+  {
+    "name": "variety",
+    "trans": [
+      "种类",
+      "particular types of things or persons"
+    ]
+  },
+  {
+    "name": "convention",
+    "trans": [
+      "习俗",
+      "a large meeting of the members of a profession, organization, or who have the same interests"
+    ]
+  },
+  {
+    "name": "victim",
+    "trans": [
+      "受害者",
+      "person who has suffered from a crime, bad situation, or event"
+    ]
+  },
+  {
+    "name": "violence",
+    "trans": [
+      "暴力",
+      "use of physical force to harm someone or damage something"
+    ]
+  },
+  {
+    "name": "lot",
+    "trans": [
+      "很多",
+      "A large quantity, or number taken together"
+    ]
+  },
+  {
+    "name": "truck",
+    "trans": [
+      "卡车",
+      "a large road vehicle used to carry things"
+    ]
+  },
+  {
+    "name": "wake",
+    "trans": [
+      "唤醒",
+      "to stop sleeping; to make someone stop sleeping"
+    ]
+  },
+  {
+    "name": "mail",
+    "trans": [
+      "邮件",
+      "a letter, package, or email"
+    ]
+  },
+  {
+    "name": "wear",
+    "trans": [
+      "穿",
+      "to have clothes, glasses, shoes, etc., on your body"
+    ]
+  },
+  {
+    "name": "weather",
+    "trans": [
+      "天气",
+      "whether it is raining, sunny, cold, etc., outside"
+    ]
+  },
+  {
+    "name": "wed",
+    "trans": [
+      "结婚",
+      "to marry; to get married"
+    ]
+  },
+  {
+    "name": "west",
+    "trans": [
+      "西方",
+      "the direction where the sun sets; opposite of east"
+    ]
+  },
+  {
+    "name": "agenda",
+    "trans": [
+      "议程",
+      "a list of subjects that people will discuss at a meeting"
+    ]
+  },
+  {
+    "name": "gaze",
+    "trans": [
+      "目光",
+      "a long continuous look at someone or something"
+    ]
+  },
+  {
+    "name": "far",
+    "trans": [
+      "远的",
+      "a long way away"
+    ]
+  },
+  {
+    "name": "counter",
+    "trans": [
+      "柜台",
+      "a long, flat surface in a shop or kitchen where work is done"
+    ]
+  },
+  {
+    "name": "passage",
+    "trans": [
+      "通道",
+      "a long, narrow area that connects one place to another"
+    ]
+  },
+  {
+    "name": "wood",
+    "trans": [
+      "木头",
+      "hard material that trees are made of and is used for building and fuel"
+    ]
+  },
+  {
+    "name": "heavily",
+    "trans": [
+      "重重地",
+      "a lot or to a great degree"
+    ]
+  },
+  {
+    "name": "much",
+    "trans": [
+      "很多",
+      "a lot; large amount; a high degree of"
+    ]
+  },
+  {
+    "name": "writer",
+    "trans": [
+      "作家",
+      "professional who writes books, articles, etc."
+    ]
+  },
+  {
+    "name": "aircraft",
+    "trans": [
+      "飞机",
+      "a machine that can fly"
+    ]
+  },
+  {
+    "name": "motor",
+    "trans": [
+      "发动机",
+      "a machine that uses energy to make something work or move"
+    ]
+  },
+  {
+    "name": "ability",
+    "trans": [
+      "能力",
+      "power, money, knowledge, or skill to do something"
+    ]
+  },
+  {
+    "name": "cloud",
+    "trans": [
+      "云",
+      "a mass of water vapor in the sky, as when it is going to rain"
+    ]
+  },
+  {
+    "name": "leather",
+    "trans": [
+      "皮革",
+      "a material made from the skin of an animal"
+    ]
+  },
+  {
+    "name": "inch",
+    "trans": [
+      "英寸",
+      "a measure of length; 1/12 of a foot (2.54 centimeters)"
+    ]
+  },
+  {
+    "name": "above",
+    "trans": [
+      "多于",
+      "in a higher place than something else"
+    ]
+  },
+  {
+    "name": "abortion",
+    "trans": [
+      "流产",
+      "a medical operation to end the time when a female is going to have a baby"
+    ]
+  },
+  {
+    "name": "motion",
+    "trans": [
+      "运动",
+      "a movement; the way something moves"
+    ]
+  },
+  {
+    "name": "web",
+    "trans": [
+      "网络",
+      "a net made by spiders; many things connected together"
+    ]
+  },
+  {
+    "name": "absolutely",
+    "trans": [
+      "绝对地",
+      "completely; totally; very"
+    ]
+  },
+  {
+    "name": "minority",
+    "trans": [
+      "少数民族",
+      "a part of a group that is less than half of the whole; a small part"
+    ]
+  },
+  {
+    "name": "mechanism",
+    "trans": [
+      "机制",
+      "a part or a set of parts of a machine that has a particular function"
+    ]
+  },
+  {
+    "name": "accept",
+    "trans": [
+      "接受",
+      "to agree to receive or take something offered"
+    ]
+  },
+  {
+    "name": "edition",
+    "trans": [
+      "版",
+      "a particular version of something that is sold to the public"
+    ]
+  },
+  {
+    "name": "access",
+    "trans": [
+      "使用权",
+      "an entrance to a place; a way in"
+    ]
+  },
+  {
+    "name": "trail",
+    "trans": [
+      "踪迹",
+      "a path through the countryside, often where people walk"
+    ]
+  },
+  {
+    "name": "circle",
+    "trans": [
+      "圆圈",
+      "a perfectly round shape or a group arranged in that shape"
+    ]
+  },
+  {
+    "name": "accord",
+    "trans": [
+      "符合",
+      "agreement or harmony"
+    ]
+  },
+  {
+    "name": "account",
+    "trans": [
+      "帐户",
+      "arrangement with a bank to keep your money for you"
+    ]
+  },
+  {
+    "name": "day",
+    "trans": [
+      "天",
+      "a period of 24 hours"
+    ]
+  },
+  {
+    "name": "era",
+    "trans": [
+      "时代",
+      "a period of time in history that is special for a particular reason"
+    ]
+  },
+  {
+    "name": "achieve",
+    "trans": [
+      "达到",
+      "to succeed in doing something good, usually by working hard"
+    ]
+  },
+  {
+    "name": "chairman",
+    "trans": [
+      "主席",
+      "a person in charge of a meeting"
+    ]
+  },
+  {
+    "name": "manufacturer",
+    "trans": [
+      "制造商",
+      "a person or company that makes a product"
+    ]
+  },
+  {
+    "name": "acquire",
+    "trans": [
+      "获得",
+      "to get or earn something by thinking or working"
+    ]
+  },
+  {
+    "name": "server",
+    "trans": [
+      "服务器",
+      "a person or thing that brings things to you when asked to"
+    ]
+  },
+  {
+    "name": "pilot",
+    "trans": [
+      "飞行员",
+      "a person who controls an airplane, spacecraft, or boat"
+    ]
+  },
+  {
+    "name": "act",
+    "trans": [
+      "行为",
+      "to behave in a certain way"
+    ]
+  },
+  {
+    "name": "action",
+    "trans": [
+      "行动",
+      "something that a person or thing does"
+    ]
+  },
+  {
+    "name": "active",
+    "trans": [
+      "积极的",
+      "moving around a lot or doing many things"
+    ]
+  },
+  {
+    "name": "actor",
+    "trans": [
+      "演员",
+      "person who acts in the theater, movies, or tv"
+    ]
+  },
+  {
+    "name": "actual",
+    "trans": [
+      "实际的",
+      "real or existing in fact, not imagined; real"
+    ]
+  },
+  {
+    "name": "lover",
+    "trans": [
+      "情人",
+      "a person who likes someone or something very strongly"
+    ]
+  },
+  {
+    "name": "ad",
+    "trans": [
+      "广告",
+      "public notice or advertisement"
+    ]
+  },
+  {
+    "name": "refugee",
+    "trans": [
+      "难民",
+      "a person who ran away from his or her country because of war"
+    ]
+  },
+  {
+    "name": "addition",
+    "trans": [
+      "添加",
+      "fact of adding something; thing that is added"
+    ]
+  },
+  {
+    "name": "additional",
+    "trans": [
+      "额外的",
+      "further or added"
+    ]
+  },
+  {
+    "name": "address",
+    "trans": [
+      "地址",
+      "exact street location of a place"
+    ]
+  },
+  {
+    "name": "scholar",
+    "trans": [
+      "学者",
+      "a person who studies and knows a lot about a particular subject"
+    ]
+  },
+  {
+    "name": "researcher",
+    "trans": [
+      "研究员",
+      "a person who studies something carefully to learn new information"
+    ]
+  },
+  {
+    "name": "terrorist",
+    "trans": [
+      "恐怖分子",
+      "a person who uses fear or violence for a political purpose"
+    ]
+  },
+  {
+    "name": "admit",
+    "trans": [
+      "承认",
+      "to agree that you did something bad, or that something bad is true"
+    ]
+  },
+  {
+    "name": "adopt",
+    "trans": [
+      "采纳",
+      "to take on responsibility for something"
+    ]
+  },
+  {
+    "name": "adult",
+    "trans": [
+      "成人",
+      "person or animal that is fully grown"
+    ]
+  },
+  {
+    "name": "advance",
+    "trans": [
+      "进步",
+      "to move forward in a certain direction"
+    ]
+  },
+  {
+    "name": "advantage",
+    "trans": [
+      "优势",
+      "thing making the chance of success higher"
+    ]
+  },
+  {
+    "name": "servant",
+    "trans": [
+      "仆人",
+      "a person who works in another person's house and takes care of them"
+    ]
+  },
+  {
+    "name": "advertise",
+    "trans": [
+      "广告",
+      "to show how good a product is, to make people buy"
+    ]
+  },
+  {
+    "name": "advice",
+    "trans": [
+      "建议",
+      "suggestion about what someone should do"
+    ]
+  },
+  {
+    "name": "critic",
+    "trans": [
+      "评论家",
+      "a person whose job is to give opinions about books, movies, or other forms of art"
+    ]
+  },
+  {
+    "name": "rival",
+    "trans": [
+      "竞争对手",
+      "a person, team, or organization that competes with another; a competitor"
+    ]
+  },
+  {
+    "name": "affair",
+    "trans": [
+      "事务",
+      "event or a set of events, often unpleasant ones"
+    ]
+  },
+  {
+    "name": "affect",
+    "trans": [
+      "影响",
+      "to do something that changes something else"
+    ]
+  },
+  {
+    "name": "afford",
+    "trans": [
+      "买得起",
+      "to have enough money to pay for something"
+    ]
+  },
+  {
+    "name": "afraid",
+    "trans": [
+      "害怕的",
+      "worried that something bad will happen; scared"
+    ]
+  },
+  {
+    "name": "advertisement",
+    "trans": [
+      "广告",
+      "a picture, short film, text, etc., that tells people about a product or service"
+    ]
+  },
+  {
+    "name": "afternoon",
+    "trans": [
+      "下午",
+      "time after 12:00 and before the evening meal"
+    ]
+  },
+  {
+    "name": "log",
+    "trans": [
+      "日志",
+      "a piece of a tree that has been cut"
+    ]
+  },
+  {
+    "name": "draft",
+    "trans": [
+      "草稿",
+      "a piece of writing or plan that is not yet finished"
+    ]
+  },
+  {
+    "name": "drama",
+    "trans": [
+      "戏剧",
+      "a piece of writing that tells a story about a serious subject or an exciting event"
+    ]
+  },
+  {
+    "name": "agency",
+    "trans": [
+      "机构",
+      "business that provides some service for others"
+    ]
+  },
+  {
+    "name": "laboratory",
+    "trans": [
+      "实验室",
+      "a place for doing research and experiments"
+    ]
+  },
+  {
+    "name": "agent",
+    "trans": [
+      "代理人",
+      "person who can represent and decide for others"
+    ]
+  },
+  {
+    "name": "pub",
+    "trans": [
+      "酒吧",
+      "a place that sells alcohol and food"
+    ]
+  },
+  {
+    "name": "shelter",
+    "trans": [
+      "庇护所",
+      "a place to live or stay that protects someone from weather"
+    ]
+  },
+  {
+    "name": "agree",
+    "trans": [
+      "同意",
+      "to have the same opinion as someone else"
+    ]
+  },
+  {
+    "name": "agreement",
+    "trans": [
+      "协议",
+      "when you share the same opinion or reach a decision"
+    ]
+  },
+  {
+    "name": "resort",
+    "trans": [
+      "采取",
+      "a place where people go on holiday"
+    ]
+  },
+  {
+    "name": "ahead",
+    "trans": [
+      "前面",
+      "in or toward the front"
+    ]
+  },
+  {
+    "name": "aid",
+    "trans": [
+      "援助",
+      "to provide things useful or needed by others"
+    ]
+  },
+  {
+    "name": "aim",
+    "trans": [
+      "目的",
+      "act of pointing something at a target"
+    ]
+  },
+  {
+    "name": "air",
+    "trans": [
+      "空气",
+      "mixture of gases around the earth that we breathe"
+    ]
+  },
+  {
+    "name": "end",
+    "trans": [
+      "结尾",
+      "a point that marks the limit of something; finish"
+    ]
+  },
+  {
+    "name": "elderly",
+    "trans": [
+      "老年",
+      "a polite word for 'old', used to describe people"
+    ]
+  },
+  {
+    "name": "platform",
+    "trans": [
+      "平台",
+      "a raised area for people to stand on"
+    ]
+  },
+  {
+    "name": "panel",
+    "trans": [
+      "控制板",
+      "a rectangular piece of wood, metal, etc., that is a part of something bigger; a group of people who discuss something"
+    ]
+  },
+  {
+    "name": "rose",
+    "trans": [
+      "玫瑰",
+      "a red flower used to show love"
+    ]
+  },
+  {
+    "name": "chamber",
+    "trans": [
+      "室",
+      "a room or space inside something used for a special purpose"
+    ]
+  },
+  {
+    "name": "restriction",
+    "trans": [
+      "限制",
+      "a rule or law that limits what people can do"
+    ]
+  },
+  {
+    "name": "storage",
+    "trans": [
+      "贮存",
+      "a safe place to keep something until it is needed"
+    ]
+  },
+  {
+    "name": "clause",
+    "trans": [
+      "条款",
+      "a separate part of a contract, a will, or another legal document"
+    ]
+  },
+  {
+    "name": "uniform",
+    "trans": [
+      "制服",
+      "a set of clothes that show you are part of a group or school"
+    ]
+  },
+  {
+    "name": "website",
+    "trans": [
+      "网站",
+      "a set of internet pages that give information about a particular person or organization"
+    ]
+  },
+  {
+    "name": "alone",
+    "trans": [
+      "独自的",
+      "without anyone or anything else"
+    ]
+  },
+  {
+    "name": "dish",
+    "trans": [
+      "盘子",
+      "a shallow container for cooking or serving food"
+    ]
+  },
+  {
+    "name": "cooperation",
+    "trans": [
+      "合作",
+      "a situation where everyone works together to get something done"
+    ]
+  },
+  {
+    "name": "cat",
+    "trans": [
+      "猫",
+      "a small animal of the lion and tiger family with four legs and a tail that is kept as a pet"
+    ]
+  },
+  {
+    "name": "adjustment",
+    "trans": [
+      "调整",
+      "a small change to make something function better"
+    ]
+  },
+  {
+    "name": "seed",
+    "trans": [
+      "种子",
+      "a small object made by a plant from which a new plant can grow; the beginning of something"
+    ]
+  },
+  {
+    "name": "cigarette",
+    "trans": [
+      "卷烟",
+      "a small paper tube filled with tobacco"
+    ]
+  },
+  {
+    "name": "alternative",
+    "trans": [
+      "选择",
+      "other choices"
+    ]
+  },
+  {
+    "name": "tip",
+    "trans": [
+      "提示",
+      "a small piece of advice; the end of something"
+    ]
+  },
+  {
+    "name": "chip",
+    "trans": [
+      "芯片",
+      "a small piece that was broken or taken off something"
+    ]
+  },
+  {
+    "name": "coin",
+    "trans": [
+      "硬币",
+      "a small, flat piece of metal used as money"
+    ]
+  },
+  {
+    "name": "amaze",
+    "trans": [
+      "惊奇",
+      "to cause wonder; to surprise completely"
+    ]
+  },
+  {
+    "name": "gap",
+    "trans": [
+      "差距",
+      "a space between two things"
+    ]
+  },
+  {
+    "name": "magic",
+    "trans": [
+      "魔法",
+      "a special power that allows impossible things to happen"
+    ]
+  },
+  {
+    "name": "amount",
+    "trans": [
+      "数量",
+      "quantity of something"
+    ]
+  },
+  {
+    "name": "analysis",
+    "trans": [
+      "分析",
+      "careful study to better understand something"
+    ]
+  },
+  {
+    "name": "mission",
+    "trans": [
+      "使命",
+      "a special task or job that is given to a person or group"
+    ]
+  },
+  {
+    "name": "area",
+    "trans": [
+      "区域",
+      "a specific section or space; part of a region"
+    ]
+  },
+  {
+    "name": "premise",
+    "trans": [
+      "前提",
+      "a statement or idea that is accepted as being true and is used for developing other ideas and actions"
+    ]
+  },
+  {
+    "name": "equation",
+    "trans": [
+      "方程",
+      "a statement showing things to be equal"
+    ]
+  },
+  {
+    "name": "faith",
+    "trans": [
+      "信仰",
+      "a strong belief that someone or something is honest and good"
+    ]
+  },
+  {
+    "name": "animal",
+    "trans": [
+      "动物",
+      "a living creature that is not a plant or person"
+    ]
+  },
+  {
+    "name": "announce",
+    "trans": [
+      "宣布",
+      "to make a public statement about a plan, decision"
+    ]
+  },
+  {
+    "name": "castle",
+    "trans": [
+      "城堡",
+      "a strong building used in the past to protect people in times of war"
+    ]
+  },
+  {
+    "name": "annual",
+    "trans": [
+      "年度的",
+      "happening once a year, or every year"
+    ]
+  },
+  {
+    "name": "bias",
+    "trans": [
+      "偏见",
+      "a strong feeling not based on facts to believe one thing over another"
+    ]
+  },
+  {
+    "name": "stake",
+    "trans": [
+      "赌注",
+      "a strong stick with a pointed end that you push into the ground"
+    ]
+  },
+  {
+    "name": "fool",
+    "trans": [
+      "傻子",
+      "a stupid or silly person"
+    ]
+  },
+  {
+    "name": "emergency",
+    "trans": [
+      "紧急情况",
+      "a sudden serious event needing immediate action"
+    ]
+  },
+  {
+    "name": "chocolate",
+    "trans": [
+      "巧克力",
+      "a sweet brown food made from cocoa beans"
+    ]
+  },
+  {
+    "name": "democracy",
+    "trans": [
+      "民主",
+      "a system of government in which the people of a country can vote to elect who will govern them"
+    ]
+  },
+  {
+    "name": "anybody",
+    "trans": [
+      "任何人",
+      "any person; anyone"
+    ]
+  },
+  {
+    "name": "column",
+    "trans": [
+      "柱子",
+      "a tall post made of stone or wood used as a support in a building; one of two or more blocks of print that appear next to each other on a page"
+    ]
+  },
+  {
+    "name": "anyone",
+    "trans": [
+      "任何人",
+      "any person"
+    ]
+  },
+  {
+    "name": "professor",
+    "trans": [
+      "教授",
+      "a teacher of high rank in a university or college"
+    ]
+  },
+  {
+    "name": "anyway",
+    "trans": [
+      "反正",
+      "a word people use to change the topic of a conversation"
+    ]
+  },
+  {
+    "name": "apart",
+    "trans": [
+      "分开",
+      "separated by an amount of time or space"
+    ]
+  },
+  {
+    "name": "toy",
+    "trans": [
+      "玩具",
+      "a thing that children play with"
+    ]
+  },
+  {
+    "name": "it",
+    "trans": [
+      "它",
+      "a thing that has been previously mentioned"
+    ]
+  },
+  {
+    "name": "absence",
+    "trans": [
+      "缺席",
+      "a time when you are not in a place where you should be"
+    ]
+  },
+  {
+    "name": "apparently",
+    "trans": [
+      "显然",
+      "according to what you heard; from what can be seen"
+    ]
+  },
+  {
+    "name": "appeal",
+    "trans": [
+      "上诉",
+      "to request a judge or others change a decision"
+    ]
+  },
+  {
+    "name": "appear",
+    "trans": [
+      "出现",
+      "to be seen, become visible; come into sight"
+    ]
+  },
+  {
+    "name": "port",
+    "trans": [
+      "港口",
+      "a town or an area of a town next to water where ships arrive and leave from"
+    ]
+  },
+  {
+    "name": "appreciate",
+    "trans": [
+      "欣赏",
+      "to be thankful for; to value or admire"
+    ]
+  },
+  {
+    "name": "approach",
+    "trans": [
+      "方法",
+      "to get close to reaching something or somewhere"
+    ]
+  },
+  {
+    "name": "appropriate",
+    "trans": [
+      "合适的",
+      "right or suitable for some situation or purpose"
+    ]
+  },
+  {
+    "name": "metal",
+    "trans": [
+      "金属",
+      "a type of hardy material that is usually hard and shiny that can be used to make things, such as iron, gold, or steel"
+    ]
+  },
+  {
+    "name": "approve",
+    "trans": [
+      "批准",
+      "to have a positive opinion of someone or something"
+    ]
+  },
+  {
+    "name": "car",
+    "trans": [
+      "车",
+      "a vehicle with four wheels and engine that can carry things"
+    ]
+  },
+  {
+    "name": "bike",
+    "trans": [
+      "自行车",
+      "a vehicle with two wheels that a person can ride"
+    ]
+  },
+  {
+    "name": "plastic",
+    "trans": [
+      "塑料",
+      "a very common, light, strong material that can be formed into many different shapes and is made by a chemical process"
+    ]
+  },
+  {
+    "name": "argue",
+    "trans": [
+      "争论",
+      "to give reasons for or against an idea or point of view"
+    ]
+  },
+  {
+    "name": "virus",
+    "trans": [
+      "病毒",
+      "a very small, basic living thing that causes disease or sickness"
+    ]
+  },
+  {
+    "name": "arm",
+    "trans": [
+      "手臂",
+      "part of your body from your shoulder to your hand"
+    ]
+  },
+  {
+    "name": "army",
+    "trans": [
+      "军队",
+      "large group of soldiers organized to fight in wars"
+    ]
+  },
+  {
+    "name": "child",
+    "trans": [
+      "孩子",
+      "a very young person, between about 2 and 15"
+    ]
+  },
+  {
+    "name": "arrest",
+    "trans": [
+      "逮捕",
+      "to use the law to catch and keep people who committed crimes"
+    ]
+  },
+  {
+    "name": "arrive",
+    "trans": [
+      "到达",
+      "to reach the place you are travelling to"
+    ]
+  },
+  {
+    "name": "article",
+    "trans": [
+      "文章",
+      "piece of writing about a particular subject"
+    ]
+  },
+  {
+    "name": "artist",
+    "trans": [
+      "艺术家",
+      "a person who is skilled and creative in art, such as a painter"
+    ]
+  },
+  {
+    "name": "logic",
+    "trans": [
+      "逻辑",
+      "a way of thinking by using facts and reasoning"
+    ]
+  },
+  {
+    "name": "blog",
+    "trans": [
+      "博客",
+      "a website with regularly updated short articles and opinions about a particular topic"
+    ]
+  },
+  {
+    "name": "victory",
+    "trans": [
+      "胜利",
+      "a win in a war, game, or competition"
+    ]
+  },
+  {
+    "name": "assess",
+    "trans": [
+      "评估",
+      "to judge something's value or suitability"
+    ]
+  },
+  {
+    "name": "fence",
+    "trans": [
+      "栅栏",
+      "a wooden or metal structure that separates an area"
+    ]
+  },
+  {
+    "name": "noun",
+    "trans": [
+      "名词",
+      "a word that refers to a person, place, thing, quality, idea, or action"
+    ]
+  },
+  {
+    "name": "poem",
+    "trans": [
+      "诗",
+      "a written composition in verse, not prose"
+    ]
+  },
+  {
+    "name": "association",
+    "trans": [
+      "协会",
+      "organization of people with the same interest"
+    ]
+  },
+  {
+    "name": "assume",
+    "trans": [
+      "认为",
+      "to believe, based on the evidence; suppose"
+    ]
+  },
+  {
+    "name": "index",
+    "trans": [
+      "指数",
+      "a written or printed list of topics or words in a particular order"
+    ]
+  },
+  {
+    "name": "journal",
+    "trans": [
+      "杂志",
+      "a written record of subjects or events"
+    ]
+  },
+  {
+    "name": "cheese",
+    "trans": [
+      "奶酪",
+      "a yellow or white food made from milk"
+    ]
+  },
+  {
+    "name": "initiative",
+    "trans": [
+      "倡议",
+      "ability to decide or act upon things yourself without depending on someone else"
+    ]
+  },
+  {
+    "name": "vision",
+    "trans": [
+      "想象",
+      "ability to see things with your eyes"
+    ]
+  },
+  {
+    "name": "capable",
+    "trans": [
+      "有能力的",
+      "able to do something; can do"
+    ]
+  },
+  {
+    "name": "attack",
+    "trans": [
+      "攻击",
+      "to try to destroy, beat, or injure"
+    ]
+  },
+  {
+    "name": "attempt",
+    "trans": [
+      "试图",
+      "to try to do something challenging or difficult"
+    ]
+  },
+  {
+    "name": "attend",
+    "trans": [
+      "出席",
+      "to be present at an event"
+    ]
+  },
+  {
+    "name": "mobile",
+    "trans": [
+      "移动的",
+      "able to move from one place to another"
+    ]
+  },
+  {
+    "name": "attention",
+    "trans": [
+      "注意力",
+      "focus of your thoughts on something"
+    ]
+  },
+  {
+    "name": "attract",
+    "trans": [
+      "吸引",
+      "to make someone notice and become interested in"
+    ]
+  },
+  {
+    "name": "efficient",
+    "trans": [
+      "高效的",
+      "able to work well without waste"
+    ]
+  },
+  {
+    "name": "over",
+    "trans": [
+      "超过",
+      "above; across; more than; on the other side"
+    ]
+  },
+  {
+    "name": "suitable",
+    "trans": [
+      "合适的",
+      "acceptable or right for someone or something"
+    ]
+  },
+  {
+    "name": "recognition",
+    "trans": [
+      "认出",
+      "accepting that something is true or that it exists"
+    ]
+  },
+  {
+    "name": "luck",
+    "trans": [
+      "运气",
+      "accidental way things happen, often good things"
+    ]
+  },
+  {
+    "name": "available",
+    "trans": [
+      "可用的",
+      "present and able to be used"
+    ]
+  },
+  {
+    "name": "average",
+    "trans": [
+      "平均的",
+      "typical or normal; usual; ordinary"
+    ]
+  },
+  {
+    "name": "avoid",
+    "trans": [
+      "避免",
+      "to prevent from happening, or stay away from"
+    ]
+  },
+  {
+    "name": "award",
+    "trans": [
+      "奖",
+      "to give a prize for doing something well"
+    ]
+  },
+  {
+    "name": "aware",
+    "trans": [
+      "意识到的",
+      "knowing or feeling that something exists"
+    ]
+  },
+  {
+    "name": "report",
+    "trans": [
+      "报告",
+      "account of something which gives the necessary facts and information"
+    ]
+  },
+  {
+    "name": "participation",
+    "trans": [
+      "参与",
+      "act of being involved in something"
+    ]
+  },
+  {
+    "name": "survival",
+    "trans": [
+      "生存",
+      "act of continuing to exist when facing difficulty"
+    ]
+  },
+  {
+    "name": "baby",
+    "trans": [
+      "婴儿",
+      "very young child, who cannot yet speak"
+    ]
+  },
+  {
+    "name": "background",
+    "trans": [
+      "背景",
+      "images, color, or information behind the main one"
+    ]
+  },
+  {
+    "name": "limitation",
+    "trans": [
+      "局限性",
+      "act of controlling or reducing the size of something"
+    ]
+  },
+  {
+    "name": "opposition",
+    "trans": [
+      "反对",
+      "act of disagreeing or trying to stop something"
+    ]
+  },
+  {
+    "name": "bag",
+    "trans": [
+      "包",
+      "soft container to put things in and carry with you"
+    ]
+  },
+  {
+    "name": "balance",
+    "trans": [
+      "平衡",
+      "to make two or more things equal"
+    ]
+  },
+  {
+    "name": "ball",
+    "trans": [
+      "球",
+      "small round object often used in a game or sport"
+    ]
+  },
+  {
+    "name": "expansion",
+    "trans": [
+      "扩张",
+      "act of expanding or becoming bigger"
+    ]
+  },
+  {
+    "name": "bank",
+    "trans": [
+      "银行",
+      "a financial institution that keeps or lends money"
+    ]
+  },
+  {
+    "name": "acquisition",
+    "trans": [
+      "获得",
+      "act of getting something"
+    ]
+  },
+  {
+    "name": "presentation",
+    "trans": [
+      "推介会",
+      "act of giving a formal talk about something"
+    ]
+  },
+  {
+    "name": "assistance",
+    "trans": [
+      "协助",
+      "act of helping someone"
+    ]
+  },
+  {
+    "name": "basic",
+    "trans": [
+      "基本的",
+      "at the most important or easiest (beginner) level"
+    ]
+  },
+  {
+    "name": "basis",
+    "trans": [
+      "基础",
+      "starting situation, fact, idea to develop from"
+    ]
+  },
+  {
+    "name": "announcement",
+    "trans": [
+      "公告",
+      "act of informing people about something publicly"
+    ]
+  },
+  {
+    "name": "battle",
+    "trans": [
+      "战斗",
+      "military fight between armies"
+    ]
+  },
+  {
+    "name": "creation",
+    "trans": [
+      "创建",
+      "act of making something"
+    ]
+  },
+  {
+    "name": "beach",
+    "trans": [
+      "海滩",
+      "large area of sand, next to an area of water"
+    ]
+  },
+  {
+    "name": "bear",
+    "trans": [
+      "熊",
+      "large brown animal with fur that lives in forests"
+    ]
+  },
+  {
+    "name": "beat",
+    "trans": [
+      "打",
+      "to win against another person or team; defeat"
+    ]
+  },
+  {
+    "name": "beautiful",
+    "trans": [
+      "美丽的",
+      "having very attractive or appealing physical qualities"
+    ]
+  },
+  {
+    "name": "registration",
+    "trans": [
+      "登记",
+      "act of recording information on an official list"
+    ]
+  },
+  {
+    "name": "development",
+    "trans": [
+      "发展",
+      "act or process of growing bigger or more advanced"
+    ]
+  },
+  {
+    "name": "involvement",
+    "trans": [
+      "参与",
+      "act or process of joining in a particular activity"
+    ]
+  },
+  {
+    "name": "bed",
+    "trans": [
+      "床",
+      "a piece of furniture that people sleep on"
+    ]
+  },
+  {
+    "name": "legislation",
+    "trans": [
+      "立法",
+      "act or process of writing and passing laws"
+    ]
+  },
+  {
+    "name": "infection",
+    "trans": [
+      "感染",
+      "act or state of becoming infected with a disease"
+    ]
+  },
+  {
+    "name": "transportation",
+    "trans": [
+      "运输",
+      "act, system, or business of moving people or goods from one place to another"
+    ]
+  },
+  {
+    "name": "laughter",
+    "trans": [
+      "笑声",
+      "action or sound of laughing"
+    ]
+  },
+  {
+    "name": "behavior",
+    "trans": [
+      "行为",
+      "way a person or thing acts; manner"
+    ]
+  },
+  {
+    "name": "behind",
+    "trans": [
+      "在后面",
+      "in or toward the back"
+    ]
+  },
+  {
+    "name": "sanction",
+    "trans": [
+      "制裁",
+      "action taken to force a country to obey laws"
+    ]
+  },
+  {
+    "name": "entertainment",
+    "trans": [
+      "娱乐",
+      "activities that make people have a good time by singing, telling jokes, etc."
+    ]
+  },
+  {
+    "name": "belong",
+    "trans": [
+      "属于",
+      "to be a member of a particular group and feel welcomed"
+    ]
+  },
+  {
+    "name": "below",
+    "trans": [
+      "以下",
+      "in a lower position, place, or level"
+    ]
+  },
+  {
+    "name": "venture",
+    "trans": [
+      "创业",
+      "activity that involves taking chances or risks"
+    ]
+  },
+  {
+    "name": "game",
+    "trans": [
+      "游戏",
+      "activity with rules that people play to have fun"
+    ]
+  },
+  {
+    "name": "work",
+    "trans": [
+      "工作",
+      "activity you do in order to make money"
+    ]
+  },
+  {
+    "name": "benefit",
+    "trans": [
+      "益处",
+      "good result or effect, something advantageous"
+    ]
+  },
+  {
+    "name": "real",
+    "trans": [
+      "真实的",
+      "actually existing or happening, not imagined"
+    ]
+  },
+  {
+    "name": "woman",
+    "trans": [
+      "女士",
+      "adult female human being"
+    ]
+  },
+  {
+    "name": "privilege",
+    "trans": [
+      "特权",
+      "advantage or right that is given to only a certain person or group of people"
+    ]
+  },
+  {
+    "name": "anxious",
+    "trans": [
+      "焦虑的",
+      "afraid of what may happen; worried and nervous"
+    ]
+  },
+  {
+    "name": "beyond",
+    "trans": [
+      "超过",
+      "on or to the farther side; in addition to"
+    ]
+  },
+  {
+    "name": "subsequently",
+    "trans": [
+      "随后",
+      "after something else has happened"
+    ]
+  },
+  {
+    "name": "breath",
+    "trans": [
+      "气息",
+      "air you take in and out of your body"
+    ]
+  },
+  {
+    "name": "beer",
+    "trans": [
+      "啤酒",
+      "alcoholic drink that is made from wheat or grains"
+    ]
+  },
+  {
+    "name": "universe",
+    "trans": [
+      "宇宙",
+      "all of space and everything in it"
+    ]
+  },
+  {
+    "name": "bill",
+    "trans": [
+      "账单",
+      "piece of paper showing what you have to pay"
+    ]
+  },
+  {
+    "name": "world",
+    "trans": [
+      "世界",
+      "all the humans, events, activities on the earth"
+    ]
+  },
+  {
+    "name": "membership",
+    "trans": [
+      "会员资格",
+      "all the people who belong to a club or group"
+    ]
+  },
+  {
+    "name": "bird",
+    "trans": [
+      "鸟",
+      "animal with feathers that uses wings to fly"
+    ]
+  },
+  {
+    "name": "household",
+    "trans": [
+      "家庭",
+      "all the people who live in a house; a family"
+    ]
+  },
+  {
+    "name": "virtually",
+    "trans": [
+      "几乎",
+      "almost completely"
+    ]
+  },
+  {
+    "name": "black",
+    "trans": [
+      "黑色的",
+      "color of the sky on a dark night"
+    ]
+  },
+  {
+    "name": "barely",
+    "trans": [
+      "仅仅",
+      "almost not possible or does not happen"
+    ]
+  },
+  {
+    "name": "though",
+    "trans": [
+      "尽管",
+      "although, despite the fact that"
+    ]
+  },
+  {
+    "name": "expenditure",
+    "trans": [
+      "支出",
+      "amount of money used during a certain time"
+    ]
+  },
+  {
+    "name": "block",
+    "trans": [
+      "堵塞",
+      "to stop from going forward or making progress"
+    ]
+  },
+  {
+    "name": "blood",
+    "trans": [
+      "血",
+      "red liquid in the bodies of people and animals"
+    ]
+  },
+  {
+    "name": "output",
+    "trans": [
+      "输出",
+      "amount of something that is produced"
+    ]
+  },
+  {
+    "name": "blow",
+    "trans": [
+      "吹",
+      "to move something using air"
+    ]
+  },
+  {
+    "name": "blue",
+    "trans": [
+      "蓝色的",
+      "color of the clear sky"
+    ]
+  },
+  {
+    "name": "board",
+    "trans": [
+      "木板",
+      "surface for posting or showing information"
+    ]
+  },
+  {
+    "name": "boat",
+    "trans": [
+      "船",
+      "small form of transport for traveling on water"
+    ]
+  },
+  {
+    "name": "body",
+    "trans": [
+      "身体",
+      "a person's physical self"
+    ]
+  },
+  {
+    "name": "quantity",
+    "trans": [
+      "数量",
+      "amount or number of something"
+    ]
+  },
+  {
+    "name": "excess",
+    "trans": [
+      "过量的",
+      "amount that is more than necessary"
+    ]
+  },
+  {
+    "name": "story",
+    "trans": [
+      "故事",
+      "an account or description of how something happened"
+    ]
+  },
+  {
+    "name": "man",
+    "trans": [
+      "男人",
+      "an adult male human being"
+    ]
+  },
+  {
+    "name": "compromise",
+    "trans": [
+      "妥协",
+      "an agreement in which each side must give up some things"
+    ]
+  },
+  {
+    "name": "discount",
+    "trans": [
+      "折扣",
+      "an amount of money taken off the usual price of something"
+    ]
+  },
+  {
+    "name": "layer",
+    "trans": [
+      "层",
+      "an amount of something that is spread over a surface"
+    ]
+  },
+  {
+    "name": "deficit",
+    "trans": [
+      "赤字",
+      "an amount that is less than needed"
+    ]
+  },
+  {
+    "name": "rat",
+    "trans": [
+      "鼠",
+      "an animal that looks like a large mouse"
+    ]
+  },
+  {
+    "name": "bottom",
+    "trans": [
+      "底部",
+      "lowest part of something; part on which it rests"
+    ]
+  },
+  {
+    "name": "country",
+    "trans": [
+      "国家",
+      "an area of land that is controlled by a government"
+    ]
+  },
+  {
+    "name": "box",
+    "trans": [
+      "盒子",
+      "a container with (usually) four straight sides and a lid"
+    ]
+  },
+  {
+    "name": "boy",
+    "trans": [
+      "男生",
+      "a young male person"
+    ]
+  },
+  {
+    "name": "brain",
+    "trans": [
+      "脑",
+      "part of the head that thinks and controls your body"
+    ]
+  },
+  {
+    "name": "slope",
+    "trans": [
+      "坡",
+      "an area of land that is higher on one side than the other"
+    ]
+  },
+  {
+    "name": "hill",
+    "trans": [
+      "爬坡道",
+      "an area of land that is higher than the land around it but smaller than a mountain"
+    ]
+  },
+  {
+    "name": "county",
+    "trans": [
+      "县",
+      "an area within a country or a state with its own local government"
+    ]
+  },
+  {
+    "name": "contest",
+    "trans": [
+      "竞赛",
+      "an event in which people try to win"
+    ]
+  },
+  {
+    "name": "adventure",
+    "trans": [
+      "冒险",
+      "an exciting and often dangerous experience"
+    ]
+  },
+  {
+    "name": "brief",
+    "trans": [
+      "简短的",
+      "short; using few words"
+    ]
+  },
+  {
+    "name": "adviser",
+    "trans": [
+      "顾问",
+      "an expert who suggests what someone should do"
+    ]
+  },
+  {
+    "name": "bright",
+    "trans": [
+      "明亮的",
+      "producing a lot of light"
+    ]
+  },
+  {
+    "name": "interpretation",
+    "trans": [
+      "解释",
+      "an explanation or opinion of the meaning of something"
+    ]
+  },
+  {
+    "name": "wound",
+    "trans": [
+      "伤口",
+      "an injury to the body that is caused when something breaks the skin"
+    ]
+  },
+  {
+    "name": "broad",
+    "trans": [
+      "广阔",
+      "wide; from the shorter two sides to the other"
+    ]
+  },
+  {
+    "name": "bid",
+    "trans": [
+      "出价",
+      "an offer to pay a particular amount of money for something"
+    ]
+  },
+  {
+    "name": "brother",
+    "trans": [
+      "兄弟",
+      "a boy or man who shares a parent with you"
+    ]
+  },
+  {
+    "name": "settlement",
+    "trans": [
+      "沉降",
+      "an official agreement that ends an argument or fight between people or groups"
+    ]
+  },
+  {
+    "name": "sequence",
+    "trans": [
+      "顺序",
+      "an ordered group of related events or things"
+    ]
+  },
+  {
+    "name": "budget",
+    "trans": [
+      "预算",
+      "amount of money planned to be spent on something"
+    ]
+  },
+  {
+    "name": "creature",
+    "trans": [
+      "生物",
+      "animal of any type"
+    ]
+  },
+  {
+    "name": "hell",
+    "trans": [
+      "地狱",
+      "any place of pain and suffering"
+    ]
+  },
+  {
+    "name": "burn",
+    "trans": [
+      "烧伤",
+      "to destroy with fire"
+    ]
+  },
+  {
+    "name": "unlike",
+    "trans": [
+      "不像",
+      "appearing or being different"
+    ]
+  },
+  {
+    "name": "neighborhood",
+    "trans": [
+      "邻里",
+      "area of a town or city that people live in"
+    ]
+  },
+  {
+    "name": "bus",
+    "trans": [
+      "公共汽车",
+      "a large road vehicle used for carrying many people"
+    ]
+  },
+  {
+    "name": "busy",
+    "trans": [
+      "忙碌的",
+      "working hard doing something; full of activity"
+    ]
+  },
+  {
+    "name": "shade",
+    "trans": [
+      "阴影",
+      "area of darkness where something stops the light"
+    ]
+  },
+  {
+    "name": "territory",
+    "trans": [
+      "领土",
+      "area of land or ocean owned or controlled by a government or person"
+    ]
+  },
+  {
+    "name": "desert",
+    "trans": [
+      "沙漠",
+      "area of land that has very little water and few plants"
+    ]
+  },
+  {
+    "name": "zone",
+    "trans": [
+      "区",
+      "area of space used for a particular reason"
+    ]
+  },
+  {
+    "name": "harbor",
+    "trans": [
+      "港口",
+      "area of water protected by land and used by ships"
+    ]
+  },
+  {
+    "name": "province",
+    "trans": [
+      "省",
+      "area that a country or nation is divided into"
+    ]
+  },
+  {
+    "name": "dispute",
+    "trans": [
+      "争议",
+      "argument between two or more parties about something"
+    ]
+  },
+  {
+    "name": "camera",
+    "trans": [
+      "相机",
+      "object that takes pictures digitally, or on film"
+    ]
+  },
+  {
+    "name": "camp",
+    "trans": [
+      "营",
+      "place where people live for a short time in tents"
+    ]
+  },
+  {
+    "name": "approximately",
+    "trans": [
+      "大约",
+      "around; nearly; almost; about (a number)"
+    ]
+  },
+  {
+    "name": "naturally",
+    "trans": [
+      "自然",
+      "as someone would expect; not surprising"
+    ]
+  },
+  {
+    "name": "cancer",
+    "trans": [
+      "癌症",
+      "any growth caused by abnormal cell division"
+    ]
+  },
+  {
+    "name": "even",
+    "trans": [
+      "甚至",
+      "as well; too"
+    ]
+  },
+  {
+    "name": "what",
+    "trans": [
+      "什么",
+      "asking for information about someone or something"
+    ]
+  },
+  {
+    "name": "league",
+    "trans": [
+      "联盟",
+      "association of sports teams that organizes matches for its members"
+    ]
+  },
+  {
+    "name": "capacity",
+    "trans": [
+      "容量",
+      "ability to hold, involve or contain people or things"
+    ]
+  },
+  {
+    "name": "capital",
+    "trans": [
+      "首都",
+      "main, or major"
+    ]
+  },
+  {
+    "name": "along",
+    "trans": [
+      "沿着",
+      "at a point on a line"
+    ]
+  },
+  {
+    "name": "ago",
+    "trans": [
+      "前",
+      "at a specified length of time in the past"
+    ]
+  },
+  {
+    "name": "card",
+    "trans": [
+      "卡片",
+      "small piece of paper or plastic used as i.d."
+    ]
+  },
+  {
+    "name": "before",
+    "trans": [
+      "前",
+      "at a time earlier than the present; previously"
+    ]
+  },
+  {
+    "name": "career",
+    "trans": [
+      "职业",
+      "particular occupation in professional life"
+    ]
+  },
+  {
+    "name": "soon",
+    "trans": [
+      "很快",
+      "at a time not long from now"
+    ]
+  },
+  {
+    "name": "carefully",
+    "trans": [
+      "小心",
+      "in a manner that involves focus and care"
+    ]
+  },
+  {
+    "name": "always",
+    "trans": [
+      "总是",
+      "at all times; in every situation"
+    ]
+  },
+  {
+    "name": "carry",
+    "trans": [
+      "携带",
+      "to hold something and move it to another place"
+    ]
+  },
+  {
+    "name": "young",
+    "trans": [
+      "年轻的",
+      "at an early stage of existence; not mature"
+    ]
+  },
+  {
+    "name": "cash",
+    "trans": [
+      "现金",
+      "physical money (not credit card or digital)"
+    ]
+  },
+  {
+    "name": "whenever",
+    "trans": [
+      "每当",
+      "at any or every time that"
+    ]
+  },
+  {
+    "name": "ever",
+    "trans": [
+      "曾经",
+      "at any time; at all times in the future"
+    ]
+  },
+  {
+    "name": "originally",
+    "trans": [
+      "起初",
+      "at first; in the beginning"
+    ]
+  },
+  {
+    "name": "meanwhile",
+    "trans": [
+      "同时",
+      "at or during the same time; in the meantime"
+    ]
+  },
+  {
+    "name": "catch",
+    "trans": [
+      "抓住",
+      "use your hands to stop and hold something flying"
+    ]
+  },
+  {
+    "name": "category",
+    "trans": [
+      "类别",
+      "groups of things that are similar in some way"
+    ]
+  },
+  {
+    "name": "during",
+    "trans": [
+      "期间",
+      "at some point in the course of an event or thing"
+    ]
+  },
+  {
+    "name": "then",
+    "trans": [
+      "然后",
+      "at that time not now"
+    ]
+  },
+  {
+    "name": "cell",
+    "trans": [
+      "细胞",
+      "short for 'cellphone'"
+    ]
+  },
+  {
+    "name": "initially",
+    "trans": [
+      "最初",
+      "at the beginning"
+    ]
+  },
+  {
+    "name": "central",
+    "trans": [
+      "中央",
+      "being in the middle"
+    ]
+  },
+  {
+    "name": "century",
+    "trans": [
+      "世纪",
+      "period of 100 years"
+    ]
+  },
+  {
+    "name": "now",
+    "trans": [
+      "现在",
+      "at the present time or moment"
+    ]
+  },
+  {
+    "name": "certain",
+    "trans": [
+      "肯定",
+      "being sure about something; without doubt"
+    ]
+  },
+  {
+    "name": "chair",
+    "trans": [
+      "椅子",
+      "a piece of furniture you sit on when sitting at a table or desk"
+    ]
+  },
+  {
+    "name": "nowadays",
+    "trans": [
+      "如今",
+      "at the present time; now"
+    ]
+  },
+  {
+    "name": "challenge",
+    "trans": [
+      "挑战",
+      "an activity you wish to try that may be hard to do"
+    ]
+  },
+  {
+    "name": "regularly",
+    "trans": [
+      "经常",
+      "at the usual time each day, week, or month"
+    ]
+  },
+  {
+    "name": "fascinate",
+    "trans": [
+      "吸引",
+      "attract or interest greatly"
+    ]
+  },
+  {
+    "name": "moderate",
+    "trans": [
+      "缓和",
+      "average in size or amount"
+    ]
+  },
+  {
+    "name": "chance",
+    "trans": [
+      "机会",
+      "possibility that something will happen"
+    ]
+  },
+  {
+    "name": "out",
+    "trans": [
+      "出去",
+      "away from the inside or center"
+    ]
+  },
+  {
+    "name": "chapter",
+    "trans": [
+      "章",
+      "one of the main sections of a book"
+    ]
+  },
+  {
+    "name": "character",
+    "trans": [
+      "特点",
+      "your personality or nature"
+    ]
+  },
+  {
+    "name": "charge",
+    "trans": [
+      "收费",
+      "to ask for money as a price for a service or goods"
+    ]
+  },
+  {
+    "name": "tail",
+    "trans": [
+      "尾巴",
+      "back end of an animal's body that sticks out"
+    ]
+  },
+  {
+    "name": "storm",
+    "trans": [
+      "风暴",
+      "bad weather with a lot of rain, snow, and strong winds"
+    ]
+  },
+  {
+    "name": "bread",
+    "trans": [
+      "面包",
+      "baked food made from flour, used in sandwiches, etc."
+    ]
+  },
+  {
+    "name": "belt",
+    "trans": [
+      "腰带",
+      "band of material worn around a person's waist"
+    ]
+  },
+  {
+    "name": "truly",
+    "trans": [
+      "确实",
+      "based on truth or fact or reality"
+    ]
+  },
+  {
+    "name": "cheap",
+    "trans": [
+      "便宜的",
+      "not costing a lot of money"
+    ]
+  },
+  {
+    "name": "check",
+    "trans": [
+      "查看",
+      "to confirm the details of something are correct"
+    ]
+  },
+  {
+    "name": "liquid",
+    "trans": [
+      "液体",
+      "basic state of things that is similar to water; not solid or gas"
+    ]
+  },
+  {
+    "name": "framework",
+    "trans": [
+      "框架",
+      "basic structure of something"
+    ]
+  },
+  {
+    "name": "firstly",
+    "trans": [
+      "首先",
+      "before anything else"
+    ]
+  },
+  {
+    "name": "aggressive",
+    "trans": [
+      "挑衅的",
+      "behaving in a very threatening way"
+    ]
+  },
+  {
+    "name": "chief",
+    "trans": [
+      "首席",
+      "most important one"
+    ]
+  },
+  {
+    "name": "equivalent",
+    "trans": [
+      "相等的",
+      "being about equal in value, use, or meaning"
+    ]
+  },
+  {
+    "name": "mature",
+    "trans": [
+      "成熟",
+      "being an adult, being fully developed physically"
+    ]
+  },
+  {
+    "name": "smart",
+    "trans": [
+      "聪明的",
+      "being clever, having a good mind"
+    ]
+  },
+  {
+    "name": "choice",
+    "trans": [
+      "选择",
+      "decision between two or more possibilities"
+    ]
+  },
+  {
+    "name": "choose",
+    "trans": [
+      "选择",
+      "to select; decide between several possibilities"
+    ]
+  },
+  {
+    "name": "prompt",
+    "trans": [
+      "迅速的",
+      "being done quickly and with no delay"
+    ]
+  },
+  {
+    "name": "circumstance",
+    "trans": [
+      "环境",
+      "condition or fact that affects a situation"
+    ]
+  },
+  {
+    "name": "keen",
+    "trans": [
+      "敏锐的",
+      "being eager or excited for something to happen"
+    ]
+  },
+  {
+    "name": "citizen",
+    "trans": [
+      "公民",
+      "person who belongs to and has rights in a country"
+    ]
+  },
+  {
+    "name": "native",
+    "trans": [
+      "本国的",
+      "being from or living in the place where you were born"
+    ]
+  },
+  {
+    "name": "eastern",
+    "trans": [
+      "东",
+      "being in the area to the east"
+    ]
+  },
+  {
+    "name": "claim",
+    "trans": [
+      "宣称",
+      "to say something is true when others may not agree"
+    ]
+  },
+  {
+    "name": "in",
+    "trans": [
+      "在",
+      "being inside something"
+    ]
+  },
+  {
+    "name": "no",
+    "trans": [
+      "不",
+      "being none; not having or being"
+    ]
+  },
+  {
+    "name": "contemporary",
+    "trans": [
+      "当代的",
+      "being of the time being discussed"
+    ]
+  },
+  {
+    "name": "clean",
+    "trans": [
+      "干净的",
+      "being free from dirt or marks because it was washed"
+    ]
+  },
+  {
+    "name": "poverty",
+    "trans": [
+      "贫困",
+      "being poor"
+    ]
+  },
+  {
+    "name": "clearly",
+    "trans": [
+      "清楚地",
+      "in a way that is easy to understand; obviously"
+    ]
+  },
+  {
+    "name": "genuine",
+    "trans": [
+      "真的",
+      "being real, actual, and not false"
+    ]
+  },
+  {
+    "name": "climb",
+    "trans": [
+      "爬",
+      "to rise gradually and steadily to a higher point"
+    ]
+  },
+  {
+    "name": "record",
+    "trans": [
+      "记录",
+      "being the highest or most extreme level achieved in an area"
+    ]
+  },
+  {
+    "name": "clock",
+    "trans": [
+      "钟",
+      "a device that shows the time"
+    ]
+  },
+  {
+    "name": "vast",
+    "trans": [
+      "广阔的",
+      "being very large in size or amount"
+    ]
+  },
+  {
+    "name": "idea",
+    "trans": [
+      "主意",
+      "belief, thought, suggestion, opinion, or plan"
+    ]
+  },
+  {
+    "name": "of",
+    "trans": [
+      "的",
+      "belonging to or connected with something"
+    ]
+  },
+  {
+    "name": "club",
+    "trans": [
+      "俱乐部",
+      "group of people who share an interest, as in sport"
+    ]
+  },
+  {
+    "name": "coach",
+    "trans": [
+      "教练",
+      "person who teaches others how to do (sport, job)"
+    ]
+  },
+  {
+    "name": "historic",
+    "trans": [
+      "历史性",
+      "belonging to the past; of what is important or famous in the past"
+    ]
+  },
+  {
+    "name": "extraordinary",
+    "trans": [
+      "非凡的",
+      "beyond what is ordinary; very unusual; remarkable"
+    ]
+  },
+  {
+    "name": "corporation",
+    "trans": [
+      "公司",
+      "big company or a combination of several companies"
+    ]
+  },
+  {
+    "name": "code",
+    "trans": [
+      "代码",
+      "a password made of a set of letters or numbers"
+    ]
+  },
+  {
+    "name": "coffee",
+    "trans": [
+      "咖啡",
+      "a brown drink made from roasted beans and boiled water"
+    ]
+  },
+  {
+    "name": "large",
+    "trans": [
+      "大的",
+      "big; of great size; broad, tall, wide, long, or fat"
+    ]
+  },
+  {
+    "name": "cold",
+    "trans": [
+      "寒冷的",
+      "having a very low temperature"
+    ]
+  },
+  {
+    "name": "hand",
+    "trans": [
+      "手",
+      "body part at the end of a person's arm"
+    ]
+  },
+  {
+    "name": "collect",
+    "trans": [
+      "收集",
+      "to gather things/people together in one place"
+    ]
+  },
+  {
+    "name": "collection",
+    "trans": [
+      "收藏",
+      "group of similar things gathered as a hobby"
+    ]
+  },
+  {
+    "name": "college",
+    "trans": [
+      "大学",
+      "school or educational institution for adults"
+    ]
+  },
+  {
+    "name": "fiction",
+    "trans": [
+      "小说",
+      "book or story including ideas, people, and events that are not real"
+    ]
+  },
+  {
+    "name": "combine",
+    "trans": [
+      "结合",
+      "to mix several things together to form one thing"
+    ]
+  },
+  {
+    "name": "album",
+    "trans": [
+      "专辑",
+      "book with a collection of photographs or pictures"
+    ]
+  },
+  {
+    "name": "mystery",
+    "trans": [
+      "神秘",
+      "book, play, or film that deals with a solution of a strange crime"
+    ]
+  },
+  {
+    "name": "comfortable",
+    "trans": [
+      "舒服的",
+      "not being worried about something; at ease"
+    ]
+  },
+  {
+    "name": "commercial",
+    "trans": [
+      "商业的",
+      "radio or television advertisement"
+    ]
+  },
+  {
+    "name": "commit",
+    "trans": [
+      "犯罪",
+      "to do something bad, usually a crime"
+    ]
+  },
+  {
+    "name": "committee",
+    "trans": [
+      "委员会",
+      "group of people who do or decide something"
+    ]
+  },
+  {
+    "name": "common",
+    "trans": [
+      "常见的",
+      "typical, normal; not unusual"
+    ]
+  },
+  {
+    "name": "uncle",
+    "trans": [
+      "叔叔",
+      "brother of your father or mother or the husband of your aunt"
+    ]
+  },
+  {
+    "name": "communication",
+    "trans": [
+      "沟通",
+      "talking to people; giving information to people"
+    ]
+  },
+  {
+    "name": "community",
+    "trans": [
+      "社区",
+      "group of people who share a common idea or area"
+    ]
+  },
+  {
+    "name": "house",
+    "trans": [
+      "房子",
+      "building in which a family, person lives"
+    ]
+  },
+  {
+    "name": "compare",
+    "trans": [
+      "比较",
+      "to consider how similar and different things are"
+    ]
+  },
+  {
+    "name": "comparison",
+    "trans": [
+      "比较",
+      "looking for differences and similarities in two or more things"
+    ]
+  },
+  {
+    "name": "office",
+    "trans": [
+      "办公室",
+      "building of set of rooms used to do business or professional activities"
+    ]
+  },
+  {
+    "name": "school",
+    "trans": [
+      "学校",
+      "building where you learn in classes with a teacher"
+    ]
+  },
+  {
+    "name": "competition",
+    "trans": [
+      "竞赛",
+      "fighting against others when trying to win something"
+    ]
+  },
+  {
+    "name": "publisher",
+    "trans": [
+      "出版商",
+      "business that produces books or magazines"
+    ]
+  },
+  {
+    "name": "personally",
+    "trans": [
+      "亲自",
+      "by a specific person, and not by anyone else"
+    ]
+  },
+  {
+    "name": "complete",
+    "trans": [
+      "完全的",
+      "to finish or reach the end of doing something"
+    ]
+  },
+  {
+    "name": "completely",
+    "trans": [
+      "完全地",
+      "in every way or as much as possible"
+    ]
+  },
+  {
+    "name": "complex",
+    "trans": [
+      "复杂的",
+      "difficult, not easy to understand or explain"
+    ]
+  },
+  {
+    "name": "via",
+    "trans": [
+      "通过",
+      "by going through, by way of"
+    ]
+  },
+  {
+    "name": "widely",
+    "trans": [
+      "广泛",
+      "by or among a large number of people"
+    ]
+  },
+  {
+    "name": "beside",
+    "trans": [
+      "旁",
+      "by the side of something; next to something"
+    ]
+  },
+  {
+    "name": "flexible",
+    "trans": [
+      "灵活的",
+      "capable of being easily bent or changed without breaking"
+    ]
+  },
+  {
+    "name": "observation",
+    "trans": [
+      "观察",
+      "careful watching and listening; remark or comment on something you have noticed"
+    ]
+  },
+  {
+    "name": "pleasant",
+    "trans": [
+      "令人愉快的",
+      "causing a good feeling"
+    ]
+  },
+  {
+    "name": "controversial",
+    "trans": [
+      "有争议的",
+      "causing a great deal of argument, discussion, or conflict"
+    ]
+  },
+  {
+    "name": "fortune",
+    "trans": [
+      "财富",
+      "chance or luck, particularly good luck"
+    ]
+  },
+  {
+    "name": "effect",
+    "trans": [
+      "影响",
+      "change brought about by a cause; result"
+    ]
+  },
+  {
+    "name": "computer",
+    "trans": [
+      "电脑",
+      "a machine for storing information and accessing the internet"
+    ]
+  },
+  {
+    "name": "infant",
+    "trans": [
+      "婴儿",
+      "child in the beginning stage of life; a baby"
+    ]
+  },
+  {
+    "name": "concept",
+    "trans": [
+      "概念",
+      "abstract idea of something or how it works"
+    ]
+  },
+  {
+    "name": "random",
+    "trans": [
+      "随机的",
+      "chosen or done without a plan or pattern"
+    ]
+  },
+  {
+    "name": "concert",
+    "trans": [
+      "音乐会",
+      "musical entertainment given in public by one or more performers"
+    ]
+  },
+  {
+    "name": "conclude",
+    "trans": [
+      "得出结论",
+      "to stop or finish; to come to the end of something"
+    ]
+  },
+  {
+    "name": "conclusion",
+    "trans": [
+      "结论",
+      "judgment or opinion after thinking for a while"
+    ]
+  },
+  {
+    "name": "distinct",
+    "trans": [
+      "清楚的",
+      "clearly different in nature from something else"
+    ]
+  },
+  {
+    "name": "conduct",
+    "trans": [
+      "执行",
+      "to direct, lead or guide something"
+    ]
+  },
+  {
+    "name": "confidence",
+    "trans": [
+      "信心",
+      "feeling that you can do well at something"
+    ]
+  },
+  {
+    "name": "coat",
+    "trans": [
+      "外套",
+      "clothing worn outside over your normal clothes"
+    ]
+  },
+  {
+    "name": "confirm",
+    "trans": [
+      "确认",
+      "to provide evidence to establish the truth of"
+    ]
+  },
+  {
+    "name": "conflict",
+    "trans": [
+      "冲突",
+      "to have opposite ideas; to disagree; to not match"
+    ]
+  },
+  {
+    "name": "money",
+    "trans": [
+      "钱",
+      "coins or notes we use to pay for things"
+    ]
+  },
+  {
+    "name": "information",
+    "trans": [
+      "信息",
+      "collection of facts and details about something"
+    ]
+  },
+  {
+    "name": "connect",
+    "trans": [
+      "连接",
+      "to join or attach things together"
+    ]
+  },
+  {
+    "name": "connection",
+    "trans": [
+      "联系",
+      "something that joins things together; being joined"
+    ]
+  },
+  {
+    "name": "consequence",
+    "trans": [
+      "结果",
+      "outcome of an event; result"
+    ]
+  },
+  {
+    "name": "gray",
+    "trans": [
+      "灰色的",
+      "color between black and white"
+    ]
+  },
+  {
+    "name": "yellow",
+    "trans": [
+      "黄色的",
+      "color of lemons or the sun"
+    ]
+  },
+  {
+    "name": "carpet",
+    "trans": [
+      "地毯",
+      "colored floor covering made of wool or other material"
+    ]
+  },
+  {
+    "name": "first",
+    "trans": [
+      "第一的",
+      "coming before all others in time or place"
+    ]
+  },
+  {
+    "name": "consideration",
+    "trans": [
+      "考虑",
+      "careful thought; thinking about something"
+    ]
+  },
+  {
+    "name": "consist",
+    "trans": [
+      "组成",
+      "to have as an essential, necessary or main part"
+    ]
+  },
+  {
+    "name": "western",
+    "trans": [
+      "西",
+      "coming from, found in, or facing towards the west"
+    ]
+  },
+  {
+    "name": "airline",
+    "trans": [
+      "航空公司",
+      "company that flies passengers in its planes"
+    ]
+  },
+  {
+    "name": "absolute",
+    "trans": [
+      "绝对",
+      "complete and total"
+    ]
+  },
+  {
+    "name": "whole",
+    "trans": [
+      "所有的",
+      "complete or full; all of"
+    ]
+  },
+  {
+    "name": "altogether",
+    "trans": [
+      "共",
+      "completely and fully"
+    ]
+  },
+  {
+    "name": "construction",
+    "trans": [
+      "建造",
+      "act of building something; thing that is built"
+    ]
+  },
+  {
+    "name": "exact",
+    "trans": [
+      "精确的",
+      "completely correct; accurate; specific"
+    ]
+  },
+  {
+    "name": "all",
+    "trans": [
+      "全部",
+      "completely; totally"
+    ]
+  },
+  {
+    "name": "literary",
+    "trans": [
+      "文学的",
+      "concerned with written works"
+    ]
+  },
+  {
+    "name": "consumer",
+    "trans": [
+      "消费者",
+      "person who uses goods or services; individual buyer"
+    ]
+  },
+  {
+    "name": "contact",
+    "trans": [
+      "接触",
+      "to get in touch with someone"
+    ]
+  },
+  {
+    "name": "contain",
+    "trans": [
+      "包含",
+      "to hold something inside something else"
+    ]
+  },
+  {
+    "name": "urban",
+    "trans": [
+      "城市的",
+      "concerning a city; located in a city"
+    ]
+  },
+  {
+    "name": "royal",
+    "trans": [
+      "皇家的",
+      "concerning a king or queen"
+    ]
+  },
+  {
+    "name": "context",
+    "trans": [
+      "语境",
+      "set of facts surrounding a person or event"
+    ]
+  },
+  {
+    "name": "institutional",
+    "trans": [
+      "制度性的",
+      "concerning a large organization such as a hospital or university"
+    ]
+  },
+  {
+    "name": "presumably",
+    "trans": [
+      "想必",
+      "concerning a true or likely nature"
+    ]
+  },
+  {
+    "name": "contrast",
+    "trans": [
+      "对比",
+      "to compare; to show clear, obvious differences"
+    ]
+  },
+  {
+    "name": "contribution",
+    "trans": [
+      "贡献",
+      "helping a cause by giving money, things, services"
+    ]
+  },
+  {
+    "name": "agricultural",
+    "trans": [
+      "农业",
+      "concerning farming"
+    ]
+  },
+  {
+    "name": "organic",
+    "trans": [
+      "有机的",
+      "concerning food made with few or no chemicals"
+    ]
+  },
+  {
+    "name": "political",
+    "trans": [
+      "政治的",
+      "concerning government or public affairs"
+    ]
+  },
+  {
+    "name": "classical",
+    "trans": [
+      "古典",
+      "concerning ideas considered to be traditional"
+    ]
+  },
+  {
+    "name": "conversation",
+    "trans": [
+      "对话",
+      "when you talk with other people; discussion or chat"
+    ]
+  },
+  {
+    "name": "sexual",
+    "trans": [
+      "性的",
+      "concerning physical activity that can produce babies"
+    ]
+  },
+  {
+    "name": "convince",
+    "trans": [
+      "说服",
+      "to persuade someone, or make them feel sure"
+    ]
+  },
+  {
+    "name": "cook",
+    "trans": [
+      "厨师",
+      "to heat food until it is ready to eat"
+    ]
+  },
+  {
+    "name": "cool",
+    "trans": [
+      "凉爽的",
+      "almost cold; not warm or hot"
+    ]
+  },
+  {
+    "name": "public",
+    "trans": [
+      "民众",
+      "concerning society in general"
+    ]
+  },
+  {
+    "name": "abstract",
+    "trans": [
+      "抽象的",
+      "concerning something that doesn't exist physically"
+    ]
+  },
+  {
+    "name": "copy",
+    "trans": [
+      "复制",
+      "to make something that looks the same as the original"
+    ]
+  },
+  {
+    "name": "corporate",
+    "trans": [
+      "公司的",
+      "concerning (usually large) companies"
+    ]
+  },
+  {
+    "name": "retail",
+    "trans": [
+      "零售",
+      "concerning the business of selling products to the public for personal use"
+    ]
+  },
+  {
+    "name": "correct",
+    "trans": [
+      "正确的",
+      "true or accurate"
+    ]
+  },
+  {
+    "name": "inner",
+    "trans": [
+      "内",
+      "concerning the inside part of something"
+    ]
+  },
+  {
+    "name": "mental",
+    "trans": [
+      "精神的",
+      "concerning the mind"
+    ]
+  },
+  {
+    "name": "genetic",
+    "trans": [
+      "遗传的",
+      "concerning the parts of a cell that determine particular characteristics"
+    ]
+  },
+  {
+    "name": "online",
+    "trans": [
+      "在线的",
+      "connected to the internet"
+    ]
+  },
+  {
+    "name": "council",
+    "trans": [
+      "理事会",
+      "group chosen to make decisions about something"
+    ]
+  },
+  {
+    "name": "ethnic",
+    "trans": [
+      "种族的",
+      "connected with people who share a cultural tradition"
+    ]
+  },
+  {
+    "name": "count",
+    "trans": [
+      "数数",
+      "to add things together to find the total number"
+    ]
+  },
+  {
+    "name": "tank",
+    "trans": [
+      "坦克",
+      "container for holding liquid or gas"
+    ]
+  },
+  {
+    "name": "inflation",
+    "trans": [
+      "通货膨胀",
+      "continual rise in the prices of products"
+    ]
+  },
+  {
+    "name": "temporary",
+    "trans": [
+      "暂时的",
+      "continuing for a limited time, not permanent"
+    ]
+  },
+  {
+    "name": "couple",
+    "trans": [
+      "夫妻",
+      "two of something; two people; a pair"
+    ]
+  },
+  {
+    "name": "court",
+    "trans": [
+      "法庭",
+      "large, flat area, to play tennis or basketball"
+    ]
+  },
+  {
+    "name": "dialog",
+    "trans": [
+      "对话",
+      "conversation between two or more individuals"
+    ]
+  },
+  {
+    "name": "cover",
+    "trans": [
+      "覆盖",
+      "thing you put over something to close or hide it"
+    ]
+  },
+  {
+    "name": "accurate",
+    "trans": [
+      "准确的",
+      "correct; not having mistakes or errors"
+    ]
+  },
+  {
+    "name": "free",
+    "trans": [
+      "自由的",
+      "costing no money"
+    ]
+  },
+  {
+    "name": "policy",
+    "trans": [
+      "政策",
+      "course of action proposed by an organization, etc."
+    ]
+  },
+  {
+    "name": "envelope",
+    "trans": [
+      "信封",
+      "cover for a letter or card"
+    ]
+  },
+  {
+    "name": "roof",
+    "trans": [
+      "屋顶",
+      "cover or top of something"
+    ]
+  },
+  {
+    "name": "wet",
+    "trans": [
+      "湿的",
+      "covered or soaked with a liquid; not dry"
+    ]
+  },
+  {
+    "name": "bloody",
+    "trans": [
+      "血腥",
+      "covered or spotted with blood on the surface"
+    ]
+  },
+  {
+    "name": "offense",
+    "trans": [
+      "罪行",
+      "criminal act; something that causes hurt"
+    ]
+  },
+  {
+    "name": "festival",
+    "trans": [
+      "节日",
+      "cultural event with a program of events"
+    ]
+  },
+  {
+    "name": "credit",
+    "trans": [
+      "信用",
+      "system to buy something and pay for it later"
+    ]
+  },
+  {
+    "name": "hook",
+    "trans": [
+      "钩",
+      "curved or bent tool"
+    ]
+  },
+  {
+    "name": "crisis",
+    "trans": [
+      "危机",
+      "unstable situation of extreme danger or difficulty"
+    ]
+  },
+  {
+    "name": "critical",
+    "trans": [
+      "批判的",
+      "being important or serious; vital; dangerous"
+    ]
+  },
+  {
+    "name": "destruction",
+    "trans": [
+      "破坏",
+      "damaging something so badly that it no longer exists"
+    ]
+  },
+  {
+    "name": "coal",
+    "trans": [
+      "煤炭",
+      "dark hard substance from the earth burnt as a fuel"
+    ]
+  },
+  {
+    "name": "cross",
+    "trans": [
+      "叉",
+      "to meet at one point"
+    ]
+  },
+  {
+    "name": "crowd",
+    "trans": [
+      "人群",
+      "large group of people together in one place"
+    ]
+  },
+  {
+    "name": "pot",
+    "trans": [
+      "锅",
+      "deep, round container that is used for cooking"
+    ]
+  },
+  {
+    "name": "cry",
+    "trans": [
+      "哭",
+      "to produce tears and sounds because of pain"
+    ]
+  },
+  {
+    "name": "culture",
+    "trans": [
+      "文化",
+      "beliefs and customs of a particular group"
+    ]
+  },
+  {
+    "name": "cup",
+    "trans": [
+      "杯子",
+      "small round container used to hold liquids for drinking"
+    ]
+  },
+  {
+    "name": "profile",
+    "trans": [
+      "轮廓",
+      "description listing the basic information about a person or group"
+    ]
+  },
+  {
+    "name": "current",
+    "trans": [
+      "当前的",
+      "happening or being in the present time"
+    ]
+  },
+  {
+    "name": "currently",
+    "trans": [
+      "现在",
+      "happening or being in the present time"
+    ]
+  },
+  {
+    "name": "reliable",
+    "trans": [
+      "可靠的",
+      "deserving of your trust, dependable"
+    ]
+  },
+  {
+    "name": "architecture",
+    "trans": [
+      "建筑学",
+      "design and construction of buildings"
+    ]
+  },
+  {
+    "name": "customer",
+    "trans": [
+      "顾客",
+      "someone who buys goods or services from a business"
+    ]
+  },
+  {
+    "name": "cut",
+    "trans": [
+      "切",
+      "to use a knife or scissors to divide or open the surface"
+    ]
+  },
+  {
+    "name": "cycle",
+    "trans": [
+      "循环",
+      "series of regular and repeated actions"
+    ]
+  },
+  {
+    "name": "although",
+    "trans": [
+      "虽然",
+      "despite the fact that; however"
+    ]
+  },
+  {
+    "name": "daily",
+    "trans": [
+      "日常的",
+      "happening every day"
+    ]
+  },
+  {
+    "name": "damage",
+    "trans": [
+      "损害",
+      "physical harm that is done to something"
+    ]
+  },
+  {
+    "name": "explanation",
+    "trans": [
+      "解释",
+      "details or reasons given to make something clear"
+    ]
+  },
+  {
+    "name": "dance",
+    "trans": [
+      "舞蹈",
+      "to move your body rhythmically to music"
+    ]
+  },
+  {
+    "name": "danger",
+    "trans": [
+      "危险",
+      "possibility of getting hurt, damaged, or killed"
+    ]
+  },
+  {
+    "name": "dangerous",
+    "trans": [
+      "危险的",
+      "involving the chance of hurt or damage; risky"
+    ]
+  },
+  {
+    "name": "criteria",
+    "trans": [
+      "标准",
+      "details used to make a decision"
+    ]
+  },
+  {
+    "name": "dark",
+    "trans": [
+      "黑暗的",
+      "having little or no light; not light in color"
+    ]
+  },
+  {
+    "name": "filter",
+    "trans": [
+      "筛选",
+      "device to remove unwanted substances from a liquid or gas"
+    ]
+  },
+  {
+    "name": "data",
+    "trans": [
+      "数据",
+      "facts or information used to calculate or analyze"
+    ]
+  },
+  {
+    "name": "unusual",
+    "trans": [
+      "异常",
+      "different from what is ordinary or normal in a way that attracts attention; not usual"
+    ]
+  },
+  {
+    "name": "date",
+    "trans": [
+      "日期",
+      "a day in the calendar such as January 3rd"
+    ]
+  },
+  {
+    "name": "daughter",
+    "trans": [
+      "女儿",
+      "a female child of someone"
+    ]
+  },
+  {
+    "name": "hard",
+    "trans": [
+      "难的",
+      "difficult to bend, break or cut; solid"
+    ]
+  },
+  {
+    "name": "dead",
+    "trans": [
+      "死的",
+      "not alive"
+    ]
+  },
+  {
+    "name": "pollution",
+    "trans": [
+      "污染",
+      "dirty or dangerous waste released into an environment"
+    ]
+  },
+  {
+    "name": "dear",
+    "trans": [
+      "亲爱的",
+      "loved or valued very much"
+    ]
+  },
+  {
+    "name": "death",
+    "trans": [
+      "死亡",
+      "when someone dies; the end of life"
+    ]
+  },
+  {
+    "name": "debate",
+    "trans": [
+      "辩论",
+      "general public discussion of a topic"
+    ]
+  },
+  {
+    "name": "decade",
+    "trans": [
+      "十年",
+      "period of 10 years"
+    ]
+  },
+  {
+    "name": "mess",
+    "trans": [
+      "混乱",
+      "dirty or untidy area"
+    ]
+  },
+  {
+    "name": "decision",
+    "trans": [
+      "决定",
+      "a choice you make about something after thinking about it"
+    ]
+  },
+  {
+    "name": "depth",
+    "trans": [
+      "深度",
+      "distance below a surface"
+    ]
+  },
+  {
+    "name": "decline",
+    "trans": [
+      "衰退",
+      "to not accept an invitation or offer; refuse"
+    ]
+  },
+  {
+    "name": "deep",
+    "trans": [
+      "深的",
+      "going far down from the surface"
+    ]
+  },
+  {
+    "name": "height",
+    "trans": [
+      "高度",
+      "distance of something from the bottom to the top"
+    ]
+  },
+  {
+    "name": "phase",
+    "trans": [
+      "阶段",
+      "distinct part or step in a process"
+    ]
+  },
+  {
+    "name": "defense",
+    "trans": [
+      "防御",
+      "process of protecting something from attack"
+    ]
+  },
+  {
+    "name": "injure",
+    "trans": [
+      "损伤",
+      "do physical harm or damage"
+    ]
+  },
+  {
+    "name": "define",
+    "trans": [
+      "定义",
+      "to explain the meaning of words"
+    ]
+  },
+  {
+    "name": "definitely",
+    "trans": [
+      "确实",
+      "without question; beyond doubt"
+    ]
+  },
+  {
+    "name": "definition",
+    "trans": [
+      "定义",
+      "explanation of word's meaning, as in dictionaries"
+    ]
+  },
+  {
+    "name": "degree",
+    "trans": [
+      "程度",
+      "unit for measuring temperature or angles"
+    ]
+  },
+  {
+    "name": "deliver",
+    "trans": [
+      "递送",
+      "to take something to a person or place"
+    ]
+  },
+  {
+    "name": "delivery",
+    "trans": [
+      "送货",
+      "act of taking something to a person or place"
+    ]
+  },
+  {
+    "name": "demand",
+    "trans": [
+      "要求",
+      "to strongly request someone to do something; insist"
+    ]
+  },
+  {
+    "name": "helpful",
+    "trans": [
+      "有帮助的",
+      "doing things that help someone"
+    ]
+  },
+  {
+    "name": "universal",
+    "trans": [
+      "普遍的",
+      "done or experienced by everyone"
+    ]
+  },
+  {
+    "name": "voluntary",
+    "trans": [
+      "自愿",
+      "done or given by their own will and not forced to do"
+    ]
+  },
+  {
+    "name": "violent",
+    "trans": [
+      "暴力",
+      "done with force; likely to cause physical damage"
+    ]
+  },
+  {
+    "name": "deny",
+    "trans": [
+      "否定",
+      "to refuse to allow or accept something"
+    ]
+  },
+  {
+    "name": "department",
+    "trans": [
+      "部门",
+      "division of a larger part or organization"
+    ]
+  },
+  {
+    "name": "depend",
+    "trans": [
+      "依赖",
+      "to need (someone or something) for support, help, etc."
+    ]
+  },
+  {
+    "name": "immediate",
+    "trans": [
+      "即时",
+      "done without delay; straight away"
+    ]
+  },
+  {
+    "name": "chart",
+    "trans": [
+      "图表",
+      "drawing showing information in a clear way"
+    ]
+  },
+  {
+    "name": "alcohol",
+    "trans": [
+      "酒精",
+      "drinks such as wine, whiskey, beer"
+    ]
+  },
+  {
+    "name": "fall",
+    "trans": [
+      "落下",
+      "dropping from a standing position to the ground"
+    ]
+  },
+  {
+    "name": "describe",
+    "trans": [
+      "描述",
+      "to tell someone the appearance, sound or smell of something"
+    ]
+  },
+  {
+    "name": "description",
+    "trans": [
+      "描述",
+      "something that tells you what something is like or looks like"
+    ]
+  },
+  {
+    "name": "while",
+    "trans": [
+      "尽管",
+      "during the time that; at the same time"
+    ]
+  },
+  {
+    "name": "whilst",
+    "trans": [
+      "同时",
+      "during the time that; at the same time"
+    ]
+  },
+  {
+    "name": "design",
+    "trans": [
+      "设计",
+      "to plan in a particular way to fulfill a purpose"
+    ]
+  },
+  {
+    "name": "sensitive",
+    "trans": [
+      "敏感的",
+      "easily hurt or damaged"
+    ]
+  },
+  {
+    "name": "desk",
+    "trans": [
+      "桌子",
+      "a piece of furniture like a table often with drawers"
+    ]
+  },
+  {
+    "name": "despite",
+    "trans": [
+      "尽管",
+      "without being affected by something; in spite of"
+    ]
+  },
+  {
+    "name": "visible",
+    "trans": [
+      "可见的",
+      "easily seen or understood"
+    ]
+  },
+  {
+    "name": "detail",
+    "trans": [
+      "细节",
+      "small part of something; tiny fact"
+    ]
+  },
+  {
+    "name": "soft",
+    "trans": [
+      "柔软的",
+      "easy to press, bend or cut; not hard or firm"
+    ]
+  },
+  {
+    "name": "apparent",
+    "trans": [
+      "明显的",
+      "easy to see or clearly understand"
+    ]
+  },
+  {
+    "name": "determine",
+    "trans": [
+      "决定",
+      "to control exactly how something will be or act"
+    ]
+  },
+  {
+    "name": "clear",
+    "trans": [
+      "清除",
+      "easy to understand; well-explained; obvious"
+    ]
+  },
+  {
+    "name": "potato",
+    "trans": [
+      "土豆",
+      "edible vegetable"
+    ]
+  },
+  {
+    "name": "device",
+    "trans": [
+      "设备",
+      "object, machine, or equipment for a specific use"
+    ]
+  },
+  {
+    "name": "impression",
+    "trans": [
+      "印象",
+      "effect or feeling resulting from an experience"
+    ]
+  },
+  {
+    "name": "mood",
+    "trans": [
+      "情绪",
+      "emotion or a state of mind; how you feel"
+    ]
+  },
+  {
+    "name": "die",
+    "trans": [
+      "死",
+      "to stop living"
+    ]
+  },
+  {
+    "name": "electricity",
+    "trans": [
+      "电",
+      "energy generated positive and negative charges"
+    ]
+  },
+  {
+    "name": "adequate",
+    "trans": [
+      "足够的",
+      "enough; good enough for what is needed"
+    ]
+  },
+  {
+    "name": "difference",
+    "trans": [
+      "不同之处",
+      "not of the same kind; unlike other things"
+    ]
+  },
+  {
+    "name": "enough",
+    "trans": [
+      "足够的",
+      "equal to what is needed; as much as required"
+    ]
+  },
+  {
+    "name": "each",
+    "trans": [
+      "每个",
+      "every one of two or more things"
+    ]
+  },
+  {
+    "name": "difficult",
+    "trans": [
+      "难的",
+      "hard; not easy; you need to work hard to do it"
+    ]
+  },
+  {
+    "name": "difficulty",
+    "trans": [
+      "困难",
+      "something that is hard to do"
+    ]
+  },
+  {
+    "name": "everywhere",
+    "trans": [
+      "到处",
+      "every place"
+    ]
+  },
+  {
+    "name": "test",
+    "trans": [
+      "测试",
+      "examination; questions to measure knowledge"
+    ]
+  },
+  {
+    "name": "case",
+    "trans": [
+      "案件",
+      "example or instance of something"
+    ]
+  },
+  {
+    "name": "dinner",
+    "trans": [
+      "晚餐",
+      "main meal of the day, usually in the evening in the us"
+    ]
+  },
+  {
+    "name": "direct",
+    "trans": [
+      "直接的",
+      "to tell someone to do something in a straight-talking way"
+    ]
+  },
+  {
+    "name": "directly",
+    "trans": [
+      "直接地",
+      "in a frank and honest way"
+    ]
+  },
+  {
+    "name": "director",
+    "trans": [
+      "导演",
+      "senior person who manages part of an organization"
+    ]
+  },
+  {
+    "name": "good",
+    "trans": [
+      "好的",
+      "excellent; high quality"
+    ]
+  },
+  {
+    "name": "stimulate",
+    "trans": [
+      "刺激",
+      "excite to action"
+    ]
+  },
+  {
+    "name": "numerous",
+    "trans": [
+      "很多的",
+      "existing in large numbers"
+    ]
+  },
+  {
+    "name": "distant",
+    "trans": [
+      "遥远",
+      "existing or happening far away in space"
+    ]
+  },
+  {
+    "name": "silver",
+    "trans": [
+      "银",
+      "expensive, near white color metal (symbol Ag)"
+    ]
+  },
+  {
+    "name": "veteran",
+    "trans": [
+      "老将",
+      "experienced through long service or practice"
+    ]
+  },
+  {
+    "name": "consultant",
+    "trans": [
+      "顾问",
+      "expert who gives (paid) advice"
+    ]
+  },
+  {
+    "name": "discover",
+    "trans": [
+      "发现",
+      "to find something new that was not known before"
+    ]
+  },
+  {
+    "name": "reason",
+    "trans": [
+      "原因",
+      "explanation for why something occurred or was done"
+    ]
+  },
+  {
+    "name": "discuss",
+    "trans": [
+      "讨论",
+      "to talk about something seriously or in great detail"
+    ]
+  },
+  {
+    "name": "discussion",
+    "trans": [
+      "讨论",
+      "any long communication about some particular topic"
+    ]
+  },
+  {
+    "name": "disease",
+    "trans": [
+      "疾病",
+      "illness that affects a person, animal, or plant"
+    ]
+  },
+  {
+    "name": "demonstration",
+    "trans": [
+      "示范",
+      "explanation of how something works"
+    ]
+  },
+  {
+    "name": "extension",
+    "trans": [
+      "扩大",
+      "extra time allowed to complete something"
+    ]
+  },
+  {
+    "name": "further",
+    "trans": [
+      "更远",
+      "extra; in addition"
+    ]
+  },
+  {
+    "name": "giant",
+    "trans": [
+      "巨大的",
+      "extremely big, or much bigger than other things"
+    ]
+  },
+  {
+    "name": "display",
+    "trans": [
+      "展示",
+      "to put so they can be seen or be bought"
+    ]
+  },
+  {
+    "name": "crucial",
+    "trans": [
+      "至关重要的",
+      "extremely important"
+    ]
+  },
+  {
+    "name": "distance",
+    "trans": [
+      "距离",
+      "amount of space between two places or things"
+    ]
+  },
+  {
+    "name": "remote",
+    "trans": [
+      "偏僻的",
+      "far away"
+    ]
+  },
+  {
+    "name": "sheep",
+    "trans": [
+      "羊",
+      "farm animal kept for meat and wool"
+    ]
+  },
+  {
+    "name": "pig",
+    "trans": [
+      "猪",
+      "farm animal that gives bacon and ham"
+    ]
+  },
+  {
+    "name": "dad",
+    "trans": [
+      "爸爸",
+      "father"
+    ]
+  },
+  {
+    "name": "district",
+    "trans": [
+      "区",
+      "area of a country, city, or town"
+    ]
+  },
+  {
+    "name": "anxiety",
+    "trans": [
+      "焦虑",
+      "fear about what might happen; worry"
+    ]
+  },
+  {
+    "name": "motivation",
+    "trans": [
+      "动机",
+      "feeling in a person that makes him or her want to do something"
+    ]
+  },
+  {
+    "name": "divide",
+    "trans": [
+      "划分",
+      "to separate something into equal pieces"
+    ]
+  },
+  {
+    "name": "tension",
+    "trans": [
+      "紧张",
+      "feeling of anxiety and inability to relax"
+    ]
+  },
+  {
+    "name": "joy",
+    "trans": [
+      "喜悦",
+      "feeling of great happiness and pleasure"
+    ]
+  },
+  {
+    "name": "document",
+    "trans": [
+      "文档",
+      "official (printed) record that gives information"
+    ]
+  },
+  {
+    "name": "dog",
+    "trans": [
+      "狗",
+      "small 4-legged animal that barks kept as a pet"
+    ]
+  },
+  {
+    "name": "dollar",
+    "trans": [
+      "美元",
+      "a basic unit of money equal to 100 cent"
+    ]
+  },
+  {
+    "name": "friendship",
+    "trans": [
+      "友谊",
+      "feeling of liking someone; good relationship"
+    ]
+  },
+  {
+    "name": "door",
+    "trans": [
+      "门",
+      "you walk through this when you go in a room"
+    ]
+  },
+  {
+    "name": "double",
+    "trans": [
+      "双倍的",
+      "two times the amount or degree; twice"
+    ]
+  },
+  {
+    "name": "doubt",
+    "trans": [
+      "怀疑",
+      "not being sure of something; lack of certainty"
+    ]
+  },
+  {
+    "name": "hunger",
+    "trans": [
+      "饥饿",
+      "feeling of needing to eat food"
+    ]
+  },
+  {
+    "name": "concern",
+    "trans": [
+      "忧虑",
+      "feeling of worry or anxiety"
+    ]
+  },
+  {
+    "name": "grateful",
+    "trans": [
+      "感激的",
+      "feeling or showing thanks; thankful"
+    ]
+  },
+  {
+    "name": "ashamed",
+    "trans": [
+      "羞愧",
+      "feeling shame or guilt because you did something wrong"
+    ]
+  },
+  {
+    "name": "confident",
+    "trans": [
+      "自信的",
+      "feeling that you can do well at something"
+    ]
+  },
+  {
+    "name": "uncertainty",
+    "trans": [
+      "不确定",
+      "feeling that you don't really know what will happen"
+    ]
+  },
+  {
+    "name": "draw",
+    "trans": [
+      "画",
+      "to create an image using pen or pencil and paper"
+    ]
+  },
+  {
+    "name": "dream",
+    "trans": [
+      "梦",
+      "images, thoughts, and feelings that are experienced during sleep"
+    ]
+  },
+  {
+    "name": "dress",
+    "trans": [
+      "裙子",
+      "women's garment with a top part and a skirt"
+    ]
+  },
+  {
+    "name": "drink",
+    "trans": [
+      "喝",
+      "to put water in your body through your mouth"
+    ]
+  },
+  {
+    "name": "sad",
+    "trans": [
+      "伤心",
+      "feeling unhappy; wishing something hadn't happened"
+    ]
+  },
+  {
+    "name": "driver",
+    "trans": [
+      "司机",
+      "someone who operates a vehicle"
+    ]
+  },
+  {
+    "name": "drop",
+    "trans": [
+      "降低",
+      "to let something fall from your hand"
+    ]
+  },
+  {
+    "name": "drug",
+    "trans": [
+      "药品",
+      "chemical used as a medicine"
+    ]
+  },
+  {
+    "name": "dry",
+    "trans": [
+      "干燥",
+      "without water; not wet"
+    ]
+  },
+  {
+    "name": "due",
+    "trans": [
+      "到期的",
+      "when something is required or expected"
+    ]
+  },
+  {
+    "name": "she",
+    "trans": [
+      "她",
+      "female person or animal mentioned before"
+    ]
+  },
+  {
+    "name": "ultimately",
+    "trans": [
+      "最终",
+      "finally, after doing other things"
+    ]
+  },
+  {
+    "name": "duty",
+    "trans": [
+      "责任",
+      "work required by your job or position"
+    ]
+  },
+  {
+    "name": "dust",
+    "trans": [
+      "灰尘",
+      "fine dry powder that builds up on surfaces"
+    ]
+  },
+  {
+    "name": "solid",
+    "trans": [
+      "坚硬的",
+      "firm or hard; not a gas or liquid"
+    ]
+  },
+  {
+    "name": "steady",
+    "trans": [
+      "稳定的",
+      "firmly fixed, supported, or balanced; not shaking, rocking, or likely to fall over"
+    ]
+  },
+  {
+    "name": "earn",
+    "trans": [
+      "赚",
+      "to get money for work"
+    ]
+  },
+  {
+    "name": "earth",
+    "trans": [
+      "地球",
+      "planet we live on"
+    ]
+  },
+  {
+    "name": "start",
+    "trans": [
+      "开始",
+      "first time or place that a thing exists; beginning"
+    ]
+  },
+  {
+    "name": "easily",
+    "trans": [
+      "容易地",
+      "without difficulty"
+    ]
+  },
+  {
+    "name": "term",
+    "trans": [
+      "学期",
+      "fixed period of weeks for learning at school"
+    ]
+  },
+  {
+    "name": "shelf",
+    "trans": [
+      "架子",
+      "flat board attached to a wall on which to store things"
+    ]
+  },
+  {
+    "name": "easy",
+    "trans": [
+      "简单的",
+      "not hard to do; not difficult"
+    ]
+  },
+  {
+    "name": "eat",
+    "trans": [
+      "吃",
+      "to put food in your mouth"
+    ]
+  },
+  {
+    "name": "economic",
+    "trans": [
+      "经济的",
+      "having to do with trade, industry, and money"
+    ]
+  },
+  {
+    "name": "edge",
+    "trans": [
+      "边缘",
+      "boundary of a surface"
+    ]
+  },
+  {
+    "name": "conventional",
+    "trans": [
+      "传统的",
+      "following the common attitudes and practices"
+    ]
+  },
+  {
+    "name": "fruit",
+    "trans": [
+      "水果",
+      "food that grows on a tree or bush"
+    ]
+  },
+  {
+    "name": "boot",
+    "trans": [
+      "启动",
+      "footwear covering your foot and part of your leg"
+    ]
+  },
+  {
+    "name": "education",
+    "trans": [
+      "教育",
+      "process of giving or receiving teaching"
+    ]
+  },
+  {
+    "name": "because",
+    "trans": [
+      "因为",
+      "for a reason"
+    ]
+  },
+  {
+    "name": "forever",
+    "trans": [
+      "永远",
+      "for a very long or seemingly endless time"
+    ]
+  },
+  {
+    "name": "effective",
+    "trans": [
+      "有效的",
+      "working efficiently to produce a desired result"
+    ]
+  },
+  {
+    "name": "per",
+    "trans": [
+      "每",
+      "for each; during each"
+    ]
+  },
+  {
+    "name": "so",
+    "trans": [
+      "所以",
+      "for that reason"
+    ]
+  },
+  {
+    "name": "why",
+    "trans": [
+      "为什么",
+      "for what reason or purpose"
+    ]
+  },
+  {
+    "name": "effort",
+    "trans": [
+      "努力",
+      "amount of work used trying to do something"
+    ]
+  },
+  {
+    "name": "egg",
+    "trans": [
+      "蛋",
+      "hard-shelled thing from which a young bird is born"
+    ]
+  },
+  {
+    "name": "sir",
+    "trans": [
+      "先生",
+      "form of address to a man you respect"
+    ]
+  },
+  {
+    "name": "format",
+    "trans": [
+      "格式",
+      "form, design, or arrangement of something"
+    ]
+  },
+  {
+    "name": "election",
+    "trans": [
+      "选举",
+      "process of choosing someone by voting"
+    ]
+  },
+  {
+    "name": "lucky",
+    "trans": [
+      "幸运的",
+      "fortunate; having good things happen to you"
+    ]
+  },
+  {
+    "name": "hence",
+    "trans": [
+      "因此",
+      "from now, later than the present time"
+    ]
+  },
+  {
+    "name": "through",
+    "trans": [
+      "通过",
+      "from one end or side of something to the other end or side"
+    ]
+  },
+  {
+    "name": "element",
+    "trans": [
+      "元素",
+      "essential or particular part of something"
+    ]
+  },
+  {
+    "name": "across",
+    "trans": [
+      "穿过",
+      "from one side to the other of something"
+    ]
+  },
+  {
+    "name": "else",
+    "trans": [
+      "别的",
+      "otherwise; if you fail to..."
+    ]
+  },
+  {
+    "name": "since",
+    "trans": [
+      "自从",
+      "from the time in the past that"
+    ]
+  },
+  {
+    "name": "e-mail",
+    "trans": [
+      "电子邮件",
+      "a system for sending messages electronically, especially from one computer to another using the internet"
+    ]
+  },
+  {
+    "name": "face",
+    "trans": [
+      "脸",
+      "front part of the head where eyes, nose, and mouth are"
+    ]
+  },
+  {
+    "name": "tennis",
+    "trans": [
+      "网球",
+      "game played by hitting a ball over a net"
+    ]
+  },
+  {
+    "name": "emerge",
+    "trans": [
+      "出现",
+      "to rise or appear out of some background"
+    ]
+  },
+  {
+    "name": "golf",
+    "trans": [
+      "高尔夫球",
+      "game played to hit a ball into a hole with a stick"
+    ]
+  },
+  {
+    "name": "preparation",
+    "trans": [
+      "准备",
+      "getting ready for something"
+    ]
+  },
+  {
+    "name": "present",
+    "trans": [
+      "展示",
+      "gift"
+    ]
+  },
+  {
+    "name": "sale",
+    "trans": [
+      "销售",
+      "giving something for money; the amount sold"
+    ]
+  },
+  {
+    "name": "down",
+    "trans": [
+      "向下",
+      "going from a higher position to a lower position"
+    ]
+  },
+  {
+    "name": "employ",
+    "trans": [
+      "采用",
+      "to pay a person to work for you; to give a job to"
+    ]
+  },
+  {
+    "name": "employee",
+    "trans": [
+      "员工",
+      "person who works for someone else for payment"
+    ]
+  },
+  {
+    "name": "into",
+    "trans": [
+      "进入",
+      "going inside something"
+    ]
+  },
+  {
+    "name": "alright",
+    "trans": [
+      "好吧",
+      "good; acceptable"
+    ]
+  },
+  {
+    "name": "empty",
+    "trans": [
+      "空的",
+      "containing nothing; with no contents"
+    ]
+  },
+  {
+    "name": "enable",
+    "trans": [
+      "使能够",
+      "to make it possible to do something"
+    ]
+  },
+  {
+    "name": "honest",
+    "trans": [
+      "诚实的",
+      "good; always telling the truth and not stealing"
+    ]
+  },
+  {
+    "name": "encourage",
+    "trans": [
+      "鼓励",
+      "to make someone more determined or confident"
+    ]
+  },
+  {
+    "name": "sand",
+    "trans": [
+      "沙",
+      "grains of rock that make beaches and deserts"
+    ]
+  },
+  {
+    "name": "more",
+    "trans": [
+      "更多的",
+      "greater in amount, number, or size"
+    ]
+  },
+  {
+    "name": "energy",
+    "trans": [
+      "活力",
+      "physical or mental strength"
+    ]
+  },
+  {
+    "name": "engage",
+    "trans": [
+      "从事",
+      "to carry out, participate in; be involved in"
+    ]
+  },
+  {
+    "name": "tall",
+    "trans": [
+      "高的",
+      "greater in height than average"
+    ]
+  },
+  {
+    "name": "enjoy",
+    "trans": [
+      "享受",
+      "to take pleasure in something"
+    ]
+  },
+  {
+    "name": "empire",
+    "trans": [
+      "帝国",
+      "group of countries controlled by one government"
+    ]
+  },
+  {
+    "name": "tune",
+    "trans": [
+      "调",
+      "group of musical notes that make a nice sound"
+    ]
+  },
+  {
+    "name": "ensure",
+    "trans": [
+      "确保",
+      "to make something sure, certain, or safe"
+    ]
+  },
+  {
+    "name": "enter",
+    "trans": [
+      "进入",
+      "to go into a room"
+    ]
+  },
+  {
+    "name": "government",
+    "trans": [
+      "政府",
+      "group of people and system which rule a nation"
+    ]
+  },
+  {
+    "name": "jury",
+    "trans": [
+      "陪审团",
+      "group of people who listen to information about something and make a decision"
+    ]
+  },
+  {
+    "name": "personnel",
+    "trans": [
+      "人员",
+      "group of people who work for a company"
+    ]
+  },
+  {
+    "name": "entire",
+    "trans": [
+      "全部的",
+      "complete or full; with no part left out; whole"
+    ]
+  },
+  {
+    "name": "bunch",
+    "trans": [
+      "束",
+      "group of things of the same kind"
+    ]
+  },
+  {
+    "name": "pile",
+    "trans": [
+      "桩",
+      "group of things one on top of another"
+    ]
+  },
+  {
+    "name": "type",
+    "trans": [
+      "类型",
+      "group of things or people sharing common features"
+    ]
+  },
+  {
+    "name": "environment",
+    "trans": [
+      "环境",
+      "natural world in which plants and animals live"
+    ]
+  },
+  {
+    "name": "environmental",
+    "trans": [
+      "环境的",
+      "of the natural world in which plants and animals live"
+    ]
+  },
+  {
+    "name": "sort",
+    "trans": [
+      "种类",
+      "group or class of similar things or people"
+    ]
+  },
+  {
+    "name": "equal",
+    "trans": [
+      "平等的",
+      "same in shape, size, or number"
+    ]
+  },
+  {
+    "name": "constantly",
+    "trans": [
+      "不断地",
+      "happening a lot or all the time"
+    ]
+  },
+  {
+    "name": "subsequent",
+    "trans": [
+      "随后的",
+      "happening after"
+    ]
+  },
+  {
+    "name": "equipment",
+    "trans": [
+      "设备",
+      "tools or materials used to perform a task"
+    ]
+  },
+  {
+    "name": "constant",
+    "trans": [
+      "持续的",
+      "happening frequently or without pause"
+    ]
+  },
+  {
+    "name": "error",
+    "trans": [
+      "错误",
+      "something that is not correct; a mistake"
+    ]
+  },
+  {
+    "name": "especially",
+    "trans": [
+      "尤其",
+      "more than usual; extremely"
+    ]
+  },
+  {
+    "name": "briefly",
+    "trans": [
+      "简要地",
+      "happening in a short period of time; using few words"
+    ]
+  },
+  {
+    "name": "essential",
+    "trans": [
+      "基本的",
+      "extremely important and necessary"
+    ]
+  },
+  {
+    "name": "establish",
+    "trans": [
+      "建立",
+      "to set or create something to last for a long time"
+    ]
+  },
+  {
+    "name": "still",
+    "trans": [
+      "仍然",
+      "happening in the past and continuing into the present"
+    ]
+  },
+  {
+    "name": "late",
+    "trans": [
+      "晚的",
+      "happening near the end of a given time"
+    ]
+  },
+  {
+    "name": "frequent",
+    "trans": [
+      "经常",
+      "happening often"
+    ]
+  },
+  {
+    "name": "weekly",
+    "trans": [
+      "每周",
+      "happening once a week"
+    ]
+  },
+  {
+    "name": "evening",
+    "trans": [
+      "晚上",
+      "last part of the day and early part of the night"
+    ]
+  },
+  {
+    "name": "event",
+    "trans": [
+      "事件",
+      "something that happens"
+    ]
+  },
+  {
+    "name": "eventually",
+    "trans": [
+      "最终",
+      "finally"
+    ]
+  },
+  {
+    "name": "prior",
+    "trans": [
+      "事先的",
+      "happening or coming earlier in time"
+    ]
+  },
+  {
+    "name": "sudden",
+    "trans": [
+      "突然的",
+      "happening or done quickly or unexpectedly"
+    ]
+  },
+  {
+    "name": "everybody",
+    "trans": [
+      "大家",
+      "every person; everyone"
+    ]
+  },
+  {
+    "name": "routine",
+    "trans": [
+      "常规",
+      "happening or done regularly or frequently"
+    ]
+  },
+  {
+    "name": "everyone",
+    "trans": [
+      "每个人",
+      "every person; everybody"
+    ]
+  },
+  {
+    "name": "everything",
+    "trans": [
+      "一切",
+      "all of the things mentioned"
+    ]
+  },
+  {
+    "name": "early",
+    "trans": [
+      "早期的",
+      "happening sooner than expected"
+    ]
+  },
+  {
+    "name": "evidence",
+    "trans": [
+      "证据",
+      "factual proof that helps to establish the truth"
+    ]
+  },
+  {
+    "name": "rapid",
+    "trans": [
+      "迅速的",
+      "happening very quickly"
+    ]
+  },
+  {
+    "name": "continuous",
+    "trans": [
+      "连续的",
+      "happening without stops"
+    ]
+  },
+  {
+    "name": "satisfaction",
+    "trans": [
+      "满意",
+      "happy feeling because of something that you did"
+    ]
+  },
+  {
+    "name": "exactly",
+    "trans": [
+      "确切地",
+      "no more and no less than; precisely"
+    ]
+  },
+  {
+    "name": "shell",
+    "trans": [
+      "壳",
+      "hard outer covering that protects"
+    ]
+  },
+  {
+    "name": "bone",
+    "trans": [
+      "骨",
+      "hard pieces of a body that form the frame of an animal"
+    ]
+  },
+  {
+    "name": "concrete",
+    "trans": [
+      "具体的",
+      "hard substance used in building made by mixing cement, sand, small stones, and water"
+    ]
+  },
+  {
+    "name": "excellent",
+    "trans": [
+      "出色的",
+      "extremely good"
+    ]
+  },
+  {
+    "name": "except",
+    "trans": [
+      "除了",
+      "not including; other than"
+    ]
+  },
+  {
+    "name": "tooth",
+    "trans": [
+      "齿",
+      "hard white thing in the mouth used for biting and eating"
+    ]
+  },
+  {
+    "name": "important",
+    "trans": [
+      "重要的",
+      "having a big effect on (person, the future)"
+    ]
+  },
+  {
+    "name": "exchange",
+    "trans": [
+      "交换",
+      "to give things of similar value to each other"
+    ]
+  },
+  {
+    "name": "possible",
+    "trans": [
+      "可能的",
+      "having a chance of happening, or being true"
+    ]
+  },
+  {
+    "name": "brilliant",
+    "trans": [
+      "杰出的",
+      "having a great amount of intelligence or talent"
+    ]
+  },
+  {
+    "name": "wealthy",
+    "trans": [
+      "富裕",
+      "having a great amount of money or property"
+    ]
+  },
+  {
+    "name": "executive",
+    "trans": [
+      "管理人员",
+      "a senior manager in a business or organization"
+    ]
+  },
+  {
+    "name": "exercise",
+    "trans": [
+      "锻炼",
+      "to work out to become stronger and healthier"
+    ]
+  },
+  {
+    "name": "employment",
+    "trans": [
+      "就业",
+      "having a job; work done for money"
+    ]
+  },
+  {
+    "name": "exist",
+    "trans": [
+      "存在",
+      "to be present, alive or real"
+    ]
+  },
+  {
+    "name": "expand",
+    "trans": [
+      "扩张",
+      "to become bigger or larger in size and amount"
+    ]
+  },
+  {
+    "name": "thick",
+    "trans": [
+      "厚的",
+      "having a large distance between two surfaces"
+    ]
+  },
+  {
+    "name": "sick",
+    "trans": [
+      "生病的",
+      "having a physical or mental illness; not feeling well"
+    ]
+  },
+  {
+    "name": "angry",
+    "trans": [
+      "生气的",
+      "having a strong feeling about something that you dislike very much"
+    ]
+  },
+  {
+    "name": "expensive",
+    "trans": [
+      "昂贵的",
+      "costing a lot of money"
+    ]
+  },
+  {
+    "name": "nervous",
+    "trans": [
+      "紧张的",
+      "having a tendency to become uneasy or anxious"
+    ]
+  },
+  {
+    "name": "experiment",
+    "trans": [
+      "实验",
+      "test performed to assess new ideas or theories"
+    ]
+  },
+  {
+    "name": "sharp",
+    "trans": [
+      "锋利的",
+      "having a thin edge or point that is able to cut"
+    ]
+  },
+  {
+    "name": "expert",
+    "trans": [
+      "专家",
+      "skillful person with special knowledge"
+    ]
+  },
+  {
+    "name": "explain",
+    "trans": [
+      "解释",
+      "to make clear or easy to understand by describing"
+    ]
+  },
+  {
+    "name": "sufficient",
+    "trans": [
+      "充足的",
+      "having as much as is needed for a particular purpose"
+    ]
+  },
+  {
+    "name": "export",
+    "trans": [
+      "出口",
+      "to send goods to be sold in another country"
+    ]
+  },
+  {
+    "name": "guilty",
+    "trans": [
+      "有罪的",
+      "having done something bad or illegal"
+    ]
+  },
+  {
+    "name": "old",
+    "trans": [
+      "老的",
+      "having existed for a long time, not young or new"
+    ]
+  },
+  {
+    "name": "express",
+    "trans": [
+      "表达",
+      "to state or show what you think or how you feel"
+    ]
+  },
+  {
+    "name": "expression",
+    "trans": [
+      "表达",
+      "act of making your thoughts and feelings known"
+    ]
+  },
+  {
+    "name": "fortunate",
+    "trans": [
+      "幸运",
+      "having good luck"
+    ]
+  },
+  {
+    "name": "already",
+    "trans": [
+      "已经",
+      "having happened or been done before this time"
+    ]
+  },
+  {
+    "name": "extent",
+    "trans": [
+      "程度",
+      "range or space included in something"
+    ]
+  },
+  {
+    "name": "awareness",
+    "trans": [
+      "意识",
+      "having knowledge of something"
+    ]
+  },
+  {
+    "name": "extra",
+    "trans": [
+      "额外的",
+      "more than necessary; additional"
+    ]
+  },
+  {
+    "name": "weak",
+    "trans": [
+      "虚弱的",
+      "having little power; not strong; easy to break"
+    ]
+  },
+  {
+    "name": "sure",
+    "trans": [
+      "当然",
+      "having no doubts about something"
+    ]
+  },
+  {
+    "name": "extremely",
+    "trans": [
+      "极其",
+      "in a way that is much more than usual or expected"
+    ]
+  },
+  {
+    "name": "possession",
+    "trans": [
+      "拥有",
+      "having or owning something"
+    ]
+  },
+  {
+    "name": "variable",
+    "trans": [
+      "多变的",
+      "having the ability to change or vary"
+    ]
+  },
+  {
+    "name": "facility",
+    "trans": [
+      "设施",
+      "piece of equipment or buildings with a special use"
+    ]
+  },
+  {
+    "name": "creative",
+    "trans": [
+      "有创造力的",
+      "having the ability to make something new"
+    ]
+  },
+  {
+    "name": "factor",
+    "trans": [
+      "因素",
+      "something that influences a result"
+    ]
+  },
+  {
+    "name": "factory",
+    "trans": [
+      "工厂",
+      "building where things are made"
+    ]
+  },
+  {
+    "name": "independence",
+    "trans": [
+      "独立",
+      "having the freedom to make your own decisions"
+    ]
+  },
+  {
+    "name": "fail",
+    "trans": [
+      "失败",
+      "to not achieve a goal, or to go wrong"
+    ]
+  },
+  {
+    "name": "failure",
+    "trans": [
+      "失败",
+      "act or result of not achieving your goals"
+    ]
+  },
+  {
+    "name": "fair",
+    "trans": [
+      "公平的",
+      "treating all people the same way"
+    ]
+  },
+  {
+    "name": "able",
+    "trans": [
+      "有能力的",
+      "having the power, skill, knowledge, or money to do something"
+    ]
+  },
+  {
+    "name": "regional",
+    "trans": [
+      "区域性的",
+      "having to do with a particular area"
+    ]
+  },
+  {
+    "name": "psychological",
+    "trans": [
+      "心理",
+      "having to do with the mind"
+    ]
+  },
+  {
+    "name": "mayor",
+    "trans": [
+      "市长",
+      "head of a city's government"
+    ]
+  },
+  {
+    "name": "familiar",
+    "trans": [
+      "熟悉的",
+      "well-known or easily recognized"
+    ]
+  },
+  {
+    "name": "tight",
+    "trans": [
+      "紧的",
+      "held together firmly; difficult to move"
+    ]
+  },
+  {
+    "name": "famous",
+    "trans": [
+      "著名的",
+      "widely known; recognized by many people"
+    ]
+  },
+  {
+    "name": "fan",
+    "trans": [
+      "扇子",
+      "thing you wave in front of your face to stay cool"
+    ]
+  },
+  {
+    "name": "upper",
+    "trans": [
+      "上",
+      "higher than others of the same kind"
+    ]
+  },
+  {
+    "name": "top",
+    "trans": [
+      "顶部",
+      "highest or upper part or point of something"
+    ]
+  },
+  {
+    "name": "frequency",
+    "trans": [
+      "频率",
+      "how often something happens"
+    ]
+  },
+  {
+    "name": "farm",
+    "trans": [
+      "农场",
+      "land used for growing crops or raising animals"
+    ]
+  },
+  {
+    "name": "way",
+    "trans": [
+      "方式",
+      "how something is done"
+    ]
+  },
+  {
+    "name": "fashion",
+    "trans": [
+      "时尚",
+      "style of dress or activity popular at some time"
+    ]
+  },
+  {
+    "name": "fast",
+    "trans": [
+      "快速地",
+      "moving or able to move quickly"
+    ]
+  },
+  {
+    "name": "enormous",
+    "trans": [
+      "巨大的",
+      "huge; very big; very large"
+    ]
+  },
+  {
+    "name": "father",
+    "trans": [
+      "父亲",
+      "a male parent"
+    ]
+  },
+  {
+    "name": "people",
+    "trans": [
+      "人们",
+      "human beings in general; plural of person"
+    ]
+  },
+  {
+    "name": "favor",
+    "trans": [
+      "青睐",
+      "helpful act of kindness"
+    ]
+  },
+  {
+    "name": "favorite",
+    "trans": [
+      "最喜欢的",
+      "most liked; best loved"
+    ]
+  },
+  {
+    "name": "feature",
+    "trans": [
+      "特征",
+      "distinctive or important point of something"
+    ]
+  },
+  {
+    "name": "federal",
+    "trans": [
+      "联邦",
+      "system of government"
+    ]
+  },
+  {
+    "name": "fee",
+    "trans": [
+      "费用",
+      "amount of money paid for a particular service"
+    ]
+  },
+  {
+    "name": "notion",
+    "trans": [
+      "概念",
+      "idea or opinion about doing something"
+    ]
+  },
+  {
+    "name": "female",
+    "trans": [
+      "女性",
+      "person of the sex that gives birth to babies"
+    ]
+  },
+  {
+    "name": "hypothesis",
+    "trans": [
+      "假设",
+      "idea that leads to further study or discussion"
+    ]
+  },
+  {
+    "name": "same",
+    "trans": [
+      "相同的",
+      "identical; not different"
+    ]
+  },
+  {
+    "name": "whether",
+    "trans": [
+      "无论",
+      "if something will happen or not"
+    ]
+  },
+  {
+    "name": "reflection",
+    "trans": [
+      "反射",
+      "image that you see in a mirror, glass, or water"
+    ]
+  },
+  {
+    "name": "field",
+    "trans": [
+      "场地",
+      "open area of land, especially without buildings"
+    ]
+  },
+  {
+    "name": "fight",
+    "trans": [
+      "斗争",
+      "act of trying to hurt someone by hitting them"
+    ]
+  },
+  {
+    "name": "next",
+    "trans": [
+      "下一个",
+      "immediately after the previous one"
+    ]
+  },
+  {
+    "name": "fill",
+    "trans": [
+      "充满",
+      "to make something full"
+    ]
+  },
+  {
+    "name": "film",
+    "trans": [
+      "电影",
+      "movie"
+    ]
+  },
+  {
+    "name": "significance",
+    "trans": [
+      "意义",
+      "importance of something; the potential for something to have a big effect"
+    ]
+  },
+  {
+    "name": "final",
+    "trans": [
+      "最终的",
+      "being the last thing in a series"
+    ]
+  },
+  {
+    "name": "finally",
+    "trans": [
+      "最后",
+      "after a long time or some difficulty"
+    ]
+  },
+  {
+    "name": "finance",
+    "trans": [
+      "金融",
+      "control of money a person/business has access to"
+    ]
+  },
+  {
+    "name": "financial",
+    "trans": [
+      "金融的",
+      "involving money"
+    ]
+  },
+  {
+    "name": "issue",
+    "trans": [
+      "问题",
+      "important topic discussed, debated, or argued over"
+    ]
+  },
+  {
+    "name": "fine",
+    "trans": [
+      "美好的",
+      "good, acceptable or satisfactory"
+    ]
+  },
+  {
+    "name": "finger",
+    "trans": [
+      "手指",
+      "one of the five long parts of the hand"
+    ]
+  },
+  {
+    "name": "finish",
+    "trans": [
+      "结束",
+      "end of something; completion"
+    ]
+  },
+  {
+    "name": "fire",
+    "trans": [
+      "火",
+      "heat and the flame produced when burning"
+    ]
+  },
+  {
+    "name": "firm",
+    "trans": [
+      "公司",
+      "fairly hard or solid, not soft"
+    ]
+  },
+  {
+    "name": "properly",
+    "trans": [
+      "适当地",
+      "in a correct or suitable way depending on the situation"
+    ]
+  },
+  {
+    "name": "reasonably",
+    "trans": [
+      "合理地",
+      "in a fair and just manner"
+    ]
+  },
+  {
+    "name": "perfectly",
+    "trans": [
+      "完美",
+      "in a faultless manner; without mistakes"
+    ]
+  },
+  {
+    "name": "fish",
+    "trans": [
+      "鱼",
+      "animal that swims and lives in the sea"
+    ]
+  },
+  {
+    "name": "fit",
+    "trans": [
+      "合身",
+      "proper or acceptable; morally or socially correct"
+    ]
+  },
+  {
+    "name": "fix",
+    "trans": [
+      "使固定",
+      "to make something whole or able to work again"
+    ]
+  },
+  {
+    "name": "stable",
+    "trans": [
+      "稳定的",
+      "in a good situation or condition; not likely to change"
+    ]
+  },
+  {
+    "name": "well",
+    "trans": [
+      "出色地",
+      "in a good way"
+    ]
+  },
+  {
+    "name": "flat",
+    "trans": [
+      "平坦的",
+      "level; even; without curves or bumps"
+    ]
+  },
+  {
+    "name": "firmly",
+    "trans": [
+      "牢牢",
+      "in a hard, steady, unchanging way"
+    ]
+  },
+  {
+    "name": "flight",
+    "trans": [
+      "航班",
+      "act of flying"
+    ]
+  },
+  {
+    "name": "successfully",
+    "trans": [
+      "成功地",
+      "in a manner that achieves a goal"
+    ]
+  },
+  {
+    "name": "floor",
+    "trans": [
+      "地面",
+      "part of a room on which you stand"
+    ]
+  },
+  {
+    "name": "flow",
+    "trans": [
+      "流动",
+      "to move steadily and easily in a certain direction"
+    ]
+  },
+  {
+    "name": "fly",
+    "trans": [
+      "飞",
+      "to travel through the air using wings"
+    ]
+  },
+  {
+    "name": "focus",
+    "trans": [
+      "重点",
+      "main purpose or center of interest or activity"
+    ]
+  },
+  {
+    "name": "hopefully",
+    "trans": [
+      "希望",
+      "in a manner wishing something to happen"
+    ]
+  },
+  {
+    "name": "gently",
+    "trans": [
+      "轻轻地",
+      "in a mild, careful, and soft manner"
+    ]
+  },
+  {
+    "name": "typically",
+    "trans": [
+      "通常",
+      "in a normal or usual way"
+    ]
+  },
+  {
+    "name": "dramatically",
+    "trans": [
+      "戏剧性地",
+      "in a sudden or extreme manner"
+    ]
+  },
+  {
+    "name": "faithfully",
+    "trans": [
+      "忠实",
+      "in a trustworthy manner"
+    ]
+  },
+  {
+    "name": "foot",
+    "trans": [
+      "脚",
+      "lowest part of the leg we use to stand on"
+    ]
+  },
+  {
+    "name": "football",
+    "trans": [
+      "足球",
+      "sport where 2 teams try to kick a ball in a goal; soccer"
+    ]
+  },
+  {
+    "name": "automatically",
+    "trans": [
+      "自动地",
+      "in a way not requiring control by a person"
+    ]
+  },
+  {
+    "name": "literally",
+    "trans": [
+      "字面上地",
+      "in a way that expresses the exact meaning of something"
+    ]
+  },
+  {
+    "name": "foreign",
+    "trans": [
+      "外国的",
+      "being of a different place or country"
+    ]
+  },
+  {
+    "name": "forest",
+    "trans": [
+      "森林",
+      "large area with many trees"
+    ]
+  },
+  {
+    "name": "significantly",
+    "trans": [
+      "显著地",
+      "in a way that is important or noticeable"
+    ]
+  },
+  {
+    "name": "forget",
+    "trans": [
+      "忘记",
+      "to not remember something"
+    ]
+  },
+  {
+    "name": "somehow",
+    "trans": [
+      "不知何故",
+      "in a way that is not known or certain"
+    ]
+  },
+  {
+    "name": "differently",
+    "trans": [
+      "不同地",
+      "in a way that is not the same"
+    ]
+  },
+  {
+    "name": "effectively",
+    "trans": [
+      "有效地",
+      "in a way that produces the result you want"
+    ]
+  },
+  {
+    "name": "furthermore",
+    "trans": [
+      "此外",
+      "in addition to what has been said"
+    ]
+  },
+  {
+    "name": "former",
+    "trans": [
+      "以前的",
+      "being something previously, but not now"
+    ]
+  },
+  {
+    "name": "also",
+    "trans": [
+      "还",
+      "in addition; too; in a similar way"
+    ]
+  },
+  {
+    "name": "equally",
+    "trans": [
+      "同样地",
+      "in an equal, similar, or identical way"
+    ]
+  },
+  {
+    "name": "forward",
+    "trans": [
+      "向前",
+      "toward what is ahead or in front"
+    ]
+  },
+  {
+    "name": "precisely",
+    "trans": [
+      "恰恰",
+      "in an exact and accurate manner"
+    ]
+  },
+  {
+    "name": "roughly",
+    "trans": [
+      "大致",
+      "in an inexact or imprecise manner"
+    ]
+  },
+  {
+    "name": "rarely",
+    "trans": [
+      "很少",
+      "in an infrequent manner"
+    ]
+  },
+  {
+    "name": "surprisingly",
+    "trans": [
+      "出奇",
+      "in an unexpected way"
+    ]
+  },
+  {
+    "name": "freedom",
+    "trans": [
+      "自由",
+      "state of being free, not being controlled"
+    ]
+  },
+  {
+    "name": "wherever",
+    "trans": [
+      "无论在哪里",
+      "in any situation or at any time that"
+    ]
+  },
+  {
+    "name": "against",
+    "trans": [
+      "反对",
+      "in opposition to; disagreeing with"
+    ]
+  },
+  {
+    "name": "southern",
+    "trans": [
+      "南部",
+      "in or from the south"
+    ]
+  },
+  {
+    "name": "abroad",
+    "trans": [
+      "国外",
+      "in or to a foreign country"
+    ]
+  },
+  {
+    "name": "fresh",
+    "trans": [
+      "新鲜的",
+      "newly made or gathered"
+    ]
+  },
+  {
+    "name": "overseas",
+    "trans": [
+      "海外",
+      "in or to a foreign country that is across a sea"
+    ]
+  },
+  {
+    "name": "friendly",
+    "trans": [
+      "友好的",
+      "acting like a friend; kind and helpful"
+    ]
+  },
+  {
+    "name": "elsewhere",
+    "trans": [
+      "别处",
+      "in or to another or different place"
+    ]
+  },
+  {
+    "name": "northern",
+    "trans": [
+      "北方",
+      "in or toward the north"
+    ]
+  },
+  {
+    "name": "front",
+    "trans": [
+      "正面",
+      "opposite of back; the forward part of an object"
+    ]
+  },
+  {
+    "name": "partly",
+    "trans": [
+      "部分地",
+      "in part; not completely"
+    ]
+  },
+  {
+    "name": "there",
+    "trans": [
+      "那里",
+      "in that place or position, at that location"
+    ]
+  },
+  {
+    "name": "among",
+    "trans": [
+      "之中",
+      "in the center of some things; in relation to several things"
+    ]
+  },
+  {
+    "name": "full",
+    "trans": [
+      "满的",
+      "containing or holding as much as possible"
+    ]
+  },
+  {
+    "name": "fully",
+    "trans": [
+      "完全",
+      "completely or entirely"
+    ]
+  },
+  {
+    "name": "fun",
+    "trans": [
+      "乐趣",
+      "amusing and enjoyable"
+    ]
+  },
+  {
+    "name": "function",
+    "trans": [
+      "功能",
+      "what something is intended to be used for; purpose"
+    ]
+  },
+  {
+    "name": "primarily",
+    "trans": [
+      "主要是",
+      "in the most basic or important way"
+    ]
+  },
+  {
+    "name": "fund",
+    "trans": [
+      "基金",
+      "to supply money for something"
+    ]
+  },
+  {
+    "name": "respectively",
+    "trans": [
+      "分别",
+      "in the order people or things were mentioned"
+    ]
+  },
+  {
+    "name": "funny",
+    "trans": [
+      "有趣的",
+      "causing laughter; amusing"
+    ]
+  },
+  {
+    "name": "at",
+    "trans": [
+      "在",
+      "in the place where something is"
+    ]
+  },
+  {
+    "name": "under",
+    "trans": [
+      "在下面",
+      "in the same place as another thing, but lower"
+    ]
+  },
+  {
+    "name": "least",
+    "trans": [
+      "至少",
+      "in the smallest or lowest way"
+    ]
+  },
+  {
+    "name": "between",
+    "trans": [
+      "之间",
+      "in the space that separates two objects"
+    ]
+  },
+  {
+    "name": "how",
+    "trans": [
+      "如何",
+      "in what way something happens or is done"
+    ]
+  },
+  {
+    "name": "anywhere",
+    "trans": [
+      "任何地方",
+      "in, at, or to any place; used in questions, with 'not'"
+    ]
+  },
+  {
+    "name": "garden",
+    "trans": [
+      "花园",
+      "yard; ground outside your house to grow plants"
+    ]
+  },
+  {
+    "name": "gas",
+    "trans": [
+      "气体",
+      "elements in our air, like oxygen or nitrogen"
+    ]
+  },
+  {
+    "name": "every",
+    "trans": [
+      "每一个",
+      "including each person or thing in a group"
+    ]
+  },
+  {
+    "name": "gather",
+    "trans": [
+      "收集",
+      "to bring people/animals together into a group"
+    ]
+  },
+  {
+    "name": "grand",
+    "trans": [
+      "盛大",
+      "including many things; very large"
+    ]
+  },
+  {
+    "name": "comprehensive",
+    "trans": [
+      "综合的",
+      "including most or all things"
+    ]
+  },
+  {
+    "name": "instruction",
+    "trans": [
+      "操作说明",
+      "information about how to do or use something"
+    ]
+  },
+  {
+    "name": "database",
+    "trans": [
+      "数据库",
+      "information stored in a computer in an organized way"
+    ]
+  },
+  {
+    "name": "general",
+    "trans": [
+      "一般的",
+      "widespread, normal or usual"
+    ]
+  },
+  {
+    "name": "generate",
+    "trans": [
+      "产生",
+      "to create or be produced or bring into existence"
+    ]
+  },
+  {
+    "name": "generation",
+    "trans": [
+      "一代",
+      "people born and living at about the same time"
+    ]
+  },
+  {
+    "name": "hint",
+    "trans": [
+      "暗示",
+      "information that helps you understand or do something more easily"
+    ]
+  },
+  {
+    "name": "proof",
+    "trans": [
+      "证明",
+      "information which shows that something is true or correct"
+    ]
+  },
+  {
+    "name": "interior",
+    "trans": [
+      "内部的",
+      "inside part of something"
+    ]
+  },
+  {
+    "name": "sake",
+    "trans": [
+      "清酒",
+      "interest or benefit of someone or something"
+    ]
+  },
+  {
+    "name": "remarkable",
+    "trans": [
+      "卓越",
+      "interesting and unexpected, worthy of notice"
+    ]
+  },
+  {
+    "name": "attraction",
+    "trans": [
+      "景点",
+      "interesting place people want to visit"
+    ]
+  },
+  {
+    "name": "gift",
+    "trans": [
+      "礼物",
+      "something given to another for a reason; present"
+    ]
+  },
+  {
+    "name": "girl",
+    "trans": [
+      "女孩",
+      "a female child"
+    ]
+  },
+  {
+    "name": "if",
+    "trans": [
+      "如果",
+      "introducing a condition for something to happen"
+    ]
+  },
+  {
+    "name": "glad",
+    "trans": [
+      "高兴的",
+      "happy that something happened; pleased"
+    ]
+  },
+  {
+    "name": "intervention",
+    "trans": [
+      "干涉",
+      "involvement in a situation to prevent future problems"
+    ]
+  },
+  {
+    "name": "glass",
+    "trans": [
+      "玻璃",
+      "hard transparent material used for making windows"
+    ]
+  },
+  {
+    "name": "global",
+    "trans": [
+      "全球的",
+      "concerning, affecting, or involving the entire world"
+    ]
+  },
+  {
+    "name": "social",
+    "trans": [
+      "社会的",
+      "involving activities among people especially free time activities"
+    ]
+  },
+  {
+    "name": "goal",
+    "trans": [
+      "目标",
+      "something you try to do or achieve; an aim"
+    ]
+  },
+  {
+    "name": "theoretical",
+    "trans": [
+      "理论的",
+      "involving the uncertain or yet to be proved parts of a particular subject"
+    ]
+  },
+  {
+    "name": "gold",
+    "trans": [
+      "金子",
+      "soft yellow metal that is very valuable"
+    ]
+  },
+  {
+    "name": "product",
+    "trans": [
+      "产品",
+      "item that can be bought"
+    ]
+  },
+  {
+    "name": "furniture",
+    "trans": [
+      "家具",
+      "items such as tables, chairs, beds, or closets"
+    ]
+  },
+  {
+    "name": "profession",
+    "trans": [
+      "职业",
+      "job requiring special education or skills"
+    ]
+  },
+  {
+    "name": "evaluation",
+    "trans": [
+      "评估",
+      "judgment about the value or condition of something"
+    ]
+  },
+  {
+    "name": "only",
+    "trans": [
+      "仅有的",
+      "just one; just that amount or thing; not more than"
+    ]
+  },
+  {
+    "name": "maintenance",
+    "trans": [
+      "维护",
+      "keeping (a machine) working by checking and fixing it"
+    ]
+  },
+  {
+    "name": "spare",
+    "trans": [
+      "空闲的",
+      "kept as something extra that can be used if it is needed"
+    ]
+  },
+  {
+    "name": "grade",
+    "trans": [
+      "年级",
+      "level of study that is completed by a student"
+    ]
+  },
+  {
+    "name": "piano",
+    "trans": [
+      "钢琴",
+      "keyboard instrument used for playing music"
+    ]
+  },
+  {
+    "name": "gentle",
+    "trans": [
+      "温和的",
+      "kind and quiet in nature; not harsh or violent"
+    ]
+  },
+  {
+    "name": "experience",
+    "trans": [
+      "经验",
+      "knowledge gained by living life, doing new things"
+    ]
+  },
+  {
+    "name": "wise",
+    "trans": [
+      "明智的",
+      "knowledgeable about life; having good judgment"
+    ]
+  },
+  {
+    "name": "silly",
+    "trans": [
+      "愚蠢的",
+      "lacking seriousness or foolish"
+    ]
+  },
+  {
+    "name": "grant",
+    "trans": [
+      "授予",
+      "to give or let someone do what they want"
+    ]
+  },
+  {
+    "name": "stupid",
+    "trans": [
+      "愚蠢的",
+      "lacking the ability to learn easily; not intelligent"
+    ]
+  },
+  {
+    "name": "shore",
+    "trans": [
+      "支撑",
+      "land along the edge of an area of water"
+    ]
+  },
+  {
+    "name": "coast",
+    "trans": [
+      "海岸",
+      "land near the sea or ocean"
+    ]
+  },
+  {
+    "name": "estate",
+    "trans": [
+      "财产",
+      "land that a person owns"
+    ]
+  },
+  {
+    "name": "big",
+    "trans": [
+      "大的",
+      "large"
+    ]
+  },
+  {
+    "name": "green",
+    "trans": [
+      "绿色的",
+      "color of young leaves"
+    ]
+  },
+  {
+    "name": "wealth",
+    "trans": [
+      "财富",
+      "large amount of money and possessions"
+    ]
+  },
+  {
+    "name": "ocean",
+    "trans": [
+      "海洋",
+      "large body of salt water that covers most of the surface of the earth"
+    ]
+  },
+  {
+    "name": "ground",
+    "trans": [
+      "地面",
+      "solid surface of the earth that we stand on"
+    ]
+  },
+  {
+    "name": "long",
+    "trans": [
+      "长的",
+      "large distance from one end to the other"
+    ]
+  },
+  {
+    "name": "cow",
+    "trans": [
+      "奶牛",
+      "large farm animal from which we get milk and beef"
+    ]
+  },
+  {
+    "name": "growth",
+    "trans": [
+      "生长",
+      "act of growing"
+    ]
+  },
+  {
+    "name": "guarantee",
+    "trans": [
+      "保证",
+      "to make a formal promise that something will happen or be done."
+    ]
+  },
+  {
+    "name": "guess",
+    "trans": [
+      "猜测",
+      "to give an answer without knowing if it is correct"
+    ]
+  },
+  {
+    "name": "guest",
+    "trans": [
+      "客人",
+      "person invited to visit or stay in someone's home"
+    ]
+  },
+  {
+    "name": "guide",
+    "trans": [
+      "指导",
+      "to lead people visiting a new or unknown place"
+    ]
+  },
+  {
+    "name": "substantial",
+    "trans": [
+      "重大的",
+      "large in amount, quantity, or size"
+    ]
+  },
+  {
+    "name": "considerable",
+    "trans": [
+      "大量",
+      "large in size, amount, or effect"
+    ]
+  },
+  {
+    "name": "guy",
+    "trans": [
+      "家伙",
+      "informal man; boy; any person"
+    ]
+  },
+  {
+    "name": "hair",
+    "trans": [
+      "头发",
+      "long thin strands on your head or body"
+    ]
+  },
+  {
+    "name": "extensive",
+    "trans": [
+      "广泛的",
+      "large; full or complete"
+    ]
+  },
+  {
+    "name": "maximum",
+    "trans": [
+      "最大限度",
+      "largest or greatest"
+    ]
+  },
+  {
+    "name": "handle",
+    "trans": [
+      "处理",
+      "to have the ability to cope with or take responsibility for"
+    ]
+  },
+  {
+    "name": "permanent",
+    "trans": [
+      "永恒的",
+      "lasting forever; not temporary or changing"
+    ]
+  },
+  {
+    "name": "after",
+    "trans": [
+      "后",
+      "later than another time, or behind something"
+    ]
+  },
+  {
+    "name": "happy",
+    "trans": [
+      "快乐的",
+      "feeling pleasure or joy; glad"
+    ]
+  },
+  {
+    "name": "discovery",
+    "trans": [
+      "发现",
+      "learning something for the first time"
+    ]
+  },
+  {
+    "name": "divorce",
+    "trans": [
+      "离婚",
+      "legal ending of a marriage"
+    ]
+  },
+  {
+    "name": "hardly",
+    "trans": [
+      "几乎不",
+      "clearly or undoubtedly not; very little"
+    ]
+  },
+  {
+    "name": "power",
+    "trans": [
+      "力量",
+      "legal or official right to perform certain actions"
+    ]
+  },
+  {
+    "name": "ownership",
+    "trans": [
+      "所有权",
+      "legal right to have something belong to you"
+    ]
+  },
+  {
+    "name": "hate",
+    "trans": [
+      "恨",
+      "to have a very strong feeling of dislike for"
+    ]
+  },
+  {
+    "name": "secondary",
+    "trans": [
+      "中学",
+      "less important than something else"
+    ]
+  },
+  {
+    "name": "pale",
+    "trans": [
+      "苍白",
+      "light in color"
+    ]
+  },
+  {
+    "name": "comedy",
+    "trans": [
+      "喜剧",
+      "light or funny play or film, usually with a happy ending"
+    ]
+  },
+  {
+    "name": "health",
+    "trans": [
+      "健康",
+      "being in a good condition; being well"
+    ]
+  },
+  {
+    "name": "healthy",
+    "trans": [
+      "健康",
+      "in good condition physically (or financially); not ill or bad"
+    ]
+  },
+  {
+    "name": "probably",
+    "trans": [
+      "大概",
+      "likely to happen or be true"
+    ]
+  },
+  {
+    "name": "heart",
+    "trans": [
+      "心",
+      "part of the body that pumps blood"
+    ]
+  },
+  {
+    "name": "heat",
+    "trans": [
+      "热",
+      "to make hot or hotter"
+    ]
+  },
+  {
+    "name": "medicine",
+    "trans": [
+      "药品",
+      "liquid or pills used to treat illness or pain; the study of treating illness or pain"
+    ]
+  },
+  {
+    "name": "heavy",
+    "trans": [
+      "重的",
+      "having a lot of weight"
+    ]
+  },
+  {
+    "name": "menu",
+    "trans": [
+      "菜单",
+      "list of dishes available at a restaurant"
+    ]
+  },
+  {
+    "name": "catalog",
+    "trans": [
+      "目录",
+      "list of items that are available for purchase"
+    ]
+  },
+  {
+    "name": "small",
+    "trans": [
+      "小的",
+      "little in size; not big"
+    ]
+  },
+  {
+    "name": "somewhat",
+    "trans": [
+      "有些",
+      "little, not very"
+    ]
+  },
+  {
+    "name": "alive",
+    "trans": [
+      "活",
+      "living; not dead"
+    ]
+  },
+  {
+    "name": "around",
+    "trans": [
+      "大约",
+      "located on every side, or along something"
+    ]
+  },
+  {
+    "name": "knife",
+    "trans": [
+      "刀",
+      "long piece of metal you use for cutting things"
+    ]
+  },
+  {
+    "name": "herself",
+    "trans": [
+      "她自己",
+      "female person that did the original action"
+    ]
+  },
+  {
+    "name": "nerve",
+    "trans": [
+      "神经",
+      "long thin cells in the body that makes feeling and movement possible"
+    ]
+  },
+  {
+    "name": "tube",
+    "trans": [
+      "管子",
+      "long, hollow object"
+    ]
+  },
+  {
+    "name": "hide",
+    "trans": [
+      "隐藏",
+      "to put a thing where it can't be found; go where you won't be found"
+    ]
+  },
+  {
+    "name": "valley",
+    "trans": [
+      "谷",
+      "long, low area between hills or mountains, often with a river running through it"
+    ]
+  },
+  {
+    "name": "highly",
+    "trans": [
+      "高度",
+      "more than usual; to a great degree"
+    ]
+  },
+  {
+    "name": "rail",
+    "trans": [
+      "轨",
+      "long, thin piece of metal"
+    ]
+  },
+  {
+    "name": "himself",
+    "trans": [
+      "他自己",
+      "the same (male) person who did the action"
+    ]
+  },
+  {
+    "name": "mortgage",
+    "trans": [
+      "抵押",
+      "long-term loan from a bank for buying property"
+    ]
+  },
+  {
+    "name": "tender",
+    "trans": [
+      "投标",
+      "loving and gentle"
+    ]
+  },
+  {
+    "name": "minimum",
+    "trans": [
+      "最低限度",
+      "lowest number or amount that is possible"
+    ]
+  },
+  {
+    "name": "printer",
+    "trans": [
+      "打印机",
+      "machine that makes copies of papers and documents"
+    ]
+  },
+  {
+    "name": "hit",
+    "trans": [
+      "打",
+      "to fight, attack or damage something or someone"
+    ]
+  },
+  {
+    "name": "golden",
+    "trans": [
+      "金的",
+      "made of valuable, heavy, yellow metal"
+    ]
+  },
+  {
+    "name": "wooden",
+    "trans": [
+      "木制的",
+      "made of wood"
+    ]
+  },
+  {
+    "name": "hole",
+    "trans": [
+      "洞",
+      "opening into or through something"
+    ]
+  },
+  {
+    "name": "holiday",
+    "trans": [
+      "假期",
+      "day when people don't go to work or school"
+    ]
+  },
+  {
+    "name": "prime",
+    "trans": [
+      "主要的",
+      "main; most important; best quality"
+    ]
+  },
+  {
+    "name": "implementation",
+    "trans": [
+      "执行",
+      "making a law, system, or plan start to happen or be used"
+    ]
+  },
+  {
+    "name": "loud",
+    "trans": [
+      "大声",
+      "making a lot of noise"
+    ]
+  },
+  {
+    "name": "quietly",
+    "trans": [
+      "悄悄",
+      "making little sound"
+    ]
+  },
+  {
+    "name": "reduction",
+    "trans": [
+      "减少",
+      "making something smaller; reducing something"
+    ]
+  },
+  {
+    "name": "attractive",
+    "trans": [
+      "吸引人的",
+      "making you like them, as by being good-looking"
+    ]
+  },
+  {
+    "name": "person",
+    "trans": [
+      "人",
+      "man, woman, or child"
+    ]
+  },
+  {
+    "name": "horse",
+    "trans": [
+      "马",
+      "large animal with 4 legs used for riding"
+    ]
+  },
+  {
+    "name": "hospital",
+    "trans": [
+      "医院",
+      "building for sick people, with doctors and nurses"
+    ]
+  },
+  {
+    "name": "hot",
+    "trans": [
+      "热的",
+      "having a high temperature"
+    ]
+  },
+  {
+    "name": "multiple",
+    "trans": [
+      "多种的",
+      "many things or people"
+    ]
+  },
+  {
+    "name": "often",
+    "trans": [
+      "经常",
+      "many times, frequently, on many occasions"
+    ]
+  },
+  {
+    "name": "fuel",
+    "trans": [
+      "燃料",
+      "material used to produce heat or power when burned"
+    ]
+  },
+  {
+    "name": "huge",
+    "trans": [
+      "巨大的",
+      "very very large"
+    ]
+  },
+  {
+    "name": "human",
+    "trans": [
+      "人类",
+      "a person; a man, woman or child"
+    ]
+  },
+  {
+    "name": "capability",
+    "trans": [
+      "能力",
+      "means, ability, or potential to do something"
+    ]
+  },
+  {
+    "name": "dimension",
+    "trans": [
+      "方面",
+      "measurement of length, width, or height"
+    ]
+  },
+  {
+    "name": "surgery",
+    "trans": [
+      "外科手术",
+      "medical treatment in which a doctor cuts into a body"
+    ]
+  },
+  {
+    "name": "husband",
+    "trans": [
+      "丈夫",
+      "married man"
+    ]
+  },
+  {
+    "name": "letter",
+    "trans": [
+      "信",
+      "message you put in an envelope and send by post"
+    ]
+  },
+  {
+    "name": "salary",
+    "trans": [
+      "薪水",
+      "money an employee is paid each year"
+    ]
+  },
+  {
+    "name": "compensation",
+    "trans": [
+      "赔偿",
+      "money given or received as payment for loss"
+    ]
+  },
+  {
+    "name": "identify",
+    "trans": [
+      "确认",
+      "to indicate who or what someone or something is"
+    ]
+  },
+  {
+    "name": "deposit",
+    "trans": [
+      "订金",
+      "money that is given for a special purpose such as proof that you will buy something, or as savings in a bank"
+    ]
+  },
+  {
+    "name": "ignore",
+    "trans": [
+      "忽略",
+      "to not listen to, look at, or pay attention to"
+    ]
+  },
+  {
+    "name": "evil",
+    "trans": [
+      "邪恶的",
+      "morally bad; causing harm to someone"
+    ]
+  },
+  {
+    "name": "increasingly",
+    "trans": [
+      "日益",
+      "more and more; in greater degree or amount"
+    ]
+  },
+  {
+    "name": "several",
+    "trans": [
+      "一些",
+      "more than two but not many"
+    ]
+  },
+  {
+    "name": "mom",
+    "trans": [
+      "妈妈",
+      "mother"
+    ]
+  },
+  {
+    "name": "grandmother",
+    "trans": [
+      "祖母",
+      "mother of your mother or father"
+    ]
+  },
+  {
+    "name": "up",
+    "trans": [
+      "向上",
+      "move higher; raise"
+    ]
+  },
+  {
+    "name": "immediately",
+    "trans": [
+      "立即地",
+      "without any delay; straight away; right (after or before)"
+    ]
+  },
+  {
+    "name": "to",
+    "trans": [
+      "到",
+      "move towards; in the direction of"
+    ]
+  },
+  {
+    "name": "promotion",
+    "trans": [
+      "晋升",
+      "moving someone to a more important position"
+    ]
+  },
+  {
+    "name": "very",
+    "trans": [
+      "非常",
+      "much; great in amount"
+    ]
+  },
+  {
+    "name": "strict",
+    "trans": [
+      "严格的",
+      "must be obeyed"
+    ]
+  },
+  {
+    "name": "salt",
+    "trans": [
+      "盐",
+      "natural white substance used to flavor or preserve food"
+    ]
+  },
+  {
+    "name": "together",
+    "trans": [
+      "一起",
+      "near close in the same place not far in a family or group"
+    ]
+  },
+  {
+    "name": "importance",
+    "trans": [
+      "重要性",
+      "being important; having a big effect on"
+    ]
+  },
+  {
+    "name": "by",
+    "trans": [
+      "经过",
+      "near; with"
+    ]
+  },
+  {
+    "name": "impossible",
+    "trans": [
+      "不可能的",
+      "very unlikely to happen or exist"
+    ]
+  },
+  {
+    "name": "most",
+    "trans": [
+      "最多",
+      "nearly all of something"
+    ]
+  },
+  {
+    "name": "vital",
+    "trans": [
+      "必不可少的",
+      "necessary"
+    ]
+  },
+  {
+    "name": "thirst",
+    "trans": [
+      "口渴",
+      "need for something to drink"
+    ]
+  },
+  {
+    "name": "improve",
+    "trans": [
+      "提升",
+      "to make, or become, something better"
+    ]
+  },
+  {
+    "name": "improvement",
+    "trans": [
+      "改进",
+      "addition or change that makes something better"
+    ]
+  },
+  {
+    "name": "innovation",
+    "trans": [
+      "创新",
+      "new invention or idea that is created"
+    ]
+  },
+  {
+    "name": "close",
+    "trans": [
+      "关闭",
+      "next to; only a short distance away"
+    ]
+  },
+  {
+    "name": "anymore",
+    "trans": [
+      "不再",
+      "no longer; no more"
+    ]
+  },
+  {
+    "name": "silence",
+    "trans": [
+      "沉默",
+      "no sound or noise"
+    ]
+  },
+  {
+    "name": "illegal",
+    "trans": [
+      "非法的",
+      "not allowed by the laws or rules"
+    ]
+  },
+  {
+    "name": "nothing",
+    "trans": [
+      "没有什么",
+      "not anything, not a single thing"
+    ]
+  },
+  {
+    "name": "unable",
+    "trans": [
+      "无法",
+      "not being able to do something"
+    ]
+  },
+  {
+    "name": "indeed",
+    "trans": [
+      "的确",
+      "actually; in fact; in reality"
+    ]
+  },
+  {
+    "name": "unlikely",
+    "trans": [
+      "不太可能",
+      "not being likely to happen or not likely to be the truth"
+    ]
+  },
+  {
+    "name": "independent",
+    "trans": [
+      "独立的",
+      "making your own decisions; not controlled by others"
+    ]
+  },
+  {
+    "name": "crazy",
+    "trans": [
+      "疯狂的",
+      "not being sensible or practical"
+    ]
+  },
+  {
+    "name": "within",
+    "trans": [
+      "之内",
+      "not beyond the limits of a particular space, time, or range"
+    ]
+  },
+  {
+    "name": "individual",
+    "trans": [
+      "个人",
+      "single person, looked at separately from others"
+    ]
+  },
+  {
+    "name": "industry",
+    "trans": [
+      "行业",
+      "factories or businesses that make certain products"
+    ]
+  },
+  {
+    "name": "dirty",
+    "trans": [
+      "肮脏的",
+      "not clean"
+    ]
+  },
+  {
+    "name": "open",
+    "trans": [
+      "打开",
+      "not closed or shut"
+    ]
+  },
+  {
+    "name": "rare",
+    "trans": [
+      "稀有的",
+      "not common or usual"
+    ]
+  },
+  {
+    "name": "influence",
+    "trans": [
+      "影响",
+      "to affect what happens; change something (indirectly)"
+    ]
+  },
+  {
+    "name": "inform",
+    "trans": [
+      "通知",
+      "to give information or facts about something"
+    ]
+  },
+  {
+    "name": "never",
+    "trans": [
+      "绝不",
+      "not ever; not at any time"
+    ]
+  },
+  {
+    "name": "initial",
+    "trans": [
+      "最初的",
+      "existing or occurring at the beginning"
+    ]
+  },
+  {
+    "name": "unknown",
+    "trans": [
+      "未知",
+      "not familiar or famous"
+    ]
+  },
+  {
+    "name": "nearby",
+    "trans": [
+      "附近",
+      "not far away"
+    ]
+  },
+  {
+    "name": "bad",
+    "trans": [
+      "坏的",
+      "not good; wrong"
+    ]
+  },
+  {
+    "name": "little",
+    "trans": [
+      "小的",
+      "not great in size, amount, or degree; small"
+    ]
+  },
+  {
+    "name": "innocent",
+    "trans": [
+      "清白的",
+      "not having done anything wrong or bad"
+    ]
+  },
+  {
+    "name": "light",
+    "trans": [
+      "光",
+      "not heavy; weighing only a little"
+    ]
+  },
+  {
+    "name": "away",
+    "trans": [
+      "离开",
+      "not here; far from here; in a different direction"
+    ]
+  },
+  {
+    "name": "low",
+    "trans": [
+      "低的",
+      "not high; being near the ground, or bottom"
+    ]
+  },
+  {
+    "name": "inside",
+    "trans": [
+      "里面",
+      "being in something"
+    ]
+  },
+  {
+    "name": "badly",
+    "trans": [
+      "严重地",
+      "not in a good way; not as wanted or liked"
+    ]
+  },
+  {
+    "name": "nowhere",
+    "trans": [
+      "无处",
+      "not in or at any place; no place"
+    ]
+  },
+  {
+    "name": "confusion",
+    "trans": [
+      "困惑",
+      "not knowing what to do"
+    ]
+  },
+  {
+    "name": "instance",
+    "trans": [
+      "实例",
+      "an example of something; case"
+    ]
+  },
+  {
+    "name": "instead",
+    "trans": [
+      "反而",
+      "when one thing is replaced by another"
+    ]
+  },
+  {
+    "name": "institution",
+    "trans": [
+      "机构",
+      "organization created for a particular cause or purpose"
+    ]
+  },
+  {
+    "name": "lazy",
+    "trans": [
+      "懒惰的",
+      "not liking to work or make an effort"
+    ]
+  },
+  {
+    "name": "few",
+    "trans": [
+      "很少",
+      "not many; small in number"
+    ]
+  },
+  {
+    "name": "insurance",
+    "trans": [
+      "保险",
+      "payments to cover potential loss/damage/injury/death"
+    ]
+  },
+  {
+    "name": "pure",
+    "trans": [
+      "纯的",
+      "not mixed with anything else"
+    ]
+  },
+  {
+    "name": "different",
+    "trans": [
+      "不同的",
+      "not of the same kind; unlike other things"
+    ]
+  },
+  {
+    "name": "new",
+    "trans": [
+      "新的",
+      "not old, recently born, built, or made"
+    ]
+  },
+  {
+    "name": "intend",
+    "trans": [
+      "打算",
+      "to plan or want to do something"
+    ]
+  },
+  {
+    "name": "fancy",
+    "trans": [
+      "想要",
+      "not plain or ordinary, expensive"
+    ]
+  },
+  {
+    "name": "false",
+    "trans": [
+      "错误的",
+      "not real or true"
+    ]
+  },
+  {
+    "name": "rough",
+    "trans": [
+      "粗糙的",
+      "not smooth, gentle, or careful"
+    ]
+  },
+  {
+    "name": "minor",
+    "trans": [
+      "次要的",
+      "not so large in size, not important or valuable"
+    ]
+  },
+  {
+    "name": "internal",
+    "trans": [
+      "内部的",
+      "within or inside"
+    ]
+  },
+  {
+    "name": "international",
+    "trans": [
+      "国际的",
+      "done or relating to several countries, not just your own"
+    ]
+  },
+  {
+    "name": "silent",
+    "trans": [
+      "沉默的",
+      "not speaking or making noise"
+    ]
+  },
+  {
+    "name": "ordinary",
+    "trans": [
+      "普通的",
+      "not special, different, or unusual"
+    ]
+  },
+  {
+    "name": "thin",
+    "trans": [
+      "薄的",
+      "not thick; not wide in size"
+    ]
+  },
+  {
+    "name": "interview",
+    "trans": [
+      "面试",
+      "to formally ask questions about a given topic"
+    ]
+  },
+  {
+    "name": "loose",
+    "trans": [
+      "松动的",
+      "not tightly attached or held"
+    ]
+  },
+  {
+    "name": "introduce",
+    "trans": [
+      "介绍",
+      "to make someone known to another by name"
+    ]
+  },
+  {
+    "name": "introduction",
+    "trans": [
+      "介绍",
+      "making someone known to another by name"
+    ]
+  },
+  {
+    "name": "occasionally",
+    "trans": [
+      "偶尔",
+      "not very often; sometimes; seldom"
+    ]
+  },
+  {
+    "name": "invest",
+    "trans": [
+      "投资",
+      "to use resources to build for the future"
+    ]
+  },
+  {
+    "name": "investigate",
+    "trans": [
+      "调查",
+      "to try to find out facts; to carry out research"
+    ]
+  },
+  {
+    "name": "investigation",
+    "trans": [
+      "调查",
+      "search for information about something"
+    ]
+  },
+  {
+    "name": "investment",
+    "trans": [
+      "投资",
+      "something purchased hoping its value will increase"
+    ]
+  },
+  {
+    "name": "ill",
+    "trans": [
+      "患病的",
+      "not well; sick"
+    ]
+  },
+  {
+    "name": "invite",
+    "trans": [
+      "邀请",
+      "to ask someone to go somewhere or do something"
+    ]
+  },
+  {
+    "name": "one",
+    "trans": [
+      "一",
+      "number 1"
+    ]
+  },
+  {
+    "name": "group",
+    "trans": [
+      "团体",
+      "number of people or things gathered together"
+    ]
+  },
+  {
+    "name": "island",
+    "trans": [
+      "岛",
+      "area of land that is surrounded by water"
+    ]
+  },
+  {
+    "name": "density",
+    "trans": [
+      "密度",
+      "number of people or things in a particular area"
+    ]
+  },
+  {
+    "name": "age",
+    "trans": [
+      "年龄",
+      "number of years a person has lived (also of things)"
+    ]
+  },
+  {
+    "name": "item",
+    "trans": [
+      "物品",
+      "distinct, individual thing, often part of a group"
+    ]
+  },
+  {
+    "name": "itself",
+    "trans": [
+      "本身",
+      "referring to it"
+    ]
+  },
+  {
+    "name": "he",
+    "trans": [
+      "他",
+      "object form of a male person you are talking about"
+    ]
+  },
+  {
+    "name": "gradually",
+    "trans": [
+      "逐步地",
+      "occurring in a slow manner over a period of time"
+    ]
+  },
+  {
+    "name": "join",
+    "trans": [
+      "加入",
+      "to bring something close to another, to become one"
+    ]
+  },
+  {
+    "name": "monthly",
+    "trans": [
+      "每月",
+      "occurring twelve times a year"
+    ]
+  },
+  {
+    "name": "weird",
+    "trans": [
+      "诡异的",
+      "odd or unusual"
+    ]
+  },
+  {
+    "name": "about",
+    "trans": [
+      "关于",
+      "of (a subject); concerning"
+    ]
+  },
+  {
+    "name": "democratic",
+    "trans": [
+      "民主的",
+      "of democracy; entitling the people to power"
+    ]
+  },
+  {
+    "name": "intellectual",
+    "trans": [
+      "知识分子",
+      "of or relating to the ability to think in a logical way and understand complicated ideas and subjects"
+    ]
+  },
+  {
+    "name": "judge",
+    "trans": [
+      "法官",
+      "to form an opinion after careful consideration"
+    ]
+  },
+  {
+    "name": "judgment",
+    "trans": [
+      "判断",
+      "opinion that is made after careful consideration"
+    ]
+  },
+  {
+    "name": "jump",
+    "trans": [
+      "跳",
+      "to push your body into the air with your legs"
+    ]
+  },
+  {
+    "name": "brown",
+    "trans": [
+      "棕色的",
+      "of the color of coffee, wood, or chocolate"
+    ]
+  },
+  {
+    "name": "qualification",
+    "trans": [
+      "资质",
+      "official record proving a certain standard or level"
+    ]
+  },
+  {
+    "name": "frequently",
+    "trans": [
+      "频繁地",
+      "often; regularly"
+    ]
+  },
+  {
+    "name": "fat",
+    "trans": [
+      "胖的",
+      "oily part of meat"
+    ]
+  },
+  {
+    "name": "right",
+    "trans": [
+      "正确的",
+      "on side where the hand that most people write with"
+    ]
+  },
+  {
+    "name": "today",
+    "trans": [
+      "今天",
+      "on this day; at the time that is happening now"
+    ]
+  },
+  {
+    "name": "key",
+    "trans": [
+      "钥匙",
+      "something you use to open a lock or start a car"
+    ]
+  },
+  {
+    "name": "kid",
+    "trans": [
+      "孩子",
+      "informal child or young person"
+    ]
+  },
+  {
+    "name": "kill",
+    "trans": [
+      "杀",
+      "to end the life of a person or other living thing"
+    ]
+  },
+  {
+    "name": "a",
+    "trans": [
+      "一个",
+      "one (of something)"
+    ]
+  },
+  {
+    "name": "any",
+    "trans": [
+      "任何",
+      "one (thing) of many; some (thing)"
+    ]
+  },
+  {
+    "name": "kitchen",
+    "trans": [
+      "厨房",
+      "place where food is cooked"
+    ]
+  },
+  {
+    "name": "another",
+    "trans": [
+      "其他",
+      "one more (thing); additional (thing)"
+    ]
+  },
+  {
+    "name": "again",
+    "trans": [
+      "再次",
+      "one more time, once more"
+    ]
+  },
+  {
+    "name": "ski",
+    "trans": [
+      "滑雪",
+      "one of a pair of long flat boards attached to boots for moving smoothly over snow"
+    ]
+  },
+  {
+    "name": "knowledge",
+    "trans": [
+      "知识",
+      "information, understanding, or skill"
+    ]
+  },
+  {
+    "name": "labor",
+    "trans": [
+      "劳动",
+      "to work hard (often physically) for many hours"
+    ]
+  },
+  {
+    "name": "planet",
+    "trans": [
+      "行星",
+      "one of the bodies that orbit the sun"
+    ]
+  },
+  {
+    "name": "lack",
+    "trans": [
+      "缺少",
+      "to not have, or not have enough, of something"
+    ]
+  },
+  {
+    "name": "land",
+    "trans": [
+      "土地",
+      "the earth; the ground"
+    ]
+  },
+  {
+    "name": "either",
+    "trans": [
+      "任何一个",
+      "one of two (used when there is a choice of two)"
+    ]
+  },
+  {
+    "name": "once",
+    "trans": [
+      "一次",
+      "one time; one instance"
+    ]
+  },
+  {
+    "name": "largely",
+    "trans": [
+      "很大程度上",
+      "in large part; mainly or chiefly"
+    ]
+  },
+  {
+    "name": "kind",
+    "trans": [
+      "种类",
+      "one type of thing"
+    ]
+  },
+  {
+    "name": "laugh",
+    "trans": [
+      "笑",
+      "to make a happy sound when something is funny"
+    ]
+  },
+  {
+    "name": "almost",
+    "trans": [
+      "几乎",
+      "only a little less than, nearly, not quite"
+    ]
+  },
+  {
+    "name": "launch",
+    "trans": [
+      "发射",
+      "to put a rocket into the air; put a ship into the water"
+    ]
+  },
+  {
+    "name": "law",
+    "trans": [
+      "法律",
+      "system or rules made by the government"
+    ]
+  },
+  {
+    "name": "lay",
+    "trans": [
+      "躺着",
+      "to put or set something down in a flat position"
+    ]
+  },
+  {
+    "name": "merely",
+    "trans": [
+      "仅仅",
+      "only, simply, or nothing more than"
+    ]
+  },
+  {
+    "name": "just",
+    "trans": [
+      "只是",
+      "only; a short time ago"
+    ]
+  },
+  {
+    "name": "liberal",
+    "trans": [
+      "自由主义",
+      "open to new ideas; believing government should actively support social needs"
+    ]
+  },
+  {
+    "name": "leader",
+    "trans": [
+      "领导者",
+      "person who is in charge of a group or task"
+    ]
+  },
+  {
+    "name": "leadership",
+    "trans": [
+      "领导",
+      "quality of being able to guide or influence others"
+    ]
+  },
+  {
+    "name": "electronic",
+    "trans": [
+      "电子的",
+      "operating by use of electricity; digital"
+    ]
+  },
+  {
+    "name": "folk",
+    "trans": [
+      "民间",
+      "ordinary people"
+    ]
+  },
+  {
+    "name": "civilian",
+    "trans": [
+      "平民",
+      "ordinary person who is not in the army"
+    ]
+  },
+  {
+    "name": "charity",
+    "trans": [
+      "慈善事业",
+      "organization providing help to the needy, the sick"
+    ]
+  },
+  {
+    "name": "supplier",
+    "trans": [
+      "供应商",
+      "organization that provides a product or service"
+    ]
+  },
+  {
+    "name": "establishment",
+    "trans": [
+      "设立",
+      "organization, institution, or place to do business"
+    ]
+  },
+  {
+    "name": "base",
+    "trans": [
+      "根据",
+      "origin or start from which something came"
+    ]
+  },
+  {
+    "name": "left",
+    "trans": [
+      "左边",
+      "side of your body your heart is on"
+    ]
+  },
+  {
+    "name": "leg",
+    "trans": [
+      "腿",
+      "part of the body from the thigh down"
+    ]
+  },
+  {
+    "name": "legal",
+    "trans": [
+      "合法的",
+      "concerning the law; allowed by law"
+    ]
+  },
+  {
+    "name": "besides",
+    "trans": [
+      "除了",
+      "other than or in addition to"
+    ]
+  },
+  {
+    "name": "forth",
+    "trans": [
+      "向前",
+      "out of a place; forward in time, place, or way"
+    ]
+  },
+  {
+    "name": "length",
+    "trans": [
+      "长度",
+      "measurement of distance or of time"
+    ]
+  },
+  {
+    "name": "yard",
+    "trans": [
+      "院子",
+      "outdoor area or garden next to a house"
+    ]
+  },
+  {
+    "name": "external",
+    "trans": [
+      "外部的",
+      "outside of something"
+    ]
+  },
+  {
+    "name": "panic",
+    "trans": [
+      "恐慌",
+      "overwhelming feeling of fear and anxiety"
+    ]
+  },
+  {
+    "name": "portrait",
+    "trans": [
+      "肖像",
+      "painting, drawing, or photograph of a person's head and shoulders"
+    ]
+  },
+  {
+    "name": "pink",
+    "trans": [
+      "粉色的",
+      "pale red color"
+    ]
+  },
+  {
+    "name": "library",
+    "trans": [
+      "图书馆",
+      "place where books and other media are kept"
+    ]
+  },
+  {
+    "name": "lie",
+    "trans": [
+      "说谎",
+      "to say something that you know is not true"
+    ]
+  },
+  {
+    "name": "lift",
+    "trans": [
+      "举起",
+      "to move something to higher position"
+    ]
+  },
+  {
+    "name": "segment",
+    "trans": [
+      "部分",
+      "part divided from the other parts of something"
+    ]
+  },
+  {
+    "name": "share",
+    "trans": [
+      "分享",
+      "part of a company you own, shown by a certificate"
+    ]
+  },
+  {
+    "name": "likely",
+    "trans": [
+      "可能",
+      "referring to the chance that something will actually happen"
+    ]
+  },
+  {
+    "name": "limit",
+    "trans": [
+      "限制",
+      "point beyond which it is not possible to go"
+    ]
+  },
+  {
+    "name": "portion",
+    "trans": [
+      "部分",
+      "part of a whole"
+    ]
+  },
+  {
+    "name": "link",
+    "trans": [
+      "关联",
+      "to join or connect together"
+    ]
+  },
+  {
+    "name": "wing",
+    "trans": [
+      "翼",
+      "part of an animal's body that is used for flying"
+    ]
+  },
+  {
+    "name": "list",
+    "trans": [
+      "列表",
+      "series of written names, words or numbers"
+    ]
+  },
+  {
+    "name": "listen",
+    "trans": [
+      "听",
+      "to use your ears to hear and understand things"
+    ]
+  },
+  {
+    "name": "mind",
+    "trans": [
+      "头脑",
+      "part of humans that allows us to think or feel"
+    ]
+  },
+  {
+    "name": "neck",
+    "trans": [
+      "脖子",
+      "part of the body joining the head and the body"
+    ]
+  },
+  {
+    "name": "eye",
+    "trans": [
+      "眼睛",
+      "part of the body that you see with"
+    ]
+  },
+  {
+    "name": "literature",
+    "trans": [
+      "文学",
+      "writings that are valued as works of art, esp. fiction, drama and poetry"
+    ]
+  },
+  {
+    "name": "nose",
+    "trans": [
+      "鼻子",
+      "part of the face used for breathing and smelling"
+    ]
+  },
+  {
+    "name": "tongue",
+    "trans": [
+      "舌头",
+      "part of the mouth that tastes food and is used for speaking"
+    ]
+  },
+  {
+    "name": "load",
+    "trans": [
+      "加载",
+      "large, often heavy, amount of something to be moved"
+    ]
+  },
+  {
+    "name": "module",
+    "trans": [
+      "模块",
+      "part or unit with a specific job"
+    ]
+  },
+  {
+    "name": "location",
+    "trans": [
+      "地点",
+      "particular position or area"
+    ]
+  },
+  {
+    "name": "fragment",
+    "trans": [
+      "分段",
+      "part that is broken off of something"
+    ]
+  },
+  {
+    "name": "emphasis",
+    "trans": [
+      "强调",
+      "particular importance to the way something is said"
+    ]
+  },
+  {
+    "name": "ideal",
+    "trans": [
+      "理想的",
+      "perfect; most suitable; best possible"
+    ]
+  },
+  {
+    "name": "week",
+    "trans": [
+      "星期",
+      "period of seven days, starts on Sunday and end on Saturday"
+    ]
+  },
+  {
+    "name": "gay",
+    "trans": [
+      "同性恋",
+      "person attracted to someone of the same sex"
+    ]
+  },
+  {
+    "name": "immigrant",
+    "trans": [
+      "移民",
+      "person moving to another country to live there"
+    ]
+  },
+  {
+    "name": "loss",
+    "trans": [
+      "损失",
+      "experience or state of failing to have or keep"
+    ]
+  },
+  {
+    "name": "hero",
+    "trans": [
+      "英雄",
+      "person of great courage and strength who saves others"
+    ]
+  },
+  {
+    "name": "peer",
+    "trans": [
+      "同行",
+      "person of the same age, class, or background as another"
+    ]
+  },
+  {
+    "name": "lovely",
+    "trans": [
+      "迷人的",
+      "attractive or beautiful"
+    ]
+  },
+  {
+    "name": "employer",
+    "trans": [
+      "雇主",
+      "person or firm that pays people to work for them"
+    ]
+  },
+  {
+    "name": "member",
+    "trans": [
+      "成员",
+      "person or thing belonging to a group or team"
+    ]
+  },
+  {
+    "name": "substitute",
+    "trans": [
+      "代替",
+      "person or thing that takes the place of something"
+    ]
+  },
+  {
+    "name": "you",
+    "trans": [
+      "你",
+      "person someone is speaking or writing to"
+    ]
+  },
+  {
+    "name": "lunch",
+    "trans": [
+      "午餐",
+      "light meal eaten in the middle of the day"
+    ]
+  },
+  {
+    "name": "student",
+    "trans": [
+      "学生",
+      "person studying at school"
+    ]
+  },
+  {
+    "name": "machine",
+    "trans": [
+      "机器",
+      "piece of equipment used to do work"
+    ]
+  },
+  {
+    "name": "athlete",
+    "trans": [
+      "运动员",
+      "person trained to compete in sports"
+    ]
+  },
+  {
+    "name": "magazine",
+    "trans": [
+      "杂志",
+      "weekly or monthly publication with pictures and stories"
+    ]
+  },
+  {
+    "name": "champion",
+    "trans": [
+      "冠军",
+      "person who fights for or supports strongly"
+    ]
+  },
+  {
+    "name": "main",
+    "trans": [
+      "主要的",
+      "most important; most often used"
+    ]
+  },
+  {
+    "name": "mainly",
+    "trans": [
+      "主要是",
+      "mostly; usually; being the largest part"
+    ]
+  },
+  {
+    "name": "maintain",
+    "trans": [
+      "维持",
+      "to keep, exist or continue without changing"
+    ]
+  },
+  {
+    "name": "governor",
+    "trans": [
+      "州长",
+      "person who leads a state or province"
+    ]
+  },
+  {
+    "name": "major",
+    "trans": [
+      "主要的",
+      "important, serious, or large in scope"
+    ]
+  },
+  {
+    "name": "majority",
+    "trans": [
+      "多数",
+      "amount that is more than half of a group"
+    ]
+  },
+  {
+    "name": "holder",
+    "trans": [
+      "持有者",
+      "person who owns or has received something"
+    ]
+  },
+  {
+    "name": "specialist",
+    "trans": [
+      "专家",
+      "person who works in one specific area of a field or profession"
+    ]
+  },
+  {
+    "name": "male",
+    "trans": [
+      "男性",
+      "characteristic of boys or men"
+    ]
+  },
+  {
+    "name": "poet",
+    "trans": [
+      "诗人",
+      "person who writes poems"
+    ]
+  },
+  {
+    "name": "manage",
+    "trans": [
+      "管理",
+      "to run or operate a business by directing others"
+    ]
+  },
+  {
+    "name": "management",
+    "trans": [
+      "管理",
+      "people who are in control of a business or group"
+    ]
+  },
+  {
+    "name": "manager",
+    "trans": [
+      "经理",
+      "person who controls and runs a business or group"
+    ]
+  },
+  {
+    "name": "manner",
+    "trans": [
+      "方式",
+      "that way that something happens or is done"
+    ]
+  },
+  {
+    "name": "manufacture",
+    "trans": [
+      "生产",
+      "to produce large numbers of products in a factory"
+    ]
+  },
+  {
+    "name": "friend",
+    "trans": [
+      "朋友",
+      "person who you like and enjoy being with"
+    ]
+  },
+  {
+    "name": "map",
+    "trans": [
+      "地图",
+      "picture showing the geography of an area"
+    ]
+  },
+  {
+    "name": "maker",
+    "trans": [
+      "创客",
+      "person, company, or object that creates things"
+    ]
+  },
+  {
+    "name": "mark",
+    "trans": [
+      "标记",
+      "to make or leave a visible sign on something; a writing symbol"
+    ]
+  },
+  {
+    "name": "this",
+    "trans": [
+      "这",
+      "person, thing, or idea near you"
+    ]
+  },
+  {
+    "name": "marriage",
+    "trans": [
+      "婚姻",
+      "formal relationship between a husband and a wife"
+    ]
+  },
+  {
+    "name": "marry",
+    "trans": [
+      "结婚",
+      "to become the husband or wife of someone"
+    ]
+  },
+  {
+    "name": "personality",
+    "trans": [
+      "性格",
+      "person's character; the way that a person usually acts"
+    ]
+  },
+  {
+    "name": "match",
+    "trans": [
+      "匹配",
+      "a sports competition between two people or teams"
+    ]
+  },
+  {
+    "name": "parent",
+    "trans": [
+      "家长",
+      "person's mother or father"
+    ]
+  },
+  {
+    "name": "material",
+    "trans": [
+      "材料",
+      "substance from which a thing is made of"
+    ]
+  },
+  {
+    "name": "injury",
+    "trans": [
+      "受伤",
+      "physical or emotional harm or damage that a person experiences"
+    ]
+  },
+  {
+    "name": "illustration",
+    "trans": [
+      "插图",
+      "picture that helps explain something"
+    ]
+  },
+  {
+    "name": "curtain",
+    "trans": [
+      "窗帘",
+      "piece of cloth used to cover a window"
+    ]
+  },
+  {
+    "name": "flag",
+    "trans": [
+      "旗帜",
+      "piece of cloth, frequently marked with a colorful symbol or sign"
+    ]
+  },
+  {
+    "name": "skirt",
+    "trans": [
+      "裙子",
+      "piece of clothing for the lower body worn by women"
+    ]
+  },
+  {
+    "name": "maybe",
+    "trans": [
+      "或许",
+      "possibly but not certainly; perhaps"
+    ]
+  },
+  {
+    "name": "tissue",
+    "trans": [
+      "组织",
+      "piece of thin, soft paper"
+    ]
+  },
+  {
+    "name": "gate",
+    "trans": [
+      "门",
+      "place in a fence which can be opened or closed"
+    ]
+  },
+  {
+    "name": "stomach",
+    "trans": [
+      "胃",
+      "place in the body where food is broken down so your body can use it"
+    ]
+  },
+  {
+    "name": "measure",
+    "trans": [
+      "措施",
+      "to calculate size, weight or temperature of"
+    ]
+  },
+  {
+    "name": "center",
+    "trans": [
+      "中心",
+      "place in the middle of something"
+    ]
+  },
+  {
+    "name": "jail",
+    "trans": [
+      "监狱",
+      "place to hold criminals being punished for a crime"
+    ]
+  },
+  {
+    "name": "gallery",
+    "trans": [
+      "画廊",
+      "place to look at various types of art"
+    ]
+  },
+  {
+    "name": "medical",
+    "trans": [
+      "医疗的",
+      "of or relating to physical health or medicine"
+    ]
+  },
+  {
+    "name": "home",
+    "trans": [
+      "家",
+      "place where a person or a family lives"
+    ]
+  },
+  {
+    "name": "medium",
+    "trans": [
+      "中等的",
+      "middle size, something between other things"
+    ]
+  },
+  {
+    "name": "intention",
+    "trans": [
+      "意图",
+      "plan, aim, or purpose"
+    ]
+  },
+  {
+    "name": "program",
+    "trans": [
+      "程序",
+      "planned set of actions; a schematic system"
+    ]
+  },
+  {
+    "name": "grass",
+    "trans": [
+      "草",
+      "plants with narrow green leaves, grown on lawns"
+    ]
+  },
+  {
+    "name": "memory",
+    "trans": [
+      "记忆",
+      "something that has been remembered"
+    ]
+  },
+  {
+    "name": "musical",
+    "trans": [
+      "音乐",
+      "play or movie set to music"
+    ]
+  },
+  {
+    "name": "mention",
+    "trans": [
+      "提到",
+      "to refer to or talk or write about something"
+    ]
+  },
+  {
+    "name": "opera",
+    "trans": [
+      "歌剧",
+      "play with music in which all the words are sung"
+    ]
+  },
+  {
+    "name": "proud",
+    "trans": [
+      "自豪的",
+      "pleased because of something you have done"
+    ]
+  },
+  {
+    "name": "poetry",
+    "trans": [
+      "诗",
+      "poetic writing; imaginative verses"
+    ]
+  },
+  {
+    "name": "tent",
+    "trans": [
+      "帐篷",
+      "portable cloth shelter used outdoors"
+    ]
+  },
+  {
+    "name": "message",
+    "trans": [
+      "信息",
+      "piece of information that is told/given to someone"
+    ]
+  },
+  {
+    "name": "approval",
+    "trans": [
+      "赞同",
+      "positive opinion of something or someone"
+    ]
+  },
+  {
+    "name": "implication",
+    "trans": [
+      "含义",
+      "possible effects or results from an action or event"
+    ]
+  },
+  {
+    "name": "method",
+    "trans": [
+      "方法",
+      "organized and planned way of doing something"
+    ]
+  },
+  {
+    "name": "middle",
+    "trans": [
+      "中间",
+      "place that is halfway between two things"
+    ]
+  },
+  {
+    "name": "vessel",
+    "trans": [
+      "血管",
+      "pot, container"
+    ]
+  },
+  {
+    "name": "mile",
+    "trans": [
+      "英里",
+      "unit of distance; 1.6 kilometers"
+    ]
+  },
+  {
+    "name": "military",
+    "trans": [
+      "军队",
+      "concerning soldiers or the armed forces"
+    ]
+  },
+  {
+    "name": "passion",
+    "trans": [
+      "热情",
+      "powerful, positive feeling about something"
+    ]
+  },
+  {
+    "name": "mine",
+    "trans": [
+      "矿",
+      "that thing that belongs to me"
+    ]
+  },
+  {
+    "name": "conservative",
+    "trans": [
+      "保守的",
+      "preferring traditional styles and values"
+    ]
+  },
+  {
+    "name": "minister",
+    "trans": [
+      "部长",
+      "an official who heads a government department"
+    ]
+  },
+  {
+    "name": "cost",
+    "trans": [
+      "成本",
+      "price you pay for something"
+    ]
+  },
+  {
+    "name": "matter",
+    "trans": [
+      "事情",
+      "problem or reason for concern"
+    ]
+  },
+  {
+    "name": "formation",
+    "trans": [
+      "形成",
+      "process of creating, or making into a particular shape"
+    ]
+  },
+  {
+    "name": "publication",
+    "trans": [
+      "发布",
+      "process of producing a book or magazine"
+    ]
+  },
+  {
+    "name": "mix",
+    "trans": [
+      "混合",
+      "to combine two or more things to make one"
+    ]
+  },
+  {
+    "name": "recovery",
+    "trans": [
+      "恢复",
+      "process of returning to a former state after problems"
+    ]
+  },
+  {
+    "name": "interaction",
+    "trans": [
+      "相互作用",
+      "process of two or more people or things affecting each other"
+    ]
+  },
+  {
+    "name": "market",
+    "trans": [
+      "市场",
+      "public event where people sell goods on tables"
+    ]
+  },
+  {
+    "name": "withdraw",
+    "trans": [
+      "提取",
+      "pull back; move away or backward from something"
+    ]
+  },
+  {
+    "name": "modern",
+    "trans": [
+      "现代的",
+      "of the present time; up to date; contemporary"
+    ]
+  },
+  {
+    "name": "penalty",
+    "trans": [
+      "惩罚",
+      "punishment for committing a crime or offense"
+    ]
+  },
+  {
+    "name": "justice",
+    "trans": [
+      "正义",
+      "quality of being fair, equal, or just"
+    ]
+  },
+  {
+    "name": "humor",
+    "trans": [
+      "幽默",
+      "quality of being funny"
+    ]
+  },
+  {
+    "name": "beauty",
+    "trans": [
+      "美丽",
+      "quality of being physically or visually attractive"
+    ]
+  },
+  {
+    "name": "monitor",
+    "trans": [
+      "监视器",
+      "electronic screen on which you can see images"
+    ]
+  },
+  {
+    "name": "charm",
+    "trans": [
+      "魅力",
+      "quality of making people like you; attractiveness"
+    ]
+  },
+  {
+    "name": "darkness",
+    "trans": [
+      "黑暗",
+      "quality of no or little light"
+    ]
+  },
+  {
+    "name": "stability",
+    "trans": [
+      "稳定",
+      "quality of not being easily moved or changed"
+    ]
+  },
+  {
+    "name": "weakness",
+    "trans": [
+      "弱点",
+      "quality of not being powerful or strong"
+    ]
+  },
+  {
+    "name": "moreover",
+    "trans": [
+      "而且",
+      "in addition to what has been said"
+    ]
+  },
+  {
+    "name": "tendency",
+    "trans": [
+      "趋势",
+      "quality that something happens or someone behaves in a particular way"
+    ]
+  },
+  {
+    "name": "scope",
+    "trans": [
+      "范围",
+      "range of things that something includes"
+    ]
+  },
+  {
+    "name": "mostly",
+    "trans": [
+      "大多",
+      "in large part; mainly or chiefly"
+    ]
+  },
+  {
+    "name": "class",
+    "trans": [
+      "班级",
+      "rank or level in society, ranked from high (rich professional people) to low (ordinary people)"
+    ]
+  },
+  {
+    "name": "resistance",
+    "trans": [
+      "反抗",
+      "refusal to accept something new or different"
+    ]
+  },
+  {
+    "name": "state",
+    "trans": [
+      "状态",
+      "region within a country, with its own government"
+    ]
+  },
+  {
+    "name": "pension",
+    "trans": [
+      "养老金",
+      "regular payments you receive after you retire"
+    ]
+  },
+  {
+    "name": "job",
+    "trans": [
+      "工作",
+      "regular work of earning money"
+    ]
+  },
+  {
+    "name": "emotional",
+    "trans": [
+      "情绪化的",
+      "related to deep feelings"
+    ]
+  },
+  {
+    "name": "mountain",
+    "trans": [
+      "山",
+      "very high piece of land, higher than a hill"
+    ]
+  },
+  {
+    "name": "mouth",
+    "trans": [
+      "嘴",
+      "part of the face used for eating and talking"
+    ]
+  },
+  {
+    "name": "academic",
+    "trans": [
+      "学术的",
+      "related to education or school; (n) educator who works at a college or university"
+    ]
+  },
+  {
+    "name": "movement",
+    "trans": [
+      "移动",
+      "part of a piece of music"
+    ]
+  },
+  {
+    "name": "movie",
+    "trans": [
+      "电影",
+      "motion picture; film"
+    ]
+  },
+  {
+    "name": "criminal",
+    "trans": [
+      "刑事",
+      "related to illegal activity; (n) a person who has done a crime"
+    ]
+  },
+  {
+    "name": "scientific",
+    "trans": [
+      "科学的",
+      "related to science"
+    ]
+  },
+  {
+    "name": "murder",
+    "trans": [
+      "谋杀",
+      "crime of deliberately killing a person"
+    ]
+  },
+  {
+    "name": "romantic",
+    "trans": [
+      "浪漫的",
+      "related to strong feelings of love between two people"
+    ]
+  },
+  {
+    "name": "museum",
+    "trans": [
+      "博物馆",
+      "building to display art, science, or history objects"
+    ]
+  },
+  {
+    "name": "clinical",
+    "trans": [
+      "临床",
+      "related to the examination and treatment of patients"
+    ]
+  },
+  {
+    "name": "structural",
+    "trans": [
+      "结构性的",
+      "related to the way something is built or organized"
+    ]
+  },
+  {
+    "name": "local",
+    "trans": [
+      "当地的",
+      "relating or restricted to a particular area, city, or town"
+    ]
+  },
+  {
+    "name": "racial",
+    "trans": [
+      "种族",
+      "relating to a person's group based on inherited physical appearance"
+    ]
+  },
+  {
+    "name": "myself",
+    "trans": [
+      "我",
+      "same person as did the action mentioned"
+    ]
+  },
+  {
+    "name": "rural",
+    "trans": [
+      "乡村的",
+      "relating to parts of a country that are outside towns and cities, with fields, woods, etc."
+    ]
+  },
+  {
+    "name": "educational",
+    "trans": [
+      "教育性的",
+      "relating to teaching in a school"
+    ]
+  },
+  {
+    "name": "fundamental",
+    "trans": [
+      "基本的",
+      "relating to the most important parts of something"
+    ]
+  },
+  {
+    "name": "nation",
+    "trans": [
+      "国家",
+      "area or region controlled by a government and army"
+    ]
+  },
+  {
+    "name": "national",
+    "trans": [
+      "国家的",
+      "concerning a nation as a whole"
+    ]
+  },
+  {
+    "name": "presidential",
+    "trans": [
+      "总统",
+      "relating to the president"
+    ]
+  },
+  {
+    "name": "natural",
+    "trans": [
+      "自然的",
+      "not made by humans; without human intervention"
+    ]
+  },
+  {
+    "name": "calm",
+    "trans": [
+      "冷静的",
+      "relaxed and not worried or angry"
+    ]
+  },
+  {
+    "name": "nature",
+    "trans": [
+      "自然",
+      "physical world, including plants, animals, rocks"
+    ]
+  },
+  {
+    "name": "near",
+    "trans": [
+      "靠近",
+      "with a small distance between things"
+    ]
+  },
+  {
+    "name": "inquiry",
+    "trans": [
+      "询问",
+      "request for information"
+    ]
+  },
+  {
+    "name": "nearly",
+    "trans": [
+      "几乎",
+      "not completely; almost"
+    ]
+  },
+  {
+    "name": "necessarily",
+    "trans": [
+      "一定",
+      "in a way that is needed or required, or is unavoidable"
+    ]
+  },
+  {
+    "name": "necessary",
+    "trans": [
+      "必要的",
+      "needed or required; unavoidable"
+    ]
+  },
+  {
+    "name": "honor",
+    "trans": [
+      "荣誉",
+      "respect given to someone who is admired"
+    ]
+  },
+  {
+    "name": "permission",
+    "trans": [
+      "允许",
+      "right to do something as allowed by another"
+    ]
+  },
+  {
+    "name": "high",
+    "trans": [
+      "高的",
+      "rising upward a great distance"
+    ]
+  },
+  {
+    "name": "moon",
+    "trans": [
+      "月亮",
+      "round object circling the earth at night"
+    ]
+  },
+  {
+    "name": "guideline",
+    "trans": [
+      "指导方针",
+      "rule, instruction, or principle"
+    ]
+  },
+  {
+    "name": "neighbor",
+    "trans": [
+      "邻居",
+      "person who lives, or is near, you"
+    ]
+  },
+  {
+    "name": "grammar",
+    "trans": [
+      "语法",
+      "rules that explain how words are used in a language"
+    ]
+  },
+  {
+    "name": "acceptable",
+    "trans": [
+      "可以接受",
+      "satisfactory; good enough"
+    ]
+  },
+  {
+    "name": "too",
+    "trans": [
+      "也",
+      "say that something is more than you want"
+    ]
+  },
+  {
+    "name": "network",
+    "trans": [
+      "网络",
+      "system of connections"
+    ]
+  },
+  {
+    "name": "complaint",
+    "trans": [
+      "抱怨",
+      "saying something is wrong and should be changed"
+    ]
+  },
+  {
+    "name": "autumn",
+    "trans": [
+      "秋天",
+      "season when the weather is getting colder, between summer and winter"
+    ]
+  },
+  {
+    "name": "news",
+    "trans": [
+      "消息",
+      "information about recent events"
+    ]
+  },
+  {
+    "name": "newspaper",
+    "trans": [
+      "报纸",
+      "sheets of paper (or online) containing news stories"
+    ]
+  },
+  {
+    "name": "paragraph",
+    "trans": [
+      "段落",
+      "section of writing that usually deals with one subject"
+    ]
+  },
+  {
+    "name": "nice",
+    "trans": [
+      "好的",
+      "good or enjoyable"
+    ]
+  },
+  {
+    "name": "grain",
+    "trans": [
+      "粮食",
+      "seeds of plants used for food"
+    ]
+  },
+  {
+    "name": "period",
+    "trans": [
+      "时期",
+      "set amount of time during which events take place"
+    ]
+  },
+  {
+    "name": "nobody",
+    "trans": [
+      "没有人",
+      "no person; no one; not any person"
+    ]
+  },
+  {
+    "name": "nor",
+    "trans": [
+      "也不",
+      "used to show two things that are both untrue or do not happen"
+    ]
+  },
+  {
+    "name": "normal",
+    "trans": [
+      "普通的",
+      "standard or regular way of doing something"
+    ]
+  },
+  {
+    "name": "normally",
+    "trans": [
+      "通常情况下",
+      "in the manner that is usual or ordinary"
+    ]
+  },
+  {
+    "name": "north",
+    "trans": [
+      "北",
+      "direction to your left when facing the rising sun"
+    ]
+  },
+  {
+    "name": "religion",
+    "trans": [
+      "宗教",
+      "set of beliefs about a god or gods"
+    ]
+  },
+  {
+    "name": "system",
+    "trans": [
+      "系统",
+      "set of organized, planned ideas that work together"
+    ]
+  },
+  {
+    "name": "apartment",
+    "trans": [
+      "公寓",
+      "set of rooms to live in on one floor of a building"
+    ]
+  },
+  {
+    "name": "mutual",
+    "trans": [
+      "相互的",
+      "shared between two or more people"
+    ]
+  },
+  {
+    "name": "notice",
+    "trans": [
+      "注意",
+      "to become aware by sight, touch, or hearing"
+    ]
+  },
+  {
+    "name": "essay",
+    "trans": [
+      "散文",
+      "short written work that displays someone's opinions or beliefs regarding a particular subject"
+    ]
+  },
+  {
+    "name": "episode",
+    "trans": [
+      "插曲",
+      "show which is part of a larger story"
+    ]
+  },
+  {
+    "name": "novel",
+    "trans": [
+      "小说",
+      "written fiction story"
+    ]
+  },
+  {
+    "name": "alongside",
+    "trans": [
+      "旁边",
+      "side by side with something"
+    ]
+  },
+  {
+    "name": "plain",
+    "trans": [
+      "清楚的",
+      "simple; easy to understand; clear"
+    ]
+  },
+  {
+    "name": "aunt",
+    "trans": [
+      "阿姨",
+      "sister of your father or mother or the wife of your uncle"
+    ]
+  },
+  {
+    "name": "nuclear",
+    "trans": [
+      "核",
+      "concerning or involving the center of an atom"
+    ]
+  },
+  {
+    "name": "mere",
+    "trans": [
+      "仅仅",
+      "small and unimportant"
+    ]
+  },
+  {
+    "name": "town",
+    "trans": [
+      "镇",
+      "small city"
+    ]
+  },
+  {
+    "name": "nurse",
+    "trans": [
+      "护士",
+      "person trained to care for sick or injured people"
+    ]
+  },
+  {
+    "name": "object",
+    "trans": [
+      "目的",
+      "to disagree; to protest against an idea or plan"
+    ]
+  },
+  {
+    "name": "objective",
+    "trans": [
+      "客观的",
+      "something you decide you want to do; goal"
+    ]
+  },
+  {
+    "name": "pocket",
+    "trans": [
+      "口袋",
+      "small cloth bag sewn into clothing to hold things"
+    ]
+  },
+  {
+    "name": "stamp",
+    "trans": [
+      "邮票",
+      "small piece of paper you buy to put on a letter that you mail"
+    ]
+  },
+  {
+    "name": "observe",
+    "trans": [
+      "观察",
+      "to watch carefully; to make a comment"
+    ]
+  },
+  {
+    "name": "obvious",
+    "trans": [
+      "明显的",
+      "easily understood and clear; plain to see"
+    ]
+  },
+  {
+    "name": "obviously",
+    "trans": [
+      "明显地",
+      "in a way that is obvious/easy to see or understand"
+    ]
+  },
+  {
+    "name": "bit",
+    "trans": [
+      "少量",
+      "small piece of something"
+    ]
+  },
+  {
+    "name": "stream",
+    "trans": [
+      "溪流",
+      "small river"
+    ]
+  },
+  {
+    "name": "occur",
+    "trans": [
+      "发生",
+      "to come to pass or to happen"
+    ]
+  },
+  {
+    "name": "cap",
+    "trans": [
+      "帽",
+      "small, soft hat often with a front visor or shade"
+    ]
+  },
+  {
+    "name": "less",
+    "trans": [
+      "较少的",
+      "smaller in amount or degree"
+    ]
+  },
+  {
+    "name": "cheek",
+    "trans": [
+      "脸颊",
+      "soft skin on each side of the face, below the eyes"
+    ]
+  },
+  {
+    "name": "snow",
+    "trans": [
+      "雪",
+      "soft white pieces of frozen water falling from the clouds"
+    ]
+  },
+  {
+    "name": "answer",
+    "trans": [
+      "回答",
+      "solution to a problem or test question"
+    ]
+  },
+  {
+    "name": "officer",
+    "trans": [
+      "官",
+      "person with an important position in an organization"
+    ]
+  },
+  {
+    "name": "official",
+    "trans": [
+      "官方的",
+      "of or done by someone in authority; formal"
+    ]
+  },
+  {
+    "name": "part",
+    "trans": [
+      "部分",
+      "some, but not all of a specific thing"
+    ]
+  },
+  {
+    "name": "oil",
+    "trans": [
+      "油",
+      "thick, black liquid in the ground used as fuel"
+    ]
+  },
+  {
+    "name": "okay",
+    "trans": [
+      "好的",
+      "yes; alright"
+    ]
+  },
+  {
+    "name": "prisoner",
+    "trans": [
+      "囚犯",
+      "someone kept in a prison as punishment for a crime"
+    ]
+  },
+  {
+    "name": "dealer",
+    "trans": [
+      "经销商",
+      "someone who buys things to sell to others"
+    ]
+  },
+  {
+    "name": "designer",
+    "trans": [
+      "设计师",
+      "someone who creates plans to make something"
+    ]
+  },
+  {
+    "name": "pro",
+    "trans": [
+      "亲",
+      "someone who earns money doing something they are particularly good at"
+    ]
+  },
+  {
+    "name": "buyer",
+    "trans": [
+      "买方",
+      "someone who gets something by paying money for it"
+    ]
+  },
+  {
+    "name": "politician",
+    "trans": [
+      "政治家",
+      "someone who is active in politics"
+    ]
+  },
+  {
+    "name": "slave",
+    "trans": [
+      "奴隶",
+      "someone who is legally owned by another person"
+    ]
+  },
+  {
+    "name": "operate",
+    "trans": [
+      "操作",
+      "to be working or being used"
+    ]
+  },
+  {
+    "name": "operation",
+    "trans": [
+      "手术",
+      "functioning; use"
+    ]
+  },
+  {
+    "name": "shareholder",
+    "trans": [
+      "股东",
+      "someone who owns a part of a corporation"
+    ]
+  },
+  {
+    "name": "opinion",
+    "trans": [
+      "观点",
+      "a person's thoughts on a topic"
+    ]
+  },
+  {
+    "name": "opportunity",
+    "trans": [
+      "机会",
+      "time/situation when a thing might be done; chance"
+    ]
+  },
+  {
+    "name": "opposite",
+    "trans": [
+      "对面的",
+      "across from or on the side facing something"
+    ]
+  },
+  {
+    "name": "listener",
+    "trans": [
+      "听众",
+      "someone who pays attention to what is said"
+    ]
+  },
+  {
+    "name": "option",
+    "trans": [
+      "选项",
+      "possibility out of several that can be chosen; choice"
+    ]
+  },
+  {
+    "name": "historian",
+    "trans": [
+      "历史学家",
+      "someone who studies or writes about the course of history"
+    ]
+  },
+  {
+    "name": "ally",
+    "trans": [
+      "盟友",
+      "someone who supports, helps, or defends you"
+    ]
+  },
+  {
+    "name": "operator",
+    "trans": [
+      "操作员",
+      "someone who uses and controls something, usually equipment"
+    ]
+  },
+  {
+    "name": "enemy",
+    "trans": [
+      "敌人",
+      "someone who wants to harm another"
+    ]
+  },
+  {
+    "name": "organization",
+    "trans": [
+      "组织",
+      "formal group of people with a particular purpose"
+    ]
+  },
+  {
+    "name": "volunteer",
+    "trans": [
+      "志愿者",
+      "someone who works willingly without pay"
+    ]
+  },
+  {
+    "name": "mate",
+    "trans": [
+      "伴侣",
+      "someone who you work, live, or go to school with"
+    ]
+  },
+  {
+    "name": "otherwise",
+    "trans": [
+      "否则",
+      "indicates that there will be a bad result if something is done, not done, or done improperly"
+    ]
+  },
+  {
+    "name": "ought",
+    "trans": [
+      "应该",
+      "what is expected; should"
+    ]
+  },
+  {
+    "name": "reporter",
+    "trans": [
+      "记者",
+      "someone whose job is to write and report news for a newspaper, magazine, television, or radio station"
+    ]
+  },
+  {
+    "name": "stranger",
+    "trans": [
+      "陌生人",
+      "someone you do not know"
+    ]
+  },
+  {
+    "name": "supplement",
+    "trans": [
+      "补充",
+      "something added to another thing to make it better"
+    ]
+  },
+  {
+    "name": "variation",
+    "trans": [
+      "变化",
+      "something almost the same as another but different"
+    ]
+  },
+  {
+    "name": "problem",
+    "trans": [
+      "问题",
+      "something difficult to deal with or causes trouble"
+    ]
+  },
+  {
+    "name": "outside",
+    "trans": [
+      "外部",
+      "area around or near something, such as a building"
+    ]
+  },
+  {
+    "name": "other",
+    "trans": [
+      "其他",
+      "something else; not the first one"
+    ]
+  },
+  {
+    "name": "overall",
+    "trans": [
+      "全面的",
+      "viewed as a whole; in general, not as details"
+    ]
+  },
+  {
+    "name": "luxury",
+    "trans": [
+      "奢华",
+      "something expensive or costly that is not needed which is bought for pleasure"
+    ]
+  },
+  {
+    "name": "achievement",
+    "trans": [
+      "成就",
+      "something good that you have successfully done"
+    ]
+  },
+  {
+    "name": "mixture",
+    "trans": [
+      "混合物",
+      "something made by combining two or more things"
+    ]
+  },
+  {
+    "name": "impressive",
+    "trans": [
+      "感人的",
+      "something makes someone admire or respect"
+    ]
+  },
+  {
+    "name": "owner",
+    "trans": [
+      "所有者",
+      "person who owns or has something"
+    ]
+  },
+  {
+    "name": "time",
+    "trans": [
+      "时间",
+      "something measured in minutes, hours, days, etc."
+    ]
+  },
+  {
+    "name": "pack",
+    "trans": [
+      "盒",
+      "to put things in a suitcase to go on a trip"
+    ]
+  },
+  {
+    "name": "page",
+    "trans": [
+      "页",
+      "one side of a sheet of paper"
+    ]
+  },
+  {
+    "name": "pain",
+    "trans": [
+      "疼痛",
+      "strong feeling of hurt or discomfort"
+    ]
+  },
+  {
+    "name": "paint",
+    "trans": [
+      "画",
+      "to apply something; coat"
+    ]
+  },
+  {
+    "name": "exception",
+    "trans": [
+      "例外",
+      "something not included in or different from a group of things"
+    ]
+  },
+  {
+    "name": "hat",
+    "trans": [
+      "帽子",
+      "something people wear to cover their heads for fashion or protection"
+    ]
+  },
+  {
+    "name": "paper",
+    "trans": [
+      "纸",
+      "pages of a book are made from this"
+    ]
+  },
+  {
+    "name": "classic",
+    "trans": [
+      "经典的",
+      "something popular or famous for a long time and is considered one of the best of its kind"
+    ]
+  },
+  {
+    "name": "biological",
+    "trans": [
+      "生物",
+      "something related to life and living things"
+    ]
+  },
+  {
+    "name": "disaster",
+    "trans": [
+      "灾难",
+      "something that causes a lot of harm or damage"
+    ]
+  },
+  {
+    "name": "park",
+    "trans": [
+      "公园",
+      "to put your car or bike in a certain place for a time"
+    ]
+  },
+  {
+    "name": "burden",
+    "trans": [
+      "负担",
+      "something that causes worry, difficulty, or hard work"
+    ]
+  },
+  {
+    "name": "participate",
+    "trans": [
+      "参加",
+      "to take part with others in doing something"
+    ]
+  },
+  {
+    "name": "incentive",
+    "trans": [
+      "激励",
+      "something that encourages a person to work hard"
+    ]
+  },
+  {
+    "name": "particular",
+    "trans": [
+      "特别的",
+      "one specific (one)"
+    ]
+  },
+  {
+    "name": "particularly",
+    "trans": [
+      "特别",
+      "specially; more than others"
+    ]
+  },
+  {
+    "name": "smooth",
+    "trans": [
+      "光滑的",
+      "something that feels pleasant and flat when you touch it; not rough"
+    ]
+  },
+  {
+    "name": "partner",
+    "trans": [
+      "伙伴",
+      "someone you have a business or personal relationship with"
+    ]
+  },
+  {
+    "name": "outcome",
+    "trans": [
+      "结果",
+      "something that happens as a result, consequence"
+    ]
+  },
+  {
+    "name": "pass",
+    "trans": [
+      "经过",
+      "to travel through or near a place"
+    ]
+  },
+  {
+    "name": "composition",
+    "trans": [
+      "作品",
+      "something that is created from different parts to make something new"
+    ]
+  },
+  {
+    "name": "priority",
+    "trans": [
+      "优先事项",
+      "something that is important and must be done before other things"
+    ]
+  },
+  {
+    "name": "path",
+    "trans": [
+      "小路",
+      "track made with stones/by walking over the ground"
+    ]
+  },
+  {
+    "name": "patient",
+    "trans": [
+      "病人",
+      "not getting annoyed when things take a long time"
+    ]
+  },
+  {
+    "name": "pattern",
+    "trans": [
+      "图案",
+      "regular repeated behavior"
+    ]
+  },
+  {
+    "name": "pause",
+    "trans": [
+      "暂停",
+      "to stop doing for a while before continuing"
+    ]
+  },
+  {
+    "name": "fact",
+    "trans": [
+      "事实",
+      "something that is known or proved to be true"
+    ]
+  },
+  {
+    "name": "payment",
+    "trans": [
+      "支付",
+      "amount of money that is paid for something"
+    ]
+  },
+  {
+    "name": "peace",
+    "trans": [
+      "和平",
+      "time when there is no war or fighting"
+    ]
+  },
+  {
+    "name": "preference",
+    "trans": [
+      "偏爱",
+      "something that is liked or wanted more than another"
+    ]
+  },
+  {
+    "name": "compound",
+    "trans": [
+      "化合物",
+      "something that is made from two or more other things"
+    ]
+  },
+  {
+    "name": "prize",
+    "trans": [
+      "奖",
+      "something that is won in a contest or given as an award"
+    ]
+  },
+  {
+    "name": "constraint",
+    "trans": [
+      "约束",
+      "something that limits or prevents someone or something from moving"
+    ]
+  },
+  {
+    "name": "indication",
+    "trans": [
+      "指示",
+      "something that signals that something else exists or will happen"
+    ]
+  },
+  {
+    "name": "obligation",
+    "trans": [
+      "义务",
+      "something that you do because it is your duty or because you feel you have to"
+    ]
+  },
+  {
+    "name": "visual",
+    "trans": [
+      "视觉的",
+      "something to look at with the eyes"
+    ]
+  },
+  {
+    "name": "percent",
+    "trans": [
+      "百分比",
+      "one one-hundredth of a whole"
+    ]
+  },
+  {
+    "name": "percentage",
+    "trans": [
+      "百分比",
+      "part of a whole divided into hundredths"
+    ]
+  },
+  {
+    "name": "perfect",
+    "trans": [
+      "完美的",
+      "so good it/they cannot be improved"
+    ]
+  },
+  {
+    "name": "assumption",
+    "trans": [
+      "假设",
+      "something you believe to be so, but aren't sure of"
+    ]
+  },
+  {
+    "name": "perform",
+    "trans": [
+      "履行",
+      "to carry out an action well or successfully"
+    ]
+  },
+  {
+    "name": "performance",
+    "trans": [
+      "表现",
+      "activity done to entertain an audience"
+    ]
+  },
+  {
+    "name": "perhaps",
+    "trans": [
+      "也许",
+      "possibly, but not certainly; maybe"
+    ]
+  },
+  {
+    "name": "thing",
+    "trans": [
+      "事物",
+      "something you cannot remember the name of"
+    ]
+  },
+  {
+    "name": "pen",
+    "trans": [
+      "笔",
+      "something you write with that uses ink"
+    ]
+  },
+  {
+    "name": "rather",
+    "trans": [
+      "相当",
+      "somewhat; fairly; not that much"
+    ]
+  },
+  {
+    "name": "personal",
+    "trans": [
+      "个人的",
+      "done by or to a particular person; individual"
+    ]
+  },
+  {
+    "name": "tone",
+    "trans": [
+      "语气",
+      "sound of a voice that shows emotion or meaning"
+    ]
+  },
+  {
+    "name": "alarm",
+    "trans": [
+      "警报",
+      "sound or light used for a warning or to wake someone"
+    ]
+  },
+  {
+    "name": "music",
+    "trans": [
+      "音乐",
+      "sounds that are sung or played to give pleasure"
+    ]
+  },
+  {
+    "name": "perspective",
+    "trans": [
+      "看法",
+      "way of thinking, an attitude toward something"
+    ]
+  },
+  {
+    "name": "representation",
+    "trans": [
+      "表示",
+      "speaking or doing something officially for another person"
+    ]
+  },
+  {
+    "name": "celebration",
+    "trans": [
+      "庆典",
+      "special event where people show the importance of something"
+    ]
+  },
+  {
+    "name": "ceremony",
+    "trans": [
+      "仪式",
+      "special social or religious event"
+    ]
+  },
+  {
+    "name": "phone",
+    "trans": [
+      "电话",
+      "to talk to someone using a telephone"
+    ]
+  },
+  {
+    "name": "photo",
+    "trans": [
+      "照片",
+      "short for photograph; a picture taken by a camera"
+    ]
+  },
+  {
+    "name": "gear",
+    "trans": [
+      "齿轮",
+      "special supplies, tools, or clothes needed for a particular activity; machinery that turns power into forward or backward movement"
+    ]
+  },
+  {
+    "name": "physical",
+    "trans": [
+      "身体的",
+      "concerning the body of a person"
+    ]
+  },
+  {
+    "name": "rate",
+    "trans": [
+      "速度",
+      "speed or frequency of events over time"
+    ]
+  },
+  {
+    "name": "pick",
+    "trans": [
+      "挑选",
+      "to decide on a thing from various choices; select"
+    ]
+  },
+  {
+    "name": "picture",
+    "trans": [
+      "图片",
+      "painting, drawing or photograph on paper or screen"
+    ]
+  },
+  {
+    "name": "piece",
+    "trans": [
+      "片",
+      "small part that of something larger"
+    ]
+  },
+  {
+    "name": "championship",
+    "trans": [
+      "锦标赛",
+      "sports competition to find the best player or team"
+    ]
+  },
+  {
+    "name": "from",
+    "trans": [
+      "从",
+      "starting at a particular place, time, or level"
+    ]
+  },
+  {
+    "name": "ease",
+    "trans": [
+      "舒适",
+      "state of being comfortable or relaxed"
+    ]
+  },
+  {
+    "name": "gender",
+    "trans": [
+      "性别",
+      "state of being male or female"
+    ]
+  },
+  {
+    "name": "attendance",
+    "trans": [
+      "出席率",
+      "state of being present at a place or event"
+    ]
+  },
+  {
+    "name": "existence",
+    "trans": [
+      "存在",
+      "state of being present, alive, or real"
+    ]
+  },
+  {
+    "name": "comfort",
+    "trans": [
+      "舒适",
+      "state of being relaxed, warm, or happy"
+    ]
+  },
+  {
+    "name": "exposure",
+    "trans": [
+      "接触",
+      "state of experiencing something directly"
+    ]
+  },
+  {
+    "name": "plane",
+    "trans": [
+      "飞机",
+      "an airplane"
+    ]
+  },
+  {
+    "name": "happiness",
+    "trans": [
+      "幸福",
+      "state of feeling pleased; feeling of satisfaction"
+    ]
+  },
+  {
+    "name": "plant",
+    "trans": [
+      "植物",
+      "living thing with leaves and roots growing in soil"
+    ]
+  },
+  {
+    "name": "complexity",
+    "trans": [
+      "复杂",
+      "state of having many parts and not being simple"
+    ]
+  },
+  {
+    "name": "diversity",
+    "trans": [
+      "多样性",
+      "state or quality of having a range of different things"
+    ]
+  },
+  {
+    "name": "stair",
+    "trans": [
+      "楼梯",
+      "steps that go from one level to another"
+    ]
+  },
+  {
+    "name": "player",
+    "trans": [
+      "玩家",
+      "person who plays sports"
+    ]
+  },
+  {
+    "name": "tale",
+    "trans": [
+      "故事",
+      "story about colorful and imaginary events"
+    ]
+  },
+  {
+    "name": "please",
+    "trans": [
+      "请",
+      "you say this when you politely ask people for things"
+    ]
+  },
+  {
+    "name": "pleasure",
+    "trans": [
+      "乐趣",
+      "feeling of happiness, enjoyment, or satisfaction"
+    ]
+  },
+  {
+    "name": "plus",
+    "trans": [
+      "加",
+      "having a value greater than zero"
+    ]
+  },
+  {
+    "name": "side",
+    "trans": [
+      "边",
+      "straight edge of an object"
+    ]
+  },
+  {
+    "name": "guitar",
+    "trans": [
+      "吉他",
+      "stringed musical instrument played with the fingers"
+    ]
+  },
+  {
+    "name": "attachment",
+    "trans": [
+      "依恋",
+      "strong affection for someone"
+    ]
+  },
+  {
+    "name": "barrier",
+    "trans": [
+      "障碍",
+      "structure or object that stops free movement"
+    ]
+  },
+  {
+    "name": "philosophy",
+    "trans": [
+      "哲学",
+      "study of ideas about the fundamental nature of life"
+    ]
+  },
+  {
+    "name": "police",
+    "trans": [
+      "警察",
+      "people, often in uniforms, who solve crimes"
+    ]
+  },
+  {
+    "name": "history",
+    "trans": [
+      "历史",
+      "study of past event"
+    ]
+  },
+  {
+    "name": "mathematics",
+    "trans": [
+      "数学",
+      "study or science of numbers and shapes"
+    ]
+  },
+  {
+    "name": "politics",
+    "trans": [
+      "政治",
+      "activities influencing the policies of a government"
+    ]
+  },
+  {
+    "name": "dramatic",
+    "trans": [
+      "戏剧性",
+      "sudden and extreme"
+    ]
+  },
+  {
+    "name": "flash",
+    "trans": [
+      "闪光",
+      "sudden bright light"
+    ]
+  },
+  {
+    "name": "pool",
+    "trans": [
+      "水池",
+      "large container or hole that is filled with water and used for people to swim in"
+    ]
+  },
+  {
+    "name": "poor",
+    "trans": [
+      "贫穷的",
+      "without money; not rich"
+    ]
+  },
+  {
+    "name": "pop",
+    "trans": [
+      "流行音乐",
+      "to cause something to open or burst suddenly"
+    ]
+  },
+  {
+    "name": "popular",
+    "trans": [
+      "受欢迎的",
+      "liked or enjoyed by many people"
+    ]
+  },
+  {
+    "name": "formal",
+    "trans": [
+      "正式的",
+      "suitable for serious, official, or important occasions"
+    ]
+  },
+  {
+    "name": "number",
+    "trans": [
+      "数字",
+      "symbols such as 1, 2, 56, 793"
+    ]
+  },
+  {
+    "name": "lecture",
+    "trans": [
+      "演讲",
+      "talk or speech about a particular subject"
+    ]
+  },
+  {
+    "name": "position",
+    "trans": [
+      "位置",
+      "specific location where someone or something is"
+    ]
+  },
+  {
+    "name": "positive",
+    "trans": [
+      "积极的",
+      "good or useful in qualities, constructive, confident"
+    ]
+  },
+  {
+    "name": "sweet",
+    "trans": [
+      "甜的",
+      "tasting like sugar; containing sugar"
+    ]
+  },
+  {
+    "name": "examination",
+    "trans": [
+      "考试",
+      "test of your knowledge of, or ability in something"
+    ]
+  },
+  {
+    "name": "possibility",
+    "trans": [
+      "可能性",
+      "something with a chance of happening or being true"
+    ]
+  },
+  {
+    "name": "exam",
+    "trans": [
+      "考试",
+      "test of your knowledge or ability in something"
+    ]
+  },
+  {
+    "name": "possibly",
+    "trans": [
+      "可能",
+      "may be true or likely, but is uncertain"
+    ]
+  },
+  {
+    "name": "post",
+    "trans": [
+      "邮政",
+      "to send a letter or package using the post office"
+    ]
+  },
+  {
+    "name": "potentially",
+    "trans": [
+      "潜在地",
+      "that could happen or become reality"
+    ]
+  },
+  {
+    "name": "concentration",
+    "trans": [
+      "专注",
+      "the ability to direct all your effort and attention on the one thing you are doing and nothing else"
+    ]
+  },
+  {
+    "name": "potential",
+    "trans": [
+      "潜在的",
+      "capable of happening or becoming reality"
+    ]
+  },
+  {
+    "name": "imagination",
+    "trans": [
+      "想像力",
+      "the ability to think of new ideas or things that are not real"
+    ]
+  },
+  {
+    "name": "pound",
+    "trans": [
+      "磅",
+      "unit of weight equal to 16 ounces or 0.4536 kg"
+    ]
+  },
+  {
+    "name": "selection",
+    "trans": [
+      "选择",
+      "the act of carefully choosing something or someone from a group"
+    ]
+  },
+  {
+    "name": "entry",
+    "trans": [
+      "入口",
+      "the act of going into some place"
+    ]
+  },
+  {
+    "name": "immigration",
+    "trans": [
+      "移民",
+      "the act of moving from one country to another for good"
+    ]
+  },
+  {
+    "name": "powerful",
+    "trans": [
+      "强大的",
+      "having control or influence over"
+    ]
+  },
+  {
+    "name": "practice",
+    "trans": [
+      "实践",
+      "to do something many times to improve a skill"
+    ]
+  },
+  {
+    "name": "bath",
+    "trans": [
+      "洗澡",
+      "the cleaning of a body by putting it completely into water"
+    ]
+  },
+  {
+    "name": "shower",
+    "trans": [
+      "淋浴",
+      "the cleaning of a body by standing under falling water"
+    ]
+  },
+  {
+    "name": "east",
+    "trans": [
+      "东方",
+      "the direction where the sun rises"
+    ]
+  },
+  {
+    "name": "measurement",
+    "trans": [
+      "测量",
+      "the finding of the size or amount of something or someone"
+    ]
+  },
+  {
+    "name": "predict",
+    "trans": [
+      "预测",
+      "to guess or estimate what will or might happen"
+    ]
+  },
+  {
+    "name": "prefer",
+    "trans": [
+      "更喜欢",
+      "to like something better than something else"
+    ]
+  },
+  {
+    "name": "chest",
+    "trans": [
+      "胸部",
+      "the front of your body between your neck and your waist"
+    ]
+  },
+  {
+    "name": "outline",
+    "trans": [
+      "大纲",
+      "the main ideas or facts about something, without the details"
+    ]
+  },
+  {
+    "name": "king",
+    "trans": [
+      "国王",
+      "the male ruler of a country that has a royal family"
+    ]
+  },
+  {
+    "name": "meat",
+    "trans": [
+      "肉",
+      "the muscles and soft parts of animals or birds that is eaten as food"
+    ]
+  },
+  {
+    "name": "unemployment",
+    "trans": [
+      "失业",
+      "the number of people in an area who want to work but do not have a job"
+    ]
+  },
+  {
+    "name": "prepare",
+    "trans": [
+      "准备",
+      "to make something ready for use"
+    ]
+  },
+  {
+    "name": "ear",
+    "trans": [
+      "耳朵",
+      "the part of the head that you hear with"
+    ]
+  },
+  {
+    "name": "half",
+    "trans": [
+      "一半",
+      "the part you get when one is divided into two; ½"
+    ]
+  },
+  {
+    "name": "I",
+    "trans": [
+      "我",
+      "the person who is speaking or writing"
+    ]
+  },
+  {
+    "name": "prospect",
+    "trans": [
+      "前景",
+      "the possibility that something might happen in the future, especially something good"
+    ]
+  },
+  {
+    "name": "press",
+    "trans": [
+      "按",
+      "to push something against something else"
+    ]
+  },
+  {
+    "name": "pressure",
+    "trans": [
+      "压力",
+      "force/weight when pressing against a thing"
+    ]
+  },
+  {
+    "name": "discipline",
+    "trans": [
+      "纪律",
+      "the teaching of self-control through instruction and practice"
+    ]
+  },
+  {
+    "name": "narrative",
+    "trans": [
+      "叙述",
+      "the telling of a story"
+    ]
+  },
+  {
+    "name": "pretty",
+    "trans": [
+      "漂亮的",
+      "being attractive to the eye in a simple way"
+    ]
+  },
+  {
+    "name": "prevent",
+    "trans": [
+      "防止",
+      "to stop something from happening or existing"
+    ]
+  },
+  {
+    "name": "previous",
+    "trans": [
+      "以前的",
+      "existing or happening before the present time"
+    ]
+  },
+  {
+    "name": "previously",
+    "trans": [
+      "之前",
+      "at an earlier time"
+    ]
+  },
+  {
+    "name": "peak",
+    "trans": [
+      "顶峰",
+      "the time or place when something or someone is best, greatest, highest"
+    ]
+  },
+  {
+    "name": "diet",
+    "trans": [
+      "饮食",
+      "the type of food that a person or animal usually eats"
+    ]
+  },
+  {
+    "name": "self",
+    "trans": [
+      "自己",
+      "the type of person you really are"
+    ]
+  },
+  {
+    "name": "primary",
+    "trans": [
+      "基本的",
+      "most important, most basic or essential"
+    ]
+  },
+  {
+    "name": "consequently",
+    "trans": [
+      "最后",
+      "therefore; as a result of something"
+    ]
+  },
+  {
+    "name": "string",
+    "trans": [
+      "细绳",
+      "thin rope"
+    ]
+  },
+  {
+    "name": "wire",
+    "trans": [
+      "金属丝",
+      "thin, flexible thread of metal"
+    ]
+  },
+  {
+    "name": "book",
+    "trans": [
+      "书",
+      "thing made of pages with writing on that you read"
+    ]
+  },
+  {
+    "name": "anything",
+    "trans": [
+      "任何事物",
+      "thing of any kind; used to refer to a thing in questions"
+    ]
+  },
+  {
+    "name": "private",
+    "trans": [
+      "私人的",
+      "personal; not to be seen by everyone"
+    ]
+  },
+  {
+    "name": "something",
+    "trans": [
+      "某物",
+      "thing that is not yet known or named"
+    ]
+  },
+  {
+    "name": "brush",
+    "trans": [
+      "刷子",
+      "thing used to comb your hair or to clean the floor"
+    ]
+  },
+  {
+    "name": "view",
+    "trans": [
+      "看法",
+      "things you are able to see from a specific place"
+    ]
+  },
+  {
+    "name": "clothing",
+    "trans": [
+      "衣服",
+      "things you wear on your body"
+    ]
+  },
+  {
+    "name": "careful",
+    "trans": [
+      "小心",
+      "thinking about what you are doing in order to avoid a mistake"
+    ]
+  },
+  {
+    "name": "future",
+    "trans": [
+      "未来",
+      "time that is to come after the present"
+    ]
+  },
+  {
+    "name": "procedure",
+    "trans": [
+      "程序",
+      "usual or standard way in which something is done"
+    ]
+  },
+  {
+    "name": "proceed",
+    "trans": [
+      "继续",
+      "to continue to do something; carry on"
+    ]
+  },
+  {
+    "name": "pregnancy",
+    "trans": [
+      "怀孕",
+      "time when a female is going to have a baby"
+    ]
+  },
+  {
+    "name": "produce",
+    "trans": [
+      "生产",
+      "to manufacture something using machines"
+    ]
+  },
+  {
+    "name": "retirement",
+    "trans": [
+      "退休",
+      "time when someone has stopped working because of their age"
+    ]
+  },
+  {
+    "name": "production",
+    "trans": [
+      "生产",
+      "process of making something on a large scale"
+    ]
+  },
+  {
+    "name": "night",
+    "trans": [
+      "夜晚",
+      "time when sun does not shine"
+    ]
+  },
+  {
+    "name": "deeply",
+    "trans": [
+      "深",
+      "to a great, intense, or extreme extent"
+    ]
+  },
+  {
+    "name": "submit",
+    "trans": [
+      "提交",
+      "to accept a superior force has power over you"
+    ]
+  },
+  {
+    "name": "profit",
+    "trans": [
+      "利润",
+      "to earn money from something"
+    ]
+  },
+  {
+    "name": "acknowledge",
+    "trans": [
+      "承认",
+      "to accept that something is true"
+    ]
+  },
+  {
+    "name": "progress",
+    "trans": [
+      "进步",
+      "to move forward or toward a place or goal"
+    ]
+  },
+  {
+    "name": "project",
+    "trans": [
+      "项目",
+      "a planned piece of work for specific purpose"
+    ]
+  },
+  {
+    "name": "promise",
+    "trans": [
+      "承诺",
+      "to say you will certainly do something"
+    ]
+  },
+  {
+    "name": "promote",
+    "trans": [
+      "推动",
+      "to try to encourage the popularity and sales of a product"
+    ]
+  },
+  {
+    "name": "pretend",
+    "trans": [
+      "假装",
+      "to act as if something is true when it is not"
+    ]
+  },
+  {
+    "name": "behave",
+    "trans": [
+      "表现",
+      "to act in a particular way; to act correctly"
+    ]
+  },
+  {
+    "name": "help",
+    "trans": [
+      "帮助",
+      "to act to enable a person to do something; assist"
+    ]
+  },
+  {
+    "name": "proper",
+    "trans": [
+      "恰当的",
+      "correct according to social or moral rules"
+    ]
+  },
+  {
+    "name": "do",
+    "trans": [
+      "做",
+      "to act; to perform actions"
+    ]
+  },
+  {
+    "name": "proposal",
+    "trans": [
+      "提议",
+      "offer or plan to people who can decide about it"
+    ]
+  },
+  {
+    "name": "propose",
+    "trans": [
+      "提出",
+      "to offer or put forward an idea for consideration"
+    ]
+  },
+  {
+    "name": "process",
+    "trans": [
+      "过程",
+      "to adopt a set of actions that produce a particular result"
+    ]
+  },
+  {
+    "name": "protect",
+    "trans": [
+      "保护",
+      "to defend someone or something from harm or danger"
+    ]
+  },
+  {
+    "name": "protection",
+    "trans": [
+      "保护",
+      "being kept from harm"
+    ]
+  },
+  {
+    "name": "crack",
+    "trans": [
+      "裂缝",
+      "to almost break something"
+    ]
+  },
+  {
+    "name": "seem",
+    "trans": [
+      "似乎",
+      "to appear to be something"
+    ]
+  },
+  {
+    "name": "prove",
+    "trans": [
+      "证明",
+      "to demonstrate truth by providing evidence"
+    ]
+  },
+  {
+    "name": "question",
+    "trans": [
+      "问题",
+      "to ask for or try to get information"
+    ]
+  },
+  {
+    "name": "bless",
+    "trans": [
+      "保佑",
+      "to ask the gods to protect someone or something"
+    ]
+  },
+  {
+    "name": "spell",
+    "trans": [
+      "拼写",
+      "to be able to say, write, or print the letters that make up a word"
+    ]
+  },
+  {
+    "name": "can",
+    "trans": [
+      "能",
+      "to be able to; have the skill to; have the time to"
+    ]
+  },
+  {
+    "name": "live",
+    "trans": [
+      "居住",
+      "to be alive"
+    ]
+  },
+  {
+    "name": "attach",
+    "trans": [
+      "附",
+      "to be associated or connected with"
+    ]
+  },
+  {
+    "name": "feel",
+    "trans": [
+      "感觉",
+      "to be aware of or experience an emotion or sensation"
+    ]
+  },
+  {
+    "name": "pull",
+    "trans": [
+      "拉",
+      "to hold something and move it toward you"
+    ]
+  },
+  {
+    "name": "hear",
+    "trans": [
+      "听到",
+      "to be aware of sound; to perceive with the ear"
+    ]
+  },
+  {
+    "name": "purchase",
+    "trans": [
+      "购买",
+      "to buy something; to get by paying money for it"
+    ]
+  },
+  {
+    "name": "exceed",
+    "trans": [
+      "超过",
+      "to be greater in number than something"
+    ]
+  },
+  {
+    "name": "purpose",
+    "trans": [
+      "目的",
+      "reason for which something is done; aim; goal"
+    ]
+  },
+  {
+    "name": "sit",
+    "trans": [
+      "坐",
+      "to be in a resting position on a chair"
+    ]
+  },
+  {
+    "name": "push",
+    "trans": [
+      "推",
+      "to force something away from you"
+    ]
+  },
+  {
+    "name": "remain",
+    "trans": [
+      "保持",
+      "to be left behind, to continue to exist"
+    ]
+  },
+  {
+    "name": "differ",
+    "trans": [
+      "不同",
+      "to be not the same as others"
+    ]
+  },
+  {
+    "name": "regret",
+    "trans": [
+      "后悔",
+      "to be sorry about something"
+    ]
+  },
+  {
+    "name": "quality",
+    "trans": [
+      "质量",
+      "high level of worth or excellence"
+    ]
+  },
+  {
+    "name": "result",
+    "trans": [
+      "结果",
+      "to be the outcome of other causes and effects"
+    ]
+  },
+  {
+    "name": "quarter",
+    "trans": [
+      "四分之一",
+      "one of four equal parts of something"
+    ]
+  },
+  {
+    "name": "lose",
+    "trans": [
+      "失去",
+      "to be unable to find something you once had"
+    ]
+  },
+  {
+    "name": "quick",
+    "trans": [
+      "快的",
+      "using very little time; moving far in little time"
+    ]
+  },
+  {
+    "name": "quickly",
+    "trans": [
+      "迅速地",
+      "without taking a lot of time; fast"
+    ]
+  },
+  {
+    "name": "quiet",
+    "trans": [
+      "安静的",
+      "not loud; making very little sound"
+    ]
+  },
+  {
+    "name": "need",
+    "trans": [
+      "需要",
+      "to be unable to manage without something; require"
+    ]
+  },
+  {
+    "name": "stand",
+    "trans": [
+      "站立",
+      "to be upright; not be sitting or lying down"
+    ]
+  },
+  {
+    "name": "quote",
+    "trans": [
+      "引用",
+      "to use someone's exact words in your writing or speech"
+    ]
+  },
+  {
+    "name": "freeze",
+    "trans": [
+      "冻结",
+      "to become hard because of very cold temperatures"
+    ]
+  },
+  {
+    "name": "recover",
+    "trans": [
+      "恢复",
+      "to become healthy after an illness or injury; to get better"
+    ]
+  },
+  {
+    "name": "radio",
+    "trans": [
+      "收音机",
+      "system for sending and receiving signals through the air"
+    ]
+  },
+  {
+    "name": "disappear",
+    "trans": [
+      "消失",
+      "to become impossible to see"
+    ]
+  },
+  {
+    "name": "rain",
+    "trans": [
+      "雨",
+      "drops of water that fall out of clouds in the sky"
+    ]
+  },
+  {
+    "name": "raise",
+    "trans": [
+      "增加",
+      "to increase a quantity, size, intensity or price"
+    ]
+  },
+  {
+    "name": "undertake",
+    "trans": [
+      "承担",
+      "to begin or attempt, commit oneself to and begin"
+    ]
+  },
+  {
+    "name": "range",
+    "trans": [
+      "范围",
+      "limits within which something extends or varies"
+    ]
+  },
+  {
+    "name": "become",
+    "trans": [
+      "变得",
+      "to begin to be; grow to be; develop into"
+    ]
+  },
+  {
+    "name": "arise",
+    "trans": [
+      "出现",
+      "to begin, to start to happen"
+    ]
+  },
+  {
+    "name": "react",
+    "trans": [
+      "反应",
+      "to behave or make a change in a particular way"
+    ]
+  },
+  {
+    "name": "expect",
+    "trans": [
+      "预计",
+      "to believe something is probably going to happen"
+    ]
+  },
+  {
+    "name": "reckon",
+    "trans": [
+      "估计",
+      "to believe that something is true or possible; to calculate or guess"
+    ]
+  },
+  {
+    "name": "lean",
+    "trans": [
+      "倾斜",
+      "to bend or move someone's body in a particular direction; (adj) very little fat"
+    ]
+  },
+  {
+    "name": "burst",
+    "trans": [
+      "爆裂",
+      "to break in a sudden and violent way"
+    ]
+  },
+  {
+    "name": "split",
+    "trans": [
+      "分裂",
+      "to break something into pieces or divide something"
+    ]
+  },
+  {
+    "name": "sigh",
+    "trans": [
+      "叹",
+      "to breathe out in a way to show boredom or disappointment"
+    ]
+  },
+  {
+    "name": "remember",
+    "trans": [
+      "记住",
+      "to bring a previous image or idea to your mind"
+    ]
+  },
+  {
+    "name": "import",
+    "trans": [
+      "进口",
+      "to bring items or goods from one country into another"
+    ]
+  },
+  {
+    "name": "reaction",
+    "trans": [
+      "反应",
+      "feeling or action in response to something"
+    ]
+  },
+  {
+    "name": "construct",
+    "trans": [
+      "构造",
+      "to build or create something"
+    ]
+  },
+  {
+    "name": "reader",
+    "trans": [
+      "读者",
+      "person who reads written or printed materials"
+    ]
+  },
+  {
+    "name": "insure",
+    "trans": [
+      "保证",
+      "to buy protection against possible loss or injury"
+    ]
+  },
+  {
+    "name": "reality",
+    "trans": [
+      "现实",
+      "what is true, as opposed to what is imagined"
+    ]
+  },
+  {
+    "name": "realize",
+    "trans": [
+      "意识到",
+      "to become aware of or understand mentally"
+    ]
+  },
+  {
+    "name": "love",
+    "trans": [
+      "爱",
+      "to care for and like someone very strong and deeply"
+    ]
+  },
+  {
+    "name": "send",
+    "trans": [
+      "发送",
+      "to cause mail or package to go to another place"
+    ]
+  },
+  {
+    "name": "embarrass",
+    "trans": [
+      "使人难堪",
+      "to cause someone to feel uncomfortable about something"
+    ]
+  },
+  {
+    "name": "reasonable",
+    "trans": [
+      "合理的",
+      "fair and sensible; appropriate"
+    ]
+  },
+  {
+    "name": "move",
+    "trans": [
+      "移动",
+      "to cause something to change to a different place"
+    ]
+  },
+  {
+    "name": "recall",
+    "trans": [
+      "记起",
+      "to remember events or details of the past"
+    ]
+  },
+  {
+    "name": "convert",
+    "trans": [
+      "转变",
+      "to change form, character, or function to another"
+    ]
+  },
+  {
+    "name": "recent",
+    "trans": [
+      "最近的",
+      "happening or beginning not long ago"
+    ]
+  },
+  {
+    "name": "recently",
+    "trans": [
+      "最近",
+      "just a while ago; not long ago"
+    ]
+  },
+  {
+    "name": "update",
+    "trans": [
+      "更新",
+      "to change something by adding the most recent information"
+    ]
+  },
+  {
+    "name": "adapt",
+    "trans": [
+      "适应",
+      "to change something to fit or suit a new purpose"
+    ]
+  },
+  {
+    "name": "recognize",
+    "trans": [
+      "认出",
+      "to remember because you have met it before"
+    ]
+  },
+  {
+    "name": "recommend",
+    "trans": [
+      "推荐",
+      "to say something is good and deserves to be chosen"
+    ]
+  },
+  {
+    "name": "transform",
+    "trans": [
+      "转换",
+      "to change the shape of something completely"
+    ]
+  },
+  {
+    "name": "translate",
+    "trans": [
+      "翻译",
+      "to change words from one language into another"
+    ]
+  },
+  {
+    "name": "edit",
+    "trans": [
+      "编辑",
+      "to check and makes changes before publication"
+    ]
+  },
+  {
+    "name": "red",
+    "trans": [
+      "红色的",
+      "being the color of blood"
+    ]
+  },
+  {
+    "name": "reduce",
+    "trans": [
+      "减少",
+      "to make something smaller or use less of it"
+    ]
+  },
+  {
+    "name": "wipe",
+    "trans": [
+      "擦拭",
+      "to clean or dry something with a cloth"
+    ]
+  },
+  {
+    "name": "refer",
+    "trans": [
+      "参考",
+      "to talk about or write about something"
+    ]
+  },
+  {
+    "name": "reference",
+    "trans": [
+      "参考",
+      "to cite a piece of research in speech or in writing"
+    ]
+  },
+  {
+    "name": "shut",
+    "trans": [
+      "关闭",
+      "to close something"
+    ]
+  },
+  {
+    "name": "reform",
+    "trans": [
+      "改革",
+      "to improve society by removing abuse and injustices"
+    ]
+  },
+  {
+    "name": "integrate",
+    "trans": [
+      "整合",
+      "to combine together; make into one thing"
+    ]
+  },
+  {
+    "name": "refuse",
+    "trans": [
+      "拒绝",
+      "to say that you will not accept something"
+    ]
+  },
+  {
+    "name": "regard",
+    "trans": [
+      "看待",
+      "to pay attention to someone or something"
+    ]
+  },
+  {
+    "name": "follow",
+    "trans": [
+      "跟随",
+      "to come after someone; be guided by someone"
+    ]
+  },
+  {
+    "name": "return",
+    "trans": [
+      "返回",
+      "to come back to a place again"
+    ]
+  },
+  {
+    "name": "register",
+    "trans": [
+      "登记",
+      "to record your name on an official list; sign up"
+    ]
+  },
+  {
+    "name": "reach",
+    "trans": [
+      "抵达",
+      "to come to or arrive at a goal or destination"
+    ]
+  },
+  {
+    "name": "meet",
+    "trans": [
+      "见面",
+      "to come together at a certain time or place"
+    ]
+  },
+  {
+    "name": "regular",
+    "trans": [
+      "常规的",
+      "occurring or being done frequently"
+    ]
+  },
+  {
+    "name": "cluster",
+    "trans": [
+      "簇",
+      "to come together to form a group of people, animals, or things"
+    ]
+  },
+  {
+    "name": "compose",
+    "trans": [
+      "撰写",
+      "to come together to form or make something"
+    ]
+  },
+  {
+    "name": "regulation",
+    "trans": [
+      "规定",
+      "official rule that controls how something is done"
+    ]
+  },
+  {
+    "name": "relate",
+    "trans": [
+      "涉及",
+      "to understand or sympathize with someone or something"
+    ]
+  },
+  {
+    "name": "relationship",
+    "trans": [
+      "关系",
+      "manner in which people, groups or countries behave toward one another"
+    ]
+  },
+  {
+    "name": "relative",
+    "trans": [
+      "相对的",
+      "measured or considered in comparison to something else"
+    ]
+  },
+  {
+    "name": "relatively",
+    "trans": [
+      "相对地",
+      "in a manner that measures or compares something to something else"
+    ]
+  },
+  {
+    "name": "eliminate",
+    "trans": [
+      "排除",
+      "to completely remove; to get rid of"
+    ]
+  },
+  {
+    "name": "retain",
+    "trans": [
+      "保持",
+      "to continue to have or use something; to keep"
+    ]
+  },
+  {
+    "name": "religious",
+    "trans": [
+      "宗教的",
+      "concerning religion or faith"
+    ]
+  },
+  {
+    "name": "drive",
+    "trans": [
+      "驾驶",
+      "to control a vehicle so that it moves somewhere"
+    ]
+  },
+  {
+    "name": "wrap",
+    "trans": [
+      "裹",
+      "to cover something on all sides with a piece of material or paper"
+    ]
+  },
+  {
+    "name": "make",
+    "trans": [
+      "制作",
+      "to create something by putting things together"
+    ]
+  },
+  {
+    "name": "invent",
+    "trans": [
+      "发明",
+      "to create something useful for the first time"
+    ]
+  },
+  {
+    "name": "remind",
+    "trans": [
+      "提醒",
+      "to make someone remember something"
+    ]
+  },
+  {
+    "name": "cope",
+    "trans": [
+      "应付",
+      "to deal successfully with a difficult problem"
+    ]
+  },
+  {
+    "name": "remove",
+    "trans": [
+      "消除",
+      "to move, erase or take away from a place"
+    ]
+  },
+  {
+    "name": "rent",
+    "trans": [
+      "租",
+      "to pay money for the use of something"
+    ]
+  },
+  {
+    "name": "devote",
+    "trans": [
+      "奉献",
+      "to decide to use or give something for something else"
+    ]
+  },
+  {
+    "name": "repeat",
+    "trans": [
+      "重复",
+      "to say something again"
+    ]
+  },
+  {
+    "name": "replace",
+    "trans": [
+      "代替",
+      "to use instead of something else"
+    ]
+  },
+  {
+    "name": "reply",
+    "trans": [
+      "回复",
+      "answer someone's question"
+    ]
+  },
+  {
+    "name": "want",
+    "trans": [
+      "想",
+      "to desire or wish for something; hope for a thing"
+    ]
+  },
+  {
+    "name": "price",
+    "trans": [
+      "价格",
+      "to determine or set the cost of something"
+    ]
+  },
+  {
+    "name": "representative",
+    "trans": [
+      "代表",
+      "typical of a particular group or thing"
+    ]
+  },
+  {
+    "name": "request",
+    "trans": [
+      "要求",
+      "to ask for something"
+    ]
+  },
+  {
+    "name": "require",
+    "trans": [
+      "要求",
+      "to need something, to make it necessary"
+    ]
+  },
+  {
+    "name": "requirement",
+    "trans": [
+      "要求",
+      "something that is a necessity"
+    ]
+  },
+  {
+    "name": "weigh",
+    "trans": [
+      "称重",
+      "to determine the weight of, using scales"
+    ]
+  },
+  {
+    "name": "research",
+    "trans": [
+      "研究",
+      "to carefully study to find and report new knowledge"
+    ]
+  },
+  {
+    "name": "grow",
+    "trans": [
+      "生长",
+      "to develop and become bigger or taller over time"
+    ]
+  },
+  {
+    "name": "resident",
+    "trans": [
+      "居民",
+      "someone who lives in a particular place"
+    ]
+  },
+  {
+    "name": "derive",
+    "trans": [
+      "派生",
+      "to develop or get something from something else"
+    ]
+  },
+  {
+    "name": "control",
+    "trans": [
+      "控制",
+      "to direct or influence the behavior of something"
+    ]
+  },
+  {
+    "name": "detect",
+    "trans": [
+      "探测",
+      "to discover or identify the presence of something"
+    ]
+  },
+  {
+    "name": "find",
+    "trans": [
+      "寻找",
+      "to discover something by looking for it"
+    ]
+  },
+  {
+    "name": "consult",
+    "trans": [
+      "咨询",
+      "to discuss something to make a decision"
+    ]
+  },
+  {
+    "name": "exhibit",
+    "trans": [
+      "展览",
+      "to display or make available for people to see"
+    ]
+  },
+  {
+    "name": "resource",
+    "trans": [
+      "资源",
+      "essential supply of something"
+    ]
+  },
+  {
+    "name": "respect",
+    "trans": [
+      "尊重",
+      "to think very highly of another person because of what they do"
+    ]
+  },
+  {
+    "name": "play",
+    "trans": [
+      "玩",
+      "to do or perform a game or sport"
+    ]
+  },
+  {
+    "name": "respond",
+    "trans": [
+      "回应",
+      "to say or write to answer the question"
+    ]
+  },
+  {
+    "name": "response",
+    "trans": [
+      "回复",
+      "something said or written as an answer to something"
+    ]
+  },
+  {
+    "name": "responsibility",
+    "trans": [
+      "责任",
+      "state of being dependable or reliable"
+    ]
+  },
+  {
+    "name": "responsible",
+    "trans": [
+      "负责任的",
+      "having the duty of dealing with something; being the cause or creator of something; behaving in a mature and reasonable manner"
+    ]
+  },
+  {
+    "name": "rest",
+    "trans": [
+      "休息",
+      "time when one relaxes, sleeps, or is inactive"
+    ]
+  },
+  {
+    "name": "restaurant",
+    "trans": [
+      "餐厅",
+      "place where you can order, buy and eat a meal"
+    ]
+  },
+  {
+    "name": "fulfill",
+    "trans": [
+      "实现",
+      "to do something that was promised or required"
+    ]
+  },
+  {
+    "name": "rush",
+    "trans": [
+      "匆忙",
+      "to do something very quickly"
+    ]
+  },
+  {
+    "name": "use",
+    "trans": [
+      "使用",
+      "to do something with, for a task or purpose"
+    ]
+  },
+  {
+    "name": "continue",
+    "trans": [
+      "继续",
+      "to do something without stopping, or after pausing"
+    ]
+  },
+  {
+    "name": "begin",
+    "trans": [
+      "开始",
+      "to do the first part of an action; to start"
+    ]
+  },
+  {
+    "name": "solar",
+    "trans": [
+      "太阳的",
+      "to do with the sun, like sunlight or the heat from the sun"
+    ]
+  },
+  {
+    "name": "consume",
+    "trans": [
+      "消耗",
+      "to eat, drink, buy or use up something"
+    ]
+  },
+  {
+    "name": "be",
+    "trans": [
+      "是",
+      "To exist; to be alive; used to give information about someone or something"
+    ]
+  },
+  {
+    "name": "anticipate",
+    "trans": [
+      "预料",
+      "to expect or look ahead to something positively"
+    ]
+  },
+  {
+    "name": "reveal",
+    "trans": [
+      "揭示",
+      "to make known, to show or prove"
+    ]
+  },
+  {
+    "name": "revenue",
+    "trans": [
+      "收入",
+      "money that is made by or paid to a business"
+    ]
+  },
+  {
+    "name": "undergo",
+    "trans": [
+      "经历",
+      "to experience something, often bad"
+    ]
+  },
+  {
+    "name": "review",
+    "trans": [
+      "审查",
+      "to carefully look at the quality of something"
+    ]
+  },
+  {
+    "name": "show",
+    "trans": [
+      "展示",
+      "to explain or teach how something is done"
+    ]
+  },
+  {
+    "name": "praise",
+    "trans": [
+      "称赞",
+      "to express approval of something or someone"
+    ]
+  },
+  {
+    "name": "protest",
+    "trans": [
+      "反对",
+      "to express opposition through action or words"
+    ]
+  },
+  {
+    "name": "neglect",
+    "trans": [
+      "忽视",
+      "to fail to take care of something"
+    ]
+  },
+  {
+    "name": "rich",
+    "trans": [
+      "富有的",
+      "having a lot of money, possessions, or resources"
+    ]
+  },
+  {
+    "name": "admire",
+    "trans": [
+      "钦佩",
+      "to feel respect or wonder toward someone"
+    ]
+  },
+  {
+    "name": "ride",
+    "trans": [
+      "骑",
+      "to sit on and control a horse or vehicle"
+    ]
+  },
+  {
+    "name": "occupy",
+    "trans": [
+      "占据",
+      "to fill a time, a space, or an area"
+    ]
+  },
+  {
+    "name": "rise",
+    "trans": [
+      "上升",
+      "to move from a lower position to a higher one"
+    ]
+  },
+  {
+    "name": "risk",
+    "trans": [
+      "风险",
+      "to take the chance that you may do something dangerous"
+    ]
+  },
+  {
+    "name": "river",
+    "trans": [
+      "河",
+      "flowing water that runs from mountains to the sea"
+    ]
+  },
+  {
+    "name": "road",
+    "trans": [
+      "路",
+      "long piece of hard land for cars to travel on"
+    ]
+  },
+  {
+    "name": "rock",
+    "trans": [
+      "岩石",
+      "big stone; hard, solid substance forming mountains"
+    ]
+  },
+  {
+    "name": "role",
+    "trans": [
+      "角色",
+      "character played by an actor"
+    ]
+  },
+  {
+    "name": "roll",
+    "trans": [
+      "卷",
+      "to move along a surface by turning many times"
+    ]
+  },
+  {
+    "name": "resolve",
+    "trans": [
+      "解决",
+      "to find an answer or way to handle a problem"
+    ]
+  },
+  {
+    "name": "calculate",
+    "trans": [
+      "计算",
+      "to find an answer using mathematics"
+    ]
+  },
+  {
+    "name": "root",
+    "trans": [
+      "根",
+      "part of a plant that grows underground"
+    ]
+  },
+  {
+    "name": "compute",
+    "trans": [
+      "计算",
+      "to find out by calculating or estimating"
+    ]
+  },
+  {
+    "name": "like",
+    "trans": [
+      "喜欢",
+      "to find something pleasing; to prefer something"
+    ]
+  },
+  {
+    "name": "round",
+    "trans": [
+      "圆形的",
+      "being in the shape of a circle or ball"
+    ]
+  },
+  {
+    "name": "route",
+    "trans": [
+      "路线",
+      "way to get from one place to another place"
+    ]
+  },
+  {
+    "name": "trace",
+    "trans": [
+      "痕迹",
+      "to find, describe or discover by investigation"
+    ]
+  },
+  {
+    "name": "stop",
+    "trans": [
+      "停止",
+      "to finish moving or to come to an end"
+    ]
+  },
+  {
+    "name": "repair",
+    "trans": [
+      "维修",
+      "to fix something that is broken; fix"
+    ]
+  },
+  {
+    "name": "rule",
+    "trans": [
+      "规则",
+      "statement that says how things should be"
+    ]
+  },
+  {
+    "name": "study",
+    "trans": [
+      "学习",
+      "to focus on learning something usually at school"
+    ]
+  },
+  {
+    "name": "specialize",
+    "trans": [
+      "专门化",
+      "to focus on one area of a field or profession"
+    ]
+  },
+  {
+    "name": "chase",
+    "trans": [
+      "追赶",
+      "to follow and try to catch someone or something"
+    ]
+  },
+  {
+    "name": "safe",
+    "trans": [
+      "安全的",
+      "being out of danger"
+    ]
+  },
+  {
+    "name": "safety",
+    "trans": [
+      "安全",
+      "state of being free from harm or danger"
+    ]
+  },
+  {
+    "name": "pursue",
+    "trans": [
+      "追求",
+      "to follow and try to catch something; to try to get something"
+    ]
+  },
+  {
+    "name": "cough",
+    "trans": [
+      "咳嗽",
+      "to force air through your throat with a short, loud noise"
+    ]
+  },
+  {
+    "name": "evaluate",
+    "trans": [
+      "评价",
+      "to form an idea to judge something carefully"
+    ]
+  },
+  {
+    "name": "poll",
+    "trans": [
+      "轮询",
+      "to get information by asking many people questions about a particular subject"
+    ]
+  },
+  {
+    "name": "learn",
+    "trans": [
+      "学习",
+      "to get knowledge or skills by study or experience"
+    ]
+  },
+  {
+    "name": "recruit",
+    "trans": [
+      "招募",
+      "to get people to come and work, join, or study with you"
+    ]
+  },
+  {
+    "name": "buy",
+    "trans": [
+      "买",
+      "to get something by paying money for it"
+    ]
+  },
+  {
+    "name": "receive",
+    "trans": [
+      "收到",
+      "to get something that someone has given or sent to you"
+    ]
+  },
+  {
+    "name": "deserve",
+    "trans": [
+      "应得",
+      "to get the appropriate reward or punishment for the way you behaved or something you did"
+    ]
+  },
+  {
+    "name": "satisfy",
+    "trans": [
+      "满足",
+      "to be happy because you met your expectation"
+    ]
+  },
+  {
+    "name": "save",
+    "trans": [
+      "节省",
+      "to rescue someone or something from a bad situation"
+    ]
+  },
+  {
+    "name": "qualify",
+    "trans": [
+      "有资格",
+      "to get the necessary skill or knowledge to do a particular job or activity"
+    ]
+  },
+  {
+    "name": "scale",
+    "trans": [
+      "规模",
+      "a device that is used to weigh a person or thing"
+    ]
+  },
+  {
+    "name": "persuade",
+    "trans": [
+      "说服",
+      "to get you to do/believe something, by giving reasons"
+    ]
+  },
+  {
+    "name": "excuse",
+    "trans": [
+      "原谅",
+      "to give a reason to explain why you did something"
+    ]
+  },
+  {
+    "name": "scene",
+    "trans": [
+      "场景",
+      "part of an act in a play"
+    ]
+  },
+  {
+    "name": "schedule",
+    "trans": [
+      "日程",
+      "to arrange a time to do something with others"
+    ]
+  },
+  {
+    "name": "scheme",
+    "trans": [
+      "方案",
+      "often dishonest plan to get or do something"
+    ]
+  },
+  {
+    "name": "communicate",
+    "trans": [
+      "交流",
+      "to give and exchange information"
+    ]
+  },
+  {
+    "name": "support",
+    "trans": [
+      "支持",
+      "to give assistance or advice to someone"
+    ]
+  },
+  {
+    "name": "science",
+    "trans": [
+      "科学",
+      "knowledge of the physical world based on facts"
+    ]
+  },
+  {
+    "name": "pay",
+    "trans": [
+      "支付",
+      "to give money for goods or work done"
+    ]
+  },
+  {
+    "name": "deal",
+    "trans": [
+      "交易",
+      "to give out (cards, etc.) to; distribute"
+    ]
+  },
+  {
+    "name": "score",
+    "trans": [
+      "分数",
+      "to get points in a sport such as kicking a ball into a goal"
+    ]
+  },
+  {
+    "name": "justify",
+    "trans": [
+      "证明合法",
+      "to give reasons why you did something or why it is right"
+    ]
+  },
+  {
+    "name": "screen",
+    "trans": [
+      "屏幕",
+      "flat surface on a computer, or tv that shows images"
+    ]
+  },
+  {
+    "name": "sea",
+    "trans": [
+      "海",
+      "place with a large amount of salt water"
+    ]
+  },
+  {
+    "name": "assign",
+    "trans": [
+      "分配",
+      "to give someone a particular job or something to do"
+    ]
+  },
+  {
+    "name": "search",
+    "trans": [
+      "搜索",
+      "to carefully look for something"
+    ]
+  },
+  {
+    "name": "season",
+    "trans": [
+      "季节",
+      "one of the four parts of the year determined mainly by the weather during that time"
+    ]
+  },
+  {
+    "name": "reward",
+    "trans": [
+      "报酬",
+      "to give something to someone because of their good work"
+    ]
+  },
+  {
+    "name": "offer",
+    "trans": [
+      "提供",
+      "to give the opportunity to accept something"
+    ]
+  },
+  {
+    "name": "entitle",
+    "trans": [
+      "赋予",
+      "to give the right to do or have something to someone"
+    ]
+  },
+  {
+    "name": "section",
+    "trans": [
+      "部分",
+      "one of the parts that form something"
+    ]
+  },
+  {
+    "name": "sector",
+    "trans": [
+      "部门",
+      "area that includes certain kinds of job"
+    ]
+  },
+  {
+    "name": "secure",
+    "trans": [
+      "安全的",
+      "to protect something from danger or harm, keep things safe"
+    ]
+  },
+  {
+    "name": "lend",
+    "trans": [
+      "借",
+      "to give to someone for a while before it is returned"
+    ]
+  },
+  {
+    "name": "yield",
+    "trans": [
+      "屈服",
+      "to give way to someone or something else"
+    ]
+  },
+  {
+    "name": "seek",
+    "trans": [
+      "寻找",
+      "to search for; to try to find; look for"
+    ]
+  },
+  {
+    "name": "dedicate",
+    "trans": [
+      "奉献",
+      "to give your energy, time, etc., completely to someone"
+    ]
+  },
+  {
+    "name": "sink",
+    "trans": [
+      "下沉",
+      "to go down below the surface of water, mud, etc."
+    ]
+  },
+  {
+    "name": "select",
+    "trans": [
+      "选择",
+      "to choose from a group, something most suitable"
+    ]
+  },
+  {
+    "name": "reverse",
+    "trans": [
+      "撤销",
+      "to go in the opposite direction"
+    ]
+  },
+  {
+    "name": "accompany",
+    "trans": [
+      "陪伴",
+      "to go somewhere with someone"
+    ]
+  },
+  {
+    "name": "sell",
+    "trans": [
+      "卖",
+      "to exchange something for money"
+    ]
+  },
+  {
+    "name": "visit",
+    "trans": [
+      "访问",
+      "to go to a place for a time, usually for a reason"
+    ]
+  },
+  {
+    "name": "senior",
+    "trans": [
+      "高级的",
+      "having higher status or authority than another person"
+    ]
+  },
+  {
+    "name": "sense",
+    "trans": [
+      "感觉",
+      "to perceive using sight, sound, taste touch or hearing"
+    ]
+  },
+  {
+    "name": "develop",
+    "trans": [
+      "发展",
+      "to grow bigger, more complex, or more advanced"
+    ]
+  },
+  {
+    "name": "sentence",
+    "trans": [
+      "句子",
+      "set of spoken or written words that make a whole statement"
+    ]
+  },
+  {
+    "name": "separate",
+    "trans": [
+      "分离",
+      "to divide into parts, or to make something divide into parts"
+    ]
+  },
+  {
+    "name": "distribute",
+    "trans": [
+      "分发",
+      "to hand in or deliver something to people"
+    ]
+  },
+  {
+    "name": "series",
+    "trans": [
+      "系列",
+      "number of things that happen one after another"
+    ]
+  },
+  {
+    "name": "serious",
+    "trans": [
+      "严肃的",
+      "needing thought or concentration; important; in a sober manner"
+    ]
+  },
+  {
+    "name": "give",
+    "trans": [
+      "给",
+      "to hand over or present something to someone"
+    ]
+  },
+  {
+    "name": "serve",
+    "trans": [
+      "服务",
+      "to give or provide something to another person"
+    ]
+  },
+  {
+    "name": "disagree",
+    "trans": [
+      "不同意",
+      "to have a different opinion from someone"
+    ]
+  },
+  {
+    "name": "negotiate",
+    "trans": [
+      "谈判",
+      "to have a formal discussion to reach an agreement"
+    ]
+  },
+  {
+    "name": "settle",
+    "trans": [
+      "定居",
+      "to move to a new environment and become accustomed to it"
+    ]
+  },
+  {
+    "name": "mean",
+    "trans": [
+      "意思是",
+      "to have a particular meaning or value"
+    ]
+  },
+  {
+    "name": "think",
+    "trans": [
+      "思考",
+      "to have an idea, opinion, or belief about something"
+    ]
+  },
+  {
+    "name": "keep",
+    "trans": [
+      "保持",
+      "to have and continue to hold something"
+    ]
+  },
+  {
+    "name": "sex",
+    "trans": [
+      "性别",
+      "state of being male or female mostly biological"
+    ]
+  },
+  {
+    "name": "dare",
+    "trans": [
+      "敢",
+      "to have enough courage to do something"
+    ]
+  },
+  {
+    "name": "know",
+    "trans": [
+      "知道",
+      "to have knowledge of things in your mind"
+    ]
+  },
+  {
+    "name": "shake",
+    "trans": [
+      "摇",
+      "to move something violently back and forth or up and down"
+    ]
+  },
+  {
+    "name": "shall",
+    "trans": [
+      "将",
+      "expressing the future tense, to expect to happen"
+    ]
+  },
+  {
+    "name": "shape",
+    "trans": [
+      "形状",
+      "outer form of something, what it looks like"
+    ]
+  },
+  {
+    "name": "involve",
+    "trans": [
+      "涉及",
+      "to have or be included as a part of something"
+    ]
+  },
+  {
+    "name": "encounter",
+    "trans": [
+      "遇到",
+      "to have or experience something, often unpleasant or difficult"
+    ]
+  },
+  {
+    "name": "possess",
+    "trans": [
+      "具有",
+      "to have or own something"
+    ]
+  },
+  {
+    "name": "dominate",
+    "trans": [
+      "支配",
+      "to have power or influence over"
+    ]
+  },
+  {
+    "name": "correspond",
+    "trans": [
+      "对应",
+      "to have similarity or equality with something"
+    ]
+  },
+  {
+    "name": "assist",
+    "trans": [
+      "协助",
+      "to help"
+    ]
+  },
+  {
+    "name": "boost",
+    "trans": [
+      "促进",
+      "to help increasing progress or growth"
+    ]
+  },
+  {
+    "name": "sponsor",
+    "trans": [
+      "赞助",
+      "to help someone or something succeed by giving them money"
+    ]
+  },
+  {
+    "name": "shift",
+    "trans": [
+      "转移",
+      "to change in position or direction"
+    ]
+  },
+  {
+    "name": "crash",
+    "trans": [
+      "碰撞",
+      "to hit something hard enough to cause serious damage"
+    ]
+  },
+  {
+    "name": "ship",
+    "trans": [
+      "船",
+      "large boat"
+    ]
+  },
+  {
+    "name": "shock",
+    "trans": [
+      "震惊",
+      "sudden bad feeling caused by something unexpected"
+    ]
+  },
+  {
+    "name": "shoot",
+    "trans": [
+      "射击",
+      "to kick or throw a ball at a goal"
+    ]
+  },
+  {
+    "name": "shop",
+    "trans": [
+      "店铺",
+      "place which sells things"
+    ]
+  },
+  {
+    "name": "tap",
+    "trans": [
+      "轻敲",
+      "to hit something lightly"
+    ]
+  },
+  {
+    "name": "short",
+    "trans": [
+      "短的",
+      "small distance from one end to the other"
+    ]
+  },
+  {
+    "name": "knock",
+    "trans": [
+      "敲",
+      "to hit something to get people's attention"
+    ]
+  },
+  {
+    "name": "embrace",
+    "trans": [
+      "拥抱",
+      "to hold someone closely"
+    ]
+  },
+  {
+    "name": "harm",
+    "trans": [
+      "伤害",
+      "to hurt, damage, or cause problems"
+    ]
+  },
+  {
+    "name": "incorporate",
+    "trans": [
+      "包含",
+      "to include or involve as part of something else"
+    ]
+  },
+  {
+    "name": "point",
+    "trans": [
+      "观点",
+      "to indicate something with your finger to others"
+    ]
+  },
+  {
+    "name": "unite",
+    "trans": [
+      "团结",
+      "to join or come together as one"
+    ]
+  },
+  {
+    "name": "isolate",
+    "trans": [
+      "隔离",
+      "to keep in a place or situation apart from others"
+    ]
+  },
+  {
+    "name": "preserve",
+    "trans": [
+      "保存",
+      "to keep something in an unchanged or perfect condition"
+    ]
+  },
+  {
+    "name": "understand",
+    "trans": [
+      "理解",
+      "to know the meaning of language, what someone says"
+    ]
+  },
+  {
+    "name": "significant",
+    "trans": [
+      "重要的",
+      "large enough to be noticed or have an effect; important"
+    ]
+  },
+  {
+    "name": "resign",
+    "trans": [
+      "辞职",
+      "to leave a job because you want to"
+    ]
+  },
+  {
+    "name": "abandon",
+    "trans": [
+      "放弃",
+      "to leave someone or something you are responsible for and not return"
+    ]
+  },
+  {
+    "name": "allow",
+    "trans": [
+      "允许",
+      "to let or permit someone do something"
+    ]
+  },
+  {
+    "name": "underlie",
+    "trans": [
+      "底层",
+      "to lie or exist beneath"
+    ]
+  },
+  {
+    "name": "counsel",
+    "trans": [
+      "法律顾问",
+      "to listen and give expert advice to someone"
+    ]
+  },
+  {
+    "name": "similar",
+    "trans": [
+      "相似的",
+      "nearly the same"
+    ]
+  },
+  {
+    "name": "simple",
+    "trans": [
+      "简单的",
+      "not hard to understand or do; not complex"
+    ]
+  },
+  {
+    "name": "simply",
+    "trans": [
+      "简单地",
+      "in an easy or clear manner"
+    ]
+  },
+  {
+    "name": "care",
+    "trans": [
+      "关心",
+      "to look after someone or something"
+    ]
+  },
+  {
+    "name": "sing",
+    "trans": [
+      "唱歌",
+      "to make musical sounds with your voice"
+    ]
+  },
+  {
+    "name": "single",
+    "trans": [
+      "单身的",
+      "only, merely"
+    ]
+  },
+  {
+    "name": "read",
+    "trans": [
+      "读",
+      "to look at and comprehend the meaning some writing"
+    ]
+  },
+  {
+    "name": "watch",
+    "trans": [
+      "手表",
+      "to look at carefully to work out what is happening"
+    ]
+  },
+  {
+    "name": "sister",
+    "trans": [
+      "姐姐",
+      "female you share a parent with"
+    ]
+  },
+  {
+    "name": "stare",
+    "trans": [
+      "盯",
+      "to look at someone or something for a long time"
+    ]
+  },
+  {
+    "name": "glance",
+    "trans": [
+      "一眼",
+      "to look at someone or something quickly"
+    ]
+  },
+  {
+    "name": "situation",
+    "trans": [
+      "情况",
+      "condition, location or position"
+    ]
+  },
+  {
+    "name": "size",
+    "trans": [
+      "尺寸",
+      "how big or small a thing is"
+    ]
+  },
+  {
+    "name": "scan",
+    "trans": [
+      "扫描",
+      "to look within something for a particular person or thing"
+    ]
+  },
+  {
+    "name": "skill",
+    "trans": [
+      "技能",
+      "ability to do something well"
+    ]
+  },
+  {
+    "name": "fade",
+    "trans": [
+      "褪色",
+      "to lose strength or freshness"
+    ]
+  },
+  {
+    "name": "service",
+    "trans": [
+      "服务",
+      "to maintain a piece of machinery so it runs well"
+    ]
+  },
+  {
+    "name": "sleep",
+    "trans": [
+      "睡觉",
+      "to rest your body in bed, as at night time"
+    ]
+  },
+  {
+    "name": "sustain",
+    "trans": [
+      "维持",
+      "to maintain, lengthen or continue to do something"
+    ]
+  },
+  {
+    "name": "alter",
+    "trans": [
+      "改变",
+      "to make a change to something"
+    ]
+  },
+  {
+    "name": "decide",
+    "trans": [
+      "决定",
+      "to make a choice about something or choose after thinking"
+    ]
+  },
+  {
+    "name": "slightly",
+    "trans": [
+      "轻微地",
+      "concerning a small quantity or degree"
+    ]
+  },
+  {
+    "name": "boom",
+    "trans": [
+      "繁荣",
+      "to make a deep hollow resonant sound"
+    ]
+  },
+  {
+    "name": "pour",
+    "trans": [
+      "倒",
+      "to make a liquid flow from one container into another"
+    ]
+  },
+  {
+    "name": "slow",
+    "trans": [
+      "慢的",
+      "moving or happening without speed; not fast"
+    ]
+  },
+  {
+    "name": "swear",
+    "trans": [
+      "发誓",
+      "to make a serious promise to do something"
+    ]
+  },
+  {
+    "name": "scream",
+    "trans": [
+      "尖叫",
+      "to make a sudden loud cry"
+    ]
+  },
+  {
+    "name": "bet",
+    "trans": [
+      "赌注",
+      "to make an agreement on the results of an event where the losers give something (usually money) to the winner"
+    ]
+  },
+  {
+    "name": "smoke",
+    "trans": [
+      "抽烟",
+      "to breathe in through a cigarette and then blow it out"
+    ]
+  },
+  {
+    "name": "try",
+    "trans": [
+      "尝试",
+      "to make an effort, to attempt to do something"
+    ]
+  },
+  {
+    "name": "provide",
+    "trans": [
+      "提供",
+      "to make available; to supply for use"
+    ]
+  },
+  {
+    "name": "shine",
+    "trans": [
+      "闪耀",
+      "to make bright light"
+    ]
+  },
+  {
+    "name": "craft",
+    "trans": [
+      "工艺",
+      "to make by hand and with much skill"
+    ]
+  },
+  {
+    "name": "society",
+    "trans": [
+      "社会",
+      "community of people living together"
+    ]
+  },
+  {
+    "name": "revise",
+    "trans": [
+      "修订",
+      "to make changes to improve something"
+    ]
+  },
+  {
+    "name": "software",
+    "trans": [
+      "软件",
+      "market for software is expected to expand"
+    ]
+  },
+  {
+    "name": "note",
+    "trans": [
+      "笔记",
+      "to make mention of something; to make a remark"
+    ]
+  },
+  {
+    "name": "soldier",
+    "trans": [
+      "士兵",
+      "person who is in the military"
+    ]
+  },
+  {
+    "name": "complicate",
+    "trans": [
+      "使复杂化",
+      "to make more difficult"
+    ]
+  },
+  {
+    "name": "solution",
+    "trans": [
+      "解决方案",
+      "something that ends a problem"
+    ]
+  },
+  {
+    "name": "solve",
+    "trans": [
+      "解决",
+      "to find a way to deal with a problem"
+    ]
+  },
+  {
+    "name": "change",
+    "trans": [
+      "改变",
+      "to make or become different, or into something else"
+    ]
+  },
+  {
+    "name": "somebody",
+    "trans": [
+      "某人",
+      "person who is not known or named"
+    ]
+  },
+  {
+    "name": "increase",
+    "trans": [
+      "增加",
+      "to make or become something larger in size or amount"
+    ]
+  },
+  {
+    "name": "someone",
+    "trans": [
+      "某人",
+      "person who is not known or named"
+    ]
+  },
+  {
+    "name": "regulate",
+    "trans": [
+      "调节",
+      "to make rules or laws to control something or someone"
+    ]
+  },
+  {
+    "name": "sometimes",
+    "trans": [
+      "有时",
+      "only at certain times; occasionally"
+    ]
+  },
+  {
+    "name": "impress",
+    "trans": [
+      "留下深刻印象",
+      "to make someone admire or respect another person or thing"
+    ]
+  },
+  {
+    "name": "somewhere",
+    "trans": [
+      "某处",
+      "at or to an unknown or unnamed place"
+    ]
+  },
+  {
+    "name": "son",
+    "trans": [
+      "儿子",
+      "male child; friendly way of addressing a boy"
+    ]
+  },
+  {
+    "name": "song",
+    "trans": [
+      "歌曲",
+      "some music with words in verse"
+    ]
+  },
+  {
+    "name": "frighten",
+    "trans": [
+      "吓唬",
+      "to make someone afraid or nervous"
+    ]
+  },
+  {
+    "name": "sorry",
+    "trans": [
+      "对不起",
+      "what you say to admit you were wrong"
+    ]
+  },
+  {
+    "name": "trick",
+    "trans": [
+      "诡计",
+      "to make someone believe something that is not true"
+    ]
+  },
+  {
+    "name": "motivate",
+    "trans": [
+      "激励",
+      "to make someone excited about doing something"
+    ]
+  },
+  {
+    "name": "source",
+    "trans": [
+      "来源",
+      "produces or provides what is wanted or needed"
+    ]
+  },
+  {
+    "name": "south",
+    "trans": [
+      "南",
+      "direction that is the opposite of north"
+    ]
+  },
+  {
+    "name": "scare",
+    "trans": [
+      "吓",
+      "to make someone feel frightened or worried"
+    ]
+  },
+  {
+    "name": "space",
+    "trans": [
+      "空间",
+      "empty area with nothing in it"
+    ]
+  },
+  {
+    "name": "depress",
+    "trans": [
+      "压抑",
+      "to make someone feel very sad; to reduce the value of something"
+    ]
+  },
+  {
+    "name": "inspire",
+    "trans": [
+      "启发",
+      "to make someone have the desire to do something"
+    ]
+  },
+  {
+    "name": "speaker",
+    "trans": [
+      "扬声器",
+      "person who makes a speech before a group"
+    ]
+  },
+  {
+    "name": "special",
+    "trans": [
+      "特别的",
+      "different from what is usual; better or greater than normal"
+    ]
+  },
+  {
+    "name": "anger",
+    "trans": [
+      "愤怒",
+      "to make someone mad, upset, or annoyed"
+    ]
+  },
+  {
+    "name": "bore",
+    "trans": [
+      "钻孔",
+      "to make someone not interested in something"
+    ]
+  },
+  {
+    "name": "interest",
+    "trans": [
+      "兴趣",
+      "to make someone want to know about something"
+    ]
+  },
+  {
+    "name": "specific",
+    "trans": [
+      "具体的",
+      "special or particular; clearly presented or stated"
+    ]
+  },
+  {
+    "name": "speech",
+    "trans": [
+      "演讲",
+      "expression of ideas or opinions"
+    ]
+  },
+  {
+    "name": "speed",
+    "trans": [
+      "速度",
+      "quality of being fast or quick"
+    ]
+  },
+  {
+    "name": "include",
+    "trans": [
+      "包括",
+      "to make someone/something part of a group"
+    ]
+  },
+  {
+    "name": "enhance",
+    "trans": [
+      "提高",
+      "to make something better; to improve"
+    ]
+  },
+  {
+    "name": "stretch",
+    "trans": [
+      "拉紧",
+      "to make something bigger or looser by pulling on it"
+    ]
+  },
+  {
+    "name": "spirit",
+    "trans": [
+      "精神",
+      "part of a person that is not physical and believed to be the source of human emotions and character"
+    ]
+  },
+  {
+    "name": "cause",
+    "trans": [
+      "原因",
+      "to make something happen; create effect or result"
+    ]
+  },
+  {
+    "name": "ban",
+    "trans": [
+      "禁止",
+      "to make something illegal or not allowed"
+    ]
+  },
+  {
+    "name": "sport",
+    "trans": [
+      "运动",
+      "game or physical exercise with rules"
+    ]
+  },
+  {
+    "name": "spot",
+    "trans": [
+      "点",
+      "see someone by chance"
+    ]
+  },
+  {
+    "name": "spread",
+    "trans": [
+      "传播",
+      "to place something over or cover a large area"
+    ]
+  },
+  {
+    "name": "spring",
+    "trans": [
+      "春天",
+      "time of year when plants start growing after winter"
+    ]
+  },
+  {
+    "name": "bend",
+    "trans": [
+      "弯曲",
+      "to make something not straight; make into a curve"
+    ]
+  },
+  {
+    "name": "seal",
+    "trans": [
+      "海豹",
+      "to make something so that it does not leak air or water"
+    ]
+  },
+  {
+    "name": "staff",
+    "trans": [
+      "职员",
+      "employees of a company"
+    ]
+  },
+  {
+    "name": "stage",
+    "trans": [
+      "阶段",
+      "place where actors or musician perform for others"
+    ]
+  },
+  {
+    "name": "trigger",
+    "trans": [
+      "扳机",
+      "to make something start happening"
+    ]
+  },
+  {
+    "name": "strengthen",
+    "trans": [
+      "加强",
+      "to make something stronger"
+    ]
+  },
+  {
+    "name": "confuse",
+    "trans": [
+      "迷惑",
+      "to make something unclear or hard to understand"
+    ]
+  },
+  {
+    "name": "assure",
+    "trans": [
+      "保证",
+      "to make sure that something happens"
+    ]
+  },
+  {
+    "name": "level",
+    "trans": [
+      "等级",
+      "to make things flat or even"
+    ]
+  },
+  {
+    "name": "standard",
+    "trans": [
+      "标准",
+      "accepted level of quality; an official measurement"
+    ]
+  },
+  {
+    "name": "star",
+    "trans": [
+      "星星",
+      "a bright planet of gas in the night sky"
+    ]
+  },
+  {
+    "name": "constitute",
+    "trans": [
+      "构成",
+      "to make up or be part of something"
+    ]
+  },
+  {
+    "name": "comprise",
+    "trans": [
+      "包括",
+      "to make up or form something"
+    ]
+  },
+  {
+    "name": "pump",
+    "trans": [
+      "泵",
+      "to make water or any other liquid move using a machine"
+    ]
+  },
+  {
+    "name": "statement",
+    "trans": [
+      "陈述",
+      "act or process of saying something formally"
+    ]
+  },
+  {
+    "name": "station",
+    "trans": [
+      "车站",
+      "place where you can catch a train or a bus"
+    ]
+  },
+  {
+    "name": "status",
+    "trans": [
+      "地位",
+      "position or rank relative to others in a society"
+    ]
+  },
+  {
+    "name": "create",
+    "trans": [
+      "创造",
+      "to make, cause, or bring into existence"
+    ]
+  },
+  {
+    "name": "stain",
+    "trans": [
+      "弄脏",
+      "to mark or change the color of something so it looks dirty"
+    ]
+  },
+  {
+    "name": "step",
+    "trans": [
+      "步",
+      "flat horizontal piece that forms stairs"
+    ]
+  },
+  {
+    "name": "stick",
+    "trans": [
+      "戳",
+      "long thin piece of wood from a tree"
+    ]
+  },
+  {
+    "name": "greet",
+    "trans": [
+      "迎接",
+      "to meet someone with friendly words and actions; to welcome"
+    ]
+  },
+  {
+    "name": "suggest",
+    "trans": [
+      "建议",
+      "to mention something that could be done; propose"
+    ]
+  },
+  {
+    "name": "cite",
+    "trans": [
+      "引用",
+      "to mention the work of others in your writing"
+    ]
+  },
+  {
+    "name": "stone",
+    "trans": [
+      "石头",
+      "hard, solid piece of rock"
+    ]
+  },
+  {
+    "name": "stir",
+    "trans": [
+      "搅拌",
+      "to mix something by making circular movements in it with a tool"
+    ]
+  },
+  {
+    "name": "breathe",
+    "trans": [
+      "呼吸",
+      "to move air into and out of your lungs"
+    ]
+  },
+  {
+    "name": "store",
+    "trans": [
+      "店铺",
+      "place where you can go to buy things"
+    ]
+  },
+  {
+    "name": "wander",
+    "trans": [
+      "漫步",
+      "to move around without purpose"
+    ]
+  },
+  {
+    "name": "leap",
+    "trans": [
+      "飞跃",
+      "to move forwards often in big steps"
+    ]
+  },
+  {
+    "name": "straight",
+    "trans": [
+      "直的",
+      "not having curves, bends, or angles"
+    ]
+  },
+  {
+    "name": "dig",
+    "trans": [
+      "挖",
+      "to move material to create a hole"
+    ]
+  },
+  {
+    "name": "strange",
+    "trans": [
+      "奇怪的",
+      "unusual or odd; surprising because unexpected"
+    ]
+  },
+  {
+    "name": "fold",
+    "trans": [
+      "折叠",
+      "to move one part of something so that it lies on top of another part"
+    ]
+  },
+  {
+    "name": "strategy",
+    "trans": [
+      "战略",
+      "careful plan or method for achieving a goal"
+    ]
+  },
+  {
+    "name": "put",
+    "trans": [
+      "放",
+      "to move or place a thing in a particular position"
+    ]
+  },
+  {
+    "name": "street",
+    "trans": [
+      "街道",
+      "road in a city with buildings and places to walk"
+    ]
+  },
+  {
+    "name": "strength",
+    "trans": [
+      "力量",
+      "being strong"
+    ]
+  },
+  {
+    "name": "go",
+    "trans": [
+      "去",
+      "to move or travel to another place"
+    ]
+  },
+  {
+    "name": "stress",
+    "trans": [
+      "压力",
+      "to be in a state of mental tension due to problems"
+    ]
+  },
+  {
+    "name": "hurry",
+    "trans": [
+      "匆忙",
+      "to move quickly"
+    ]
+  },
+  {
+    "name": "slide",
+    "trans": [
+      "滑动",
+      "to move smoothly and easily, usually over a surface"
+    ]
+  },
+  {
+    "name": "strike",
+    "trans": [
+      "罢工",
+      "to hit something"
+    ]
+  },
+  {
+    "name": "swing",
+    "trans": [
+      "摇摆",
+      "to move smoothly backwards and forwards or from side to side while hanging from something"
+    ]
+  },
+  {
+    "name": "come",
+    "trans": [
+      "来",
+      "to move toward someone; go with someone"
+    ]
+  },
+  {
+    "name": "walk",
+    "trans": [
+      "走",
+      "to move with your legs at a slowish pace"
+    ]
+  },
+  {
+    "name": "strong",
+    "trans": [
+      "强的",
+      "having big muscles; physically powerful"
+    ]
+  },
+  {
+    "name": "run",
+    "trans": [
+      "跑步",
+      "to move your legs faster than walking"
+    ]
+  },
+  {
+    "name": "struggle",
+    "trans": [
+      "斗争",
+      "to try very hard to do something difficult"
+    ]
+  },
+  {
+    "name": "owe",
+    "trans": [
+      "欠",
+      "to need to pay money to a person, bank, business, etc."
+    ]
+  },
+  {
+    "name": "rid",
+    "trans": [
+      "摆脱",
+      "to no longer be wanted so you throw it away"
+    ]
+  },
+  {
+    "name": "stuff",
+    "trans": [
+      "东西",
+      "generic description for things, materials, objects"
+    ]
+  },
+  {
+    "name": "disappoint",
+    "trans": [
+      "辜负",
+      "to not meet the expectations of others or yourself"
+    ]
+  },
+  {
+    "name": "let",
+    "trans": [
+      "让",
+      "to not stop someone from doing something"
+    ]
+  },
+  {
+    "name": "perceive",
+    "trans": [
+      "感知",
+      "to notice or become aware of something"
+    ]
+  },
+  {
+    "name": "distinguish",
+    "trans": [
+      "区分",
+      "to notice the difference between two or more things or people"
+    ]
+  },
+  {
+    "name": "get",
+    "trans": [
+      "得到",
+      "to obtain, receive, or be given something"
+    ]
+  },
+  {
+    "name": "appoint",
+    "trans": [
+      "委",
+      "to officially choose a person for a job, position"
+    ]
+  },
+  {
+    "name": "success",
+    "trans": [
+      "成功",
+      "achievement of a desired purpose or goal"
+    ]
+  },
+  {
+    "name": "successful",
+    "trans": [
+      "成功的",
+      "having the desired effect or result"
+    ]
+  },
+  {
+    "name": "govern",
+    "trans": [
+      "治理",
+      "to officially control and lead an area"
+    ]
+  },
+  {
+    "name": "mount",
+    "trans": [
+      "山",
+      "to organize and begin an action; to attach to a support"
+    ]
+  },
+  {
+    "name": "suddenly",
+    "trans": [
+      "突然",
+      "in an unexpected or very quick manner"
+    ]
+  },
+  {
+    "name": "suffer",
+    "trans": [
+      "遭受",
+      "to experience pain, illness, or injury"
+    ]
+  },
+  {
+    "name": "have",
+    "trans": [
+      "有",
+      "to own, possess, or hold something"
+    ]
+  },
+  {
+    "name": "call",
+    "trans": [
+      "称呼",
+      "to phone someone"
+    ]
+  },
+  {
+    "name": "take",
+    "trans": [
+      "拿",
+      "to pick up something and go away with it"
+    ]
+  },
+  {
+    "name": "suggestion",
+    "trans": [
+      "建议",
+      "idea about what someone should do"
+    ]
+  },
+  {
+    "name": "suit",
+    "trans": [
+      "套装",
+      "to be appropriate for a given situation"
+    ]
+  },
+  {
+    "name": "situate",
+    "trans": [
+      "位于",
+      "to place someone or something in a particular place or position"
+    ]
+  },
+  {
+    "name": "sum",
+    "trans": [
+      "和",
+      "amount when all is added together; total"
+    ]
+  },
+  {
+    "name": "click",
+    "trans": [
+      "点击",
+      "to press a button"
+    ]
+  },
+  {
+    "name": "summer",
+    "trans": [
+      "夏天",
+      "part of the year when the weather is hot"
+    ]
+  },
+  {
+    "name": "sun",
+    "trans": [
+      "太阳",
+      "the hot shining star the earth moves around"
+    ]
+  },
+  {
+    "name": "bite",
+    "trans": [
+      "咬",
+      "to press down on or cut into something with the teeth"
+    ]
+  },
+  {
+    "name": "restrict",
+    "trans": [
+      "限制",
+      "to prevent from doing something"
+    ]
+  },
+  {
+    "name": "supply",
+    "trans": [
+      "供应",
+      "to give or sell goods to others for their use"
+    ]
+  },
+  {
+    "name": "exclude",
+    "trans": [
+      "排除",
+      "to prevent someone from access to a group"
+    ]
+  },
+  {
+    "name": "suppose",
+    "trans": [
+      "认为",
+      "to imagine or guess what might happen"
+    ]
+  },
+  {
+    "name": "breed",
+    "trans": [
+      "品种",
+      "to produce baby animals of specific kinds"
+    ]
+  },
+  {
+    "name": "defend",
+    "trans": [
+      "保卫",
+      "to protect against an attack"
+    ]
+  },
+  {
+    "name": "surface",
+    "trans": [
+      "表面",
+      "of the top layer; superficial"
+    ]
+  },
+  {
+    "name": "input",
+    "trans": [
+      "输入",
+      "to put in information, advice, or opinions"
+    ]
+  },
+  {
+    "name": "surprise",
+    "trans": [
+      "惊喜",
+      "to do something that another person didn't expect"
+    ]
+  },
+  {
+    "name": "restore",
+    "trans": [
+      "恢复",
+      "to put or bring back into existence or use, mend"
+    ]
+  },
+  {
+    "name": "surround",
+    "trans": [
+      "环绕",
+      "to be on every side of something"
+    ]
+  },
+  {
+    "name": "survey",
+    "trans": [
+      "民意调查",
+      "to ask people a question about a particular topic"
+    ]
+  },
+  {
+    "name": "pose",
+    "trans": [
+      "姿势",
+      "to put someone in a position to be photographed"
+    ]
+  },
+  {
+    "name": "survive",
+    "trans": [
+      "存活",
+      "to continue to live despite illness or trouble"
+    ]
+  },
+  {
+    "name": "place",
+    "trans": [
+      "地方",
+      "to put something in a certain location or position"
+    ]
+  },
+  {
+    "name": "bury",
+    "trans": [
+      "埋葬",
+      "to put something into the ground and cover it"
+    ]
+  },
+  {
+    "name": "grab",
+    "trans": [
+      "抓住",
+      "to quickly reach out and take something in your hand."
+    ]
+  },
+  {
+    "name": "borrow",
+    "trans": [
+      "借",
+      "to receive something from someone and later return it"
+    ]
+  },
+  {
+    "name": "sweep",
+    "trans": [
+      "扫",
+      "to remove dust or dirt from a surface with a broom or brush"
+    ]
+  },
+  {
+    "name": "swim",
+    "trans": [
+      "游泳",
+      "to move through water by moving parts of the body"
+    ]
+  },
+  {
+    "name": "interpret",
+    "trans": [
+      "解释",
+      "to repeat what was said in another language"
+    ]
+  },
+  {
+    "name": "rescue",
+    "trans": [
+      "救援",
+      "to save something from danger or harm"
+    ]
+  },
+  {
+    "name": "remark",
+    "trans": [
+      "评论",
+      "to say an opinion or make a comment about something"
+    ]
+  },
+  {
+    "name": "table",
+    "trans": [
+      "桌子",
+      "raised flat surface"
+    ]
+  },
+  {
+    "name": "value",
+    "trans": [
+      "价值",
+      "to say how much money something is worth"
+    ]
+  },
+  {
+    "name": "tell",
+    "trans": [
+      "告诉",
+      "to say or communicate information to someone"
+    ]
+  },
+  {
+    "name": "joke",
+    "trans": [
+      "开玩笑",
+      "to say or do things that are meant to be funny"
+    ]
+  },
+  {
+    "name": "blame",
+    "trans": [
+      "责备",
+      "to say someone is responsible for something bad"
+    ]
+  },
+  {
+    "name": "damn",
+    "trans": [
+      "该死",
+      "to say someone should be punished for their bad behavior"
+    ]
+  },
+  {
+    "name": "declare",
+    "trans": [
+      "宣布",
+      "to say something in an official or sure way"
+    ]
+  },
+  {
+    "name": "apologize",
+    "trans": [
+      "道歉",
+      "to say sorry because of a mistake or injury you made"
+    ]
+  },
+  {
+    "name": "accuse",
+    "trans": [
+      "控",
+      "to say that someone has done something bad or wrong"
+    ]
+  },
+  {
+    "name": "tape",
+    "trans": [
+      "磁带",
+      "to stick things together using an adhesive strip"
+    ]
+  },
+  {
+    "name": "target",
+    "trans": [
+      "目标",
+      "a goal or amount you are trying to achieve"
+    ]
+  },
+  {
+    "name": "task",
+    "trans": [
+      "任务",
+      "big or small piece of work someone has to do"
+    ]
+  },
+  {
+    "name": "tax",
+    "trans": [
+      "税",
+      "money taken by a government from its people"
+    ]
+  },
+  {
+    "name": "taxi",
+    "trans": [
+      "出租车",
+      "car that transports people for money"
+    ]
+  },
+  {
+    "name": "tea",
+    "trans": [
+      "茶",
+      "drink made when you put dried leaves in hot water"
+    ]
+  },
+  {
+    "name": "teach",
+    "trans": [
+      "教",
+      "to help someone learn or do something"
+    ]
+  },
+  {
+    "name": "teacher",
+    "trans": [
+      "老师",
+      "person who teaches others, especially in a school"
+    ]
+  },
+  {
+    "name": "team",
+    "trans": [
+      "团队",
+      "group of people working on a task together"
+    ]
+  },
+  {
+    "name": "technical",
+    "trans": [
+      "技术的",
+      "of practical use of machines or science in industry"
+    ]
+  },
+  {
+    "name": "technique",
+    "trans": [
+      "技术",
+      "way of doing by using special knowledge or skill"
+    ]
+  },
+  {
+    "name": "telephone",
+    "trans": [
+      "电话",
+      "machine used to talk to someone who is far away"
+    ]
+  },
+  {
+    "name": "criticize",
+    "trans": [
+      "批评",
+      "to say that someone or something is bad"
+    ]
+  },
+  {
+    "name": "talk",
+    "trans": [
+      "讲话",
+      "to say things or ideas to someone with words"
+    ]
+  },
+  {
+    "name": "tend",
+    "trans": [
+      "趋向",
+      "to regularly behave in a certain way"
+    ]
+  },
+  {
+    "name": "ask",
+    "trans": [
+      "问",
+      "to say to someone that you want something"
+    ]
+  },
+  {
+    "name": "steal",
+    "trans": [
+      "偷",
+      "to secretly take something that belongs to another"
+    ]
+  },
+  {
+    "name": "broadcast",
+    "trans": [
+      "播送",
+      "to send out signals by radio or television"
+    ]
+  },
+  {
+    "name": "dismiss",
+    "trans": [
+      "解雇",
+      "to send someone away"
+    ]
+  },
+  {
+    "name": "cast",
+    "trans": [
+      "投掷",
+      "to send, throw, or move something or someone in a direction"
+    ]
+  },
+  {
+    "name": "break",
+    "trans": [
+      "休息",
+      "to separate into pieces by force, or by dropping"
+    ]
+  },
+  {
+    "name": "install",
+    "trans": [
+      "安装",
+      "to set up a piece of equipment so that it is ready to use"
+    ]
+  },
+  {
+    "name": "expose",
+    "trans": [
+      "暴露",
+      "to show something that is usually hidden, covered, or protected"
+    ]
+  },
+  {
+    "name": "lead",
+    "trans": [
+      "带领",
+      "to show the way or guide others"
+    ]
+  },
+  {
+    "name": "slip",
+    "trans": [
+      "滑",
+      "to slide out of position or fall to the ground by accident"
+    ]
+  },
+  {
+    "name": "text",
+    "trans": [
+      "文本",
+      "written part of a book or other work"
+    ]
+  },
+  {
+    "name": "evolve",
+    "trans": [
+      "发展",
+      "to slowly change or develop into something better"
+    ]
+  },
+  {
+    "name": "grin",
+    "trans": [
+      "咧嘴笑",
+      "to smile a big smile"
+    ]
+  },
+  {
+    "name": "shout",
+    "trans": [
+      "喊",
+      "to speak very loudly because you want to get their attention"
+    ]
+  },
+  {
+    "name": "ruin",
+    "trans": [
+      "废墟",
+      "to spoil something, to make it useless"
+    ]
+  },
+  {
+    "name": "theater",
+    "trans": [
+      "剧院",
+      "place where shows are performed on a stage"
+    ]
+  },
+  {
+    "name": "theme",
+    "trans": [
+      "主题",
+      "main subject to discuss or describe"
+    ]
+  },
+  {
+    "name": "themselves",
+    "trans": [
+      "他们自己",
+      "reflexive form of they"
+    ]
+  },
+  {
+    "name": "implement",
+    "trans": [
+      "实施",
+      "to start and carry out a plan or government policy; (n) tool"
+    ]
+  },
+  {
+    "name": "found",
+    "trans": [
+      "成立",
+      "to start something such as a company or organization"
+    ]
+  },
+  {
+    "name": "summarize",
+    "trans": [
+      "总结",
+      "to state the main or most important ideas of something"
+    ]
+  },
+  {
+    "name": "allege",
+    "trans": [
+      "声称",
+      "to state without proof"
+    ]
+  },
+  {
+    "name": "therefore",
+    "trans": [
+      "所以",
+      "for that reason"
+    ]
+  },
+  {
+    "name": "specify",
+    "trans": [
+      "指定",
+      "to state, name, or mention exactly and clearly"
+    ]
+  },
+  {
+    "name": "float",
+    "trans": [
+      "漂浮",
+      "to stay on the surface of a liquid and not sink"
+    ]
+  },
+  {
+    "name": "cancel",
+    "trans": [
+      "取消",
+      "to stop a planned event from happening"
+    ]
+  },
+  {
+    "name": "hesitate",
+    "trans": [
+      "犹豫",
+      "to stop before doing something because you are unsure what to do"
+    ]
+  },
+  {
+    "name": "disturb",
+    "trans": [
+      "打扰",
+      "to stop someone from working or sleeping"
+    ]
+  },
+  {
+    "name": "suspend",
+    "trans": [
+      "暂停",
+      "to stop something for a period of time; to interrupt"
+    ]
+  },
+  {
+    "name": "retire",
+    "trans": [
+      "退休",
+      "to stop working because you have reached a certain age"
+    ]
+  },
+  {
+    "name": "threat",
+    "trans": [
+      "威胁",
+      "warning of probable trouble"
+    ]
+  },
+  {
+    "name": "threaten",
+    "trans": [
+      "威胁",
+      "to say you will harm or hurt someone"
+    ]
+  },
+  {
+    "name": "emphasize",
+    "trans": [
+      "强调",
+      "to stress the items that are important"
+    ]
+  },
+  {
+    "name": "throughout",
+    "trans": [
+      "自始至终",
+      "over or across an entire thing or place, or in every part of something"
+    ]
+  },
+  {
+    "name": "throw",
+    "trans": [
+      "扔",
+      "to use your arm to make a thing fly through the air"
+    ]
+  },
+  {
+    "name": "thus",
+    "trans": [
+      "因此",
+      "therefore; so; as a result"
+    ]
+  },
+  {
+    "name": "ticket",
+    "trans": [
+      "票",
+      "piece of paper that lets you enter or use something"
+    ]
+  },
+  {
+    "name": "urge",
+    "trans": [
+      "敦促",
+      "to strongly persuade someone to do something"
+    ]
+  },
+  {
+    "name": "till",
+    "trans": [
+      "直到",
+      "until"
+    ]
+  },
+  {
+    "name": "analyze",
+    "trans": [
+      "分析",
+      "to study carefully to find out the meaning of"
+    ]
+  },
+  {
+    "name": "win",
+    "trans": [
+      "赢",
+      "to succeed in a game or contest"
+    ]
+  },
+  {
+    "name": "tire",
+    "trans": [
+      "胎",
+      "lose energy and feel that you need to rest"
+    ]
+  },
+  {
+    "name": "overcome",
+    "trans": [
+      "克服",
+      "to succeed in a struggle"
+    ]
+  },
+  {
+    "name": "title",
+    "trans": [
+      "标题",
+      "name given to something to identify or describe it"
+    ]
+  },
+  {
+    "name": "accomplish",
+    "trans": [
+      "完成",
+      "to succeed in doing; complete successfully"
+    ]
+  },
+  {
+    "name": "collapse",
+    "trans": [
+      "坍塌",
+      "to suddenly fall down or break apart"
+    ]
+  },
+  {
+    "name": "imply",
+    "trans": [
+      "意味着",
+      "to suggest something, without saying it directly"
+    ]
+  },
+  {
+    "name": "tomorrow",
+    "trans": [
+      "明天",
+      "day after today"
+    ]
+  },
+  {
+    "name": "advise",
+    "trans": [
+      "建议",
+      "to suggest what should be done"
+    ]
+  },
+  {
+    "name": "tackle",
+    "trans": [
+      "处理",
+      "to take action to solve a difficult problem"
+    ]
+  },
+  {
+    "name": "tonight",
+    "trans": [
+      "今晚",
+      "night following this day"
+    ]
+  },
+  {
+    "name": "entertain",
+    "trans": [
+      "招待",
+      "to take care of guests by helping them enjoy their time"
+    ]
+  },
+  {
+    "name": "bring",
+    "trans": [
+      "带来",
+      "to take or go with someone to a place"
+    ]
+  },
+  {
+    "name": "happen",
+    "trans": [
+      "发生",
+      "to take place or occur"
+    ]
+  },
+  {
+    "name": "topic",
+    "trans": [
+      "话题",
+      "matter people talk or write about"
+    ]
+  },
+  {
+    "name": "total",
+    "trans": [
+      "全部的",
+      "whole number or amount of something"
+    ]
+  },
+  {
+    "name": "totally",
+    "trans": [
+      "完全",
+      "in a complete way; completely; absolutely"
+    ]
+  },
+  {
+    "name": "tough",
+    "trans": [
+      "艰难的",
+      "very difficult to do or deal with"
+    ]
+  },
+  {
+    "name": "tour",
+    "trans": [
+      "旅游",
+      "a journey to visit several places for pleasure"
+    ]
+  },
+  {
+    "name": "tourist",
+    "trans": [
+      "游客",
+      "someone who travels to a place for pleasure"
+    ]
+  },
+  {
+    "name": "strip",
+    "trans": [
+      "条",
+      "to take something away from (someone)"
+    ]
+  },
+  {
+    "name": "toward",
+    "trans": [
+      "朝向",
+      "facing or moving in the direction of something"
+    ]
+  },
+  {
+    "name": "bother",
+    "trans": [
+      "打扰",
+      "to take the trouble to do something"
+    ]
+  },
+  {
+    "name": "chat",
+    "trans": [
+      "聊天",
+      "to talk in a friendly and relaxed manner"
+    ]
+  },
+  {
+    "name": "whisper",
+    "trans": [
+      "耳语",
+      "to talk with breath but no voice"
+    ]
+  },
+  {
+    "name": "track",
+    "trans": [
+      "追踪",
+      "to follow behind someone to see what they are doing"
+    ]
+  },
+  {
+    "name": "trade",
+    "trans": [
+      "贸易",
+      "to buy, sell and exchange goods in business"
+    ]
+  },
+  {
+    "name": "traditional",
+    "trans": [
+      "传统的",
+      "involved in a tradition"
+    ]
+  },
+  {
+    "name": "traffic",
+    "trans": [
+      "交通",
+      "amount of activity over a communication system"
+    ]
+  },
+  {
+    "name": "educate",
+    "trans": [
+      "教育",
+      "to teach someone in a school or college"
+    ]
+  },
+  {
+    "name": "thank",
+    "trans": [
+      "感谢",
+      "to tell someone you are grateful to them"
+    ]
+  },
+  {
+    "name": "transfer",
+    "trans": [
+      "转移",
+      "to move something from one place to another"
+    ]
+  },
+  {
+    "name": "aside",
+    "trans": [
+      "放在一边",
+      "to the side; out of the way; for later use"
+    ]
+  },
+  {
+    "name": "consider",
+    "trans": [
+      "考虑",
+      "to think carefully about something"
+    ]
+  },
+  {
+    "name": "transport",
+    "trans": [
+      "运输",
+      "to carry things from one place to another"
+    ]
+  },
+  {
+    "name": "believe",
+    "trans": [
+      "相信",
+      "to think or accept that something is true"
+    ]
+  },
+  {
+    "name": "travel",
+    "trans": [
+      "旅行",
+      "to go to a place that is far away"
+    ]
+  },
+  {
+    "name": "treat",
+    "trans": [
+      "对待",
+      "to act in a certain way toward someone"
+    ]
+  },
+  {
+    "name": "treatment",
+    "trans": [
+      "治疗",
+      "way someone acts toward another"
+    ]
+  },
+  {
+    "name": "tree",
+    "trans": [
+      "树",
+      "tall green plants in a forest"
+    ]
+  },
+  {
+    "name": "trend",
+    "trans": [
+      "趋势",
+      "general direction of developing, proceeding"
+    ]
+  },
+  {
+    "name": "trial",
+    "trans": [
+      "审判",
+      "concerning or used in a trial"
+    ]
+  },
+  {
+    "name": "stroke",
+    "trans": [
+      "中风",
+      "to touch someone or something repeatedly in a caring way"
+    ]
+  },
+  {
+    "name": "sail",
+    "trans": [
+      "帆",
+      "to travel on water in a ship or boat"
+    ]
+  },
+  {
+    "name": "trip",
+    "trans": [
+      "旅行",
+      "journey or visit to a place"
+    ]
+  },
+  {
+    "name": "trouble",
+    "trans": [
+      "麻烦",
+      "state of difficulty or stress"
+    ]
+  },
+  {
+    "name": "resist",
+    "trans": [
+      "抵抗",
+      "to try to stop or prevent something"
+    ]
+  },
+  {
+    "name": "compete",
+    "trans": [
+      "竞争",
+      "to try to win something such as a race or game"
+    ]
+  },
+  {
+    "name": "trust",
+    "trans": [
+      "相信",
+      "to be confident that someone is honest and reliable"
+    ]
+  },
+  {
+    "name": "truth",
+    "trans": [
+      "真相",
+      "real facts about something"
+    ]
+  },
+  {
+    "name": "spin",
+    "trans": [
+      "旋转",
+      "to turn around repeatedly"
+    ]
+  },
+  {
+    "name": "twist",
+    "trans": [
+      "捻",
+      "to turn something in opposite directions at the same time"
+    ]
+  },
+  {
+    "name": "look",
+    "trans": [
+      "看",
+      "to turn your eyes in a particular direction"
+    ]
+  },
+  {
+    "name": "twice",
+    "trans": [
+      "两次",
+      "two times"
+    ]
+  },
+  {
+    "name": "figure",
+    "trans": [
+      "数字",
+      "to understand after thinking; work out"
+    ]
+  },
+  {
+    "name": "hold",
+    "trans": [
+      "抓住",
+      "to use hands or arms to carry or keep something"
+    ]
+  },
+  {
+    "name": "spend",
+    "trans": [
+      "花费",
+      "to use money to pay for something"
+    ]
+  },
+  {
+    "name": "typical",
+    "trans": [
+      "典型的",
+      "normal; usual; expected"
+    ]
+  },
+  {
+    "name": "force",
+    "trans": [
+      "力量",
+      "to use physical strength or violence to persuade"
+    ]
+  },
+  {
+    "name": "say",
+    "trans": [
+      "说",
+      "to use words to tell a message"
+    ]
+  },
+  {
+    "name": "speak",
+    "trans": [
+      "说话",
+      "to use words to tell information, express thoughts"
+    ]
+  },
+  {
+    "name": "see",
+    "trans": [
+      "看",
+      "to use your eyes to look at something"
+    ]
+  },
+  {
+    "name": "smell",
+    "trans": [
+      "闻",
+      "to use your nose to sense something"
+    ]
+  },
+  {
+    "name": "march",
+    "trans": [
+      "行进",
+      "to walk with regular steps as a group"
+    ]
+  },
+  {
+    "name": "unclear",
+    "trans": [
+      "不清楚",
+      "not easy to understand; not obvious"
+    ]
+  },
+  {
+    "name": "defeat",
+    "trans": [
+      "击败",
+      "to win against someone in something such as a fight or game"
+    ]
+  },
+  {
+    "name": "pray",
+    "trans": [
+      "祈祷",
+      "to wish or hope for something to happen or be true"
+    ]
+  },
+  {
+    "name": "strain",
+    "trans": [
+      "拉紧",
+      "too much pressure on a person or system that can cause problems"
+    ]
+  },
+  {
+    "name": "soil",
+    "trans": [
+      "土壤",
+      "top layer of earth in which plants grow"
+    ]
+  },
+  {
+    "name": "head",
+    "trans": [
+      "头",
+      "top part of your body with eyes and a mouth"
+    ]
+  },
+  {
+    "name": "rear",
+    "trans": [
+      "后部",
+      "towards the back part of something"
+    ]
+  },
+  {
+    "name": "unfortunately",
+    "trans": [
+      "很遗憾",
+      "in a way that is to be regretted; unluckily"
+    ]
+  },
+  {
+    "name": "journey",
+    "trans": [
+      "旅行",
+      "traveling from one place to another; trip"
+    ]
+  },
+  {
+    "name": "unique",
+    "trans": [
+      "独特的",
+      "unlike other things; being the only one like it"
+    ]
+  },
+  {
+    "name": "unit",
+    "trans": [
+      "单元",
+      "single thing or person; a part of something larger"
+    ]
+  },
+  {
+    "name": "therapy",
+    "trans": [
+      "治疗",
+      "treatment intended to help fix your problem or medical illness"
+    ]
+  },
+  {
+    "name": "upset",
+    "trans": [
+      "沮丧的",
+      "troubled, worried, or angry"
+    ]
+  },
+  {
+    "name": "van",
+    "trans": [
+      "货车",
+      "truck with an enclosed cargo space"
+    ]
+  },
+  {
+    "name": "university",
+    "trans": [
+      "大学",
+      "high-level educational institution; college"
+    ]
+  },
+  {
+    "name": "pipe",
+    "trans": [
+      "管道",
+      "tube a round, hollow piece of metal, plastic, or wood"
+    ]
+  },
+  {
+    "name": "unless",
+    "trans": [
+      "除非",
+      "negative of 'if'"
+    ]
+  },
+  {
+    "name": "twin",
+    "trans": [
+      "双",
+      "two children born from the same mother at the same time"
+    ]
+  },
+  {
+    "name": "ratio",
+    "trans": [
+      "比率",
+      "two numbers that show ​the relationship between two groups of people or things"
+    ]
+  },
+  {
+    "name": "vice",
+    "trans": [
+      "副",
+      "type of evildoing"
+    ]
+  },
+  {
+    "name": "climate",
+    "trans": [
+      "气候",
+      "typical weather conditions in a particular place"
+    ]
+  },
+  {
+    "name": "blind",
+    "trans": [
+      "瞎的",
+      "unable to see; with eyes that cannot see"
+    ]
+  },
+  {
+    "name": "raw",
+    "trans": [
+      "生的",
+      "uncooked"
+    ]
+  },
+  {
+    "name": "upon",
+    "trans": [
+      "之上",
+      "more formal term for on"
+    ]
+  },
+  {
+    "name": "beneath",
+    "trans": [
+      "下面",
+      "under; in or to a lower position; below"
+    ]
+  },
+  {
+    "name": "illness",
+    "trans": [
+      "疾病",
+      "unhealthy condition of the mind or body"
+    ]
+  },
+  {
+    "name": "word",
+    "trans": [
+      "单词",
+      "unit of language that has a meaning"
+    ]
+  },
+  {
+    "name": "meter",
+    "trans": [
+      "仪表",
+      "unit of length equal to 100 cm or about 39 inches"
+    ]
+  },
+  {
+    "name": "year",
+    "trans": [
+      "年",
+      "unit of time equal to 12 months"
+    ]
+  },
+  {
+    "name": "useful",
+    "trans": [
+      "有用",
+      "that can help with a particular task"
+    ]
+  },
+  {
+    "name": "usual",
+    "trans": [
+      "通常",
+      "being the way things occur most of the time"
+    ]
+  },
+  {
+    "name": "usually",
+    "trans": [
+      "通常",
+      "normally; regularly"
+    ]
+  },
+  {
+    "name": "minute",
+    "trans": [
+      "分钟",
+      "unit of time equal to 60 seconds"
+    ]
+  },
+  {
+    "name": "ugly",
+    "trans": [
+      "丑陋的",
+      "unpleasant to look at; not attractive"
+    ]
+  },
+  {
+    "name": "yet",
+    "trans": [
+      "然而",
+      "until now; up to the present"
+    ]
+  },
+  {
+    "name": "until",
+    "trans": [
+      "直到",
+      "up to, to indicate a point in time when something happens"
+    ]
+  },
+  {
+    "name": "could",
+    "trans": [
+      "可以",
+      "used as the past form of can, to show possibility"
+    ]
+  },
+  {
+    "name": "but",
+    "trans": [
+      "但",
+      "used before you say something different, opposite"
+    ]
+  },
+  {
+    "name": "various",
+    "trans": [
+      "各种各样的",
+      "several; consisting of different things or types"
+    ]
+  },
+  {
+    "name": "vary",
+    "trans": [
+      "各不相同",
+      "to be changeable, both up and down"
+    ]
+  },
+  {
+    "name": "ourselves",
+    "trans": [
+      "我们自己",
+      "used by a speaker to show that they and one or more people are affected by their action"
+    ]
+  },
+  {
+    "name": "vehicle",
+    "trans": [
+      "车辆",
+      "machine (such as a car) that is used to carry things"
+    ]
+  },
+  {
+    "name": "everyday",
+    "trans": [
+      "每天",
+      "used or seen daily; suitable for daily use; ordinary"
+    ]
+  },
+  {
+    "name": "actually",
+    "trans": [
+      "实际上",
+      "used to add new (often different) information"
+    ]
+  },
+  {
+    "name": "version",
+    "trans": [
+      "版本",
+      "particular form of something and other forms"
+    ]
+  },
+  {
+    "name": "with",
+    "trans": [
+      "和",
+      "used to express that people or things are together"
+    ]
+  },
+  {
+    "name": "might",
+    "trans": [
+      "可能",
+      "used to express that something could happen"
+    ]
+  },
+  {
+    "name": "secondly",
+    "trans": [
+      "第二",
+      "used to give a point or reason after the first"
+    ]
+  },
+  {
+    "name": "should",
+    "trans": [
+      "应该",
+      "used to indicate what is proper or reasonable"
+    ]
+  },
+  {
+    "name": "or",
+    "trans": [
+      "或者",
+      "used to link alternatives, to introduce another choice"
+    ]
+  },
+  {
+    "name": "some",
+    "trans": [
+      "一些",
+      "used to refer to a person or thing that is not known"
+    ]
+  },
+  {
+    "name": "the",
+    "trans": [
+      "这",
+      "used to refer to something already mentioned"
+    ]
+  },
+  {
+    "name": "video",
+    "trans": [
+      "视频",
+      "recording capturing action with sound"
+    ]
+  },
+  {
+    "name": "we",
+    "trans": [
+      "我们",
+      "used to refer to the speaker and other people together"
+    ]
+  },
+  {
+    "name": "village",
+    "trans": [
+      "村庄",
+      "small town in the country"
+    ]
+  },
+  {
+    "name": "they",
+    "trans": [
+      "他们",
+      "used to refer to two or more people, animals, or things"
+    ]
+  },
+  {
+    "name": "and",
+    "trans": [
+      "和",
+      "used to refer to two or more things"
+    ]
+  },
+  {
+    "name": "both",
+    "trans": [
+      "两个都",
+      "used to refer to two things at the same time"
+    ]
+  },
+  {
+    "name": "must",
+    "trans": [
+      "必须",
+      "used to say that something is required or necessary"
+    ]
+  },
+  {
+    "name": "without",
+    "trans": [
+      "没有",
+      "used to say you don't have something or it isn't in a place"
+    ]
+  },
+  {
+    "name": "versus",
+    "trans": [
+      "相对",
+      "used to show that a thing or person is against another thing or person"
+    ]
+  },
+  {
+    "name": "visitor",
+    "trans": [
+      "游客",
+      "one who goes to a place to see it (or someone)"
+    ]
+  },
+  {
+    "name": "for",
+    "trans": [
+      "为了",
+      "used to show the purpose, or need of something"
+    ]
+  },
+  {
+    "name": "that",
+    "trans": [
+      "那",
+      "used to show which person or thing we are talking about"
+    ]
+  },
+  {
+    "name": "voice",
+    "trans": [
+      "嗓音",
+      "sound made when you speak or sing"
+    ]
+  },
+  {
+    "name": "volume",
+    "trans": [
+      "体积",
+      "level of sound produced by an object, such as a radio or television"
+    ]
+  },
+  {
+    "name": "may",
+    "trans": [
+      "可能",
+      "used to talk about what is possible"
+    ]
+  },
+  {
+    "name": "than",
+    "trans": [
+      "比",
+      "used when comparing two things"
+    ]
+  },
+  {
+    "name": "vote",
+    "trans": [
+      "投票",
+      "to make a choice for or against, as in an election"
+    ]
+  },
+  {
+    "name": "wait",
+    "trans": [
+      "等待",
+      "to spend time until an expected thing happens"
+    ]
+  },
+  {
+    "name": "will",
+    "trans": [
+      "将要",
+      "used with verbs to express the future"
+    ]
+  },
+  {
+    "name": "wall",
+    "trans": [
+      "墙",
+      "high, flat side of a room or building"
+    ]
+  },
+  {
+    "name": "functional",
+    "trans": [
+      "功能性的",
+      "useful; not just for decoration"
+    ]
+  },
+  {
+    "name": "electric",
+    "trans": [
+      "电的",
+      "using a particular type of energy carried through metal wire"
+    ]
+  },
+  {
+    "name": "war",
+    "trans": [
+      "战争",
+      "situation where armies fight each other"
+    ]
+  },
+  {
+    "name": "warm",
+    "trans": [
+      "温暖的",
+      "slightly hot; not very hot"
+    ]
+  },
+  {
+    "name": "warn",
+    "trans": [
+      "警告",
+      "to tell someone about possible danger"
+    ]
+  },
+  {
+    "name": "wash",
+    "trans": [
+      "洗",
+      "to clean someone or something with soap and water"
+    ]
+  },
+  {
+    "name": "waste",
+    "trans": [
+      "浪费",
+      "to use valuable things ineffectively"
+    ]
+  },
+  {
+    "name": "digital",
+    "trans": [
+      "数字的",
+      "using electronic signals or computers"
+    ]
+  },
+  {
+    "name": "wave",
+    "trans": [
+      "海浪",
+      "to move your hand or arm to say hello or goodbye"
+    ]
+  },
+  {
+    "name": "experimental",
+    "trans": [
+      "实验性的",
+      "using techniques that are different or untried before"
+    ]
+  },
+  {
+    "name": "train",
+    "trans": [
+      "火车",
+      "vehicle that carries people and runs on rails"
+    ]
+  },
+  {
+    "name": "really",
+    "trans": [
+      "真的",
+      "very"
+    ]
+  },
+  {
+    "name": "precise",
+    "trans": [
+      "精确的",
+      "very accurate and exact expression or detail"
+    ]
+  },
+  {
+    "name": "mad",
+    "trans": [
+      "疯狂的",
+      "very angry, very strong feelings, crazy"
+    ]
+  },
+  {
+    "name": "terrible",
+    "trans": [
+      "糟糕的",
+      "very bad; horrible"
+    ]
+  },
+  {
+    "name": "weapon",
+    "trans": [
+      "武器",
+      "something that is used for fighting"
+    ]
+  },
+  {
+    "name": "awful",
+    "trans": [
+      "可怕",
+      "very bad; horrible; terrible"
+    ]
+  },
+  {
+    "name": "severe",
+    "trans": [
+      "严重",
+      "very bad; very serious"
+    ]
+  },
+  {
+    "name": "weekend",
+    "trans": [
+      "周末",
+      "Saturday and Sunday"
+    ]
+  },
+  {
+    "name": "massive",
+    "trans": [
+      "大量的",
+      "very big; very large and heavy"
+    ]
+  },
+  {
+    "name": "fantastic",
+    "trans": [
+      "极好的",
+      "very fanciful in design, construction, or appearance"
+    ]
+  },
+  {
+    "name": "weight",
+    "trans": [
+      "重量",
+      "how heavy something is"
+    ]
+  },
+  {
+    "name": "great",
+    "trans": [
+      "伟大的",
+      "very good; fantastic; wonderful"
+    ]
+  },
+  {
+    "name": "welcome",
+    "trans": [
+      "欢迎",
+      "friendly greeting to someone who has arrived"
+    ]
+  },
+  {
+    "name": "extreme",
+    "trans": [
+      "极端",
+      "very great in degree"
+    ]
+  },
+  {
+    "name": "greatly",
+    "trans": [
+      "大大地",
+      "very much"
+    ]
+  },
+  {
+    "name": "radical",
+    "trans": [
+      "激进的",
+      "very new and different from what is traditional"
+    ]
+  },
+  {
+    "name": "ancient",
+    "trans": [
+      "古老的",
+      "very old; having lived a very long time ago"
+    ]
+  },
+  {
+    "name": "newly",
+    "trans": [
+      "新",
+      "very recently; just done or made"
+    ]
+  },
+  {
+    "name": "whatever",
+    "trans": [
+      "任何",
+      "anything or everything needed; no matter what"
+    ]
+  },
+  {
+    "name": "moment",
+    "trans": [
+      "片刻",
+      "very short or brief period of time"
+    ]
+  },
+  {
+    "name": "parallel",
+    "trans": [
+      "平行线",
+      "very similar and often occurring at the same time"
+    ]
+  },
+  {
+    "name": "slight",
+    "trans": [
+      "轻微",
+      "very small in degree or amount"
+    ]
+  },
+  {
+    "name": "whereas",
+    "trans": [
+      "然而",
+      "taking into consideration the fact that"
+    ]
+  },
+  {
+    "name": "steel",
+    "trans": [
+      "钢",
+      "very strong metal made of iron and other substances mixed together"
+    ]
+  },
+  {
+    "name": "intense",
+    "trans": [
+      "激烈的",
+      "very strong, great, or extreme in degree"
+    ]
+  },
+  {
+    "name": "horrible",
+    "trans": [
+      "可怕",
+      "very unpleasant"
+    ]
+  },
+  {
+    "name": "tiny",
+    "trans": [
+      "微小的",
+      "very, very small"
+    ]
+  },
+  {
+    "name": "quite",
+    "trans": [
+      "相当",
+      "very; in a complete or total manner"
+    ]
+  },
+  {
+    "name": "white",
+    "trans": [
+      "白色的",
+      "lightest color; the color of fresh snow and milk"
+    ]
+  },
+  {
+    "name": "form",
+    "trans": [
+      "形式",
+      "visible shape or style; type; kind"
+    ]
+  },
+  {
+    "name": "curious",
+    "trans": [
+      "好奇的",
+      "wanting to know more about something"
+    ]
+  },
+  {
+    "name": "competitive",
+    "trans": [
+      "竞争的",
+      "wanting to win or to be better than others"
+    ]
+  },
+  {
+    "name": "wide",
+    "trans": [
+      "宽的",
+      "having a great distance from one side to the other"
+    ]
+  },
+  {
+    "name": "sound",
+    "trans": [
+      "声音",
+      "waves traveling in air or water that can be heard"
+    ]
+  },
+  {
+    "name": "wife",
+    "trans": [
+      "妻子",
+      "married woman"
+    ]
+  },
+  {
+    "name": "wild",
+    "trans": [
+      "荒野",
+      "living in nature; not tame"
+    ]
+  },
+  {
+    "name": "mode",
+    "trans": [
+      "模式",
+      "way of acting or doing something"
+    ]
+  },
+  {
+    "name": "yes",
+    "trans": [
+      "是的",
+      "way to say you agree or will do something"
+    ]
+  },
+  {
+    "name": "wind",
+    "trans": [
+      "风",
+      "natural movement of outside air as part of the weather"
+    ]
+  },
+  {
+    "name": "window",
+    "trans": [
+      "窗户",
+      "opening in a wall or door to let in light"
+    ]
+  },
+  {
+    "name": "wine",
+    "trans": [
+      "葡萄酒",
+      "alcoholic drink made from the juice of grapes"
+    ]
+  },
+  {
+    "name": "custom",
+    "trans": [
+      "风俗",
+      "what is usual or normal"
+    ]
+  },
+  {
+    "name": "winter",
+    "trans": [
+      "冬天",
+      "coldest season of the year"
+    ]
+  },
+  {
+    "name": "who",
+    "trans": [
+      "WHO",
+      "what or which person or people, to ask about, talking about"
+    ]
+  },
+  {
+    "name": "food",
+    "trans": [
+      "食物",
+      "what people and animals eat to live"
+    ]
+  },
+  {
+    "name": "name",
+    "trans": [
+      "姓名",
+      "what something or someone is called"
+    ]
+  },
+  {
+    "name": "wish",
+    "trans": [
+      "希望",
+      "to want something to happen or to become true"
+    ]
+  },
+  {
+    "name": "probability",
+    "trans": [
+      "可能性",
+      "what the chances are that something will happen"
+    ]
+  },
+  {
+    "name": "hello",
+    "trans": [
+      "你好",
+      "what you say when you meet someone"
+    ]
+  },
+  {
+    "name": "hi",
+    "trans": [
+      "你好",
+      "what you say when you meet someone; hello"
+    ]
+  },
+  {
+    "name": "excitement",
+    "trans": [
+      "激动",
+      "when people feel very happy and enthusiastic"
+    ]
+  },
+  {
+    "name": "wonder",
+    "trans": [
+      "想知道",
+      "surprise caused by experiencing something amazing"
+    ]
+  },
+  {
+    "name": "wonderful",
+    "trans": [
+      "精彩的",
+      "producing feelings of enjoyment or delight"
+    ]
+  },
+  {
+    "name": "invitation",
+    "trans": [
+      "邀请函",
+      "when someone asks you to do something or go somewhere"
+    ]
+  },
+  {
+    "name": "pregnant",
+    "trans": [
+      "孕",
+      "when women carry a child inside them that is not yet born"
+    ]
+  },
+  {
+    "name": "youth",
+    "trans": [
+      "青年",
+      "when you are young; a young person"
+    ]
+  },
+  {
+    "name": "worker",
+    "trans": [
+      "工人",
+      "person who works"
+    ]
+  },
+  {
+    "name": "pride",
+    "trans": [
+      "自豪",
+      "when you respect yourself"
+    ]
+  },
+  {
+    "name": "worry",
+    "trans": [
+      "担心",
+      "to feel concerned or troubled about something"
+    ]
+  },
+  {
+    "name": "worth",
+    "trans": [
+      "值得",
+      "how much something is worth; the value of something"
+    ]
+  },
+  {
+    "name": "hope",
+    "trans": [
+      "希望",
+      "when you wish something would happen; what you wish"
+    ]
+  },
+  {
+    "name": "boundary",
+    "trans": [
+      "边界",
+      "where one area ends and another begins"
+    ]
+  },
+  {
+    "name": "wrong",
+    "trans": [
+      "错误的",
+      "not right, incorrect; not true; bad"
+    ]
+  },
+  {
+    "name": "rice",
+    "trans": [
+      "米",
+      "white or brown grains from a plant used for food"
+    ]
+  },
+  {
+    "name": "yeah",
+    "trans": [
+      "是的",
+      "yes (informal)"
+    ]
+  },
+  {
+    "name": "sugar",
+    "trans": [
+      "糖",
+      "white sweet substance used to make foods sweeter"
+    ]
+  },
+  {
+    "name": "determination",
+    "trans": [
+      "决心",
+      "will to achieve a goal despite difficulties"
+    ]
+  },
+  {
+    "name": "cable",
+    "trans": [
+      "电缆",
+      "wire carrying electricity, tv signals, internet, etc."
+    ]
+  },
+  {
+    "name": "yesterday",
+    "trans": [
+      "昨天",
+      "day before today"
+    ]
+  },
+  {
+    "name": "surely",
+    "trans": [
+      "一定",
+      "with certainty; definitely"
+    ]
+  },
+  {
+    "name": "rapidly",
+    "trans": [
+      "迅速地",
+      "with great speed"
+    ]
+  },
+  {
+    "name": "regardless",
+    "trans": [
+      "不管",
+      "without being affected or concerned by something difficult or troubling"
+    ]
+  },
+  {
+    "name": "not",
+    "trans": [
+      "不是",
+      "word indicating the negative of verbs, adjectives, etc."
+    ]
+  },
+  {
+    "name": "yourself",
+    "trans": [
+      "你自己",
+      "reflexive form of 'you', used for an emphasis"
+    ]
+  },
+  {
+    "name": "verb",
+    "trans": [
+      "动词",
+      "word that expresses an action or state"
+    ]
+  },
+  {
+    "name": "when",
+    "trans": [
+      "什么时候",
+      "word you use to ask about the time or day"
+    ]
+  },
+  {
+    "name": "where",
+    "trans": [
+      "在哪里",
+      "word you use to ask the location of something"
+    ]
+  },
+  {
+    "name": "candidate",
+    "trans": [
+      "候选人",
+      "a person being considered for a job or position in office"
+    ]
+  },
+  {
+    "name": "language",
+    "trans": [
+      "语言",
+      "words or signs used to communicate messages"
+    ]
+  },
+  {
+    "name": "conference",
+    "trans": [
+      "会议",
+      "an event where people exchange ideas"
+    ]
+  },
+  {
+    "name": "efficiency",
+    "trans": [
+      "效率",
+      "working well; producing something without waste"
+    ]
+  },
+  {
+    "name": "partnership",
+    "trans": [
+      "合伙",
+      "working with others for some purpose"
+    ]
+  },
+  {
+    "name": "valuable",
+    "trans": [
+      "有价值的",
+      "worth a lot of money"
+    ]
+  },
+  {
+    "name": "criticism",
+    "trans": [
+      "批评",
+      "written or spoken remarks about what is bad about someone or something"
+    ]
+  },
+  {
+    "name": "own",
+    "trans": [
+      "自己的",
+      "yours, his, hers, etc.; not belonging to another"
+    ]
+  }
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -4155,6 +4155,21 @@ const indonesianDicts: DictionaryResource[] = [
   },
 ]
 
+//NGSL核心词汇
+const ngslDicts: DictionaryResource[] = [
+  {
+    id: 'NGSL_1.2',
+    name: 'NGSL 2809核心词',
+    description: '新概念英语常用词表（New General Service List）2809个核心词，含中文释义',
+    category: '英语学习',
+    tags: ['核心词汇', '雅思', 'NGSL'],
+    url: '/dicts/NGSL_1.2.json',
+    length: 2809,
+    language: 'en',
+    languageCategory: 'en',
+  },
+]
+
 /**
  * Built-in dictionaries in an array.
  * Why arrays? Because it keeps the order across browsers.
@@ -4168,6 +4183,7 @@ export const dictionaryResources: DictionaryResource[] = [
   ...germanExam,
   ...kazakhHapinDicts,
   ...indonesianDicts,
+  ...ngslDicts,
 
   // {
   //   id: 'zhtest',


### PR DESCRIPTION
## 做了什么

在 public/dicts 目录下添加了 NGSL（新通用服务词表）2809 核心词汇词典。

## 为什么

NGSL 是基于语料库研究整理的高频英语词汇表，收录了日常英语中最常用的核心词汇。对于希望系统性建立英语基础词汇量的用户来说非常实用，学习效率高。

## 改动内容

- 新增 `NGSL_1.2.json` 词典文件
- 在词典配置中注册了新词典